### PR TITLE
CRITICAL FIX: Resolve PowerShell Context Issue

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -545,7 +545,7 @@ jobs:
           case "${{ matrix.platform }}" in
             "windows")
               echo "🪟 Windows-specific checks:"
-              echo "  - PowerShell version: $PSVersionTable.PSVersion"
+              echo "  - PowerShell version: Available (context: bash)"
               echo "  - Path separator: \\"
               echo "  - Line endings: CRLF expected"
               ;;


### PR DESCRIPTION
## Critical Issue Fix

Resolves critical PowerShell context issue identified in PR #7 review.

**Problem**: Line 548 was using PowerShell variable  in a bash context, which would cause workflow failures.

**Solution**: Replace with generic message since all platforms use bash shell context in this section.

**Impact**: Prevents workflow failures on Windows platform testing.

🤖 Generated with [Claude Code](https://claude.ai/code)