### PR TITLE
High Priority: Increase workflow timeout to 25 minutes

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -20,7 +20,7 @@ jobs:
   cross-platform-test:
     name: Test on ${{ matrix.os }} with Node ${{ matrix.node-version }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 25
     
     strategy:
       fail-fast: false  # Continue testing other platforms even if one fails


### PR DESCRIPTION
## Summary
- Increased workflow timeout from 15 to 25 minutes for comprehensive cross-platform testing
- Ensures sufficient time for all 9 matrix combinations (3 OS × 3 Node.js versions)
- Prevents timeout failures during extensive manual workflow testing

## Test plan
- [x] Verify timeout setting applied correctly
- [x] Confirm no breaking changes to existing functionality
- [x] Test with comprehensive workflow execution

🤖 Generated with [Claude Code](https://claude.ai/code)