### PR TITLE
Fix Docker Compose test for MCP server architecture

### DIFF
--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -75,12 +75,12 @@ jobs:
           severity-cutoff: high
         continue-on-error: true
 
-      - name: Test container startup (with security constraints)
+      - name: Test MCP server initialization (with security constraints)
         run: |
-          echo "🚀 Testing container startup for ${{ matrix.platform }}..."
+          echo "🚀 Testing MCP server initialization for ${{ matrix.platform }}..."
           
-          # Start container in background with security constraints
-          docker run -d \
+          # Run MCP server with security constraints and capture logs
+          docker run \
             --name dollhousemcp-test \
             --platform ${{ matrix.platform }} \
             --user 1001:1001 \
@@ -89,104 +89,45 @@ jobs:
             --tmpfs /tmp \
             --memory 512m \
             --cpus 0.5 \
-            dollhousemcp:latest-${{ matrix.platform }}
+            dollhousemcp:latest-${{ matrix.platform }} &
           
-          # Wait for container to initialize
-          echo "⏳ Waiting for container to initialize..."
-          sleep 10
+          # Wait for container to complete initialization
+          echo "⏳ Waiting for MCP server initialization..."
+          docker wait dollhousemcp-test || true
           
-          # Check if container is running
-          if docker ps | grep dollhousemcp-test; then
-            echo "✅ Container started successfully"
+          # Check logs for successful initialization
+          if docker logs dollhousemcp-test 2>&1 | grep -q "DollhouseMCP server running on stdio"; then
+            echo "✅ MCP server initialized successfully"
           else
-            echo "❌ Container failed to start"
-            docker logs dollhousemcp-test
-            exit 1
-          fi
-
-      - name: Test health check
-        run: |
-          echo "🔍 Testing health check for ${{ matrix.platform }}..."
-          
-          # Wait for health check to pass (up to 2 minutes)
-          timeout=120
-          elapsed=0
-          
-          while [ $elapsed -lt $timeout ]; do
-            # Robust health status parsing for different Docker versions
-            health_status=$(docker inspect dollhousemcp-test 2>/dev/null | \
-              python3 -c "import json,sys; data=json.load(sys.stdin); print(data[0]['State']['Health'].get('Status','none') if data and 'State' in data[0] and 'Health' in data[0]['State'] else 'none')" 2>/dev/null || echo "none")
-            
-            if [ "$health_status" = "healthy" ]; then
-              echo "✅ Health check passed"
-              break
-            elif [ "$health_status" = "unhealthy" ]; then
-              echo "❌ Health check failed"
-              docker logs dollhousemcp-test
-              exit 1
-            else
-              echo "⏳ Waiting for health check... ($elapsed/$timeout seconds, status: $health_status)"
-              sleep 5
-              elapsed=$((elapsed + 5))
-            fi
-          done
-          
-          if [ $elapsed -ge $timeout ]; then
-            echo "❌ Health check timeout (final status: $health_status)"
+            echo "❌ MCP server failed to initialize"
             docker logs dollhousemcp-test
             exit 1
           fi
 
       - name: Test MCP server functionality
         run: |
-          echo "🧪 Testing MCP server functionality for ${{ matrix.platform }}..."
+          echo "🔍 Testing MCP server functionality for ${{ matrix.platform }}..."
           
-          # Test if the server is responsive (basic check)
-          docker exec dollhousemcp-test node -e "
-            const fs = require('fs');
-            const path = require('path');
-            
-            // Check if dist/index.js exists and is readable
-            const serverPath = path.join('/app', 'dist', 'index.js');
-            if (!fs.existsSync(serverPath)) {
-              console.error('❌ Server file not found');
-              process.exit(1);
-            }
-            
-            // Check if personas directory exists
-            const personasPath = path.join('/app', 'personas');
-            if (!fs.existsSync(personasPath)) {
-              console.error('❌ Personas directory not found');
-              process.exit(1);
-            }
-            
-            // Check if we can require the server module
-            try {
-              require(serverPath);
-              console.log('✅ MCP server module loads successfully');
-            } catch (error) {
-              console.error('❌ MCP server module failed to load:', error.message);
-              process.exit(1);
-            }
-          "
-
-      - name: Test container logs
-        run: |
-          echo "📝 Checking container logs for ${{ matrix.platform }}..."
-          docker logs dollhousemcp-test
+          # Test persona loading
+          if docker logs dollhousemcp-test 2>&1 | grep -q "Loaded persona:"; then
+            echo "✅ MCP server loaded personas successfully"
+            persona_count=$(docker logs dollhousemcp-test 2>&1 | grep -c "Loaded persona:" || echo "0")
+            echo "📊 Loaded $persona_count personas"
+          else
+            echo "❌ MCP server failed to load personas"
+            docker logs dollhousemcp-test
+            exit 1
+          fi
           
-          # Check for critical error patterns (excluding expected/harmless errors)
-          error_count=$(docker logs dollhousemcp-test 2>&1 | \
-            grep -i "fatal\|critical\|panic\|segmentation fault\|out of memory" | \
-            wc -l || echo "0")
-          
-          if [ "$error_count" -gt 0 ]; then
-            echo "❌ Found $error_count critical error(s) in logs"
-            docker logs dollhousemcp-test 2>&1 | grep -i "fatal\|critical\|panic\|segmentation fault\|out of memory" || true
+          # Verify no critical errors during initialization
+          if docker logs dollhousemcp-test 2>&1 | grep -i "error\|failed\|exception"; then
+            echo "❌ Critical errors found during MCP server initialization"
+            docker logs dollhousemcp-test
             exit 1
           else
-            echo "✅ No critical errors found in logs"
+            echo "✅ No critical errors during initialization"
           fi
+
 
       - name: Cleanup container
         if: always()
@@ -231,14 +172,25 @@ jobs:
           docker compose run --rm dollhousemcp &
           compose_pid=$!
           
-          # Wait for container to start and initialize
-          sleep 5
+          # Wait for initialization with retry logic
+          echo "⏳ Waiting for MCP server initialization..."
+          timeout=30
+          elapsed=0
+          initialized=false
           
-          # Check if initialization completed successfully
-          if docker compose logs dollhousemcp 2>/dev/null | grep -q "DollhouseMCP server running on stdio"; then
-            echo "✅ Docker Compose MCP server initialized successfully"
-          else
-            echo "❌ Docker Compose MCP server failed to initialize"
+          while [ $elapsed -lt $timeout ]; do
+            if docker compose logs dollhousemcp 2>/dev/null | grep -q "DollhouseMCP server running on stdio"; then
+              echo "✅ Docker Compose MCP server initialized successfully"
+              initialized=true
+              break
+            fi
+            sleep 2
+            elapsed=$((elapsed + 2))
+            echo "⏳ Waiting... ($elapsed/$timeout seconds)"
+          done
+          
+          if [ "$initialized" = false ]; then
+            echo "❌ Docker Compose MCP server failed to initialize within $timeout seconds"
             docker compose logs dollhousemcp
             exit 1
           fi

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -172,6 +172,9 @@ jobs:
           docker compose run --rm dollhousemcp &
           compose_pid=$!
           
+          # Brief initial wait to prevent race conditions
+          sleep 3
+          
           # Wait for initialization with retry logic
           echo "⏳ Waiting for MCP server initialization..."
           timeout=30
@@ -199,21 +202,24 @@ jobs:
         run: |
           echo "🔍 Testing Docker Compose MCP server functionality..."
           
+          # Cache logs once for efficiency
+          compose_logs=$(docker compose logs dollhousemcp 2>/dev/null || echo "")
+          
           # Test that server can load personas and initialize properly
           echo "Testing MCP server persona loading..."
           
-          if docker compose logs dollhousemcp 2>/dev/null | grep -q "Loaded persona:"; then
+          if echo "$compose_logs" | grep -q "Loaded persona:"; then
             echo "✅ MCP server loaded personas successfully"
-            persona_count=$(docker compose logs dollhousemcp 2>/dev/null | grep -c "Loaded persona:" || echo "0")
+            persona_count=$(echo "$compose_logs" | grep -c "Loaded persona:" || echo "0")
             echo "📊 Loaded $persona_count personas"
           else
             echo "❌ MCP server failed to load personas"
-            docker compose logs dollhousemcp
+            echo "$compose_logs"
             exit 1
           fi
           
           # Verify no critical errors during initialization
-          if docker compose logs dollhousemcp 2>/dev/null | grep -i "error\|failed\|exception"; then
+          if echo "$compose_logs" | grep -i "error\|failed\|exception"; then
             echo "❌ Critical errors found during MCP server initialization"
             exit 1
           else

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -172,8 +172,8 @@ jobs:
           docker compose run --rm dollhousemcp &
           compose_pid=$!
           
-          # Brief initial wait to prevent race conditions
-          sleep 3
+          # Initial wait to prevent race conditions (recommended 3-5 seconds)
+          sleep 5
           
           # Wait for initialization with retry logic
           echo "⏳ Waiting for MCP server initialization..."

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -226,62 +226,46 @@ jobs:
       - name: Test Docker Compose startup
         run: |
           echo "🚀 Testing Docker Compose startup..."
-          docker compose up -d dollhousemcp
           
-          # Wait for service to be ready
-          sleep 15
+          # Run MCP server and capture logs (MCP servers exit after initialization)
+          docker compose run --rm dollhousemcp &
+          compose_pid=$!
           
-          # Check if service is running
-          if docker compose ps dollhousemcp | grep "Up"; then
-            echo "✅ Docker Compose service started successfully"
+          # Wait for container to start and initialize
+          sleep 5
+          
+          # Check if initialization completed successfully
+          if docker compose logs dollhousemcp 2>/dev/null | grep -q "DollhouseMCP server running on stdio"; then
+            echo "✅ Docker Compose MCP server initialized successfully"
           else
-            echo "❌ Docker Compose service failed to start"
+            echo "❌ Docker Compose MCP server failed to initialize"
             docker compose logs dollhousemcp
             exit 1
           fi
 
-      - name: Test Docker Compose health
+      - name: Test Docker Compose functionality
         run: |
-          echo "🔍 Testing Docker Compose health..."
+          echo "🔍 Testing Docker Compose MCP server functionality..."
           
-          # Get container ID with error handling
-          container_id=$(docker compose ps -q dollhousemcp 2>/dev/null || echo "")
+          # Test that server can load personas and initialize properly
+          echo "Testing MCP server persona loading..."
           
-          if [ -z "$container_id" ]; then
-            echo "❌ Could not find Docker Compose container"
-            docker compose ps
+          if docker compose logs dollhousemcp 2>/dev/null | grep -q "Loaded persona:"; then
+            echo "✅ MCP server loaded personas successfully"
+            persona_count=$(docker compose logs dollhousemcp 2>/dev/null | grep -c "Loaded persona:" || echo "0")
+            echo "📊 Loaded $persona_count personas"
+          else
+            echo "❌ MCP server failed to load personas"
+            docker compose logs dollhousemcp
             exit 1
           fi
           
-          echo "Container ID: $container_id"
-          
-          # Robust health status check
-          health_status=$(docker inspect $container_id 2>/dev/null | \
-            python3 -c "import json,sys; data=json.load(sys.stdin); print(data[0]['State']['Health'].get('Status','none') if data and 'State' in data[0] and 'Health' in data[0]['State'] else 'none')" 2>/dev/null || echo "none")
-          
-          echo "Health status: $health_status"
-          
-          # Wait up to 1 minute for health check
-          timeout=60
-          elapsed=0
-          
-          while [ $elapsed -lt $timeout ] && [ "$health_status" != "healthy" ]; do
-            if [ "$health_status" = "unhealthy" ]; then
-              echo "❌ Docker Compose health check failed"
-              docker compose logs dollhousemcp
-              exit 1
-            fi
-            
-            sleep 5
-            elapsed=$((elapsed + 5))
-            health_status=$(docker inspect $container_id 2>/dev/null | \
-              python3 -c "import json,sys; data=json.load(sys.stdin); print(data[0]['State']['Health'].get('Status','none') if data and 'State' in data[0] and 'Health' in data[0]['State'] else 'none')" 2>/dev/null || echo "none")
-          done
-          
-          if [ "$health_status" = "healthy" ]; then
-            echo "✅ Docker Compose health check passed"
+          # Verify no critical errors during initialization
+          if docker compose logs dollhousemcp 2>/dev/null | grep -i "error\|failed\|exception"; then
+            echo "❌ Critical errors found during MCP server initialization"
+            exit 1
           else
-            echo "⚠️ Health check not available or pending (final status: $health_status)"
+            echo "✅ No critical errors during initialization"
           fi
 
       - name: Cleanup Docker Compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install only production dependencies
-RUN npm ci --only=production && npm cache clean --force
+RUN npm ci --omit=dev && npm cache clean --force
 
 # Copy built application from builder stage
 COPY --from=builder /app/dist ./dist
@@ -42,8 +42,7 @@ COPY --from=builder /app/personas ./personas
 RUN chown -R dollhouse:nodejs /app
 USER dollhouse
 
-# Expose port (if needed for future HTTP interface)
-EXPOSE 3000
+# No ports needed for stdio-based MCP servers
 
 # No health check needed for stdio-based MCP servers
 # MCP servers initialize, load personas, and exit when no input stream available

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,8 @@ USER dollhouse
 # Expose port (if needed for future HTTP interface)
 EXPOSE 3000
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD node -e "console.log('Health check passed')" || exit 1
+# No health check needed for stdio-based MCP servers
+# MCP servers initialize, load personas, and exit when no input stream available
 
 # Set environment variables
 ENV NODE_ENV=production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,8 @@ services:
       - NODE_ENV=production
       - PERSONAS_DIR=/app/personas
     volumes:
-      # Mount custom personas directory (optional)
-      - ./custom-personas:/app/custom-personas:ro
+      # Mount custom personas directory (optional - extends default personas)
+      - ./custom-personas:/app/personas/custom:ro
     # Resource limits for standalone Docker Compose
     mem_limit: 512m
     cpus: 0.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,13 +28,8 @@ services:
         reservations:
           memory: 128M
           cpus: '0.1'
-    # Health check
-    healthcheck:
-      test: ["CMD", "node", "-e", "console.log('Health check passed')"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
+    # No health check needed for stdio-based MCP servers
+    # MCP servers initialize, load personas, and exit (expected behavior)
 
   # Development service
   dollhousemcp-dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '3.8'
+# Docker Compose configuration for DollhouseMCP
+# Note: version field is obsolete and removed per Docker Compose v2
 
 services:
   dollhousemcp:
@@ -8,7 +9,8 @@ services:
       target: production
     image: dollhousemcp:latest
     container_name: dollhousemcp
-    restart: unless-stopped
+    # MCP servers are stdio-based and exit after initialization (expected behavior)
+    restart: "no"
     environment:
       - NODE_ENV=production
       - PERSONAS_DIR=/app/personas

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,17 +17,10 @@ services:
     volumes:
       # Mount custom personas directory (optional)
       - ./custom-personas:/app/custom-personas:ro
-    # Network mode for MCP communication
-    network_mode: "host"
-    # Resource limits
-    deploy:
-      resources:
-        limits:
-          memory: 512M
-          cpus: '0.5'
-        reservations:
-          memory: 128M
-          cpus: '0.1'
+    # Resource limits for standalone Docker Compose
+    mem_limit: 512m
+    cpus: 0.5
+    # Note: MCP servers use stdio communication, no special network mode needed
     # No health check needed for stdio-based MCP servers
     # MCP servers initialize, load personas, and exit (expected behavior)
 


### PR DESCRIPTION
## Summary
- Fix Docker Compose test logic to align with MCP server architecture
- Remove obsolete `version` field from docker-compose.yml (Docker Compose v2 compatibility)
- Update restart policy from `unless-stopped` to `"no"` for stdio-based servers
- Test successful initialization rather than persistent daemon status

## Root Cause
MCP servers are stdio-based and exit after initialization (expected behavior), not long-running daemons.

## Test plan
- ✅ Tests MCP server persona loading and initialization
- ✅ Verifies no critical errors during startup
- ✅ Removes Docker Compose v2 warnings  
- ✅ Aligns with MCP architecture patterns

🤖 Generated with [Claude Code](https://claude.ai/code)