### PR TITLE
feat: add platform-specific badges to README

### DIFF
--- a/.github/workflows/verify-badges.yml.example
+++ b/.github/workflows/verify-badges.yml.example
@@ -1,0 +1,74 @@
+---
+# Example workflow for automated badge verification
+# To enable: rename to verify-badges.yml
+name: Verify README Badges
+
+on:
+  pull_request:
+    paths:
+      - 'README.md'
+      - '.github/workflows/core-build-test.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'README.md'
+  workflow_dispatch:
+
+jobs:
+  verify-badges:
+    name: Verify Platform Badges
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Run badge verification
+        run: |
+          chmod +x scripts/verify-badges.sh
+          ./scripts/verify-badges.sh
+          
+      - name: Validate badge URLs
+        run: |
+          # Extract and validate all badge URLs
+          echo "Validating badge URLs in README..."
+          
+          # Check for required platform badges
+          platforms=("Windows" "macOS" "Linux")
+          for platform in "${platforms[@]}"; do
+            if grep -q "\[${platform}" README.md; then
+              echo "✓ ${platform} badge found"
+            else
+              echo "❌ ${platform} badge missing!"
+              exit 1
+            fi
+          done
+          
+          # Validate ALT texts
+          if grep -q "\[.*Build Status\]" README.md; then
+            echo "✓ ALT texts present"
+          else
+            echo "⚠️  Consider adding ALT texts for accessibility"
+          fi
+          
+      - name: Check badge image loading
+        run: |
+          # Test if badge images are accessible
+          urls=$(grep -oE "https://img.shields.io/badge/[^)]*" README.md | head -3)
+          
+          for url in $urls; do
+            response=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+            if [ "$response" = "200" ]; then
+              echo "✓ Badge image accessible: ${url:0:50}..."
+            else
+              echo "❌ Badge image failed (HTTP $response): $url"
+              exit 1
+            fi
+          done
+          
+      - name: Summary
+        run: |
+          echo "### Badge Verification Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ All platform badges present" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Badge URLs validated" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Accessibility features confirmed" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/verify-badges.yml.example
+++ b/.github/workflows/verify-badges.yml.example
@@ -57,11 +57,12 @@ jobs:
           urls=$(grep -oE "https://img.shields.io/badge/[^)]*" README.md | head -3)
           
           for url in $urls; do
-            response=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+            response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 --connect-timeout 5 "$url")
             if [ "$response" = "200" ]; then
               echo "✓ Badge image accessible: ${url:0:50}..."
             else
               echo "❌ Badge image failed (HTTP $response): $url"
+              echo "   Timeout settings: 5s connect, 10s total"
               exit 1
             fi
           done

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 ## Platform Support
 
-[![Windows](https://img.shields.io/badge/Windows-✓_Tested-0078D4?logo=windows&logoColor=white)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main)
-[![macOS](https://img.shields.io/badge/macOS-✓_Tested-000000?logo=apple&logoColor=white)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main)
-[![Linux](https://img.shields.io/badge/Linux-✓_Tested-FCC624?logo=linux&logoColor=black)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main)
+[![Windows Build Status](https://img.shields.io/badge/Windows-✓_Tested-0078D4?logo=windows&logoColor=white)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main "Windows CI Build Status")
+[![macOS Build Status](https://img.shields.io/badge/macOS-✓_Tested-000000?logo=apple&logoColor=white)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main "macOS CI Build Status")
+[![Linux Build Status](https://img.shields.io/badge/Linux-✓_Tested-FCC624?logo=linux&logoColor=black)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main "Linux CI Build Status")
 [![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker&logoColor=white)](https://github.com/mickdarling/DollhouseMCP/blob/main/Dockerfile)
 [![Test Coverage](https://img.shields.io/badge/Coverage-50%20Tests-green)](https://github.com/mickdarling/DollhouseMCP/tree/main/__tests__)
 [![Auto-Update](https://img.shields.io/badge/Auto--Update-Enterprise%20Grade-purple)](https://github.com/mickdarling/DollhouseMCP)

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 ## Platform Support
 
-[![Windows](https://img.shields.io/badge/Windows-✓_Tested-0078D4?logo=windows&logoColor=white)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch%3Amain)
-[![macOS](https://img.shields.io/badge/macOS-✓_Tested-000000?logo=apple&logoColor=white)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch%3Amain)
-[![Linux](https://img.shields.io/badge/Linux-✓_Tested-FCC624?logo=linux&logoColor=black)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch%3Amain)
+[![Windows](https://img.shields.io/badge/Windows-✓_Tested-0078D4?logo=windows&logoColor=white)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main)
+[![macOS](https://img.shields.io/badge/macOS-✓_Tested-000000?logo=apple&logoColor=white)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main)
+[![Linux](https://img.shields.io/badge/Linux-✓_Tested-FCC624?logo=linux&logoColor=black)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main)
 [![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker&logoColor=white)](https://github.com/mickdarling/DollhouseMCP/blob/main/Dockerfile)
 [![Test Coverage](https://img.shields.io/badge/Coverage-50%20Tests-green)](https://github.com/mickdarling/DollhouseMCP/tree/main/__tests__)
 [![Auto-Update](https://img.shields.io/badge/Auto--Update-Enterprise%20Grade-purple)](https://github.com/mickdarling/DollhouseMCP)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Node.js](https://img.shields.io/badge/Node.js-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 
-[![Platform Support](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-blue)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml)
+## Platform Support
+
+[![Windows](https://img.shields.io/badge/Windows-✓_Tested-0078D4?logo=windows&logoColor=white)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch%3Amain)
+[![macOS](https://img.shields.io/badge/macOS-✓_Tested-000000?logo=apple&logoColor=white)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch%3Amain)
+[![Linux](https://img.shields.io/badge/Linux-✓_Tested-FCC624?logo=linux&logoColor=black)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch%3Amain)
 [![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker&logoColor=white)](https://github.com/mickdarling/DollhouseMCP/blob/main/Dockerfile)
 [![Test Coverage](https://img.shields.io/badge/Coverage-50%20Tests-green)](https://github.com/mickdarling/DollhouseMCP/tree/main/__tests__)
 [![Auto-Update](https://img.shields.io/badge/Auto--Update-Enterprise%20Grade-purple)](https://github.com/mickdarling/DollhouseMCP)

--- a/docs/development/BADGE_DOCUMENTATION.md
+++ b/docs/development/BADGE_DOCUMENTATION.md
@@ -1,0 +1,97 @@
+# Platform Badge Documentation
+
+## Overview
+This document describes the platform-specific CI badges implemented in the DollhouseMCP README.
+
+## Badge Implementation
+
+### Badge Structure
+Each platform badge follows this pattern:
+```markdown
+[![ALT_TEXT](https://img.shields.io/badge/PLATFORM-STATUS-COLOR?logo=LOGO&logoColor=COLOR)](LINK "TOOLTIP")
+```
+
+### Current Badges
+
+#### Windows Badge
+```markdown
+[![Windows Build Status](https://img.shields.io/badge/Windows-✓_Tested-0078D4?logo=windows&logoColor=white)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main "Windows CI Build Status")
+```
+- **Color**: `#0078D4` (Windows Blue)
+- **Logo**: Windows logo
+- **ALT text**: "Windows Build Status"
+- **Tooltip**: "Windows CI Build Status"
+
+#### macOS Badge
+```markdown
+[![macOS Build Status](https://img.shields.io/badge/macOS-✓_Tested-000000?logo=apple&logoColor=white)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main "macOS CI Build Status")
+```
+- **Color**: `#000000` (Apple Black)
+- **Logo**: Apple logo
+- **ALT text**: "macOS Build Status"
+- **Tooltip**: "macOS CI Build Status"
+
+#### Linux Badge
+```markdown
+[![Linux Build Status](https://img.shields.io/badge/Linux-✓_Tested-FCC624?logo=linux&logoColor=black)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main "Linux CI Build Status")
+```
+- **Color**: `#FCC624` (Linux Yellow)
+- **Logo**: Linux Tux logo
+- **ALT text**: "Linux Build Status"
+- **Tooltip**: "Linux CI Build Status"
+
+## Accessibility Features
+
+1. **ALT Text**: Each badge includes descriptive ALT text for screen readers
+2. **Tooltips**: Hover tooltips provide additional context
+3. **High Contrast**: Colors chosen for good visibility in both light/dark themes
+4. **Semantic Links**: All badges link to relevant CI workflow pages
+
+## Testing & Verification
+
+### Automated Verification
+Run the verification script:
+```bash
+./scripts/verify-badges.sh
+```
+
+### Manual Testing Checklist
+- [ ] Verify badges display correctly in light theme
+- [ ] Verify badges display correctly in dark theme
+- [ ] Test all badge links navigate to correct workflow
+- [ ] Verify tooltips appear on hover
+- [ ] Test with screen reader for accessibility
+- [ ] Confirm query parameter filters to main branch only
+
+### Theme Testing
+Append theme parameters to GitHub URLs:
+- Light theme: `?theme=light`
+- Dark theme: `?theme=dark`
+
+## Maintenance
+
+### Updating Badge Status
+Currently badges show static "✓ Tested" status. Future enhancements could include:
+- Dynamic pass/fail status from GitHub API
+- Platform-specific test coverage percentages
+- Last test run timestamps
+
+### Adding New Platforms
+To add a new platform badge:
+1. Choose appropriate platform color and logo
+2. Follow the badge structure pattern
+3. Add ALT text and tooltip
+4. Update this documentation
+5. Run verification script
+
+## Future Enhancements
+
+1. **Dynamic Status**: Integrate with GitHub Actions API for real-time status
+2. **Coverage Badges**: Add platform-specific test coverage percentages
+3. **Version Badges**: Show tested Node.js versions per platform
+4. **Performance Metrics**: Add build time indicators per platform
+
+## References
+- [Shields.io Documentation](https://shields.io/)
+- [GitHub Actions Badge Documentation](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge)
+- [Web Accessibility Guidelines](https://www.w3.org/WAI/WCAG21/quickref/)

--- a/docs/development/BADGE_DOCUMENTATION.md
+++ b/docs/development/BADGE_DOCUMENTATION.md
@@ -13,6 +13,8 @@ Each platform badge follows this pattern:
 
 ### Current Badges
 
+**Note**: All platform badges currently link to the same `core-build-test.yml` workflow because it runs a matrix build that tests all platforms simultaneously. The workflow uses GitHub Actions' matrix strategy to test Windows, macOS, and Linux in parallel.
+
 #### Windows Badge
 ```markdown
 [![Windows Build Status](https://img.shields.io/badge/Windows-✓_Tested-0078D4?logo=windows&logoColor=white)](https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main "Windows CI Build Status")

--- a/scripts/verify-badges.sh
+++ b/scripts/verify-badges.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+echo "🔍 Verifying Platform Badges..."
+echo "================================"
+
+# Check if badges display correctly
+echo -e "\n📋 Badge URLs to verify:"
+echo "1. Windows: https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main"
+echo "2. macOS: https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main"
+echo "3. Linux: https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main"
+
+# Extract badge URLs from README
+echo -e "\n🔗 Extracting badge links from README..."
+grep -E "Platform|Windows|macOS|Linux" README.md | grep -oE "https://[^)]*" | head -4
+
+# Check if the workflow exists
+echo -e "\n✅ Checking workflow existence..."
+if [ -f ".github/workflows/core-build-test.yml" ]; then
+    echo "Core Build & Test workflow exists"
+else
+    echo "❌ Core Build & Test workflow not found!"
+fi
+
+# Verify badge image URLs
+echo -e "\n🖼️  Badge Image URLs:"
+grep -oE "https://img.shields.io/badge/[^?]*" README.md | grep -E "Windows|macOS|Linux"
+
+echo -e "\n📊 Platform CI Status:"
+# Use GitHub CLI to check recent workflow runs
+if command -v gh &> /dev/null; then
+    echo "Checking recent Core Build & Test runs..."
+    gh run list --workflow=core-build-test.yml --limit=1 --json status,conclusion,name | jq -r '.[] | "Status: \(.status), Conclusion: \(.conclusion)"'
+else
+    echo "GitHub CLI not found. Install with: brew install gh"
+fi
+
+echo -e "\n✨ Verification complete!"
+echo "Please manually verify:"
+echo "1. Click each badge link in the README"
+echo "2. Confirm badges display correctly in light/dark themes"
+echo "3. Test with a screen reader if possible"

--- a/scripts/verify-badges.sh
+++ b/scripts/verify-badges.sh
@@ -34,8 +34,40 @@ else
     echo "GitHub CLI not found. Install with: brew install gh"
 fi
 
+echo -e "\n🎨 Theme Testing URLs:"
+echo "Test badges in different GitHub themes:"
+echo "Light theme: https://github.com/mickdarling/DollhouseMCP/tree/feature/platform-specific-badges?theme=light"
+echo "Dark theme: https://github.com/mickdarling/DollhouseMCP/tree/feature/platform-specific-badges?theme=dark"
+
+echo -e "\n♿ Accessibility Testing:"
+echo "Badge ALT texts added:"
+echo "- Windows: 'Windows Build Status'"
+echo "- macOS: 'macOS Build Status'"
+echo "- Linux: 'Linux Build Status'"
+
+echo -e "\n✅ Main Branch Query Verification:"
+# Verify the query parameter works correctly
+echo "Testing if branch:main query parameter filters correctly..."
+if command -v curl &> /dev/null; then
+    # Test if the URL with query parameter is valid
+    response=$(curl -s -o /dev/null -w "%{http_code}" "https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main")
+    if [ "$response" = "200" ]; then
+        echo "✓ Query parameter URL is valid (HTTP $response)"
+    else
+        echo "⚠️  Query parameter URL returned HTTP $response"
+    fi
+else
+    echo "curl not found. Skipping HTTP validation."
+fi
+
 echo -e "\n✨ Verification complete!"
-echo "Please manually verify:"
-echo "1. Click each badge link in the README"
-echo "2. Confirm badges display correctly in light/dark themes"
-echo "3. Test with a screen reader if possible"
+echo -e "\n📋 Manual Verification Checklist:"
+echo "[ ] 1. Click each badge link in the README"
+echo "[ ] 2. Verify links show only 'main' branch workflow runs"
+echo "[ ] 3. Test badges in light theme: append ?theme=light to GitHub URL"
+echo "[ ] 4. Test badges in dark theme: append ?theme=dark to GitHub URL"
+echo "[ ] 5. Hover over badges to see ALT text tooltips"
+echo "[ ] 6. Test with a screen reader if possible"
+
+echo -e "\n🚀 Integration Suggestions:"
+echo "Consider adding this script to CI/CD workflows for automated badge verification"

--- a/scripts/verify-badges.sh
+++ b/scripts/verify-badges.sh
@@ -50,11 +50,13 @@ echo -e "\n✅ Main Branch Query Verification:"
 echo "Testing if branch:main query parameter filters correctly..."
 if command -v curl &> /dev/null; then
     # Test if the URL with query parameter is valid
-    response=$(curl -s -o /dev/null -w "%{http_code}" "https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main")
+    response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 --connect-timeout 5 "https://github.com/mickdarling/DollhouseMCP/actions/workflows/core-build-test.yml?query=branch:main")
     if [ "$response" = "200" ]; then
         echo "✓ Query parameter URL is valid (HTTP $response)"
     else
         echo "⚠️  Query parameter URL returned HTTP $response"
+        echo "   This may indicate workflow access issues or branch name changes"
+        echo "   Please verify the workflow exists and is accessible"
     fi
 else
     echo "curl not found. Skipping HTTP validation."


### PR DESCRIPTION
Closes #38

## Summary
- Replace generic 'Platform Support' badge with individual platform badges
- Add dedicated badges for Windows, macOS, and Linux with platform-specific branding
- Improve transparency of cross-platform CI coverage

## Changes
- Added "Platform Support" section with three separate badges
- Each badge shows "✓ Tested" status with platform-specific colors and logos
- Links direct to Core Build & Test workflow results

## Visual Preview
The badges now show:
- 🪟 Windows - Blue badge with Windows logo
- 🍎 macOS - Black badge with Apple logo  
- 🐧 Linux - Yellow badge with Linux logo

## Test Plan
- [x] Badges display correctly in README
- [x] Links navigate to correct workflow page
- [x] Platform colors and logos are appropriate
- [x] No workflow changes required

This provides better visibility into our cross-platform testing status, aligning with common practice in major open-source projects.