### PR TITLE
docs: correct version history and add unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to DollhouseMCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Persona active indicator system with 2 new MCP tools (Issue #31)
+- `configure_indicator` tool for customizing persona indicator display
+- `get_indicator_config` tool for viewing current indicator settings
+- Environment variable support for persistent indicator configuration
+- Multiple indicator styles: full, minimal, compact, and custom
+- 23 new tests for indicator functionality (102 total tests)
+
+### Changed
+- Total MCP tools increased from 21 to 23
+- Enhanced documentation with Claude Desktop setup clarifications
+
 ## [1.1.0] - 2025-07-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -836,7 +836,21 @@ This project is licensed under the **AGPL-3.0** License with Platform Stability 
 
 ## 🏷️ Version History
 
-### Phase 2B+ (Current) - July 3, 2025
+### Unreleased (Current)
+- ✅ **Persona active indicator system** with 2 new MCP tools (Issue #31)
+- ✅ **102 comprehensive tests** covering all functionality
+- ✅ **23 total MCP tools** including configure_indicator and get_indicator_config
+- ✅ **Enhanced documentation** with Claude Desktop setup clarifications
+
+### v1.1.0 - July 4, 2025
+- ✅ **Platform-specific badges** for Windows, macOS, Linux visibility
+- ✅ **GitHub Project management** with issue templates and milestones
+- ✅ **ARM64 Docker fix** switching from Alpine to Debian base images
+- ✅ **100% workflow reliability** (except Docker ARM64)
+- ✅ **First GitHub release** with CHANGELOG.md
+- ✅ **21 total MCP tools** at time of release
+
+### Phase 2B+ - July 3, 2025
 - ✅ **Enterprise-grade auto-update system** with 4 new MCP tools
 - ✅ **50 comprehensive tests** covering all functionality  
 - ✅ **Security hardening** - eliminated all command injection vulnerabilities


### PR DESCRIPTION
## Summary
- Correct version history to properly separate released vs unreleased features
- Add "Unreleased" section for features added after v1.1.0 release
- Update CHANGELOG with matching unreleased section

## Changes
1. **Version History Corrections**:
   - Removed "(Current)" from Phase 2B+ (July 3, 2025) as it's historical
   - Added "Unreleased (Current)" section for persona indicator features
   - Properly documented what was in v1.1.0 release vs what's unreleased

2. **CHANGELOG Updates**:
   - Added [Unreleased] section with persona indicator features
   - Listed the 2 new MCP tools and 23 new tests
   - Documented that we now have 23 total tools (up from 21)

## Why This Matters
The version history was incorrectly showing Phase 2B+ as current when we've actually moved beyond that. The persona indicator system (PR #41) was added after the v1.1.0 release, so it should be in an "Unreleased" section until the next release.

This maintains accurate historical records while clearly showing what's in the current development version.

🤖 Generated with [Claude Code](https://claude.ai/code)