### PR TITLE
Fix remaining ReDoS vulnerability in InputValidator (Alert #10)

### DIFF
--- a/src/security/InputValidator.ts
+++ b/src/security/InputValidator.ts
@@ -37,7 +37,7 @@ export function validatePath(inputPath: string): string {
   
   // Remove leading/trailing slashes and normalize
   // Length limits added to prevent ReDoS attacks
-  const normalized = inputPath.replace(/^\/+|\/+$/g, '').replace(/\/{1,100}/g, '/');
+  const normalized = inputPath.replace(/^\/{1,100}|\/{1,100}$/g, '').replace(/\/{1,100}/g, '/');
   
   if (!VALIDATION_PATTERNS.SAFE_PATH.test(normalized)) {
     throw new Error('Invalid path format. Use alphanumeric characters, hyphens, underscores, dots, and forward slashes only.');


### PR DESCRIPTION
## Summary
This fixes the new code scanning alert #10 that appeared after PR #147 was merged.

## Problem
After fixing the second regex pattern in PR #147, CodeQL detected that the first regex pattern `/^\/+|\/+$/g` on line 40 still had unbounded `+` quantifiers.

## Timeline
- **11:34 UTC**: Alerts #8 and #9 created (fixed in PR #147)
- **17:01 UTC**: Alert #10 created after PR #147 (this PR fixes it)

## Solution
Added explicit length limits to ALL regex patterns in the replace chain:
```diff
- const normalized = inputPath.replace(/^\/+|\/+$/g, '').replace(/\/{1,100}/g, '/');
+ const normalized = inputPath.replace(/^\/{1,100}|\/{1,100}$/g, '').replace(/\/{1,100}/g, '/');
```

Now both patterns have bounded quantifiers:
1. `/^\/{1,100}|\/{1,100}$/g` - Removes up to 100 leading/trailing slashes
2. `/\/{1,100}/g` - Collapses up to 100 consecutive slashes

## Testing
- ✅ All 31 InputValidator tests pass
- ✅ The pattern still correctly removes leading/trailing slashes
- ✅ 100 slashes is more than sufficient for any legitimate use case

## Security Impact
This completes the ReDoS mitigation for InputValidator.ts by ensuring all regex patterns have explicit bounds.

🤖 Generated with [Claude Code](https://claude.ai/code)