### PR TITLE
fix: Include default personas in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "dist/**/*.js",
     "dist/**/*.d.ts",
     "dist/**/*.d.ts.map",
+    "data/personas/**/*.md",
     "!dist/__tests__/**",
     "!dist/**/*.test.*",
     "README.md",


### PR DESCRIPTION
## Summary
This PR fixes issue #369 by ensuring that default personas are included in the npm package. Previously, new installations had no content, leading to a poor first experience.

## Problem
- The `data/personas/` directory exists in the repository with 5 default personas
- However, it was not included in the npm package because it wasn't in the `files` field of package.json
- New users installing from npm got no default content

## Solution
Added `data/personas/**/*.md` to the `files` field in package.json to include all markdown persona files in the npm package.

## Changes
- Updated package.json to include `data/personas/**/*.md` in the files array

## Default Personas Included
1. **business-consultant.md** - Professional business analysis persona
2. **creative-writer.md** - Creative writing and storytelling persona
3. **debug-detective.md** - Technical debugging assistant persona
4. **eli5-explainer.md** - Explain Like I'm 5 persona for simple explanations
5. **technical-analyst.md** - Technical analysis and documentation persona

## Testing
```bash
# Verified with npm pack dry run
npm pack --dry-run

# Output shows all personas included:
# npm notice 2.2kB data/personas/business-consultant.md
# npm notice 1.8kB data/personas/creative-writer.md
# npm notice 2.4kB data/personas/debug-detective.md
# npm notice 2.0kB data/personas/eli5-explainer.md
# npm notice 1.8kB data/personas/technical-analyst.md
```

## Impact
- New users will have immediate access to 5 high-quality personas
- Better first-time user experience
- No more "empty content" errors on fresh installations

## Checklist
- [x] Code change is minimal and focused
- [x] Tested with `npm pack --dry-run`
- [x] No breaking changes
- [x] Fixes critical user experience issue

Fixes #369