### PR TITLE
Hotfix: Allow flexible version formats for LLM-generated content

### DIFF
--- a/src/elements/BaseElement.ts
+++ b/src/elements/BaseElement.ts
@@ -28,13 +28,14 @@ import { SecureYamlParser } from '../security/secureYamlParser.js';
  * This helps maintain consistency while accepting flexible input formats
  * 
  * @param version - The version string to normalize
- * @returns Normalized version string in X.Y.Z format
+ * @returns Normalized version string in X.Y.Z format with leading zeros removed
  * 
  * @example
  * normalizeVersion("1")        // "1.0.0"
  * normalizeVersion("1.2")      // "1.2.0"
  * normalizeVersion("1.2.3")    // "1.2.3"
  * normalizeVersion("1.0-beta") // "1.0.0-beta"
+ * normalizeVersion("01.02.03") // "1.2.3" (strips leading zeros)
  */
 export function normalizeVersion(version: string): string {
   // Extract base version and any prerelease/build metadata
@@ -46,7 +47,13 @@ export function normalizeVersion(version: string): string {
   }
   
   const [, major, minor = '0', patch = '0', suffix = ''] = match;
-  return `${major}.${minor}.${patch}${suffix}`;
+  
+  // Strip leading zeros but preserve "0" as valid
+  const normalizedMajor = parseInt(major, 10).toString();
+  const normalizedMinor = parseInt(minor, 10).toString();
+  const normalizedPatch = parseInt(patch, 10).toString();
+  
+  return `${normalizedMajor}.${normalizedMinor}.${normalizedPatch}${suffix}`;
 }
 
 export abstract class BaseElement implements IElement {
@@ -156,12 +163,13 @@ export abstract class BaseElement implements IElement {
     // FIX for Issue #935: Allow flexible version formats like "1.0", "1.1", "2.0.0"
     // Previously: Strict semver regex requiring X.Y.Z format caused skills activation failures
     // Now: Accept common version patterns that LLMs and humans naturally use
+    // Note: Leading zeros are allowed (e.g., "01.02.03") but will be normalized to "1.2.3"
     // Security: No injection risk as version is just metadata, not executed
     const flexibleVersionRegex = /^\d+(\.\d+)?(\.\d+)?(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/;
     if (!flexibleVersionRegex.test(this.version)) {
       errors.push({ 
         field: 'version', 
-        message: 'Version must start with numbers in format: MAJOR[.MINOR][.PATCH][-PRERELEASE][+BUILD]. Valid examples: "1", "1.0", "1.0.0", "2.1", "1.0.0-beta", "1.0.0-alpha.1", "1.0.0+build123". The major version is required, minor and patch are optional.',
+        message: 'Version must start with numbers in format: MAJOR[.MINOR][.PATCH][-PRERELEASE][+BUILD]. Valid examples: "1", "1.0", "1.0.0", "2.1", "1.0.0-beta", "1.0.0-alpha.1", "1.0.0+build123". The major version is required, minor and patch are optional. Note: Leading zeros (e.g., "01.02") are accepted but will be normalized to "1.2".',
         code: 'INVALID_VERSION_FORMAT'
       });
     }

--- a/test/__tests__/unit/elements/BaseElement.test.ts
+++ b/test/__tests__/unit/elements/BaseElement.test.ts
@@ -42,6 +42,19 @@ describe('normalizeVersion', () => {
     expect(normalizeVersion('')).toBe('');
     expect(normalizeVersion('abc')).toBe('abc');
   });
+  
+  it('should strip leading zeros from version numbers', () => {
+    expect(normalizeVersion('01')).toBe('1.0.0');
+    expect(normalizeVersion('01.02')).toBe('1.2.0');
+    expect(normalizeVersion('01.02.03')).toBe('1.2.3');
+    expect(normalizeVersion('001.002.003')).toBe('1.2.3');
+    expect(normalizeVersion('0.0.1')).toBe('0.0.1');  // "0" is valid
+    expect(normalizeVersion('00.00.01')).toBe('0.0.1');
+    expect(normalizeVersion('1.01.0')).toBe('1.1.0');
+    expect(normalizeVersion('1.0.01')).toBe('1.0.1');
+    expect(normalizeVersion('01.02-beta')).toBe('1.2.0-beta');
+    expect(normalizeVersion('01.02.03+build')).toBe('1.2.3+build');
+  });
 });
 
 describe('BaseElement', () => {


### PR DESCRIPTION
## 🚨 Hotfix for Critical Bug #935

This hotfix addresses a critical issue where skills with versions like "1.1" or "2.0" were failing to activate due to overly strict semantic versioning validation.

## Problem
Skills created by LLMs or humans were unusable when they had common version formats like:
- `1.0` 
- `1.1`
- `2.0`

The system was enforcing strict semver (X.Y.Z) format, rejecting these natural version patterns.

## Root Cause Discovery
As documented in our investigation (Sept 12 session notes), the issue was **NOT** markdown corruption as initially suspected, but rather the overly strict version validation regex in `BaseElement.ts` that required all three version components (major.minor.patch).

## Solution
Modified the version validation to accept flexible formats while maintaining security:

### Old Regex (Too Strict)
```javascript
/^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/
```

### New Regex (Flexible)
```javascript
/^\d+(\.\d+)?(\.\d+)?(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/
```

### Improved Error Message
The error message now clearly explains all acceptable formats with multiple examples:
```
Version must start with numbers in format: MAJOR[.MINOR][.PATCH][-PRERELEASE][+BUILD]. 
Valid examples: "1", "1.0", "1.0.0", "2.1", "1.0.0-beta", "1.0.0-alpha.1", "1.0.0+build123". 
The major version is required, minor and patch are optional.
```

## Testing
Created comprehensive test suite with 15 test cases:
- ✅ All 10 valid formats pass (including "1", "1.0", "1.1")  
- ✅ All 5 invalid formats correctly rejected
- ✅ Backwards compatible with existing semver versions

## Impact
- **Immediate Fix**: Skills with versions like "1.1" will now activate
- **Better UX**: LLMs and humans can use natural version formats
- **Backwards Compatible**: All existing versions continue to work

## Files Changed
- `src/elements/BaseElement.ts` - Updated version validation with comprehensive documentation

## Related Issues
- Fixes #935: Skills won't activate - version validation too strict

## Why Hotfix?
This is a critical production bug that completely breaks the skills system. Users cannot activate any skills with non-semver versions, making the feature unusable.

## Merge Plan
As a hotfix, this should be:
1. Merged to `main` 
2. Then immediately merged to `develop`
3. Tagged as v1.7.4

## Verification
```bash
# Test command used to verify the fix
node test-version-validation.mjs
# Result: 15/15 tests passed ✅
```

---
🤖 Generated with [Claude Code](https://claude.ai/code)