### PR TITLE
fix(sonarcloud): Fix S7723 - Array constructor modernization (15 issues)

### DIFF
--- a/test/__tests__/performance/redos-regression.test.ts
+++ b/test/__tests__/performance/redos-regression.test.ts
@@ -38,7 +38,7 @@ describe('ReDoS Performance Regression Tests', () => {
 
     it('should handle alternating valid/invalid characters efficiently', () => {
       // Creates a pattern like: a!a!a!a!... that challenges replace operations
-      const pathological = Array(5000).fill(null)
+      const pathological = new Array(5000).fill(null)
         .map((_, i) => i % 2 === 0 ? 'a' : '!').join('');
       
       const duration = measureTime(() => {

--- a/test/__tests__/portfolio/RelationshipTypes.test.ts
+++ b/test/__tests__/portfolio/RelationshipTypes.test.ts
@@ -434,7 +434,7 @@ describe('RelationshipTypes', () => {
       });
 
       it('should handle large arrays efficiently', () => {
-        const large = Array(1000).fill(null).map((_, i) => ({
+        const large = new Array(1000).fill(null).map((_, i) => ({
           element: `personas:test${i}`,
           strength: Math.random()
         }));

--- a/test/__tests__/security/framework/SecurityTestFramework.ts
+++ b/test/__tests__/security/framework/SecurityTestFramework.ts
@@ -75,7 +75,7 @@ export class SecurityTestFramework {
     const payloads = this.MALICIOUS_PAYLOADS[payloadType];
     
     for (const payload of payloads) {
-      const args = Array(argPosition + 1).fill('safe-value');
+      const args = new Array(argPosition + 1).fill('safe-value');
       args[argPosition] = payload;
       
       await expect(async () => {

--- a/test/__tests__/security/secureYamlParser.test.ts
+++ b/test/__tests__/security/secureYamlParser.test.ts
@@ -382,8 +382,8 @@ version: ${version}
       const largeMetadata: any = {
         name: 'Test',
         description: 'A test persona',
-        triggers: Array(50).fill('trigger'),
-        content_flags: Array(20).fill('flag')
+        triggers: new Array(50).fill('trigger'),
+        content_flags: new Array(20).fill('flag')
       };
 
       const yaml = `---

--- a/test/__tests__/security/tests/yaml-deserialization.test.ts
+++ b/test/__tests__/security/tests/yaml-deserialization.test.ts
@@ -213,7 +213,7 @@ malicious_field: !!js/function "alert()"
           valid: true
         },
         {
-          triggers: Array(25).fill('trigger'), // Too many
+          triggers: new Array(25).fill('trigger'), // Too many
           valid: false
         },
         {

--- a/test/__tests__/unit/GitHubClient.test.ts
+++ b/test/__tests__/unit/GitHubClient.test.ts
@@ -70,7 +70,7 @@ describe('GitHubClient', () => {
 
     it('should enforce rate limiting', async () => {
       // Fill up rate limit
-      const requests = Array(SECURITY_LIMITS.RATE_LIMIT_REQUESTS).fill(Date.now());
+      const requests = new Array(SECURITY_LIMITS.RATE_LIMIT_REQUESTS).fill(Date.now());
       rateLimitTracker.set('github_api', requests);
 
       await expect(githubClient.fetchFromGitHub(testUrl))

--- a/test/__tests__/unit/config/ConfigManager.test.ts
+++ b/test/__tests__/unit/config/ConfigManager.test.ts
@@ -66,7 +66,7 @@ describe('ConfigManager', () => {
     
     it('should handle concurrent getInstance calls safely', async () => {
       // Simulate concurrent calls
-      const promises = Array(10).fill(null).map(() => 
+      const promises = new Array(10).fill(null).map(() => 
         Promise.resolve(ConfigManager.getInstance())
       );
       

--- a/test/__tests__/unit/elements/memories/Memory.concurrent.test.ts
+++ b/test/__tests__/unit/elements/memories/Memory.concurrent.test.ts
@@ -257,7 +257,7 @@ describe('Memory Concurrent Access', () => {
       const entry = await memory.addEntry('Race condition test');
       
       // Try to delete the same entry multiple times concurrently
-      const deletePromises = Array(5).fill(null).map(() => 
+      const deletePromises = new Array(5).fill(null).map(() => 
         memory.deleteEntry(entry.id)
       );
       

--- a/test/__tests__/unit/portfolio/DefaultElementProvider.test.ts
+++ b/test/__tests__/unit/portfolio/DefaultElementProvider.test.ts
@@ -328,7 +328,7 @@ describe('DefaultElementProvider', () => {
       mockLogger.error.mockClear();
       
       // Call populateDefaults multiple times concurrently
-      const promises = Array(5).fill(null).map(() => 
+      const promises = new Array(5).fill(null).map(() => 
         testProvider.populateDefaults(portfolioDir)
       );
       
@@ -403,7 +403,7 @@ describe('DefaultElementProvider', () => {
       const testProvider = new TestableDefaultElementProvider([dataDir]);
       
       // Call populateDefaults multiple times concurrently
-      const promises = Array(10).fill(null).map(() => 
+      const promises = new Array(10).fill(null).map(() => 
         testProvider.populateDefaults(portfolioDir)
       );
       

--- a/test/__tests__/unit/security/yamlBombDetection.test.ts
+++ b/test/__tests__/unit/security/yamlBombDetection.test.ts
@@ -220,7 +220,7 @@ describe('YAML Bomb Detection', () => {
   describe('Performance', () => {
     it('should handle large YAML efficiently', () => {
       // Create a large but safe YAML
-      const largeYaml = Array(100).fill(null).map((_, i) => 
+      const largeYaml = new Array(100).fill(null).map((_, i) => 
         `item${i}: value${i}`
       ).join('\n');
       

--- a/test/__tests__/unit/submitContentMethod.test.ts
+++ b/test/__tests__/unit/submitContentMethod.test.ts
@@ -206,7 +206,7 @@ describe('submitContent method improvements', () => {
       
       // Parallel search time
       const parallelStart = Date.now();
-      const promises = Array(ELEMENT_COUNT).fill(0).map(() => 
+      const promises = new Array(ELEMENT_COUNT).fill(0).map(() => 
         new Promise(resolve => setTimeout(resolve, SEARCH_DELAY))
       );
       await Promise.allSettled(promises);

--- a/test/__tests__/unit/utils/ErrorHandler.test.ts
+++ b/test/__tests__/unit/utils/ErrorHandler.test.ts
@@ -112,7 +112,7 @@ describe('ErrorHandler', () => {
     it('should truncate long stack traces', () => {
       // Create an error with a very long stack trace
       const error = new Error('Test');
-      const longStack = Array(50).fill('at someFunction (file.js:1:1)').join('\n');
+      const longStack = new Array(50).fill('at someFunction (file.js:1:1)').join('\n');
       error.stack = `Error: Test\n${longStack}`;
       
       const info = ErrorHandler.extractErrorInfo(error);
@@ -370,7 +370,7 @@ describe('ErrorHandler', () => {
     it('should truncate very long stack traces', () => {
       const originalError = new Error('Deep error');
       // Create a very long stack
-      const longStack = Array(100).fill('at function (file.js:1:1)').join('\n');
+      const longStack = new Array(100).fill('at function (file.js:1:1)').join('\n');
       originalError.stack = `Error: Deep error\n${longStack}`;
       
       const error = new ApplicationError('Wrapped', ErrorCategory.SYSTEM_ERROR, undefined, undefined, originalError);


### PR DESCRIPTION
Resolves #1223

Modernizes Array constructor usage to follow SonarCloud rule S7723.

## Changes
- Replaced `Array(n)` with `new Array(n)` for explicit constructor invocation
- 15 instances fixed across 11 test files

## Files Modified
- performance/redos-regression.test.ts
- portfolio/RelationshipTypes.test.ts  
- security/framework/SecurityTestFramework.ts
- security/secureYamlParser.test.ts (2 instances)
- security/tests/yaml-deserialization.test.ts
- unit/GitHubClient.test.ts
- unit/config/ConfigManager.test.ts
- unit/elements/memories/Memory.concurrent.test.ts
- unit/portfolio/DefaultElementProvider.test.ts (2 instances)
- unit/security/yamlBombDetection.test.ts
- unit/submitContentMethod.test.ts
- unit/utils/ErrorHandler.test.ts (2 instances)

## Testing
- ✅ Build passes
- ✅ 2323 tests pass
- ✅ Pre-existing GitHubRateLimiter test failures unrelated (Issue #1165)

## Impact
- **SonarCloud**: -15 reliability issues resolved
- **Severity**: Low
- **Risk**: Zero (no behavior changes, only syntax modernization)