### PR TITLE
docs: Add Jeet Singh to NPM contributors list

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,12 @@
     "email": "mick@mickdarling.com",
     "url": "https://github.com/mickdarling"
   },
+  "contributors": [
+    {
+      "name": "Jeet Singh",
+      "url": "https://github.com/jeetsingh008"
+    }
+  ],
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Adds Jeet Singh (@jeetsingh008) to the NPM package contributors list, recognizing his valuable contributions merged in v1.9.6.

## Changes

- Added `contributors` field to `package.json`
- Includes Jeet Singh with GitHub profile link

## Contribution Details

**PR #1035** (deployed in v1.9.6):
- Performance optimization: Improved whitespace detection in memory file parsing  
- Security enhancement: Strengthened path traversal protection

## Why This Matters

1. **Proper Attribution**: Real human contributors deserve recognition on NPM
2. **Community Encouragement**: Shows we value external contributions  
3. **Standard Practice**: NPM displays contributors on the package page

## Impact

- NPM package page will display Jeet Singh in contributors section
- Future contributors see we properly credit community work

Fixes #1240