### PR TITLE
chore: Add .obsidian/ and test-results/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ scripts/validation/run-sync-test-with-pat.sh
 .idea/
 *.swp
 *.swo
+.obsidian/
 
 # Personal development notes (user-specific workflow docs)
 dev-notes/
@@ -46,6 +47,9 @@ Thumbs.db
 test/coverage/
 test/coverage-integration/
 *.lcov
+
+# Test results
+test-results/
 
 # Integration test temporary files
 .test-tmp/


### PR DESCRIPTION
## Summary

Addresses Todd's code review feedback by adding two user-specific/generated directories to `.gitignore`.

## Changes

1. **Added `.obsidian/`** to IDE files section
   - Personal Obsidian vault files (user-specific)
   - Should not be tracked in version control
   
2. **Added `test-results/`** to test artifacts section  
   - Generated test output files
   - Should not be tracked in version control

## Why This Matters

Both directories contain content that is either:
- User-specific (Obsidian preferences/vault)
- Generated/temporary (test results)

Neither should be committed to the repository.

## Testing

- [x] Changes verified in `.gitignore`
- [x] No code changes, configuration only

## Related Feedback

Part of Todd's code review feedback addressing repository organization and best practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)