### PR TITLE
hotfix: Add MCP registry publishing workflow to main

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,60 @@
+name: Publish to MCP Registry
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (test without publishing)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write  # Required for OIDC authentication
+  contents: read   # Required for checkout
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Download mcp-publisher CLI
+        run: |
+          # Pinned to v1.3.3 for reproducibility
+          curl -L https://github.com/modelcontextprotocol/publish/releases/download/v1.3.3/mcp-publisher-linux-x64 -o /tmp/mcp-publisher
+          chmod +x /tmp/mcp-publisher
+          sudo mv /tmp/mcp-publisher /usr/local/bin/mcp-publisher
+
+      - name: Verify mcp-publisher installation
+        run: mcp-publisher --version
+
+      - name: Login to MCP Registry (OIDC)
+        run: mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: |
+          if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
+            echo "Running in DRY-RUN mode"
+            mcp-publisher publish --dry-run
+          else
+            mcp-publisher publish
+          fi


### PR DESCRIPTION
## Purpose

This hotfix adds the MCP registry publishing workflow (from PR #1367) to `main` to enable manual workflow testing.

## Problem

GitHub Actions workflows must exist on the default branch (`main`) to be triggered via `workflow_dispatch`. The workflow was merged to `develop` in PR #1367 but isn't available for manual triggering until it exists on `main`.

## Solution

Cherry-pick the workflow file from develop (commit 9d6bc9b9) to main via hotfix branch.

## Changes

- ✅ Add `.github/workflows/publish-mcp-registry.yml` (workflow-only, no code changes)

## Testing

After merge, will manually trigger workflow with `--dry-run` flag to verify functionality before v1.9.19 release.

## GitFlow Compliance

- Created from: `main`
- Merges to: `main` then `develop`
- Type: Hotfix (workflow infrastructure)

## Checklist

- [x] Workflow file validated
- [x] No code changes
- [x] GitFlow hotfix process followed
- [ ] Merge to main
- [ ] Merge to develop
- [ ] Test workflow with dry-run