### PR TITLE
fix: add missing shell: bash declarations to MCP registry workflow

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -38,6 +38,7 @@ jobs:
         run: npm run build
 
       - name: Download mcp-publisher CLI
+        shell: bash
         run: |
           # Pinned to v1.3.3 for reproducibility
           curl -L https://github.com/modelcontextprotocol/publish/releases/download/v1.3.3/mcp-publisher-linux-x64 -o /tmp/mcp-publisher
@@ -51,6 +52,7 @@ jobs:
         run: mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
+        shell: bash
         run: |
           if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
             echo "Running in DRY-RUN mode"


### PR DESCRIPTION
## Fix for failing workflow validation tests

### Problem
The publish-mcp-registry.yml workflow was missing `shell: bash` declarations for steps that use bash-specific syntax (conditional logic with `[ ]`). This caused the github-workflow-validation test to fail.

### Solution
- Added `shell: bash` to the 'Download mcp-publisher CLI' step
- Added `shell: bash` to the 'Publish to MCP Registry' step

### Testing
✅ Tests now pass: `npm test -- --no-coverage github-workflow-validation`

### Impact
This is a required fix for the v1.9.19 release process.