### PR TITLE
fix: Update server.json to 2025-10-17 schema for MCP registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",


### PR DESCRIPTION
## Hotfix: Update server.json Schema

### Issue
MCP registry publishing fails due to deprecated schema:
```
Error: deprecated schema detected: https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json
```

### Root Cause
Our `server.json` is using the September schema (2025-09-29), but the current schema is from October (2025-10-17).

### Changes
- **Updated schema URL**: `2025-09-29` → `2025-10-17`
- Already compliant with camelCase naming convention
- No other changes needed (already migrated)

### Migration Checklist
- [x] Schema URL updated to current version
- [x] Using camelCase field names (registryType, not registry_type)
- [x] No status or official metadata fields
- [x] Version field included for npm package type

### Testing
- Fixes the dry-run test failure from workflow run #18606341617
- Will allow v1.9.19 to be published to MCP registry

### References
- [Schema CHANGELOG](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/CHANGELOG.md)
- Related to PR #1372 (workflow fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>