### PR TITLE
fix: Correct mcpName capitalization for MCP Registry publishing (v1.9.20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+## [1.9.20] - 2025-10-17
+
+**Fix Release**: MCP Registry Publishing Compatibility
+
+### Fixed
+- MCP Registry publishing case sensitivity issue (#XXXX)
+  - Corrected `mcpName` field in package.json to match GitHub organization capitalization
+  - Changed from `io.github.dollhousemcp/mcp-server` to `io.github.DollhouseMCP/mcp-server`
+  - Resolves NPM package validation errors when publishing to MCP Registry
+  - Ensures proper namespace permission matching
+
+### Context
+The MCP Registry performs two case-sensitive validations:
+1. Permission check against GitHub org name (`io.github.DollhouseMCP/*`)
+2. NPM package validation against `mcpName` field in package.json
+
+The initial implementation incorrectly used lowercase for `mcpName`, causing a validation mismatch. This patch release corrects the capitalization to match our GitHub organization name.
+
 ## [1.9.19] - 2025-10-17
 
 **Comprehensive Release**: 90 commits including security fixes, PostHog telemetry, MCP registry support, and major cleanup

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "1.9.19",
+  "version": "1.9.20",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",
@@ -102,7 +102,7 @@
     "url": "https://github.com/DollhouseMCP/mcp-server/issues"
   },
   "homepage": "https://dollhousemcp.com",
-  "mcpName": "io.github.dollhousemcp/mcp-server",
+  "mcpName": "io.github.DollhouseMCP/mcp-server",
   "files": [
     "dist/**/*.js",
     "dist/**/*.d.ts",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "1.9.19",
+  "version": "1.9.20",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "1.9.19",
+      "version": "1.9.20",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Problem

The MCP Registry publishing workflow has been failing due to a case sensitivity mismatch between:
1. **GitHub org permissions**: `io.github.DollhouseMCP/*` (with capitals)
2. **NPM package validation**: Expects `mcpName` field to match server.json name
3. **Original mcpName value**: Was set to `io.github.dollhousemcp/mcp-server` (lowercase)

This caused the registry validation to fail with:
```
NPM package ownership validation failed. 
Expected mcpName 'io.github.DollhouseMCP/mcp-server', 
got 'io.github.dollhousemcp/mcp-server'
```

## Root Cause

The `mcpName` field was incorrectly set to lowercase when initially added (commit 423a21e8). The MCP Registry performs two case-sensitive checks:
- Permission check against GitHub org name
- NPM validation against the `mcpName` field in package.json

## Solution

✅ **Update `mcpName` in package.json** from `io.github.dollhousemcp/mcp-server` to `io.github.DollhouseMCP/mcp-server`
✅ **Bump version to 1.9.20** for patch release
✅ **Update server.json** versions to match
✅ **Document in CHANGELOG** with context

This corrects the capitalization to match our actual GitHub organization name and resolves both validation checks.

## Changes

- `package.json`: Updated `mcpName` field capitalization + version bump
- `server.json`: Updated version fields to 1.9.20
- `CHANGELOG.md`: Added v1.9.20 release entry with full context

## Testing Plan

After merge:
1. Publish v1.9.20 to NPM
2. Trigger MCP registry publishing workflow
3. Verify both permission and NPM validation pass
4. Confirm successful publication to registry.modelcontextprotocol.io

## Related Issues

Fixes the MCP registry publishing issue identified during v1.9.19 release (workflow runs #18605366287 through #18606555832).

🤖 Generated with [Claude Code](https://claude.com/claude-code)