### PR TITLE
Hotfix v1.9.22 - Revert jsdom to resolve test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [1.9.22] - 2025-10-23
+
+**Hotfix Release**: Resolve jsdom test failures
+
+### Fixed
+- **jsdom version compatibility** (Hotfix)
+  - Reverted jsdom from 27.0.1 to 27.0.0 due to parse5 ES module import issues
+  - Fixes test failures in MemoryManager and other test suites
+  - The jsdom 27.0.1 update introduced a breaking change with parse5 becoming an ES module
+  - Will revisit jsdom 27.0.1 update in future release with proper ES module configuration
+
 ## [1.9.21] - 2025-10-23
 
 **Patch Release**: Memory validation system activation and element formatting

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "1.9.20",
+  "version": "1.9.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "1.9.20",
+      "version": "1.9.21",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.1",
@@ -17,7 +17,7 @@
         "express": "^5.1.0",
         "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0",
-        "jsdom": "^27.0.1",
+        "jsdom": "27.0.0",
         "node-fetch": "^3.3.2",
         "posthog-node": "^5.10.0",
         "uuid": "^11.1.0",
@@ -6562,20 +6562,20 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.1.tgz",
-      "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
+      "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/dom-selector": "^6.7.2",
-        "cssstyle": "^5.3.1",
+        "@asamuzakjp/dom-selector": "^6.5.4",
+        "cssstyle": "^5.3.0",
         "data-urls": "^6.0.0",
-        "decimal.js": "^10.6.0",
+        "decimal.js": "^10.5.0",
         "html-encoding-sniffer": "^4.0.0",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "parse5": "^8.0.0",
+        "parse5": "^7.3.0",
         "rrweb-cssom": "^0.8.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
@@ -6584,8 +6584,8 @@
         "webidl-conversions": "^8.0.0",
         "whatwg-encoding": "^3.1.1",
         "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^15.1.0",
-        "ws": "^8.18.3",
+        "whatwg-url": "^15.0.0",
+        "ws": "^8.18.2",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
@@ -6598,18 +6598,6 @@
         "canvas": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/jsesc": {
@@ -7201,7 +7189,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "1.9.21",
+  "version": "1.9.22",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",
@@ -138,7 +138,7 @@
     "express": "^5.1.0",
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.0",
-    "jsdom": "^27.0.1",
+    "jsdom": "27.0.0",
     "node-fetch": "^3.3.2",
     "posthog-node": "^5.10.0",
     "uuid": "^11.1.0",


### PR DESCRIPTION
## Hotfix v1.9.22

**Critical**: Resolves test failures preventing v1.9.21 NPM publish

### Issue
- jsdom 27.0.1 (from PR #1382) introduced breaking change with parse5 ES module
- Caused test failures in MemoryManager and other test suites on main branch
- Prevented successful NPM publish of v1.9.21

### Fix
- Reverted jsdom from 27.0.1 to 27.0.0
- All tests now passing

### Test Results
✅ MemoryManager.test.ts: 46/46 tests passing
✅ Build successful
✅ TypeScript compilation successful

### Next Steps
After merge:
1. Create GitHub release v1.9.22
2. NPM will publish automatically
3. Merge hotfix to develop

**Note**: Will revisit jsdom 27.0.1 update in future release with proper ES module configuration