### PR TITLE
fix: Update server.json version to 1.9.22

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "1.9.20",
+  "version": "1.9.22",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "1.9.20",
+      "version": "1.9.22",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Issue
CI tests failing on main and develop due to version mismatch between package.json (1.9.22) and server.json (1.9.20).

## Root Cause
The hotfix v1.9.22 updated package.json but did not update server.json, causing the mcp-registry-workflow tests to fail.

## Changes
- Update `server.json` version field to 1.9.22
- Update `server.json` packages[0].version to 1.9.22

## Test Results
✅ All 34 tests in mcp-registry-workflow.test.ts now passing

## Failing Workflows Fixed
- Cross-Platform Simple (macOS, Ubuntu, Windows)
- Extended Node Compatibility

## Related
- Hotfix PR #1392
- Release v1.9.22