### PR TITLE
hotfix: Remove Code Smells badge from README.github.md

### DIFF
--- a/README.github.md
+++ b/README.github.md
@@ -18,7 +18,6 @@
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=DollhouseMCP_mcp-server&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=DollhouseMCP_mcp-server)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=DollhouseMCP_mcp-server&metric=bugs)](https://sonarcloud.io/summary/new_code?id=DollhouseMCP_mcp-server)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=DollhouseMCP_mcp-server&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=DollhouseMCP_mcp-server)
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=DollhouseMCP_mcp-server&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=DollhouseMCP_mcp-server)
 
 ## Platform Support
 [![Windows Build Status](https://img.shields.io/badge/Windows-✓_Tested-0078D4?logo=windows&logoColor=white)](https://github.com/DollhouseMCP/mcp-server/actions/workflows/core-build-test.yml?query=branch:main "Windows CI Build Status")


### PR DESCRIPTION
## Summary
Hotfix to align README.github.md with README.md by removing the Code Smells badge.

## Issue
PR #1397 merged both README files to main, but README.github.md still had 7 badges while README.md correctly had only 6.

## Fix
Remove Code Smells badge from README.github.md to match README.md.

## Result
Both README files now consistently show only the 6 critical quality metrics:
- Quality Gate Status (passing)
- Security Rating (A)
- Maintainability Rating (A)
- Reliability Rating (A)
- Bugs (0)
- Vulnerabilities (0)

## Type
- [ ] Feature
- [ ] Bug Fix
- [x] Hotfix
- [ ] Documentation