### PR TITLE
fix: Increase timeout for zip bomb test to handle Windows performance

### DIFF
--- a/test/__tests__/unit/converter.test.ts
+++ b/test/__tests__/unit/converter.test.ts
@@ -543,7 +543,7 @@ Follow these steps:
             // The CLI code would detect this and reject it
             const uncompressedSize = 10 * 60 * 1024 * 1024; // 600MB
             expect(uncompressedSize).toBeGreaterThan(500 * 1024 * 1024); // Over 500MB limit
-        });
+        }, 60000); // 60s timeout for Windows file creation performance
 
         it('should cleanup temp files on successful extraction', async () => {
             const skillDir = createTestSkillDirectory('cleanup-success');


### PR DESCRIPTION
## Summary
- Increased timeout from 10s to 60s for the zip bomb validation test
- Addresses Windows CI failures in Extended Node Compatibility workflow

## Problem
The test `should validate extracted size to prevent zip bombs` was timing out on Windows CI runners (both Node 20.x and 22.x) while passing on Ubuntu and macOS.

The test creates 10 × 60MB files (600MB total) to simulate a zip bomb scenario. Windows file system operations are slower than Linux/macOS, causing the test to exceed the default 10-second Jest timeout.

## Solution
Added explicit 60-second timeout to the test to accommodate Windows file creation performance.

## Testing
- All platforms (Ubuntu, macOS) continue to pass
- Windows timeout issue should be resolved with extended timeout

## Evidence
Failed runs (all Windows):
- Run 731-734: ❌ Windows Node 20.x & 22.x timeout
- Last successful run 730: ✅ Before this test was added

🤖 Generated with [Claude Code](https://claude.com/claude-code)