### PR TITLE
fix(ci): Allow Dependabot security PRs to target main branch

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -26,14 +26,15 @@ jobs:
             
             console.log(`PR from ${headRef} to ${baseRef}`);
             
-            // Allow PRs to main only from develop or hotfix branches
+            // Allow PRs to main only from develop, hotfix, release, or dependabot branches
             if (baseRef === 'main') {
               const isFromDevelop = headRef === 'develop';
               const isHotfix = headRef.startsWith('hotfix/');
               const isRelease = headRef.startsWith('release/');
-              
-              if (!isFromDevelop && !isHotfix && !isRelease) {
-                core.setFailed(`PRs to main must come from develop, release/*, or hotfix/* branches. Current branch: ${headRef}`);
+              const isDependabot = headRef.startsWith('dependabot/');
+
+              if (!isFromDevelop && !isHotfix && !isRelease && !isDependabot) {
+                core.setFailed(`PRs to main must come from develop, release/*, hotfix/*, or dependabot/* branches. Current branch: ${headRef}`);
                 
                 // Add comment to PR
                 await github.rest.issues.createComment({
@@ -41,32 +42,38 @@ jobs:
                   repo: context.repo.repo,
                   issue_number: pr.number,
                   body: `## ❌ Branch Protection Policy Violation
-                  
+
                   PRs to \`main\` branch must originate from:
                   - \`develop\` branch (for regular releases)
                   - \`release/*\` branches (for release candidates)
                   - \`hotfix/*\` branches (for emergency fixes)
-                  
+                  - \`dependabot/*\` branches (for automated security updates)
+
                   **Current branch**: \`${headRef}\`
-                  
+
                   ### Recommended Actions:
                   1. If this is a regular feature, merge to \`develop\` first
                   2. If this is a hotfix, rename your branch to \`hotfix/description\`
                   3. If this is a release, create from \`develop\` as \`release/version\`
-                  
+
                   Please follow our [GitFlow branching strategy](https://github.com/${{ github.repository }}/blob/main/CONTRIBUTING.md#branching-strategy).`
                 });
               } else {
                 console.log(`✅ Valid source branch: ${headRef}`);
-                
-                // Add approval comment
+
+                // Add approval comment with context-specific message
+                const prType = isDependabot ? 'automated security update' :
+                              isRelease ? 'release' :
+                              isHotfix ? 'hotfix' :
+                              'release from develop';
+
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr.number,
                   body: `## ✅ Branch Protection Check Passed
-                  
-                  This PR correctly targets \`main\` from \`${headRef}\`.`
+
+                  This PR correctly targets \`main\` from \`${headRef}\` (${prType}).`
                 });
               }
             }


### PR DESCRIPTION
## Summary
Updates the branch-protection workflow to allow Dependabot automated security updates to create PRs directly to the main branch.

## Problem
PR #1476 (js-yaml security update) is failing the "Verify PR Source Branch" check because Dependabot security updates target the default branch (main) regardless of the `dependabot.yml` configuration, which specifies `develop` as the target branch for regular dependency updates.

The existing GitFlow policy only allowed PRs to main from:
- `develop` branch
- `release/*` branches
- `hotfix/*` branches

This blocked legitimate Dependabot security updates coming from `dependabot/*` branches.

## Changes
- ✅ Add `isDependabot` check for branches starting with `dependabot/`
- ✅ Update validation logic to allow `dependabot/*` branches to target main
- ✅ Enhanced error message to document Dependabot as an allowed exception
- ✅ Improved success message with context-specific PR type identification

## Testing
This change will be validated when:
1. This PR passes the branch protection check (as a `hotfix/*` branch)
2. After merging to main, PR #1476 should pass the check automatically

## Impact
- Allows GitHub Dependabot security alerts to function properly with our GitFlow workflow
- Regular Dependabot dependency updates will continue targeting `develop` as configured
- No impact on existing branch protection policies for human-created PRs

## Related Issues
- Resolves the blocker for PR #1476 (js-yaml security update)
- Aligns with standard Dependabot security alert behavior

## Checklist
- [x] Changes are focused and minimal
- [x] Error messages updated for clarity
- [x] Success messages provide helpful context
- [x] No breaking changes to existing workflow