### PR TITLE
fix(deps): Backport js-yaml security update to develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7001,9 +7001,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
## Summary
Backports the js-yaml security update (4.1.0 → 4.1.1) from main to develop to ensure both branches have the security fix.

## Background
PR #1476 merged the js-yaml security update to `main` as part of Dependabot's security alert workflow. This PR brings the same update to `develop` to keep both branches secure.

## Changes
- Bump js-yaml from 4.1.0 to 4.1.1 (security update)

## Testing
This is a cherry-pick of commit `ca8abc24` which already passed all CI checks on main.

## Related
- Original PR: #1476 (merged to main)
- Security advisory: Dependabot security alert

## Checklist
- [x] Cherry-picked from verified main commit
- [x] No conflicts during cherry-pick
- [x] Security update only, no breaking changes