### PR TITLE
fix(test): Add jsdom ESM dependencies to Jest transform patterns

### DIFF
--- a/test/jest.config.cjs
+++ b/test/jest.config.cjs
@@ -47,7 +47,7 @@ const config = {
   roots: ['<rootDir>'],
   testTimeout: 30000, // Increased to 30s to prevent teardown issues with async file operations
   transformIgnorePatterns: [
-    'node_modules/(?!(@modelcontextprotocol|zod)/)'
+    'node_modules/(?!(@modelcontextprotocol|zod|jsdom|parse5|entities|whatwg-url|tr46|webidl-conversions)/)'
   ],
   resolver: 'ts-jest-resolver',
   // FIX: Force serial test execution in CI to prevent worker teardown race conditions


### PR DESCRIPTION
## Summary

Fixes the Extended Node Compatibility workflow failures caused by jsdom 27.2.0 upgrade (PR #1509).

## Problem

jsdom 27.2.0 and its dependencies (`parse5`, `entities`, etc.) are now ES Modules. Jest was failing with:

```
Must use import to load ES Module: node_modules/jsdom/node_modules/parse5/dist/index.js
```

## Solution

Added jsdom and its ESM dependencies to `transformIgnorePatterns` in Jest config so Jest can properly transform them:

- `jsdom`
- `parse5`
- `entities`
- `whatwg-url`
- `tr46`
- `webidl-conversions`

## Test Plan

- [x] Full test suite passes locally (2,869 tests)
- [x] Previously failing test (`GenericElementTools.integration`) now passes
- [ ] Extended Node Compatibility workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)