### PR TITLE
fix(test): Handle nested node_modules in Jest transform patterns

### DIFF
--- a/test/jest.config.cjs
+++ b/test/jest.config.cjs
@@ -47,7 +47,9 @@ const config = {
   roots: ['<rootDir>'],
   testTimeout: 30000, // Increased to 30s to prevent teardown issues with async file operations
   transformIgnorePatterns: [
-    'node_modules/(?!(@modelcontextprotocol|zod|jsdom|parse5|entities|whatwg-url|tr46|webidl-conversions)/)'
+    // Match ESM packages at any nesting level in node_modules
+    // The .* allows matching nested node_modules (e.g., node_modules/jsdom/node_modules/parse5)
+    'node_modules/(?!(.*/)?(@modelcontextprotocol|zod|jsdom|parse5|entities|whatwg-url|tr46|webidl-conversions)/)'
   ],
   resolver: 'ts-jest-resolver',
   // FIX: Force serial test execution in CI to prevent worker teardown race conditions


### PR DESCRIPTION
## Summary

Follow-up fix for PR #1515. The previous fix didn't account for **nested node_modules** directories.

## Problem

In CI, npm sometimes doesn't hoist dependencies, resulting in nested structures:
```
node_modules/jsdom/node_modules/parse5/dist/index.js
```

The previous regex only matched top-level:
```
node_modules/(?!(jsdom|parse5)/)
```

This didn't match nested paths like `node_modules/jsdom/node_modules/parse5`.

## Solution

Updated the regex to use `(.*/)?` prefix to match at any nesting level:
```javascript
'node_modules/(?!(.*/)?(@modelcontextprotocol|zod|jsdom|parse5|entities|whatwg-url|tr46|webidl-conversions)/)'
```

## Why it passed locally

Local development often has flat node_modules due to hoisting. CI environments may have different dependency resolution resulting in nested structures.

## Test Plan

- [x] Tests pass locally
- [ ] Extended Node Compatibility workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)