### PR TITLE
docs: Fix version history for v1.9.27 release

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -27,6 +27,10 @@ permissions:
   id-token: write   # Required for OIDC/Trusted Publishing
   contents: read    # Required for checkout
 
+env:
+  NODE_OPTIONS: '--max-old-space-size=4096 --experimental-vm-modules'
+  CI: true
+
 jobs:
   publish-npm:
     name: Publish to npm Registry
@@ -48,6 +52,9 @@ jobs:
 
       - name: Build project
         run: npm run build
+
+      - name: Clear Jest cache
+        run: npx jest --clearCache
 
       - name: Run tests
         run: npm test

--- a/README.md
+++ b/README.md
@@ -890,7 +890,27 @@ For detailed guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## 🏷️ Version History
 
-### v1.9.27 - 2025-11-07
+### v1.9.27 - 2025-12-05
+
+**Patch Release**: Dependency Updates & Bug Fixes
+
+#### 📦 Dependencies
+- express 5.1.0 → 5.2.1
+- posthog-node 5.11.0 → 5.14.1
+- tsx 4.20.6 → 4.21.0
+- zod 4.1.12 → 4.1.13
+- jsdom 27.0.0 → 27.2.0
+- @types/node 24.10.0 → 24.10.1
+
+#### 🐛 Bug Fixes
+- Jest ESM compatibility for jsdom nested modules (#1515, #1516)
+
+#### 🔒 Security
+- MCP SDK already updated to 1.24.0 in v1.9.26-hotfix (CVE-2025-66414)
+
+---
+
+### v1.9.26 - 2025-11-07
 
 **Major Feature Release**: Element Source Priority System & Critical Bug Fixes
 
@@ -914,7 +934,7 @@ For detailed guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 - SonarCloud badges restored to README chunk file
 
 #### 📦 Dependencies
-- @modelcontextprotocol/sdk 1.20.2 → 1.21.0
+- @modelcontextprotocol/sdk 1.20.2 → 1.24.0 (security update for CVE-2025-66414)
 - posthog-node 5.10.3 → 5.11.0
 - @types/archiver 6.0.4 → 7.0.0
 - @types/node 24.9.1 → 24.10.0

--- a/test/docker-v1913-memory-fixes/Dockerfile
+++ b/test/docker-v1913-memory-fixes/Dockerfile
@@ -12,10 +12,11 @@ WORKDIR /home/claude
 
 # Copy the local MCP server source with our v1.9.13 fixes
 # Note: Build context should be run from mcp-server root: docker build -f test/docker-v1913-memory-fixes/Dockerfile .
-COPY --chown=claude:claude package*.json /home/claude/mcp-server/
-COPY --chown=claude:claude tsconfig.json /home/claude/mcp-server/
-COPY --chown=claude:claude src /home/claude/mcp-server/src/
-COPY --chown=claude:claude scripts /home/claude/mcp-server/scripts/
+# Use --chmod to set read-only permissions for copied files (SonarCloud docker:S6504)
+COPY --chown=claude:claude --chmod=644 package*.json /home/claude/mcp-server/
+COPY --chown=claude:claude --chmod=644 tsconfig.json /home/claude/mcp-server/
+COPY --chown=claude:claude --chmod=644 src /home/claude/mcp-server/src/
+COPY --chown=claude:claude --chmod=755 scripts /home/claude/mcp-server/scripts/
 
 # Build the MCP server
 WORKDIR /home/claude/mcp-server


### PR DESCRIPTION
## Summary

Hotfix addressing post-release issues for v1.9.27.

### Changes

1. **README.md Version History Fix**:
   - Corrected v1.9.27 date to 2025-12-05 (was incorrectly showing 2025-11-07)
   - Added proper v1.9.27 release notes (dependency updates patch release)
   - Restored v1.9.26 as the Element Source Priority System major release

2. **SonarCloud Security Hotspots Fix** (4 issues):
   - Fixed `docker:S6504` in `test/docker-v1913-memory-fixes/Dockerfile`
   - Added `--chmod=644` for files and `--chmod=755` for scripts directories
   - Pre-existing issues from Sept 29, 2025 - not introduced by v1.9.27

3. **NPM Publish Workflow Fix**:
   - Added `NODE_OPTIONS` and `CI` environment variables (matches core-build-test.yml)
   - Added Jest cache clear before tests (prevents jsdom/parse5 ESM issues)
   - Fixes test failures during npm publish

### Test Plan
- [x] README version history is correct
- [x] SonarCloud security hotspots addressed
- [x] npm publish workflow aligned with core-build-test.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)