### PR TITLE
fix(ci): Add TEST_PERSONAS_DIR to npm publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -30,6 +30,7 @@ permissions:
 env:
   NODE_OPTIONS: '--max-old-space-size=4096 --experimental-vm-modules'
   CI: true
+  TEST_PERSONAS_DIR: ${{ github.workspace }}/test-personas
 
 jobs:
   publish-npm:
@@ -46,6 +47,13 @@ jobs:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
+
+      - name: Setup test environment
+        shell: bash
+        run: |
+          echo "TEST_PERSONAS_DIR: $TEST_PERSONAS_DIR"
+          mkdir -p "$TEST_PERSONAS_DIR"
+          echo "✅ Test personas directory ready: $TEST_PERSONAS_DIR"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Add TEST_PERSONAS_DIR environment variable to npm publish workflow
- Add setup step to create the test-personas directory
- Fixes CI environment validation test failures during npm publish

The npm publish workflow was missing environment variables that other test workflows define, causing tests to fail.

## Test plan
- [ ] CI passes on this PR
- [ ] Re-run npm publish workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)