### PR TITLE
fix(ci): Clear legacy token to enable OIDC auth for npm publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Publish to npm (with provenance)
         if: github.event.inputs.dry_run != 'true'
         shell: bash
+        env:
+          # Clear any legacy token - OIDC handles auth via provenance
+          NODE_AUTH_TOKEN: ''
         run: |
           # Publish with provenance for supply chain security
           # Uses OIDC authentication (no token needed!)


### PR DESCRIPTION
## Summary
- Fixes npm publish failures caused by stale `NODE_AUTH_TOKEN` overriding OIDC authentication
- The `setup-node` action was injecting a token from the `NPM_TOKEN` secret, which took precedence over OIDC/Trusted Publishing
- This explicitly clears `NODE_AUTH_TOKEN` so `npm publish --provenance` uses OIDC as intended

## Root Cause
The workflow was configured for OIDC/Trusted Publishing but `actions/setup-node` with `registry-url` automatically populates `NODE_AUTH_TOKEN` from any existing `NPM_TOKEN` secret. The expired token was being used instead of OIDC.

## Test plan
- [ ] Merge this PR
- [ ] Re-run `gh workflow run "Publish to npm" --ref main`
- [ ] Verify v1.9.27 publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)