### PR TITLE
fix(ci): Remove registry-url to enable OIDC authentication

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -44,7 +44,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          # Note: Do NOT set registry-url here - it creates an .npmrc that
+          # requires NODE_AUTH_TOKEN and breaks OIDC/provenance authentication
           cache: 'npm'
 
       - name: Install dependencies
@@ -69,12 +70,10 @@ jobs:
       - name: Publish to npm (with provenance)
         if: github.event.inputs.dry_run != 'true'
         shell: bash
-        env:
-          # Clear any legacy token - OIDC handles auth via provenance
-          NODE_AUTH_TOKEN: ''
         run: |
           # Publish with provenance for supply chain security
-          # Uses OIDC authentication (no token needed!)
+          # Uses OIDC authentication - npm automatically gets an OIDC token
+          # from GitHub Actions when --provenance is specified
           npm publish --provenance --access public
 
       - name: Dry run (skip publish)


### PR DESCRIPTION
## Summary
Fixes npm publish failing with OIDC/Trusted Publishing by removing the `registry-url` parameter from `setup-node`.

## Problem
The `setup-node` action with `registry-url` creates an `.npmrc` file that requires `NODE_AUTH_TOKEN`:
```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
```

This breaks OIDC because:
1. **With stale token**: npm uses the expired token → "Access token expired"
2. **With empty token**: npm has no auth → "ENEEDAUTH" 
3. **Without .npmrc**: npm publish --provenance uses OIDC automatically ✓

## Solution
Remove `registry-url` from setup-node so npm uses OIDC authentication via the `--provenance` flag.

## Test plan
- [ ] Merge this PR
- [ ] Re-run `gh workflow run "Publish to npm" --ref main`
- [ ] Verify v1.9.27 publishes successfully with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)