### PR TITLE
fix(ci): Use Node 22 for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -43,9 +43,10 @@ jobs:
       - name: Setup Node.js for npm
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          # Note: Do NOT set registry-url here - it creates an .npmrc that
-          # requires NODE_AUTH_TOKEN and breaks OIDC/provenance authentication
+          # Node 22.x includes npm 11.x which is required for OIDC trusted publishing
+          # npm 10.x (bundled with Node 20.x) does not support OIDC authentication
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
Fixes npm publish by upgrading to Node.js 22.x which includes npm 11.x - **required** for OIDC trusted publishing.

## Root Cause
npm OIDC trusted publishing requires **npm CLI 11.5.1 or later**:
- Node.js 20.x ships with npm 10.8.2 → **No OIDC support**
- Node.js 22.x ships with npm 11.x → **OIDC support** ✓

The workflow was failing with `ENEEDAUTH` because npm 10.x doesn't know how to request an OIDC token from GitHub Actions.

## Changes
- Upgrade from Node 20.x to Node 22.x in publish workflow
- Restore `registry-url` (required for npm to know which registry to authenticate with)
- Add comments explaining the version requirements

## References
- [npm trusted publishing with OIDC is generally available](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/)
- npm 11.x requires Node.js `^20.17.0 || >=22.9.0`

## Test plan
- [ ] Merge this PR
- [ ] Re-run `gh workflow run "Publish to npm" --ref main`  
- [ ] Verify v1.9.27 publishes successfully with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)