### PR TITLE
fix(ci): Clear legacy npmrc and token before OIDC publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -72,6 +72,12 @@ jobs:
         if: github.event.inputs.dry_run != 'true'
         shell: bash
         run: |
+          # Clear any legacy token that might override OIDC authentication
+          # The setup-node action may inject NODE_AUTH_TOKEN from org/repo secrets
+          # which takes precedence over OIDC. We must remove it for OIDC to work.
+          rm -f ~/.npmrc
+          unset NODE_AUTH_TOKEN
+
           # Publish with provenance for supply chain security
           # Uses OIDC authentication - npm automatically gets an OIDC token
           # from GitHub Actions when --provenance is specified


### PR DESCRIPTION
## Summary
Fixes npm publish by clearing the legacy `.npmrc` and `NODE_AUTH_TOKEN` before attempting OIDC authentication.

## Problem
The `setup-node` action injects `NODE_AUTH_TOKEN` from organization/repository secrets into `~/.npmrc`. Even though provenance is being signed successfully, npm tries to use the stale token for the actual publish request, resulting in:
```
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log
npm notice Access token expired or revoked. Please try logging in again.
npm error 404 Not Found
```

## Solution
Before running `npm publish --provenance`:
1. Remove `~/.npmrc` (contains the token reference)
2. Unset `NODE_AUTH_TOKEN` environment variable

This forces npm to use OIDC authentication via the `--provenance` flag.

## Test plan
- [ ] Merge this PR
- [ ] Re-run `gh workflow run "Publish to npm" --ref main`
- [ ] Verify v1.9.27 publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)