### PR TITLE
fix(ci): Override NODE_AUTH_TOKEN in step env for OIDC publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -71,12 +71,16 @@ jobs:
       - name: Publish to npm (with provenance)
         if: github.event.inputs.dry_run != 'true'
         shell: bash
+        env:
+          # Override any inherited NODE_AUTH_TOKEN with empty value
+          # This forces npm to use OIDC authentication via --provenance
+          NODE_AUTH_TOKEN: ''
+          # Prevent npm from using the .npmrc created by setup-node
+          NPM_CONFIG_USERCONFIG: ''
         run: |
-          # Clear any legacy token that might override OIDC authentication
-          # The setup-node action may inject NODE_AUTH_TOKEN from org/repo secrets
-          # which takes precedence over OIDC. We must remove it for OIDC to work.
+          # Remove any .npmrc files that might contain stale tokens
           rm -f ~/.npmrc
-          unset NODE_AUTH_TOKEN
+          rm -f /home/runner/work/_temp/.npmrc
 
           # Publish with provenance for supply chain security
           # Uses OIDC authentication - npm automatically gets an OIDC token


### PR DESCRIPTION
## Summary
Properly clears the stale npm token by overriding at the step environment level.

## Problem
The previous fix tried to `unset NODE_AUTH_TOKEN` in the shell script, but GitHub Actions injects environment variables at the step level before the script runs. The `unset` command only affects the current shell, not the already-injected environment.

## Solution
Override the environment variables at the step level using `env:`:
```yaml
env:
  NODE_AUTH_TOKEN: ''
  NPM_CONFIG_USERCONFIG: ''
```

This ensures npm has no token to use and must fall back to OIDC authentication.

## Test plan
- [ ] Merge this PR  
- [ ] Re-run `gh workflow run "Publish to npm" --ref main`
- [ ] Verify v1.9.27 publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)