### PR TITLE
fix(ci): Create clean npmrc for OIDC publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -75,6 +75,9 @@ jobs:
           # Override any inherited NODE_AUTH_TOKEN with empty value
           # This forces npm to use OIDC authentication via --provenance
           NODE_AUTH_TOKEN: ''
+          # Unset NPM_CONFIG_USERCONFIG to prevent npm from using the .npmrc
+          # created by setup-node (which contains token reference that blocks OIDC)
+          NPM_CONFIG_USERCONFIG: ''
         run: |
           # Create a clean .npmrc with just the registry (no token reference)
           # This allows npm to use OIDC while still knowing which registry to use


### PR DESCRIPTION
## Summary
Creates a fresh `.npmrc` with just the registry URL to enable OIDC authentication.

## Problem
Previous fixes either:
1. Left stale token → "Access token expired"
2. Removed all config → "ENEEDAUTH" (npm doesn't know where to publish)

## Solution
- Create `~/.npmrc` with just `registry=https://registry.npmjs.org/`
- Keep `NODE_AUTH_TOKEN=''` override in step env
- npm now knows WHERE to publish but has no token, forcing OIDC

## Test plan
- [ ] Merge this PR
- [ ] Re-run `gh workflow run "Publish to npm" --ref main`
- [ ] Verify v1.9.27 publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)