### PR TITLE
fix(ci): Remove registry-url to enable pure OIDC authentication

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -46,7 +46,8 @@ jobs:
           # Node 22.x includes npm 11.x which is required for OIDC trusted publishing
           # npm 10.x (bundled with Node 20.x) does not support OIDC authentication
           node-version: '22.x'
-          registry-url: 'https://registry.npmjs.org'
+          # NOTE: Do NOT use registry-url here! It creates .npmrc with token placeholder
+          # that blocks OIDC detection. npm will use default registry automatically.
           cache: 'npm'
 
       - name: Install dependencies
@@ -71,21 +72,12 @@ jobs:
       - name: Publish to npm (with provenance)
         if: github.event.inputs.dry_run != 'true'
         shell: bash
-        env:
-          # Override any inherited NODE_AUTH_TOKEN with empty value
-          # This forces npm to use OIDC authentication via --provenance
-          NODE_AUTH_TOKEN: ''
-          # Unset NPM_CONFIG_USERCONFIG to prevent npm from using the .npmrc
-          # created by setup-node (which contains token reference that blocks OIDC)
-          NPM_CONFIG_USERCONFIG: ''
         run: |
-          # Create a clean .npmrc with just the registry (no token reference)
-          # This allows npm to use OIDC while still knowing which registry to use
-          echo "registry=https://registry.npmjs.org/" > ~/.npmrc
-
           # Publish with provenance for supply chain security
-          # Uses OIDC authentication - npm automatically gets an OIDC token
-          # from GitHub Actions when --provenance is specified
+          # Uses OIDC authentication automatically when:
+          # 1. id-token: write permission is set
+          # 2. Running on GitHub Actions
+          # 3. No .npmrc with token configuration (we removed registry-url from setup-node)
           npm publish --provenance --access public
 
       - name: Dry run (skip publish)


### PR DESCRIPTION
## Summary
Removes `registry-url` parameter from `actions/setup-node` to enable pure OIDC authentication.

## Problem
Previous 11 attempts to fix npm OIDC publishing all failed because:
1. `actions/setup-node` with `registry-url` creates `.npmrc` with token placeholder
2. npm sees token configuration and tries token-based auth
3. Token is empty/stale → `ENEEDAUTH` error
4. npm never falls back to OIDC when token config exists

## Solution
**Remove the root cause** - don't let setup-node create any token configuration:
- Remove `registry-url` parameter
- npm defaults to npmjs.org registry
- No `.npmrc` with token = npm detects OIDC environment
- OIDC auth works automatically

## Changes
- Removed `registry-url: 'https://registry.npmjs.org'` from setup-node
- Simplified publish step (no env overrides needed)
- Added documentation comments

## Test plan
- [ ] Merge this PR
- [ ] Run `gh workflow run "Publish to npm" --ref main`
- [ ] Verify v1.9.27 publishes successfully

## Research
Full debugging documented in DollhouseMCP memory: `npm-oidc-troubleshooting-research-2025-12-05`

🤖 Generated with [Claude Code](https://claude.com/claude-code)