### PR TITLE
fix(ci): Upgrade npm to 11.x for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -43,12 +43,18 @@ jobs:
       - name: Setup Node.js for npm
         uses: actions/setup-node@v4
         with:
-          # Node 22.x includes npm 11.x which is required for OIDC trusted publishing
-          # npm 10.x (bundled with Node 20.x) does not support OIDC authentication
+          # Node 22.x is required for npm 11.x compatibility
+          # Note: Node 22.x ships with npm 10.x by default, so we upgrade npm separately below
           node-version: '22.x'
           # NOTE: Do NOT use registry-url here! It creates .npmrc with token placeholder
           # that blocks OIDC detection. npm will use default registry automatically.
           cache: 'npm'
+
+      - name: Upgrade npm to 11.x for OIDC support
+        run: |
+          echo "Current npm version: $(npm --version)"
+          npm install -g npm@11
+          echo "Upgraded npm version: $(npm --version)"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Adds npm 11.x upgrade step before publish for OIDC support
- Root cause: Node 22.x ships with npm 10.9.4, but OIDC requires npm 11.5.1+

## Root Cause Analysis

Diagnostic output from PR #1535 showed:
- ✅ OIDC environment variables present (`ACTIONS_ID_TOKEN_REQUEST_URL`)
- ✅ No .npmrc blocking files
- ✅ No NPM_CONFIG vars
- ✅ No NODE_AUTH_TOKEN
- ❌ **npm version 10.9.4** (requires 11.5.1+)

This explains why 12+ publish attempts failed with `ENEEDAUTH` despite correct OIDC configuration.

## Changes
- Added explicit `npm install -g npm@11` step after setup-node
- Updated comment to clarify Node 22 ships with npm 10.x

## Test plan
- [ ] CI checks pass
- [ ] Merge and run publish workflow
- [ ] Verify npm version 11.x in diagnostic output
- [ ] Verify successful publish to npm

## References
- npm OIDC requirement: https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
- Memory: `npm-oidc-troubleshooting-research-2025-12-05`

🤖 Generated with [Claude Code](https://claude.com/claude-code)