### PR TITLE
debug(ci): Add verbose logging for npm OIDC diagnosis

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -98,13 +98,17 @@ jobs:
       - name: Publish to npm (with provenance)
         if: github.event.inputs.dry_run != 'true'
         shell: bash
+        env:
+          # Ensure provenance is enabled for OIDC detection
+          NPM_CONFIG_PROVENANCE: 'true'
         run: |
           # Publish with provenance for supply chain security
           # Uses OIDC authentication automatically when:
           # 1. id-token: write permission is set
           # 2. Running on GitHub Actions
           # 3. No .npmrc with token configuration (we removed registry-url from setup-node)
-          npm publish --provenance --access public
+          # Using --loglevel verbose to diagnose OIDC issues
+          npm publish --provenance --access public --loglevel verbose
 
       - name: Dry run (skip publish)
         if: github.event.inputs.dry_run == 'true'


### PR DESCRIPTION
## Summary
- Adds verbose npm logging to diagnose OIDC authentication failure
- Sets `NPM_CONFIG_PROVENANCE=true` env var as recommended in npm issues

## Current Status
After npm 11.6.4 upgrade (PR #1536), we still get `ENEEDAUTH`:

- ✅ npm 11.6.4 (>= 11.5.1 required)
- ✅ OIDC environment variables present
- ✅ No blocking .npmrc files
- ❌ Still failing with ENEEDAUTH

## Purpose
The verbose logging will show exactly what npm is attempting for authentication and may reveal:
1. If OIDC token exchange is being attempted
2. What the actual auth failure is
3. If trusted publisher config on npmjs.com is the issue

## Test plan
- [ ] CI checks pass
- [ ] Merge and run publish workflow
- [ ] Analyze verbose npm output for OIDC details

🤖 Generated with [Claude Code](https://claude.com/claude-code)