### PR TITLE
fix(npm): Add provenance to publishConfig for OIDC

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
   ],
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   },
   "funding": {
     "type": "github",


### PR DESCRIPTION
## Summary
Adding `provenance: true` to `publishConfig` in package.json as recommended fix for OIDC token exchange failures.

## Root Cause
Per [npm/cli#8730](https://github.com/npm/cli/issues/8730), the OIDC token exchange may fail with scoped packages unless provenance is explicitly configured in package.json.

## Changes
- Added `"provenance": true` to publishConfig

## Test plan
- [ ] CI checks pass
- [ ] Merge and run publish workflow
- [ ] Verify OIDC token exchange succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)