### PR TITLE
test: round-trip serialization regression test suite (#920)

### DIFF
--- a/tests/e2e/round-trip-serialization.test.ts
+++ b/tests/e2e/round-trip-serialization.test.ts
@@ -312,8 +312,9 @@ describeOrSkip('Round-Trip Serialization Regression (#920)', () => {
       const file = await findElementFile('personas', 'rt-combining');
       // Unicode normalization (NFC) may compose combining chars into precomposed forms
       // (e + \u0301 → é). Either form is acceptable — the content must not be lost.
-      expect(file).toMatch(/Caf[eé\u0301]+ au lait/);
-      expect(file).toMatch(/A[nñ\u0303]+o nuevo/);
+      // Use alternation instead of character class to avoid S5868 (combined chars in [])
+      expect(file).toMatch(/Caf(?:é|e\u0301) au lait/);
+      expect(file).toMatch(/A(?:ñ|n\u0303)o nuevo/);
     });
   });
 


### PR DESCRIPTION
## Summary

19 automated regression tests validating round-trip serialization fidelity across all 6 element types. This is the final issue in the serialization audit epic (#907).

**Phase 1** — Basic round-trip: create → read file → verify structure (6 tests, all types)
**Phase 2** — Boolean/number type preservation: confirms #914 fix prevents corruption (2 tests)
**Phase 3** — Non-ASCII content: emoji, CJK, accented Latin (3 tests)
**Phase 4** — Field ordering: canonical METADATA_FIELD_ORDER produces deterministic output (1 test)
**Phase 5** — Known mutation vectors: documents intentional vs fixed mutations (6 tests)
**Phase 6** — Markdown bold regression: confirms #906 fix (1 test)

**Notable finding documented**: Non-BMP emoji (e.g., 🎯 U+1F3AF) are escaped to `\U0001F3AF` by js-yaml during serialization. BMP emoji (✅, ⚠️) survive as-is. This is expected YAML serializer behavior, not a bug.

Closes DollhouseMCP/mcp-server-v2-refactor#920

## Test plan

- [x] All 19 round-trip tests pass
- [x] Full suite: 330 suites, 8484 tests, zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)