### PR TITLE
fix: publish @dollhousemcp/safety to npm, fix nested metadata validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,11 @@
       "name": "@dollhousemcp/mcp-server",
       "version": "2.0.0-rc.2",
       "license": "AGPL-3.0-or-later",
+      "workspaces": [
+        "packages/safety"
+      ],
       "dependencies": {
-        "@dollhousemcp/safety": "file:packages/safety",
+        "@dollhousemcp/safety": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.25.1",
         "@types/dompurify": "^3.2.0",
         "@types/uuid": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "url": "https://github.com/sponsors/mickdarling"
   },
   "dependencies": {
-    "@dollhousemcp/safety": "file:packages/safety",
+    "@dollhousemcp/safety": "^1.0.0",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@types/dompurify": "^3.2.0",
     "@types/uuid": "^10.0.0",
@@ -194,6 +194,9 @@
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },
+  "workspaces": [
+    "packages/safety"
+  ],
   "engines": {
     "node": ">=20.0.0",
     "npm": ">=10.0.0"

--- a/src/handlers/element-crud/editElement.ts
+++ b/src/handlers/element-crud/editElement.ts
@@ -562,6 +562,18 @@ export async function editElement(
     normalizedType,
     input as Record<string, unknown>
   );
+
+  // Also validate nested metadata sub-object (the top-level 'metadata' key is
+  // skipped by detectUnknownMetadataProperties as a special route field, so
+  // dangerous/unknown properties inside it would go unchecked otherwise)
+  if (input.metadata && typeof input.metadata === 'object' && !Array.isArray(input.metadata)) {
+    const nestedWarnings = detectUnknownMetadataProperties(
+      normalizedType,
+      input.metadata as Record<string, unknown>
+    );
+    unknownPropertyWarnings.push(...nestedWarnings);
+  }
+
   const warningText = formatUnknownPropertyWarnings(unknownPropertyWarnings);
 
   if (unknownPropertyWarnings.length > 0) {

--- a/src/services/SerializationService.ts
+++ b/src/services/SerializationService.ts
@@ -611,7 +611,7 @@ export class SerializationService {
       cleanMetadata = false,
       cleaningStrategy = 'remove-undefined',
       schema = 'failsafe',
-      sortKeys = true,
+      sortKeys: _sortKeys = true,
       skipInvalid = true,
       noRefs = true
     } = options;


### PR DESCRIPTION
## Summary
- **Published `@dollhousemcp/safety@1.0.0` to npm** — the `file:packages/safety` dependency caused `npx -y @dollhousemcp/mcp-server@rc` to crash because npm resolves `file:` references on the consumer's machine
- **Added npm workspaces** — local development still uses the local safety package via workspace symlinks, published package resolves from the registry
- **Fixed nested metadata validation** — properties inside `input.metadata` (e.g. `__proto__`, `constructor`, `prototype`, `type`) are now validated for unknown/dangerous fields instead of silently accepted
- **Fixed lint warning** — unused `sortKeys` variable in SerializationService.ts

## Test plan
- [x] `npm run lint` — passes clean (0 warnings)
- [x] `npm run build` — passes
- [x] Unit tests — 8,494 passed, 0 failed
- [x] Integration tests — 1,239 passed, 0 failed (2 previously failing tests now pass)
- [x] `npm run pre-commit` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)