### PR TITLE
ci: add safety package version check

### DIFF
--- a/.github/workflows/safety-package-check.yml
+++ b/.github/workflows/safety-package-check.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check if safety package needs publishing
+        shell: bash
         run: |
           LOCAL_VERSION=$(node -e "console.log(require('./packages/safety/package.json').version)")
           echo "Local safety version: $LOCAL_VERSION"


### PR DESCRIPTION
## Summary
- Adds a CI workflow that runs on PRs touching `packages/safety/src/` or `packages/safety/package.json`
- Compares the local version against what's published on npm
- Fails with a clear error message if code changed but version wasn't bumped
- Prevents shipping stale `@dollhousemcp/safety` code with mcp-server

## How it works
- PR touches safety source → workflow triggers
- Reads local version from `packages/safety/package.json`
- Queries npm for published version
- If they match → fail (code changed but not versioned)
- If they differ → pass (version was bumped, ready to publish)

## Test plan
- [x] Workflow only triggers on safety package changes (path filter)
- [x] Lightweight check (2 min timeout, single npm query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)