### PR TITLE
docs: update release links to v2.0.0-rc.4

### DIFF
--- a/docs/guides/public-beta-onboarding.md
+++ b/docs/guides/public-beta-onboarding.md
@@ -35,7 +35,7 @@ That's it. Claude Code handles the rest.
 
 ### Claude Desktop
 
-**One-click**: Download the [Desktop Extension (.mcpb)](https://github.com/DollhouseMCP/mcp-server/releases/tag/v2.0.0-rc.2) and open it.
+**One-click**: Download the [Desktop Extension (.mcpb)](https://github.com/DollhouseMCP/mcp-server/releases/tag/v2.0.0-rc.4) and open it.
 
 **Manual config** — add this to your Claude Desktop configuration file:
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -2,13 +2,13 @@
 
 DollhouseMCP works with any MCP-compatible AI client. Pick your platform below.
 
-> **v2.0.0-rc.2**: DollhouseMCP v2 is currently a release candidate. Use `@rc` when installing via npm/npx (e.g., `@dollhousemcp/mcp-server@rc`). The Desktop Extension (.mcpb) always installs the latest release. When v2 reaches GA, the `@rc` tag will no longer be needed.
+> **v2.0.0-rc.4**: DollhouseMCP v2 is currently a release candidate. Use `@rc` when installing via npm/npx (e.g., `@dollhousemcp/mcp-server@rc`). The Desktop Extension (.mcpb) always installs the latest release. When v2 reaches GA, the `@rc` tag will no longer be needed.
 
 ---
 
 ## Claude Desktop (One-Click Install)
 
-Download the [DollhouseMCP Desktop Extension](https://github.com/DollhouseMCP/mcp-server/releases/tag/v2.0.0-rc.2) (`.mcpb` file) and open it. Claude Desktop installs everything automatically — no terminal, no configuration file editing.
+Download the [DollhouseMCP Desktop Extension](https://github.com/DollhouseMCP/mcp-server/releases/tag/v2.0.0-rc.4) (`.mcpb` file) and open it. Claude Desktop installs everything automatically — no terminal, no configuration file editing.
 
 The `.mcpb` format is an [MCP Bundle](https://github.com/modelcontextprotocol/mcpb) — a portable package containing the server and all dependencies. Node.js ships with Claude Desktop, so DollhouseMCP works out-of-the-box.
 


### PR DESCRIPTION
## Summary
Updated .mcpb download links in quick-start.md and public-beta-onboarding.md from RC2 to RC4.

## Files changed
- `docs/guides/quick-start.md` — version banner + desktop extension link
- `docs/guides/public-beta-onboarding.md` — desktop extension link

🤖 Generated with [Claude Code](https://claude.com/claude-code)