### PR TITLE
fix: debounce file watcher to prevent memory loading loop (#1687)

### DIFF
--- a/src/services/FileWatchService.ts
+++ b/src/services/FileWatchService.ts
@@ -323,7 +323,7 @@ export class FileWatchService {
    */
   dispose(): void {
     // Clear all pending debounce timers to prevent post-dispose handler calls
-    for (const [dir, timer] of this.debounceTimers) {
+    for (const [, timer] of this.debounceTimers) {
       clearTimeout(timer);
     }
     this.debounceTimers.clear();

--- a/tests/unit/services/FileWatchService.debounce.test.ts
+++ b/tests/unit/services/FileWatchService.debounce.test.ts
@@ -6,10 +6,10 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
-import * as fs from 'fs/promises';
-import { writeFileSync, mkdirSync } from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import * as fs from 'node:fs/promises';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import { FileWatchService } from '../../../src/services/FileWatchService.js';
 
 describe('FileWatchService debouncing (Issue #1687)', () => {


### PR DESCRIPTION
## Summary

Fix infinite memory loading loop caused by FileWatchService polling at 250ms with no debouncing or scan-overlap protection.

## Problem

On portfolios with 1000+ memories, the polling fallback watcher creates a loop:
1. Poll detects file changes (250ms interval)
2. Handlers invalidate storage layer, triggering full rescan
3. Rescan loads all memory files, touching metadata
4. Next poll (250ms later) detects those touches as changes
5. Repeat indefinitely — flooding logs with "Failed to load 174 memories" every 1-2 seconds

## Fix

Three changes to `src/services/FileWatchService.ts`:

**Adaptive polling interval** — scales with directory size:
- Base: 2 seconds (was 250ms)
- Adds 2ms per file in the directory
- Caps at 10 seconds
- 1000-file portfolio: ~4 second interval instead of 250ms

**Scan-in-progress guard** — skips the poll cycle if the previous scan's handlers are still running. Prevents overlapping scans.

**fs.watch debouncing** — coalesces rapid-fire filesystem notifications into a single batched handler call per 500ms window with deduplication.

## Impact

- Breaks the infinite loop for large portfolios
- File watching features remain fully functional (settings unchanged)
- Small portfolios see minimal difference (2s base vs 250ms, but no practical impact since file watching is for detecting external edits)

## Test plan

- [x] All 8,804 tests pass
- [x] Build passes
- [ ] Manual: verify file watcher still detects external edits to portfolio files
- [ ] Manual: verify no repeated "Failed to load memories" in logs

Fixes #1687

🤖 Generated with [Claude Code](https://claude.ai/code)