### PR TITLE
fix: log level dropdown defaults to info instead of all

### DIFF
--- a/src/web/public/logs.js
+++ b/src/web/public/logs.js
@@ -100,7 +100,7 @@
             <select id="log-level">
               <option value="">All</option>
               <option value="debug">debug</option>
-              <option value="info">info</option>
+              <option value="info" selected>info</option>
               <option value="warn">warn</option>
               <option value="error">error</option>
             </select>


### PR DESCRIPTION
## Summary
One-line fix: adds `selected` attribute to the info option in the log viewer dropdown.

## Problem
PR #1715 set `filterLevel='info'` in JS and synced via `levelSelect.value`, but the browser renders the HTML `<select>` before JS executes. The first `<option>` ("All") was always visually selected on page load — even in incognito windows.

## Fix
```html
<!-- Before -->
<option value="info">info</option>

<!-- After -->
<option value="info" selected>info</option>
```

Companion to #1715 (security log backpressure fix).

## Test plan
- [x] Verified in incognito window — dropdown shows "info" on first load
- [x] Verified "All" and "debug" still selectable from dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)