### PR TITLE
hotfix: v2.0.4 — include web assets in npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.0.4] - 2026-04-02
+
+### Hotfix: npm package missing web assets
+
+- **Fix**: `package.json` `files` field now includes `dist/web/public/**` and `dist/seed-elements/**`
+- v2.0.3 was missing `.html`, `.css`, and font files from the web console, causing `--web` mode to crash with `NotFoundError`
+- Also missing seed element `.yaml` files, causing seed memory installation to fail
+- Added package inclusion tests to prevent regression
+
 ## [2.0.3] - 2026-04-02
 
 ### Setup Tab — Interactive Installer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",
@@ -126,6 +126,8 @@
     "dist/**/*.js",
     "dist/**/*.d.ts",
     "dist/**/*.d.ts.map",
+    "dist/web/public/**",
+    "dist/seed-elements/**",
     "data/personas/**/*.md",
     "data/skills/**/*.md",
     "data/templates/**/*.md",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "transport": {
         "type": "stdio"
       }

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -1108,6 +1108,62 @@ describe('Setup Tab — Generated Panel DOM Validation', () => {
   });
 });
 
+// ── npm package inclusion check ───────────────────────────────────────
+// Verifies that static web assets and seed elements are included in the
+// npm package via the files field in package.json.
+
+describe('Setup Tab — Package Inclusion', () => {
+  let packageJson: Record<string, unknown>;
+
+  beforeAll(async () => {
+    const raw = await readFileAsync(join(__dirname, '..', '..', '..', 'package.json'), 'utf-8');
+    packageJson = JSON.parse(raw);
+  });
+
+  it('files field includes dist/web/public/** for HTML, CSS, and fonts', () => {
+    const files = packageJson.files as string[];
+    expect(files).toContain('dist/web/public/**');
+  });
+
+  it('files field includes dist/seed-elements/** for seed memories', () => {
+    const files = packageJson.files as string[];
+    expect(files).toContain('dist/seed-elements/**');
+  });
+
+  it('dist/web/public/index.html exists', () => {
+    const indexPath = join(__dirname, '..', '..', '..', 'dist', 'web', 'public', 'index.html');
+    expect(() => readFileSync(indexPath)).not.toThrow();
+  });
+
+  it('dist/web/public/setup.css exists', () => {
+    const cssPath = join(__dirname, '..', '..', '..', 'dist', 'web', 'public', 'setup.css');
+    expect(() => readFileSync(cssPath)).not.toThrow();
+  });
+
+  it('dist/web/public/setup.js exists', () => {
+    const jsPath = join(__dirname, '..', '..', '..', 'dist', 'web', 'public', 'setup.js');
+    expect(() => readFileSync(jsPath)).not.toThrow();
+  });
+
+  it('dist/web/public/styles.css exists', () => {
+    const cssPath = join(__dirname, '..', '..', '..', 'dist', 'web', 'public', 'styles.css');
+    expect(() => readFileSync(cssPath)).not.toThrow();
+  });
+
+  it('dist/web/public/fonts.css exists', () => {
+    const cssPath = join(__dirname, '..', '..', '..', 'dist', 'web', 'public', 'fonts.css');
+    expect(() => readFileSync(cssPath)).not.toThrow();
+  });
+
+  it('dist/seed-elements/memories/ has seed files', async () => {
+    const seedDir = join(__dirname, '..', '..', '..', 'dist', 'seed-elements', 'memories');
+    const { readdirSync } = await import('node:fs');
+    const files = readdirSync(seedDir).map(String);
+    expect(files.length).toBeGreaterThan(0);
+    expect(files.some(f => f.endsWith('.yaml'))).toBe(true);
+  });
+});
+
 // ── Dependency check ──────────────────────────────────────────────────
 
 describe('Setup Tab — Dependencies', () => {


### PR DESCRIPTION
## Hotfix v2.0.4

v2.0.3 npm package was missing `dist/web/public/*.html`, `*.css`, font files, and `dist/seed-elements/**/*.yaml`. This broke `--web` mode on fresh installs (NotFoundError crash).

### Fix
- Added `dist/web/public/**` and `dist/seed-elements/**` to package.json `files` field
- Added package inclusion regression tests

### Impact
- `npx @dollhousemcp/mcp-server@latest --web` crashed on first run for any new user
- Seed memory installation failed silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)