### PR TITLE
fix: version bump script now updates server.json

### DIFF
--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -150,10 +150,10 @@ const updateConfigs = [
   },
   {
     name: 'server.json',
+    // MCP registry requires both top-level version and packages[0].version
     updates: [
       {
-        // Update both top-level and packages[0] version fields
-        pattern: /"version":\s*"[\d\.]+(-[\w\.]+)?"/g,
+        pattern: /"version":\s*"[\d.]+(-[\w.]+)?"/g,
         replacement: `"version": "${newVersion}"`
       }
     ],

--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -149,6 +149,17 @@ const updateConfigs = [
     optional: true // Don't fail if file doesn't exist
   },
   {
+    name: 'server.json',
+    updates: [
+      {
+        // Update both top-level and packages[0] version fields
+        pattern: /"version":\s*"[\d\.]+(-[\w\.]+)?"/g,
+        replacement: `"version": "${newVersion}"`
+      }
+    ],
+    required: true
+  },
+  {
     name: 'Dockerfile',
     updates: [
       {


### PR DESCRIPTION
## Summary
- Adds `server.json` to the file list in `scripts/update-version.mjs` so both version fields (top-level and `packages[0]`) are updated automatically during version bumps
- Eliminates the manual `server.json` edit that was needed every release since v2.0.3

Closes #1749

## Test plan
- [x] `npm run update:version -- 9.9.9 --dry-run` shows `✅ Updated server.json`
- [x] `mcp-registry-workflow` test suite passes (34/34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)