### PR TITLE
fix: crypto hardening — configurable token passphrase and distinct mock encryption

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -204,6 +204,11 @@ const envSchema = z.object({
   DOLLHOUSE_DISABLE_ENCRYPTION: z.coerce.boolean().default(false),
   DOLLHOUSE_ENCRYPTION_SECRET: z.string().optional(),
   DOLLHOUSE_ENCRYPTION_SALT: z.string().optional(),
+
+  // Token encryption secret (SEC-01, #1735)
+  // When set, replaces the predictable machine-derived passphrase for token encryption.
+  // Strongly recommended for any shared or multi-user environment.
+  DOLLHOUSE_TOKEN_SECRET: z.string().optional(),
 });
 
 /**

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -208,7 +208,8 @@ const envSchema = z.object({
   // Token encryption secret (SEC-01, #1735)
   // When set, replaces the predictable machine-derived passphrase for token encryption.
   // Strongly recommended for any shared or multi-user environment.
-  DOLLHOUSE_TOKEN_SECRET: z.string().optional(),
+  // Minimum 32 characters enforced to prevent weak passphrases.
+  DOLLHOUSE_TOKEN_SECRET: z.string().min(32).optional(),
 });
 
 /**

--- a/src/security/encryption/PatternEncryptor.ts
+++ b/src/security/encryption/PatternEncryptor.ts
@@ -76,8 +76,8 @@ const DEFAULT_CONFIG: EncryptionConfig = {
     : env.NODE_ENV === 'production',
   secret: env.DOLLHOUSE_ENCRYPTION_SECRET,
   iterations: 100000,
-  // SECURITY FIX: Configurable salt to prevent rainbow table attacks
-  // Falls back to default only if not configured
+  // SECURITY FIX: Configurable salt to prevent rainbow table attacks (#1733)
+  // Falls back to default with startup warning if not configured
   salt: env.DOLLHOUSE_ENCRYPTION_SALT || 'dollhouse-pattern-encryption-v1',
 };
 
@@ -134,6 +134,11 @@ export class PatternEncryptor {
       );
     }
 
+    // SEC-05 (#1733): Warn if using the static default salt
+    if (!env.DOLLHOUSE_ENCRYPTION_SALT) {
+      logger.warn('⚠️  Pattern encryption using default salt. Set DOLLHOUSE_ENCRYPTION_SALT for stronger protection.');
+    }
+
     logger.info('Initializing pattern encryption', {
       algorithm: this.ALGORITHM,
       iterations: this.config.iterations,
@@ -163,14 +168,14 @@ export class PatternEncryptor {
     }
 
     if (!this.config.enabled) {
-      // Encryption disabled - return mock encrypted structure
-      // This allows testing without encryption enabled
+      // Encryption disabled — return mock structure with MOCK: prefix (#1733)
+      // so it cannot be confused with real ciphertext
       logger.debug('Encryption disabled, returning mock structure');
       return {
-        encryptedData: Buffer.from(pattern).toString('base64'),
+        encryptedData: `MOCK:${Buffer.from(pattern).toString('base64')}`,
         algorithm: this.ALGORITHM,
-        iv: randomBytes(this.IV_LENGTH).toString('base64'),
-        authTag: randomBytes(this.AUTH_TAG_LENGTH).toString('base64'),
+        iv: '',
+        authTag: '',
       };
     }
 
@@ -231,9 +236,12 @@ export class PatternEncryptor {
     }
 
     if (!this.config.enabled) {
-      // Encryption disabled - decode the base64 mock data
+      // Encryption disabled — decode mock data, stripping MOCK: prefix (#1733)
       logger.debug('Encryption disabled, decoding mock structure');
-      return Buffer.from(encrypted.encryptedData, 'base64').toString('utf8');
+      const data = encrypted.encryptedData.startsWith('MOCK:')
+        ? encrypted.encryptedData.slice(5)
+        : encrypted.encryptedData;
+      return Buffer.from(data, 'base64').toString('utf8');
     }
 
     if (!this.encryptionKey) {

--- a/src/security/encryption/PatternEncryptor.ts
+++ b/src/security/encryption/PatternEncryptor.ts
@@ -136,7 +136,10 @@ export class PatternEncryptor {
 
     // SEC-05 (#1733): Warn if using the static default salt
     if (!env.DOLLHOUSE_ENCRYPTION_SALT) {
-      logger.warn('⚠️  Pattern encryption using default salt. Set DOLLHOUSE_ENCRYPTION_SALT for stronger protection.');
+      logger.warn(
+        '⚠️  Pattern encryption using default salt. Set DOLLHOUSE_ENCRYPTION_SALT to a random 32+ character string ' +
+        '(e.g. `openssl rand -hex 32`) for stronger protection against rainbow table attacks.'
+      );
     }
 
     logger.info('Initializing pattern encryption', {

--- a/src/security/tokenManager.ts
+++ b/src/security/tokenManager.ts
@@ -453,9 +453,10 @@ export class TokenManager {
   }
 
   /**
-   * Machine-derived passphrase — kept for backward compatibility with tokens
-   * encrypted before DOLLHOUSE_TOKEN_SECRET was available.
-   * @deprecated Use DOLLHOUSE_TOKEN_SECRET env var instead
+   * Machine-derived passphrase — fallback when DOLLHOUSE_TOKEN_SECRET is not
+   * set, and migration path for tokens encrypted before that env var existed.
+   * Not deprecated; still the default for installations that haven't opted in
+   * to an explicit secret.
    */
   private getMachinePassphrase(): string {
     // codeql[js/insufficient-password-hashing] — These are NOT password hashes.

--- a/src/security/tokenManager.ts
+++ b/src/security/tokenManager.ts
@@ -439,11 +439,25 @@ export class TokenManager {
   }
 
   /**
-   * Get machine-specific passphrase for encryption
-   * Uses a combination of machine ID and user info for uniqueness
+   * Get passphrase for token encryption.
+   *
+   * Priority: DOLLHOUSE_TOKEN_SECRET env var → machine-derived passphrase (fallback).
+   * The machine-derived passphrase uses homedir + USER which is predictable (#1735).
+   * Set DOLLHOUSE_TOKEN_SECRET for stronger protection.
+   */
+  private getPassphrase(): string {
+    if (process.env.DOLLHOUSE_TOKEN_SECRET) {
+      return process.env.DOLLHOUSE_TOKEN_SECRET;
+    }
+    return this.getMachinePassphrase();
+  }
+
+  /**
+   * Machine-derived passphrase — kept for backward compatibility with tokens
+   * encrypted before DOLLHOUSE_TOKEN_SECRET was available.
+   * @deprecated Use DOLLHOUSE_TOKEN_SECRET env var instead
    */
   private getMachinePassphrase(): string {
-    // Use a combination of hostname, username, and a fixed app identifier.
     // codeql[js/insufficient-password-hashing] — These are NOT password hashes.
     // SHA-256 is used to derive a stable machine fingerprint from system identifiers
     // (home directory path, OS username). The actual token encryption uses pbkdf2Sync
@@ -453,6 +467,32 @@ export class TokenManager {
     const appId = 'DollhouseMCP-TokenStore-v1';
 
     return `${appId}-${hostname}-${username}`;
+  }
+
+  /**
+   * Attempt decryption with the primary passphrase, then fall back to the
+   * machine-derived passphrase for backward compatibility (#1735).
+   */
+  private decryptWithFallback(salt: Buffer, iv: Buffer, tag: Buffer, encrypted: Buffer): string {
+    const primaryPassphrase = this.getPassphrase();
+    try {
+      return this.decryptToken(primaryPassphrase, salt, iv, tag, encrypted);
+    } catch {
+      // If primary passphrase differs from machine passphrase, try fallback
+      const machinePassphrase = this.getMachinePassphrase();
+      if (machinePassphrase !== primaryPassphrase) {
+        logger.info('Primary passphrase failed, trying machine passphrase migration path');
+        return this.decryptToken(machinePassphrase, salt, iv, tag, encrypted);
+      }
+      throw new SecurityError('Token decryption failed');
+    }
+  }
+
+  private decryptToken(passphrase: string, salt: Buffer, iv: Buffer, tag: Buffer, encrypted: Buffer): string {
+    const key = this.deriveKey(passphrase, salt);
+    const decipher = crypto.createDecipheriv(TokenManager.ALGORITHM, key, iv);
+    decipher.setAuthTag(tag);
+    return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8');
   }
 
   /**
@@ -480,7 +520,7 @@ export class TokenManager {
       // Generate encryption components
       const salt = crypto.randomBytes(TokenManager.SALT_LENGTH);
       const iv = crypto.randomBytes(TokenManager.IV_LENGTH);
-      const passphrase = this.getMachinePassphrase();
+      const passphrase = this.getPassphrase();
       const key = this.deriveKey(passphrase, salt);
 
       // Encrypt token
@@ -556,18 +596,9 @@ export class TokenManager {
       const tag = stored.subarray(TokenManager.SALT_LENGTH + TokenManager.IV_LENGTH, TokenManager.SALT_LENGTH + TokenManager.IV_LENGTH + TokenManager.TAG_LENGTH);
       const encrypted = stored.subarray(TokenManager.SALT_LENGTH + TokenManager.IV_LENGTH + TokenManager.TAG_LENGTH);
 
-      // Derive decryption key
-      const passphrase = this.getMachinePassphrase();
-      const key = this.deriveKey(passphrase, salt);
-
-      // Decrypt token
-      const decipher = crypto.createDecipheriv(TokenManager.ALGORITHM, key, iv);
-      decipher.setAuthTag(tag);
-      
-      const decrypted = Buffer.concat([
-        decipher.update(encrypted),
-        decipher.final()
-      ]).toString('utf8');
+      // Decrypt with primary passphrase; fall back to machine passphrase for
+      // backward compatibility with tokens stored before DOLLHOUSE_TOKEN_SECRET (#1735)
+      const decrypted = this.decryptWithFallback(salt, iv, tag, encrypted);
 
       // Validate decrypted token
       if (!this.validateTokenFormat(decrypted)) {


### PR DESCRIPTION
## Summary

Two crypto hardening fixes from the security audit:

### Token encryption passphrase (#1735, SEC-01)
`getMachinePassphrase()` derived the encryption key from `homedir()` + `process.env.USER` — predictable for anyone with filesystem access.

**Fix:** New `DOLLHOUSE_TOKEN_SECRET` env var provides an explicit passphrase override. When set, it replaces the machine-derived passphrase. Backward compatible: `decryptWithFallback()` tries the primary passphrase first, then falls back to the machine passphrase for tokens encrypted before the env var existed.

### Static salt and mock encryption (#1733, SEC-05)
- Default salt `'dollhouse-pattern-encryption-v1'` shared across all installations
- Mock encryption (when disabled) returned base64 with random IV/authTag, structurally identical to real ciphertext

**Fix:**
- Startup warning logged when using the default salt, prompting operators to set `DOLLHOUSE_ENCRYPTION_SALT`
- Mock encryption now uses `MOCK:` prefix with empty IV/authTag — clearly distinct from real ciphertext
- Decrypt handles both prefixed and legacy mock data

Closes #1735
Closes #1733

## Test plan
- [x] All PatternEncryptor tests pass (config, encrypt/decrypt, context tracker)
- [x] Token manager rate limit + scopes tests pass
- [x] `tokenManager.storage.test.ts` has 6 pre-existing failures on develop (unrelated ESM mock issue) — no regressions
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)