### PR TITLE
refactor: code quality batch — deduplicate escalateSeverity, fix hasCriticalIssues

### DIFF
--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -1164,7 +1164,7 @@ export class AgentManager extends BaseElementManager<Agent> {
 
     // 3. Unicode normalization via InputNormalizer
     const normalized = InputNormalizer.normalize(parameters, '$.parameters');
-    if (normalized.hasCriticalIssues) {
+    if (normalized.hasHighOrCriticalIssues) {
       throw new Error(
         `Template parameter security validation failed: ${normalized.errors.join('; ')}`
       );

--- a/src/security/InputNormalizer.ts
+++ b/src/security/InputNormalizer.ts
@@ -20,7 +20,7 @@
  * // At the validation boundary (GenericElementValidator)
  * const normalized = InputNormalizer.normalize(data);
  *
- * if (normalized.hasCriticalIssues) {
+ * if (normalized.hasHighOrCriticalIssues) {
  *   return ValidatorHelpers.fail(normalized.errors);
  * }
  *
@@ -34,6 +34,7 @@
 
 import { UnicodeValidator } from './validators/unicodeValidator.js';
 import { SecurityMonitor } from './securityMonitor.js';
+import { escalateSeverity } from './constants.js';
 
 /**
  * Result from input normalization
@@ -43,8 +44,10 @@ export interface NormalizationResult<T = unknown> {
   data: T;
   /** Whether normalization detected any issues */
   hasIssues: boolean;
-  /** Whether critical issues were detected that should fail validation */
+  /** Whether critical-severity issues were detected */
   hasCriticalIssues: boolean;
+  /** Whether high-or-critical issues were detected that should fail validation (#1782-6) */
+  hasHighOrCriticalIssues: boolean;
   /** All errors detected during normalization (critical issues) */
   errors: string[];
   /** All warnings detected during normalization (non-critical issues) */
@@ -114,7 +117,7 @@ export class InputNormalizer {
 
           // Categorize by severity
           if (unicodeResult.severity) {
-            maxSeverity = this.escalateSeverity(maxSeverity, unicodeResult.severity);
+            maxSeverity = escalateSeverity(maxSeverity, unicodeResult.severity);
 
             if (unicodeResult.severity === 'critical' || unicodeResult.severity === 'high') {
               errors.push(...pathIssues);
@@ -152,12 +155,13 @@ export class InputNormalizer {
     // Normalize the input
     const normalizedData = normalizeValue(input, path) as T;
 
-    // Calculate aggregate status
+    // Calculate aggregate status (#1782-6: separate critical-only from high+critical)
     const hasIssues = errors.length > 0 || warnings.length > 0;
-    const hasCriticalIssues = maxSeverity === 'critical' || maxSeverity === 'high';
+    const hasCriticalIssues = maxSeverity === 'critical';
+    const hasHighOrCriticalIssues = maxSeverity === 'critical' || maxSeverity === 'high';
 
-    // Log if critical issues detected
-    if (hasCriticalIssues) {
+    // Log if high or critical issues detected
+    if (hasHighOrCriticalIssues) {
       SecurityMonitor.logSecurityEvent({
         type: 'UNICODE_VALIDATION_ERROR',
         severity: maxSeverity === 'critical' ? 'CRITICAL' : 'HIGH',
@@ -170,25 +174,12 @@ export class InputNormalizer {
       data: normalizedData,
       hasIssues,
       hasCriticalIssues,
+      hasHighOrCriticalIssues,
       errors,
       warnings,
       issuesByPath,
       maxSeverity
     };
-  }
-
-  /**
-   * Escalate severity level (higher severity takes precedence)
-   */
-  private static escalateSeverity(
-    current: 'low' | 'medium' | 'high' | 'critical' | undefined,
-    newSeverity: 'low' | 'medium' | 'high' | 'critical'
-  ): 'low' | 'medium' | 'high' | 'critical' {
-    const severityLevels = { low: 1, medium: 2, high: 3, critical: 4 };
-    const currentLevel = current ? severityLevels[current] : 0;
-    const newLevel = severityLevels[newSeverity];
-
-    return newLevel > currentLevel ? newSeverity : (current || 'low');
   }
 
   /**

--- a/src/security/constants.ts
+++ b/src/security/constants.ts
@@ -39,6 +39,22 @@ export const SECURITY_LIMITS = {
   YAML_BOMB_AMPLIFICATION_THRESHOLD: 5
 };
 
+/** Shared severity type used across security validators (#1782-7) */
+export type SecuritySeverityLevel = 'low' | 'medium' | 'high' | 'critical';
+
+/**
+ * Escalate severity level — higher severity takes precedence.
+ * Extracted from UnicodeValidator and InputNormalizer to eliminate duplication (#1782-7).
+ */
+export function escalateSeverity(
+  current: SecuritySeverityLevel | undefined,
+  newSeverity: SecuritySeverityLevel
+): SecuritySeverityLevel {
+  const levels = { low: 1, medium: 2, high: 3, critical: 4 };
+  const currentLevel = current ? levels[current] : 0;
+  return levels[newSeverity] > currentLevel ? newSeverity : (current || 'low');
+}
+
 // Input validation patterns
 export const VALIDATION_PATTERNS = {
   SAFE_FILENAME: /^[a-zA-Z0-9][a-zA-Z0-9\-_.]{0,250}[a-zA-Z0-9]$/,

--- a/src/security/validators/unicodeValidator.ts
+++ b/src/security/validators/unicodeValidator.ts
@@ -12,6 +12,7 @@
  */
 
 import { SecurityMonitor } from '../securityMonitor.js';
+import { escalateSeverity } from '../constants.js';
 
 export interface UnicodeValidationResult {
   isValid: boolean;
@@ -111,13 +112,13 @@ export class UnicodeValidator {
       const suspiciousPatterns = this.detectSuspiciousPatterns(content);
       issues.push(...suspiciousPatterns.issues);
       if (suspiciousPatterns.severity) {
-        severity = this.escalateSeverity(severity, suspiciousPatterns.severity);
+        severity = escalateSeverity(severity, suspiciousPatterns.severity);
       }
 
       // 2. Remove direction override characters (prevents RLO/LRO attacks)
       if (this.DIRECTION_OVERRIDE_CHARS.test(normalized)) {
         issues.push('Direction override characters detected');
-        severity = this.escalateSeverity(severity, 'high');
+        severity = escalateSeverity(severity, 'high');
         normalized = normalized.replace(this.DIRECTION_OVERRIDE_CHARS, '');
         
         SecurityMonitor.logSecurityEvent({
@@ -134,10 +135,10 @@ export class UnicodeValidator {
         const hasDirectionMarks = /[\u200E\u200F]/.test(normalized);
         if (hasDirectionMarks) {
           issues.push('Direction marks (LRM/RLM) detected');
-          severity = this.escalateSeverity(severity, 'high');
+          severity = escalateSeverity(severity, 'high');
         } else {
           issues.push('Zero-width or non-printable characters detected');
-          severity = this.escalateSeverity(severity, 'medium');
+          severity = escalateSeverity(severity, 'medium');
         }
         normalized = normalized
           .replace(this.ZERO_WIDTH_CHARS, '')
@@ -151,7 +152,7 @@ export class UnicodeValidator {
       const mixedScriptResult = this.detectMixedScripts(normalized);
       if (mixedScriptResult.isSuspicious) {
         issues.push(`Mixed script usage detected: ${mixedScriptResult.scripts.join(', ')}`);
-        severity = this.escalateSeverity(severity, 'high');
+        severity = escalateSeverity(severity, 'high');
         
         SecurityMonitor.logSecurityEvent({
           type: 'UNICODE_MIXED_SCRIPT',
@@ -167,7 +168,7 @@ export class UnicodeValidator {
       if (confusableResult.hasConfusables) {
         normalized = confusableResult.normalized;
         issues.push('Confusable Unicode characters detected and normalized');
-        severity = this.escalateSeverity(severity, 'medium');
+        severity = escalateSeverity(severity, 'medium');
         
         // Log if this happens in legitimate multilingual context
         if (!mixedScriptResult.isSuspicious) {
@@ -237,7 +238,7 @@ export class UnicodeValidator {
     for (const { range, name } of suspiciousRanges) {
       if (range.test(content)) {
         issues.push(`Suspicious Unicode range detected: ${name}`);
-        severity = this.escalateSeverity(severity, 'medium');
+        severity = escalateSeverity(severity, 'medium');
       }
     }
 
@@ -245,7 +246,7 @@ export class UnicodeValidator {
     // This avoids ReDoS vulnerabilities from complex regex patterns
     if (this.hasMalformedSurrogates(content)) {
       issues.push('Malformed surrogate pairs detected');
-      severity = this.escalateSeverity(severity, 'high');
+      severity = escalateSeverity(severity, 'high');
     }
 
     return { issues, severity };
@@ -290,20 +291,6 @@ export class UnicodeValidator {
        detectedScripts.includes('CYRILLIC'));
 
     return { isSuspicious, scripts: detectedScripts };
-  }
-
-  /**
-   * Escalate severity level (higher severity takes precedence)
-   */
-  private static escalateSeverity(
-    current: 'low' | 'medium' | 'high' | 'critical' | undefined, 
-    newSeverity: 'low' | 'medium' | 'high' | 'critical'
-  ): 'low' | 'medium' | 'high' | 'critical' {
-    const severityLevels = { low: 1, medium: 2, high: 3, critical: 4 };
-    const currentLevel = current ? severityLevels[current] : 0;
-    const newLevel = severityLevels[newSeverity];
-    
-    return newLevel > currentLevel ? newSeverity : (current || 'low');
   }
 
   /**

--- a/src/services/validation/GenericElementValidator.ts
+++ b/src/services/validation/GenericElementValidator.ts
@@ -63,8 +63,8 @@ export class GenericElementValidator implements ElementValidator {
     // STEP 1: NORMALIZE at the boundary (before any validation)
     const normalized = InputNormalizer.normalize(data);
 
-    // Fail fast if critical Unicode issues detected
-    if (normalized.hasCriticalIssues) {
+    // Fail fast if high or critical Unicode issues detected
+    if (normalized.hasHighOrCriticalIssues) {
       return ValidatorHelpers.fail(normalized.errors);
     }
 
@@ -170,8 +170,8 @@ export class GenericElementValidator implements ElementValidator {
     // STEP 1: NORMALIZE changes at the boundary
     const normalized = InputNormalizer.normalize(changes);
 
-    // Fail fast if critical Unicode issues detected
-    if (normalized.hasCriticalIssues) {
+    // Fail fast if high or critical Unicode issues detected
+    if (normalized.hasHighOrCriticalIssues) {
       return ValidatorHelpers.fail(normalized.errors);
     }
 

--- a/tests/unit/security/InputNormalizer.test.ts
+++ b/tests/unit/security/InputNormalizer.test.ts
@@ -20,7 +20,7 @@ describe('InputNormalizer', () => {
 
       expect(result.data).toBe('hello world');
       expect(result.hasIssues).toBe(false);
-      expect(result.hasCriticalIssues).toBe(false);
+      expect(result.hasHighOrCriticalIssues).toBe(false);
       expect(result.errors).toEqual([]);
       expect(result.warnings).toEqual([]);
     });
@@ -273,7 +273,7 @@ describe('InputNormalizer', () => {
       const result = InputNormalizer.normalize(input);
 
       expect(result.maxSeverity).toBe('high');
-      expect(result.hasCriticalIssues).toBe(true);
+      expect(result.hasHighOrCriticalIssues).toBe(true);
     });
 
     it('should categorize errors vs warnings by severity', () => {
@@ -286,7 +286,7 @@ describe('InputNormalizer', () => {
 
       expect(result.errors.length).toBeGreaterThan(0);
       expect(result.warnings.length).toBeGreaterThan(0);
-      expect(result.hasCriticalIssues).toBe(true);
+      expect(result.hasHighOrCriticalIssues).toBe(true);
     });
   });
 
@@ -445,7 +445,7 @@ describe('InputNormalizer', () => {
       const result = InputNormalizer.normalize(input);
 
       expect(result.data.systemPrompt).toBe('You are a helpful assistant');
-      expect(result.hasCriticalIssues).toBe(true);
+      expect(result.hasHighOrCriticalIssues).toBe(true);
       expect(result.errors.length).toBeGreaterThan(0);
     });
 


### PR DESCRIPTION
## Summary

Two code quality fixes from #1782:

### Deduplicate `escalateSeverity` (#1782-7)
Identical implementations existed in `UnicodeValidator` and `InputNormalizer`. Extracted to a shared `escalateSeverity()` function in `constants.ts`. Both files now import and use the shared version. Net -6 lines.

### Fix `hasCriticalIssues` severity conflation (#1782-6)
`NormalizationResult.hasCriticalIssues` triggered on both `high` and `critical` severity, despite its name. Split into:
- `hasCriticalIssues` — `critical` severity only
- `hasHighOrCriticalIssues` — `high` or `critical` (the previous behavior)

All callers (`GenericElementValidator` x2, `AgentManager` x1) updated to use `hasHighOrCriticalIssues`, **preserving existing fail-fast behavior**. Future callers now have the option to check `hasCriticalIssues` for a stricter threshold.

### Not addressed (already correct or absent in codebase)
- #1782-8 (`testPattern` fails open) — no `testPattern` function exists; `RegexValidator.validate` already throws on oversized input
- #1782-9 (YAML bomb threshold) — threshold is already 5 with documented rationale in constants.ts

Ref #1782

## Test plan
- [x] 276 tests pass across all affected files (InputNormalizer, unicodeValidator, GenericElementValidator, AgentManager)
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)