### PR TITLE
feat: CLI commands for console token management (#1790)

### DIFF
--- a/docs/guides/console-auth.md
+++ b/docs/guides/console-auth.md
@@ -437,13 +437,60 @@ TOKEN=$(jq -r '.tokens[0].token' ~/.dollhouse/run/console-token.auth.json)
 
 ---
 
+## CLI token management
+
+The `dollhouse-console-token` command provides a terminal interface for token operations. All commands support `--json` for scripted consumption.
+
+**Show the current token:**
+
+```bash
+# Print the raw token (for piping to clipboard or env vars)
+dollhouse-console-token show
+
+# JSON output with metadata
+dollhouse-console-token show --json
+
+# Masked (safe for screen sharing)
+dollhouse-console-token show --masked
+```
+
+**Rotate the token (requires TOTP enrollment):**
+
+```bash
+# Interactive — prompts for TOTP code
+dollhouse-console-token rotate
+
+# Non-interactive — pass the code directly
+dollhouse-console-token rotate --code 123456
+
+# JSON output for scripts
+dollhouse-console-token rotate --json --code 123456
+```
+
+**Revoke the token (rotate + invalidate all sessions):**
+
+```bash
+dollhouse-console-token revoke
+dollhouse-console-token revoke --code 123456 --json
+```
+
+**Exit codes:**
+
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | User error (missing file, invalid args) |
+| `2` | Auth/confirmation failure (wrong TOTP, not enrolled) |
+
+---
+
 ## Security notes
 
 - **Treat the token like an SSH key or API key.** Anyone who holds it has full admin access to the local management API — including the ability to install MCP configs, approve tool permissions, kill sessions, and read all logs on the host.
 - **Don't commit `console-token.auth.json` anywhere.** It lives under `~/.dollhouse/` which isn't a git repo by default, but if anyone symlinks or copies that directory, the token goes with it.
 - **Don't paste the token into chat, email, or pull request descriptions.** It's localhost-only, but paranoia is cheap.
 - **Don't expose port 5907 beyond localhost without TLS.** The binding is still `127.0.0.1` only. Bearer-over-HTTP is fine for localhost but unsafe the moment you change the bind address.
-- **If you suspect token compromise, rotate immediately.** Use `POST /api/console/token/rotate` with a TOTP code. If you haven't enrolled TOTP, delete the token file and restart the server as a fallback.
+- **If you suspect token compromise, rotate immediately.** Use `dollhouse-console-token rotate` or `POST /api/console/token/rotate` with a TOTP code. If you haven't enrolled TOTP, delete the token file and restart the server as a fallback.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "bin": {
     "dollhousemcp": "dist/index.js",
-    "mcp-server": "dist/index.js"
+    "mcp-server": "dist/index.js",
+    "dollhouse-console-token": "dist/cli/console-token.js"
   },
   "scripts": {
     "prebuild": "npm run build:safety && node scripts/generate-version.js",

--- a/src/cli/console-token.ts
+++ b/src/cli/console-token.ts
@@ -51,9 +51,15 @@ async function promptTotpCode(): Promise<string> {
   const rl = createInterface({ input: stdin, output: stdout });
   try {
     const code = await rl.question(chalk.cyan('Enter TOTP code (or backup code): '));
-    const trimmed = code.trim();
+    // Strip whitespace and dashes — users may type backup codes as "XXXX-XXXX"
+    const trimmed = code.trim().replaceAll(/[\s-]/g, '');
     if (!trimmed) {
       console.error(chalk.red('No confirmation code provided.'));
+      process.exit(2);
+    }
+    // Accept 6-digit TOTP codes or 8-char alphanumeric backup codes
+    if (!/^\d{6}$/.test(trimmed) && !/^[0-9A-Za-z]{8}$/.test(trimmed)) {
+      console.error(chalk.red('Invalid code format. Enter a 6-digit TOTP code or an 8-character backup code.'));
       process.exit(2);
     }
     return trimmed;

--- a/src/cli/console-token.ts
+++ b/src/cli/console-token.ts
@@ -20,15 +20,13 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import { createInterface } from 'node:readline/promises';
 import { stdin, stdout } from 'node:process';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
 import {
   ConsoleTokenStore,
   readTokenFileRaw,
   TotpError,
   DEFAULT_TOKEN_FILE,
   type ConsoleTokenFile,
-  type MaskedTokenEntry,
+  type RotationResult,
 } from '../web/console/consoleToken.js';
 import { env } from '../config/env.js';
 
@@ -53,9 +51,56 @@ async function promptTotpCode(): Promise<string> {
   const rl = createInterface({ input: stdin, output: stdout });
   try {
     const code = await rl.question(chalk.cyan('Enter TOTP code (or backup code): '));
-    return code.trim();
+    const trimmed = code.trim();
+    if (!trimmed) {
+      console.error(chalk.red('No confirmation code provided.'));
+      process.exit(2);
+    }
+    return trimmed;
   } finally {
     rl.close();
+  }
+}
+
+/**
+ * Shared rotation logic for both `rotate` and `revoke` commands.
+ * Initializes the store, checks TOTP enrollment, obtains the confirmation
+ * code (from --code flag or interactive prompt), and calls rotatePrimary.
+ *
+ * @param operation - 'rotation' or 'revocation' for user-facing messages
+ */
+async function executeRotation(
+  options: { json?: boolean; code?: string },
+  operation: 'rotation' | 'revocation',
+): Promise<RotationResult> {
+  const filePath = resolveTokenFilePath();
+  const store = new ConsoleTokenStore(filePath);
+  await store.ensureInitialized('CLI');
+
+  if (!store.isTotpEnrolled()) {
+    if (options.json) {
+      console.log(JSON.stringify({ error: 'TOTP enrollment required', code: 'TOTP_REQUIRED' }));
+    } else {
+      console.error(chalk.red(`Token ${operation} requires TOTP enrollment.`));
+      console.error(chalk.gray('Enroll via the Security tab or the TOTP enrollment API.'));
+    }
+    process.exit(2);
+  }
+
+  const code = options.code || await promptTotpCode();
+
+  try {
+    return await store.rotatePrimary(code);
+  } catch (err) {
+    if (err instanceof TotpError) {
+      if (options.json) {
+        console.log(JSON.stringify({ error: err.message, code: err.code }));
+      } else {
+        console.error(chalk.red(`${operation.charAt(0).toUpperCase() + operation.slice(1)} failed: ${err.message}`));
+      }
+      process.exit(2);
+    }
+    throw err;
   }
 }
 
@@ -113,50 +158,18 @@ program
   .option('--json', 'Output as JSON for scripted consumption')
   .option('--code <code>', 'TOTP confirmation code (prompts if omitted)')
   .action(async (options: { json?: boolean; code?: string }) => {
-    const filePath = resolveTokenFilePath();
-    const store = new ConsoleTokenStore(filePath);
-    await store.ensureInitialized('CLI');
-
-    if (!store.isTotpEnrolled()) {
-      if (options.json) {
-        console.log(JSON.stringify({ error: 'TOTP enrollment required', code: 'TOTP_REQUIRED' }));
-      } else {
-        console.error(chalk.red('Token rotation requires TOTP enrollment.'));
-        console.error(chalk.gray('Enroll via the Security tab or the TOTP enrollment API.'));
-      }
-      process.exit(2);
-    }
-
-    const code = options.code || await promptTotpCode();
-    if (!code) {
-      console.error(chalk.red('No confirmation code provided.'));
-      process.exit(2);
-    }
-
-    try {
-      const result = await store.rotatePrimary(code);
-      if (options.json) {
-        console.log(JSON.stringify({
-          token: result.token,
-          rotatedAt: result.rotatedAt,
-          graceUntil: result.graceUntil,
-        }, null, 2));
-      } else {
-        console.log(chalk.green('Token rotated successfully.'));
-        console.log(result.token);
-        console.log(chalk.gray(`Rotated at: ${result.rotatedAt}`));
-        console.log(chalk.gray(`Old token valid until: ${new Date(result.graceUntil).toISOString()}`));
-      }
-    } catch (err) {
-      if (err instanceof TotpError) {
-        if (options.json) {
-          console.log(JSON.stringify({ error: err.message, code: err.code }));
-        } else {
-          console.error(chalk.red('Rotation failed: ' + err.message));
-        }
-        process.exit(2);
-      }
-      throw err;
+    const result = await executeRotation(options, 'rotation');
+    if (options.json) {
+      console.log(JSON.stringify({
+        token: result.token,
+        rotatedAt: result.rotatedAt,
+        graceUntil: result.graceUntil,
+      }, null, 2));
+    } else {
+      console.log(chalk.green('Token rotated successfully.'));
+      console.log(result.token);
+      console.log(chalk.gray(`Rotated at: ${result.rotatedAt}`));
+      console.log(chalk.gray(`Old token valid until: ${new Date(result.graceUntil).toISOString()}`));
     }
   });
 
@@ -170,50 +183,18 @@ program
   .action(async (options: { json?: boolean; code?: string }) => {
     // For Phase 2 with a single primary token, revoke == rotate.
     // When multi-device tokens land, --id <uuid> removes a specific
-    // non-primary token from the store. For now, delegate to rotate.
-    const filePath = resolveTokenFilePath();
-    const store = new ConsoleTokenStore(filePath);
-    await store.ensureInitialized('CLI');
-
-    if (!store.isTotpEnrolled()) {
-      if (options.json) {
-        console.log(JSON.stringify({ error: 'TOTP enrollment required', code: 'TOTP_REQUIRED' }));
-      } else {
-        console.error(chalk.red('Token revocation requires TOTP enrollment.'));
-        console.error(chalk.gray('Enroll via the Security tab or the TOTP enrollment API.'));
-      }
-      process.exit(2);
-    }
-
-    const code = options.code || await promptTotpCode();
-    if (!code) {
-      console.error(chalk.red('No confirmation code provided.'));
-      process.exit(2);
-    }
-
-    try {
-      const result = await store.rotatePrimary(code);
-      if (options.json) {
-        console.log(JSON.stringify({
-          revoked: true,
-          newToken: result.token,
-          rotatedAt: result.rotatedAt,
-        }, null, 2));
-      } else {
-        console.log(chalk.green('Token revoked. A new token has been issued.'));
-        console.log(result.token);
-        console.log(chalk.gray('All sessions using the old token will lose access after the grace window.'));
-      }
-    } catch (err) {
-      if (err instanceof TotpError) {
-        if (options.json) {
-          console.log(JSON.stringify({ error: err.message, code: err.code }));
-        } else {
-          console.error(chalk.red('Revocation failed: ' + err.message));
-        }
-        process.exit(2);
-      }
-      throw err;
+    // non-primary token from the store.
+    const result = await executeRotation(options, 'revocation');
+    if (options.json) {
+      console.log(JSON.stringify({
+        revoked: true,
+        newToken: result.token,
+        rotatedAt: result.rotatedAt,
+      }, null, 2));
+    } else {
+      console.log(chalk.green('Token revoked. A new token has been issued.'));
+      console.log(result.token);
+      console.log(chalk.gray('All sessions using the old token will lose access after the grace window.'));
     }
   });
 

--- a/src/cli/console-token.ts
+++ b/src/cli/console-token.ts
@@ -100,7 +100,36 @@ async function executeRotation(
       }
       process.exit(2);
     }
-    throw err;
+    console.error(chalk.red(`Unexpected error during ${operation}: ${err instanceof Error ? err.message : String(err)}`));
+    process.exit(1);
+  }
+}
+
+/**
+ * Format and print the result of a rotation/revocation operation.
+ * Handles both JSON and human-readable output for rotate and revoke.
+ */
+function printRotationResult(
+  result: RotationResult,
+  options: { json?: boolean },
+  operation: 'rotation' | 'revocation',
+): void {
+  if (options.json) {
+    const output = operation === 'rotation'
+      ? { token: result.token, rotatedAt: result.rotatedAt, graceUntil: result.graceUntil }
+      : { revoked: true, newToken: result.token, rotatedAt: result.rotatedAt };
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    const successMsg = operation === 'rotation'
+      ? 'Token rotated successfully.'
+      : 'Token revoked. A new token has been issued.';
+    const statusMsg = operation === 'rotation'
+      ? `Old token valid until: ${new Date(result.graceUntil).toISOString()}`
+      : 'All sessions using the old token will lose access after the grace window.';
+    console.log(chalk.green(successMsg));
+    console.log(result.token);
+    console.log(chalk.gray(`Rotated at: ${result.rotatedAt}`));
+    console.log(chalk.gray(statusMsg));
   }
 }
 
@@ -159,18 +188,7 @@ program
   .option('--code <code>', 'TOTP confirmation code (prompts if omitted)')
   .action(async (options: { json?: boolean; code?: string }) => {
     const result = await executeRotation(options, 'rotation');
-    if (options.json) {
-      console.log(JSON.stringify({
-        token: result.token,
-        rotatedAt: result.rotatedAt,
-        graceUntil: result.graceUntil,
-      }, null, 2));
-    } else {
-      console.log(chalk.green('Token rotated successfully.'));
-      console.log(result.token);
-      console.log(chalk.gray(`Rotated at: ${result.rotatedAt}`));
-      console.log(chalk.gray(`Old token valid until: ${new Date(result.graceUntil).toISOString()}`));
-    }
+    printRotationResult(result, options, 'rotation');
   });
 
 // ── revoke ──────────────────────────────────────────────────────────────
@@ -185,17 +203,7 @@ program
     // When multi-device tokens land, --id <uuid> removes a specific
     // non-primary token from the store.
     const result = await executeRotation(options, 'revocation');
-    if (options.json) {
-      console.log(JSON.stringify({
-        revoked: true,
-        newToken: result.token,
-        rotatedAt: result.rotatedAt,
-      }, null, 2));
-    } else {
-      console.log(chalk.green('Token revoked. A new token has been issued.'));
-      console.log(result.token);
-      console.log(chalk.gray('All sessions using the old token will lose access after the grace window.'));
-    }
+    printRotationResult(result, options, 'revocation');
   });
 
 program.parse(process.argv);

--- a/src/cli/console-token.ts
+++ b/src/cli/console-token.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+
+/**
+ * CLI commands for console token management (#1790).
+ *
+ * Usage:
+ *   dollhouse console token show [--json]
+ *   dollhouse console token rotate [--json]
+ *   dollhouse console token revoke [--id <uuid>] [--json]
+ *
+ * Exit codes:
+ *   0 — success
+ *   1 — user error (missing file, invalid args)
+ *   2 — auth/confirmation failure (wrong TOTP code, not enrolled)
+ *
+ * @since v2.1.0 — Issue #1790
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { createInterface } from 'node:readline/promises';
+import { stdin, stdout } from 'node:process';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import {
+  ConsoleTokenStore,
+  readTokenFileRaw,
+  TotpError,
+  DEFAULT_TOKEN_FILE,
+  type ConsoleTokenFile,
+  type MaskedTokenEntry,
+} from '../web/console/consoleToken.js';
+import { env } from '../config/env.js';
+
+/** Resolve the token file path from env or default. */
+function resolveTokenFilePath(): string {
+  return env.DOLLHOUSE_CONSOLE_TOKEN_FILE || DEFAULT_TOKEN_FILE;
+}
+
+/** Read token file or exit with error. */
+async function readFileOrExit(filePath: string): Promise<ConsoleTokenFile> {
+  const data = await readTokenFileRaw(filePath);
+  if (!data) {
+    console.error(chalk.red('Token file not found or corrupt: ' + filePath));
+    console.error(chalk.gray('The token file is created automatically when the server starts.'));
+    process.exit(1);
+  }
+  return data;
+}
+
+/** Prompt the user for a TOTP code on stdin. */
+async function promptTotpCode(): Promise<string> {
+  const rl = createInterface({ input: stdin, output: stdout });
+  try {
+    const code = await rl.question(chalk.cyan('Enter TOTP code (or backup code): '));
+    return code.trim();
+  } finally {
+    rl.close();
+  }
+}
+
+// ── Program ─────────────────────────────────────────────────────────────
+
+const program = new Command();
+
+program
+  .name('dollhouse console token')
+  .description('Manage console authentication tokens');
+
+// ── show ────────────────────────────────────────────────────────────────
+
+program
+  .command('show')
+  .description('Print the current primary console token')
+  .option('--json', 'Output as JSON for scripted consumption')
+  .option('--masked', 'Show masked token instead of full value')
+  .action(async (options: { json?: boolean; masked?: boolean }) => {
+    const filePath = resolveTokenFilePath();
+    const data = await readFileOrExit(filePath);
+    const primary = data.tokens[0];
+    if (!primary) {
+      console.error(chalk.red('No tokens found in the token file.'));
+      process.exit(1);
+    }
+
+    if (options.json) {
+      const output: Record<string, unknown> = {
+        id: primary.id,
+        name: primary.name,
+        kind: primary.kind,
+        token: options.masked ? primary.token.slice(0, 8) + '...' : primary.token,
+        scopes: primary.scopes,
+        createdAt: primary.createdAt,
+        lastUsedAt: primary.lastUsedAt,
+        createdVia: primary.createdVia,
+        filePath,
+        totpEnrolled: data.totp.enrolled,
+      };
+      console.log(JSON.stringify(output, null, 2));
+    } else {
+      const tokenDisplay = options.masked
+        ? primary.token.slice(0, 8) + chalk.gray('•'.repeat(56))
+        : primary.token;
+      console.log(tokenDisplay);
+    }
+  });
+
+// ── rotate ──────────────────────────────────────────────────────────────
+
+program
+  .command('rotate')
+  .description('Rotate the primary console token (requires TOTP confirmation)')
+  .option('--json', 'Output as JSON for scripted consumption')
+  .option('--code <code>', 'TOTP confirmation code (prompts if omitted)')
+  .action(async (options: { json?: boolean; code?: string }) => {
+    const filePath = resolveTokenFilePath();
+    const store = new ConsoleTokenStore(filePath);
+    await store.ensureInitialized('CLI');
+
+    if (!store.isTotpEnrolled()) {
+      if (options.json) {
+        console.log(JSON.stringify({ error: 'TOTP enrollment required', code: 'TOTP_REQUIRED' }));
+      } else {
+        console.error(chalk.red('Token rotation requires TOTP enrollment.'));
+        console.error(chalk.gray('Enroll via the Security tab or the TOTP enrollment API.'));
+      }
+      process.exit(2);
+    }
+
+    const code = options.code || await promptTotpCode();
+    if (!code) {
+      console.error(chalk.red('No confirmation code provided.'));
+      process.exit(2);
+    }
+
+    try {
+      const result = await store.rotatePrimary(code);
+      if (options.json) {
+        console.log(JSON.stringify({
+          token: result.token,
+          rotatedAt: result.rotatedAt,
+          graceUntil: result.graceUntil,
+        }, null, 2));
+      } else {
+        console.log(chalk.green('Token rotated successfully.'));
+        console.log(result.token);
+        console.log(chalk.gray(`Rotated at: ${result.rotatedAt}`));
+        console.log(chalk.gray(`Old token valid until: ${new Date(result.graceUntil).toISOString()}`));
+      }
+    } catch (err) {
+      if (err instanceof TotpError) {
+        if (options.json) {
+          console.log(JSON.stringify({ error: err.message, code: err.code }));
+        } else {
+          console.error(chalk.red('Rotation failed: ' + err.message));
+        }
+        process.exit(2);
+      }
+      throw err;
+    }
+  });
+
+// ── revoke ──────────────────────────────────────────────────────────────
+
+program
+  .command('revoke')
+  .description('Revoke a token — rotates the primary to invalidate the current value')
+  .option('--json', 'Output as JSON for scripted consumption')
+  .option('--code <code>', 'TOTP confirmation code (prompts if omitted)')
+  .action(async (options: { json?: boolean; code?: string }) => {
+    // For Phase 2 with a single primary token, revoke == rotate.
+    // When multi-device tokens land, --id <uuid> removes a specific
+    // non-primary token from the store. For now, delegate to rotate.
+    const filePath = resolveTokenFilePath();
+    const store = new ConsoleTokenStore(filePath);
+    await store.ensureInitialized('CLI');
+
+    if (!store.isTotpEnrolled()) {
+      if (options.json) {
+        console.log(JSON.stringify({ error: 'TOTP enrollment required', code: 'TOTP_REQUIRED' }));
+      } else {
+        console.error(chalk.red('Token revocation requires TOTP enrollment.'));
+        console.error(chalk.gray('Enroll via the Security tab or the TOTP enrollment API.'));
+      }
+      process.exit(2);
+    }
+
+    const code = options.code || await promptTotpCode();
+    if (!code) {
+      console.error(chalk.red('No confirmation code provided.'));
+      process.exit(2);
+    }
+
+    try {
+      const result = await store.rotatePrimary(code);
+      if (options.json) {
+        console.log(JSON.stringify({
+          revoked: true,
+          newToken: result.token,
+          rotatedAt: result.rotatedAt,
+        }, null, 2));
+      } else {
+        console.log(chalk.green('Token revoked. A new token has been issued.'));
+        console.log(result.token);
+        console.log(chalk.gray('All sessions using the old token will lose access after the grace window.'));
+      }
+    } catch (err) {
+      if (err instanceof TotpError) {
+        if (options.json) {
+          console.log(JSON.stringify({ error: err.message, code: err.code }));
+        } else {
+          console.error(chalk.red('Revocation failed: ' + err.message));
+        }
+        process.exit(2);
+      }
+      throw err;
+    }
+  });
+
+program.parse(process.argv);

--- a/tests/unit/cli/console-token.test.ts
+++ b/tests/unit/cli/console-token.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for the console token CLI commands (#1790).
+ *
+ * These tests exercise the CLI logic by constructing a real
+ * ConsoleTokenStore backed by a temp file, then calling the store
+ * methods that the CLI commands invoke. We test the store interaction
+ * layer, not the Commander.js argument parsing (which is covered by
+ * Commander's own tests).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Secret, TOTP } from 'otpauth';
+import {
+  ConsoleTokenStore,
+  readTokenFileRaw,
+  TotpError,
+} from '../../../src/web/console/consoleToken.js';
+
+function currentTotpCode(base32Secret: string): string {
+  const totp = new TOTP({
+    issuer: 'DollhouseMCP',
+    label: 'test',
+    algorithm: 'SHA1',
+    digits: 6,
+    period: 30,
+    secret: Secret.fromBase32(base32Secret),
+  });
+  return totp.generate();
+}
+
+async function enrollTotp(store: ConsoleTokenStore): Promise<string> {
+  const begin = store.beginTotpEnrollment();
+  await store.confirmTotpEnrollment(begin.pendingId, currentTotpCode(begin.secret));
+  return begin.secret;
+}
+
+describe('console token CLI operations', () => {
+  let testDir: string;
+  let tokenFilePath: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'dollhouse-cli-token-test-'));
+    tokenFilePath = join(testDir, 'console-token.auth.json');
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('show', () => {
+    it('reads the primary token from the file', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      const entry = await store.ensureInitialized('Kermit');
+
+      const data = await readTokenFileRaw(tokenFilePath);
+      expect(data).not.toBeNull();
+      expect(data!.tokens[0].token).toBe(entry.token);
+      expect(data!.tokens[0].token).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('returns null for a missing file', async () => {
+      const data = await readTokenFileRaw(join(testDir, 'nonexistent.json'));
+      expect(data).toBeNull();
+    });
+
+    it('provides masked view via listMasked', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      await store.ensureInitialized('Kermit');
+
+      const masked = store.listMasked();
+      expect(masked).toHaveLength(1);
+      expect(masked[0].tokenPreview).toMatch(/^[0-9a-f]{8}•+$/);
+      expect(masked[0]).not.toHaveProperty('token');
+    });
+
+    it('includes TOTP status in file data', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      await store.ensureInitialized('Kermit');
+
+      const data = await readTokenFileRaw(tokenFilePath);
+      expect(data!.totp.enrolled).toBe(false);
+    });
+  });
+
+  describe('rotate', () => {
+    it('rotates with a valid TOTP code', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      const entry = await store.ensureInitialized('Kermit');
+      const originalToken = entry.token;
+      const secret = await enrollTotp(store);
+
+      const result = await store.rotatePrimary(currentTotpCode(secret));
+      expect(result.token).toMatch(/^[0-9a-f]{64}$/);
+      expect(result.token).not.toBe(originalToken);
+      expect(result.rotatedAt).toBeTruthy();
+    });
+
+    it('rejects when TOTP is not enrolled', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      await store.ensureInitialized('Kermit');
+
+      await expect(store.rotatePrimary('123456')).rejects.toThrow(TotpError);
+      try {
+        await store.rotatePrimary('123456');
+      } catch (err) {
+        expect((err as TotpError).code).toBe('TOTP_REQUIRED');
+      }
+    });
+
+    it('rejects with a wrong code', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      await store.ensureInitialized('Kermit');
+      await enrollTotp(store);
+
+      await expect(store.rotatePrimary('000000')).rejects.toThrow(TotpError);
+      try {
+        await store.rotatePrimary('000000');
+      } catch (err) {
+        expect((err as TotpError).code).toBe('INVALID_TOTP_CODE');
+      }
+    });
+
+    it('persists new token to disk after rotation', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      await store.ensureInitialized('Kermit');
+      const secret = await enrollTotp(store);
+
+      const result = await store.rotatePrimary(currentTotpCode(secret));
+      const data = await readTokenFileRaw(tokenFilePath);
+      expect(data!.tokens[0].token).toBe(result.token);
+      expect(data!.tokens[0].createdVia).toBe('rotation');
+    });
+  });
+
+  describe('revoke (delegates to rotate)', () => {
+    it('revokes by rotating the primary token', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      const entry = await store.ensureInitialized('Kermit');
+      const originalToken = entry.token;
+      const secret = await enrollTotp(store);
+
+      // Revoke == rotate for the single-token case
+      const result = await store.rotatePrimary(currentTotpCode(secret));
+      expect(result.token).not.toBe(originalToken);
+
+      // Old token should not verify after grace expires
+      // (verified in store tests; here we just confirm the operation succeeded)
+      expect(store.verify(result.token)).not.toBeNull();
+    });
+  });
+
+  describe('JSON output structure', () => {
+    it('show JSON includes expected fields', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      const entry = await store.ensureInitialized('Kermit');
+
+      const data = await readTokenFileRaw(tokenFilePath);
+      const primary = data!.tokens[0];
+      // Simulate the JSON output structure from the CLI
+      const output = {
+        id: primary.id,
+        name: primary.name,
+        kind: primary.kind,
+        token: primary.token,
+        scopes: primary.scopes,
+        createdAt: primary.createdAt,
+        lastUsedAt: primary.lastUsedAt,
+        createdVia: primary.createdVia,
+        filePath: tokenFilePath,
+        totpEnrolled: data!.totp.enrolled,
+      };
+      expect(output.id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(output.token).toMatch(/^[0-9a-f]{64}$/);
+      expect(output.kind).toBe('console');
+      expect(output.totpEnrolled).toBe(false);
+    });
+
+    it('rotate JSON includes token and timing', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      await store.ensureInitialized('Kermit');
+      const secret = await enrollTotp(store);
+
+      const result = await store.rotatePrimary(currentTotpCode(secret));
+      const output = {
+        token: result.token,
+        rotatedAt: result.rotatedAt,
+        graceUntil: result.graceUntil,
+      };
+      expect(output.token).toMatch(/^[0-9a-f]{64}$/);
+      expect(output.rotatedAt).toBeTruthy();
+      expect(output.graceUntil).toBeGreaterThan(Date.now());
+    });
+  });
+});

--- a/tests/unit/cli/console-token.test.ts
+++ b/tests/unit/cli/console-token.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Secret, TOTP } from 'otpauth';
@@ -155,7 +155,7 @@ describe('console token CLI operations', () => {
   describe('JSON output structure', () => {
     it('show JSON includes expected fields', async () => {
       const store = new ConsoleTokenStore(tokenFilePath);
-      const entry = await store.ensureInitialized('Kermit');
+      await store.ensureInitialized('Kermit');
 
       const data = await readTokenFileRaw(tokenFilePath);
       const primary = data!.tokens[0];

--- a/tests/unit/cli/console-token.test.ts
+++ b/tests/unit/cli/console-token.test.ts
@@ -37,6 +37,56 @@ async function enrollTotp(store: ConsoleTokenStore): Promise<string> {
   return begin.secret;
 }
 
+/**
+ * Replicate the CLI's code format validation logic for testing.
+ * Matches the check in promptTotpCode (console-token.ts:55-64).
+ */
+function isValidCodeFormat(raw: string): boolean {
+  const trimmed = raw.trim().replaceAll(/[\s-]/g, '');
+  if (!trimmed) return false;
+  return /^\d{6}$/.test(trimmed) || /^[0-9A-Za-z]{8}$/.test(trimmed);
+}
+
+describe('TOTP code format validation', () => {
+  it('accepts a 6-digit TOTP code', () => {
+    expect(isValidCodeFormat('123456')).toBe(true);
+  });
+
+  it('accepts an 8-character alphanumeric backup code', () => {
+    expect(isValidCodeFormat('ABCD1234')).toBe(true);
+  });
+
+  it('accepts backup codes with dashes stripped', () => {
+    expect(isValidCodeFormat('ABCD-1234')).toBe(true);
+  });
+
+  it('accepts backup codes with spaces stripped', () => {
+    expect(isValidCodeFormat('ABCD 1234')).toBe(true);
+  });
+
+  it('accepts lowercase backup codes', () => {
+    expect(isValidCodeFormat('abcd1234')).toBe(true);
+  });
+
+  it('rejects empty input', () => {
+    expect(isValidCodeFormat('')).toBe(false);
+    expect(isValidCodeFormat('   ')).toBe(false);
+  });
+
+  it('rejects codes that are too short', () => {
+    expect(isValidCodeFormat('12345')).toBe(false);
+  });
+
+  it('rejects codes that are too long', () => {
+    expect(isValidCodeFormat('1234567')).toBe(false);
+    expect(isValidCodeFormat('ABCDE12345')).toBe(false);
+  });
+
+  it('rejects non-alphanumeric characters', () => {
+    expect(isValidCodeFormat('ABC!1234')).toBe(false);
+  });
+});
+
 describe('console token CLI operations', () => {
   let testDir: string;
   let tokenFilePath: string;
@@ -152,6 +202,41 @@ describe('console token CLI operations', () => {
     });
   });
 
+  describe('show --masked', () => {
+    it('masks the token to first 8 chars for JSON output', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      await store.ensureInitialized('Kermit');
+
+      const data = await readTokenFileRaw(tokenFilePath);
+      const primary = data!.tokens[0];
+      const masked = primary.token.slice(0, 8) + '...';
+      expect(masked).toHaveLength(11);
+      expect(masked).toMatch(/^[0-9a-f]{8}\.\.\.$/);
+    });
+
+    it('masks the token to first 8 chars for terminal output', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      await store.ensureInitialized('Kermit');
+
+      const data = await readTokenFileRaw(tokenFilePath);
+      const primary = data!.tokens[0];
+      const masked = primary.token.slice(0, 8) + '\u2022'.repeat(56);
+      expect(masked).toHaveLength(64);
+      expect(masked.slice(0, 8)).toMatch(/^[0-9a-f]{8}$/);
+    });
+  });
+
+  describe('show with TOTP enrolled', () => {
+    it('reports totpEnrolled: true after enrollment', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      await store.ensureInitialized('Kermit');
+      await enrollTotp(store);
+
+      const data = await readTokenFileRaw(tokenFilePath);
+      expect(data!.totp.enrolled).toBe(true);
+    });
+  });
+
   describe('JSON output structure', () => {
     it('show JSON includes expected fields', async () => {
       const store = new ConsoleTokenStore(tokenFilePath);
@@ -192,6 +277,68 @@ describe('console token CLI operations', () => {
       expect(output.token).toMatch(/^[0-9a-f]{64}$/);
       expect(output.rotatedAt).toBeTruthy();
       expect(output.graceUntil).toBeGreaterThan(Date.now());
+    });
+
+    it('revoke JSON includes revoked flag and new token', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      await store.ensureInitialized('Kermit');
+      const secret = await enrollTotp(store);
+
+      const result = await store.rotatePrimary(currentTotpCode(secret));
+      const output = {
+        revoked: true,
+        newToken: result.token,
+        rotatedAt: result.rotatedAt,
+      };
+      expect(output.revoked).toBe(true);
+      expect(output.newToken).toMatch(/^[0-9a-f]{64}$/);
+      expect(output.rotatedAt).toBeTruthy();
+    });
+
+    it('rotate and revoke JSON have different shapes', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      await store.ensureInitialized('Kermit');
+      const secret = await enrollTotp(store);
+
+      const result = await store.rotatePrimary(currentTotpCode(secret));
+      const rotateJson = { token: result.token, rotatedAt: result.rotatedAt, graceUntil: result.graceUntil };
+      const revokeJson = { revoked: true, newToken: result.token, rotatedAt: result.rotatedAt };
+
+      // Rotate exposes graceUntil, revoke does not
+      expect(rotateJson).toHaveProperty('graceUntil');
+      expect(revokeJson).not.toHaveProperty('graceUntil');
+      // Revoke has revoked flag, rotate does not
+      expect(revokeJson).toHaveProperty('revoked', true);
+      expect(rotateJson).not.toHaveProperty('revoked');
+    });
+  });
+
+  describe('error code classification', () => {
+    it('TOTP_REQUIRED has the correct error code', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      await store.ensureInitialized('Kermit');
+
+      try {
+        await store.rotatePrimary('123456');
+        fail('Expected TotpError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(TotpError);
+        expect((err as TotpError).code).toBe('TOTP_REQUIRED');
+      }
+    });
+
+    it('INVALID_TOTP_CODE has the correct error code', async () => {
+      const store = new ConsoleTokenStore(tokenFilePath);
+      await store.ensureInitialized('Kermit');
+      await enrollTotp(store);
+
+      try {
+        await store.rotatePrimary('000000');
+        fail('Expected TotpError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(TotpError);
+        expect((err as TotpError).code).toBe('INVALID_TOTP_CODE');
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `dollhouse-console-token` CLI with `show`, `rotate`, and `revoke` subcommands
- All commands support `--json` for scripted/headless consumption
- `rotate` and `revoke` require TOTP confirmation (interactive prompt or `--code` flag)
- Exit codes: 0 success, 1 user error, 2 auth/confirmation failure

## Details

**`show`** — prints the primary token value (raw by default, `--masked` for screen-safe, `--json` with full metadata including TOTP enrollment status)

**`rotate`** — calls `ConsoleTokenStore.rotatePrimary()` with TOTP confirmation. Prompts for code on stdin or accepts `--code <code>` for non-interactive use.

**`revoke`** — same as rotate for the single-token case. When multi-device tokens land, `--id <uuid>` will remove a specific non-primary token. For now, revoke == rotate-to-invalidate.

**Tests:** 11 unit tests covering all operations, error cases (TOTP not enrolled, wrong code), and JSON output structure. 520 total (509 web + 11 CLI).

**Docs:** CLI section added to `console-auth.md` with examples for all subcommands.

## Test plan

- [x] `npx tsc --noEmit` — clean typecheck
- [x] `npx jest tests/unit/cli/console-token.test.ts` — 11 tests pass
- [x] `npx jest tests/unit/web/ tests/unit/cli/` — 520 tests pass

Closes #1790

🤖 Generated with [Claude Code](https://claude.com/claude-code)