### PR TITLE
feat: triage Dependabot alerts, add osv-scanner and dependency-review (#1800)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,16 @@
+name: Dependency Review
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate
+          fail-on-scopes: runtime

--- a/.github/workflows/ghsa-monitor.yml
+++ b/.github/workflows/ghsa-monitor.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check dismissed GHSAs for updates
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -28,24 +29,31 @@ jobs:
             echo "Checking $GHSA..."
 
             # Query OSV.dev API for current vulnerability state
-            RESPONSE=$(curl -s "https://api.osv.dev/v1/vulns/$GHSA")
+            OSV_RESPONSE=$(curl -s "https://api.osv.dev/v1/vulns/$GHSA")
 
-            # Check if the vulnerability has been withdrawn
-            WITHDRAWN=$(echo "$RESPONSE" | jq -r '.withdrawn // empty')
-            if [ -n "$WITHDRAWN" ]; then
-              CHANGES_FOUND="${CHANGES_FOUND}\n- **$GHSA**: Withdrawn on $WITHDRAWN (can be removed from osv-scanner.toml)"
+            # Query GitHub Advisory Database for additional coverage
+            GH_RESPONSE=$(curl -s -H "Authorization: bearer $GH_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "{\"query\": \"{ securityAdvisory(ghsaId: \\\"$GHSA\\\") { withdrawnAt, severity, cvss { score }, updatedAt } }\"}" \
+              https://api.github.com/graphql 2>/dev/null)
+
+            # Check if the vulnerability has been withdrawn (either source)
+            OSV_WITHDRAWN=$(echo "$OSV_RESPONSE" | jq -r '.withdrawn // empty')
+            GH_WITHDRAWN=$(echo "$GH_RESPONSE" | jq -r '.data.securityAdvisory.withdrawnAt // empty' 2>/dev/null)
+
+            if [ -n "$OSV_WITHDRAWN" ] || [ -n "$GH_WITHDRAWN" ]; then
+              WITHDRAWN_DATE="${OSV_WITHDRAWN:-$GH_WITHDRAWN}"
+              CHANGES_FOUND="${CHANGES_FOUND}\n- **$GHSA**: Withdrawn on $WITHDRAWN_DATE (can be removed from osv-scanner.toml)"
               continue
             fi
 
-            # Check if severity has changed (compare with our documented assessment)
-            SEVERITY=$(echo "$RESPONSE" | jq -r '
-              .severity[]? |
-              select(.type == "CVSS_V3") |
-              .score // empty
-            ' 2>/dev/null | head -1)
+            # Check if severity changed on GitHub Advisory Database
+            GH_SEVERITY=$(echo "$GH_RESPONSE" | jq -r '.data.securityAdvisory.severity // empty' 2>/dev/null)
+            GH_CVSS=$(echo "$GH_RESPONSE" | jq -r '.data.securityAdvisory.cvss.score // empty' 2>/dev/null)
+            GH_UPDATED=$(echo "$GH_RESPONSE" | jq -r '.data.securityAdvisory.updatedAt // empty' 2>/dev/null)
 
             # Check if affected versions have changed (new fix available)
-            HAS_FIX=$(echo "$RESPONSE" | jq -r '
+            HAS_FIX=$(echo "$OSV_RESPONSE" | jq -r '
               .affected[]? |
               .ranges[]? |
               .events[]? |
@@ -53,10 +61,10 @@ jobs:
               .fixed
             ' 2>/dev/null | head -1)
 
+            OSV_MODIFIED=$(echo "$OSV_RESPONSE" | jq -r '.modified // empty')
+
             if [ -n "$HAS_FIX" ]; then
-              # Check if this is a new fix we haven't seen
-              MODIFIED=$(echo "$RESPONSE" | jq -r '.modified // empty')
-              CHANGES_FOUND="${CHANGES_FOUND}\n- **$GHSA**: Fix available (version $HAS_FIX), last modified $MODIFIED"
+              CHANGES_FOUND="${CHANGES_FOUND}\n- **$GHSA**: Fix available (version $HAS_FIX), last modified $OSV_MODIFIED (CVSS: ${GH_CVSS:-unknown})"
             fi
           done
 
@@ -69,8 +77,30 @@ jobs:
             echo "No changes detected in dismissed GHSAs."
           fi
 
-      - name: Create issue if changes detected
+      - name: Check for duplicate issues
         if: env.changes_found == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Search for open issues with the same title prefix to avoid duplicates
+          EXISTING=$(gh issue list \
+            --label "security" \
+            --state open \
+            --search "Security: Dismissed GHSA updates detected" \
+            --json number \
+            --jq 'length')
+
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "duplicate=true" >> "$GITHUB_ENV"
+            echo "Skipping issue creation — an open GHSA reclassification issue already exists."
+          else
+            echo "duplicate=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Create issue if changes detected
+        if: env.changes_found == 'true' && env.duplicate == 'false'
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -82,6 +112,7 @@ jobs:
           ## Dismissed GHSA Reclassification Alert
 
           The weekly GHSA monitor detected changes to vulnerabilities we previously dismissed in \`osv-scanner.toml\`.
+          Sources checked: **OSV.dev** and **GitHub Advisory Database**.
 
           ### Changes Detected
           ${CHANGES}

--- a/.github/workflows/ghsa-monitor.yml
+++ b/.github/workflows/ghsa-monitor.yml
@@ -37,9 +37,21 @@ jobs:
               -d "{\"query\": \"{ securityAdvisory(ghsaId: \\\"$GHSA\\\") { withdrawnAt, severity, cvss { score }, updatedAt } }\"}" \
               https://api.github.com/graphql 2>/dev/null)
 
+            # Validate GraphQL response — skip GitHub data if errors or null
+            GH_VALID="true"
+            GH_ERRORS=$(echo "$GH_RESPONSE" | jq -r '.errors // empty' 2>/dev/null)
+            GH_DATA=$(echo "$GH_RESPONSE" | jq -r '.data.securityAdvisory // empty' 2>/dev/null)
+            if [ -n "$GH_ERRORS" ] || [ -z "$GH_DATA" ]; then
+              echo "  Warning: GitHub Advisory DB returned no data for $GHSA (falling back to OSV.dev only)"
+              GH_VALID="false"
+            fi
+
             # Check if the vulnerability has been withdrawn (either source)
             OSV_WITHDRAWN=$(echo "$OSV_RESPONSE" | jq -r '.withdrawn // empty')
-            GH_WITHDRAWN=$(echo "$GH_RESPONSE" | jq -r '.data.securityAdvisory.withdrawnAt // empty' 2>/dev/null)
+            GH_WITHDRAWN=""
+            if [ "$GH_VALID" = "true" ]; then
+              GH_WITHDRAWN=$(echo "$GH_RESPONSE" | jq -r '.data.securityAdvisory.withdrawnAt // empty' 2>/dev/null)
+            fi
 
             if [ -n "$OSV_WITHDRAWN" ] || [ -n "$GH_WITHDRAWN" ]; then
               WITHDRAWN_DATE="${OSV_WITHDRAWN:-$GH_WITHDRAWN}"
@@ -47,10 +59,11 @@ jobs:
               continue
             fi
 
-            # Check if severity changed on GitHub Advisory Database
-            GH_SEVERITY=$(echo "$GH_RESPONSE" | jq -r '.data.securityAdvisory.severity // empty' 2>/dev/null)
-            GH_CVSS=$(echo "$GH_RESPONSE" | jq -r '.data.securityAdvisory.cvss.score // empty' 2>/dev/null)
-            GH_UPDATED=$(echo "$GH_RESPONSE" | jq -r '.data.securityAdvisory.updatedAt // empty' 2>/dev/null)
+            # Extract severity from GitHub Advisory Database (if available)
+            GH_CVSS="unknown"
+            if [ "$GH_VALID" = "true" ]; then
+              GH_CVSS=$(echo "$GH_RESPONSE" | jq -r '.data.securityAdvisory.cvss.score // "unknown"' 2>/dev/null)
+            fi
 
             # Check if affected versions have changed (new fix available)
             HAS_FIX=$(echo "$OSV_RESPONSE" | jq -r '

--- a/.github/workflows/ghsa-monitor.yml
+++ b/.github/workflows/ghsa-monitor.yml
@@ -1,0 +1,99 @@
+name: GHSA Reclassification Monitor
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Every Monday at 9 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-ghsa-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check dismissed GHSAs for updates
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Extract GHSA IDs from osv-scanner.toml
+          GHSA_IDS=$(grep '^id = ' osv-scanner.toml | sed 's/id = "//;s/"//' | sort -u)
+
+          CHANGES_FOUND=""
+
+          for GHSA in $GHSA_IDS; do
+            echo "Checking $GHSA..."
+
+            # Query OSV.dev API for current vulnerability state
+            RESPONSE=$(curl -s "https://api.osv.dev/v1/vulns/$GHSA")
+
+            # Check if the vulnerability has been withdrawn
+            WITHDRAWN=$(echo "$RESPONSE" | jq -r '.withdrawn // empty')
+            if [ -n "$WITHDRAWN" ]; then
+              CHANGES_FOUND="${CHANGES_FOUND}\n- **$GHSA**: Withdrawn on $WITHDRAWN (can be removed from osv-scanner.toml)"
+              continue
+            fi
+
+            # Check if severity has changed (compare with our documented assessment)
+            SEVERITY=$(echo "$RESPONSE" | jq -r '
+              .severity[]? |
+              select(.type == "CVSS_V3") |
+              .score // empty
+            ' 2>/dev/null | head -1)
+
+            # Check if affected versions have changed (new fix available)
+            HAS_FIX=$(echo "$RESPONSE" | jq -r '
+              .affected[]? |
+              .ranges[]? |
+              .events[]? |
+              select(.fixed) |
+              .fixed
+            ' 2>/dev/null | head -1)
+
+            if [ -n "$HAS_FIX" ]; then
+              # Check if this is a new fix we haven't seen
+              MODIFIED=$(echo "$RESPONSE" | jq -r '.modified // empty')
+              CHANGES_FOUND="${CHANGES_FOUND}\n- **$GHSA**: Fix available (version $HAS_FIX), last modified $MODIFIED"
+            fi
+          done
+
+          if [ -n "$CHANGES_FOUND" ]; then
+            echo "changes_found=true" >> "$GITHUB_ENV"
+            # Write to file for the next step (avoids env var escaping issues)
+            printf "%b" "$CHANGES_FOUND" > /tmp/ghsa-changes.txt
+          else
+            echo "changes_found=false" >> "$GITHUB_ENV"
+            echo "No changes detected in dismissed GHSAs."
+          fi
+
+      - name: Create issue if changes detected
+        if: env.changes_found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CHANGES=$(cat /tmp/ghsa-changes.txt)
+          gh issue create \
+            --title "Security: Dismissed GHSA updates detected ($(date +%Y-%m-%d))" \
+            --label "security" \
+            --body "$(cat <<EOF
+          ## Dismissed GHSA Reclassification Alert
+
+          The weekly GHSA monitor detected changes to vulnerabilities we previously dismissed in \`osv-scanner.toml\`.
+
+          ### Changes Detected
+          ${CHANGES}
+
+          ### Action Required
+          Review each change and determine if:
+          1. The vulnerability should be **re-opened** in Dependabot
+          2. The \`osv-scanner.toml\` entry should be **updated or removed**
+          3. A dependency **upgrade** is now available and should be applied
+
+          ### References
+          - [Original triage: #1800](https://github.com/DollhouseMCP/mcp-server/issues/1800)
+          - [osv-scanner.toml](../blob/develop/osv-scanner.toml)
+          EOF
+          )"

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -16,6 +16,7 @@
 # --- handlebars (7 alerts) ---
 # Dev dependency only — transitive dep of ts-jest.
 # Never imported by source code, does not ship to production.
+# Last modified upstream: 2026-03-28 to 2026-03-30
 
 [[IgnoredVulns]]
 id = "GHSA-2w6w-674q-4c4q"
@@ -49,6 +50,7 @@ reason = "handlebars is a dev-only transitive dep of ts-jest. Never imported by 
 # Transitive dep via install-mcp → giget → tar@6.2.1.
 # install-mcp's runtime code (dist/run.js) never imports giget or tar.
 # The library is installed but never loaded. Dead code path.
+# Last modified upstream: 2026-02-04 to 2026-03-16
 
 [[IgnoredVulns]]
 id = "GHSA-9ppj-qmqm-q256"
@@ -77,6 +79,7 @@ reason = "tar is a transitive dep via install-mcp→giget. install-mcp never imp
 # --- lodash (2 alerts) ---
 # Dev dependency only — transitive dep of archiver (used only in tests).
 # No source code imports lodash. Does not ship to production.
+# Last modified upstream: 2026-04-02
 
 [[IgnoredVulns]]
 id = "GHSA-r5fr-rjxr-66jc"
@@ -90,6 +93,7 @@ reason = "lodash is a dev-only transitive dep of archiver (used only in tests). 
 # Runtime dep via Express 5.2.1, but server binds exclusively to 127.0.0.1
 # with static route patterns. No user-controlled route registration.
 # ReDoS requires complex optional groups we don't define.
+# Last modified upstream: 2026-03-30
 
 [[IgnoredVulns]]
 id = "GHSA-27v5-c462-wpq7"
@@ -102,6 +106,7 @@ reason = "Express server binds to 127.0.0.1 only with static route patterns. No 
 # --- picomatch (3 alerts, 1 GHSA ID) ---
 # Dev dependency only — transitive dep of jest/eslint.
 # Does not ship to production.
+# Last modified upstream: 2026-03-28
 
 [[IgnoredVulns]]
 id = "GHSA-3v7f-55p6-f55p"

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -5,6 +5,13 @@
 #
 # Analysis date: 2026-04-06
 # Related issue: https://github.com/DollhouseMCP/mcp-server/issues/1800
+#
+# Total dismissed: 20 alerts across 5 packages (as of 2026-04-06)
+#   handlebars: 7 (dev-only, ts-jest transitive)
+#   tar:        6 (dead code, install-mcp→giget never imported)
+#   picomatch:  3 (dev-only, jest/eslint transitive)
+#   lodash:     2 (dev-only, archiver transitive)
+#   path-to-regexp: 2 (tolerable risk, localhost + static routes)
 
 # --- handlebars (7 alerts) ---
 # Dev dependency only — transitive dep of ts-jest.

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,101 @@
+# OSV-Scanner Ignore Configuration
+# Purpose: OpenSSF Scorecard queries OSV.dev independently of Dependabot.
+# Dismissing Dependabot alerts has no effect on the Scorecard Vulnerabilities
+# score — only osv-scanner.toml entries are respected.
+#
+# Analysis date: 2026-04-06
+# Related issue: https://github.com/DollhouseMCP/mcp-server/issues/1800
+
+# --- handlebars (7 alerts) ---
+# Dev dependency only — transitive dep of ts-jest.
+# Never imported by source code, does not ship to production.
+
+[[IgnoredVulns]]
+id = "GHSA-2w6w-674q-4c4q"
+reason = "handlebars is a dev-only transitive dep of ts-jest. Never imported by source code, does not ship to production."
+
+[[IgnoredVulns]]
+id = "GHSA-xhpv-hc6g-r9c6"
+reason = "handlebars is a dev-only transitive dep of ts-jest. Never imported by source code, does not ship to production."
+
+[[IgnoredVulns]]
+id = "GHSA-xjpj-3mr7-gcpf"
+reason = "handlebars is a dev-only transitive dep of ts-jest. Never imported by source code, does not ship to production."
+
+[[IgnoredVulns]]
+id = "GHSA-3mfm-83xf-c92r"
+reason = "handlebars is a dev-only transitive dep of ts-jest. Never imported by source code, does not ship to production."
+
+[[IgnoredVulns]]
+id = "GHSA-7rx3-28cr-v5wh"
+reason = "handlebars is a dev-only transitive dep of ts-jest. Never imported by source code, does not ship to production."
+
+[[IgnoredVulns]]
+id = "GHSA-442j-39wm-28r2"
+reason = "handlebars is a dev-only transitive dep of ts-jest. Never imported by source code, does not ship to production."
+
+[[IgnoredVulns]]
+id = "GHSA-2qvq-rjwj-gvw9"
+reason = "handlebars is a dev-only transitive dep of ts-jest. Never imported by source code, does not ship to production."
+
+# --- tar (6 alerts) ---
+# Transitive dep via install-mcp → giget → tar@6.2.1.
+# install-mcp's runtime code (dist/run.js) never imports giget or tar.
+# The library is installed but never loaded. Dead code path.
+
+[[IgnoredVulns]]
+id = "GHSA-9ppj-qmqm-q256"
+reason = "tar is a transitive dep via install-mcp→giget. install-mcp never imports giget at runtime — dead code path."
+
+[[IgnoredVulns]]
+id = "GHSA-qffp-2rhf-9h96"
+reason = "tar is a transitive dep via install-mcp→giget. install-mcp never imports giget at runtime — dead code path."
+
+[[IgnoredVulns]]
+id = "GHSA-83g3-92jg-28cx"
+reason = "tar is a transitive dep via install-mcp→giget. install-mcp never imports giget at runtime — dead code path."
+
+[[IgnoredVulns]]
+id = "GHSA-34x7-hfp2-rc4v"
+reason = "tar is a transitive dep via install-mcp→giget. install-mcp never imports giget at runtime — dead code path."
+
+[[IgnoredVulns]]
+id = "GHSA-r6q2-hw4h-h46w"
+reason = "tar is a transitive dep via install-mcp→giget. install-mcp never imports giget at runtime — dead code path."
+
+[[IgnoredVulns]]
+id = "GHSA-8qq5-rm4j-mr97"
+reason = "tar is a transitive dep via install-mcp→giget. install-mcp never imports giget at runtime — dead code path."
+
+# --- lodash (2 alerts) ---
+# Dev dependency only — transitive dep of archiver (used only in tests).
+# No source code imports lodash. Does not ship to production.
+
+[[IgnoredVulns]]
+id = "GHSA-r5fr-rjxr-66jc"
+reason = "lodash is a dev-only transitive dep of archiver (used only in tests). Does not ship to production."
+
+[[IgnoredVulns]]
+id = "GHSA-f23m-r3pf-42rh"
+reason = "lodash is a dev-only transitive dep of archiver (used only in tests). Does not ship to production."
+
+# --- path-to-regexp (2 alerts) ---
+# Runtime dep via Express 5.2.1, but server binds exclusively to 127.0.0.1
+# with static route patterns. No user-controlled route registration.
+# ReDoS requires complex optional groups we don't define.
+
+[[IgnoredVulns]]
+id = "GHSA-27v5-c462-wpq7"
+reason = "Express server binds to 127.0.0.1 only with static route patterns. No user-controlled routing. Will resolve with Express router update."
+
+[[IgnoredVulns]]
+id = "GHSA-j3q9-mxjg-w52f"
+reason = "Express server binds to 127.0.0.1 only with static route patterns. No user-controlled routing. Will resolve with Express router update."
+
+# --- picomatch (3 alerts, 1 GHSA ID) ---
+# Dev dependency only — transitive dep of jest/eslint.
+# Does not ship to production.
+
+[[IgnoredVulns]]
+id = "GHSA-3v7f-55p6-f55p"
+reason = "picomatch is a dev-only transitive dep of jest/eslint. Does not ship to production."

--- a/tests/unit/osv-scanner-config.test.ts
+++ b/tests/unit/osv-scanner-config.test.ts
@@ -1,0 +1,81 @@
+/**
+ * OSV Scanner Configuration Validation Tests
+ *
+ * Validates that osv-scanner.toml is well-formed and all entries
+ * follow the expected structure. Catches manual edit mistakes before
+ * they silently break OpenSSF Scorecard triage.
+ */
+
+import { describe, expect, it, beforeAll } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const OSV_SCANNER_PATH = path.resolve(__dirname, '../../osv-scanner.toml');
+
+describe('OSV Scanner Configuration', () => {
+  let content: string;
+
+  beforeAll(() => {
+    content = fs.readFileSync(OSV_SCANNER_PATH, 'utf-8');
+  });
+
+  it('should exist at the repo root', () => {
+    expect(fs.existsSync(OSV_SCANNER_PATH)).toBe(true);
+  });
+
+  it('should be valid TOML with only [[IgnoredVulns]] blocks', () => {
+    // Every non-comment, non-blank line should be either a section header or a key = value
+    const lines = content.split('\n').filter(l => l.trim() && !l.trim().startsWith('#'));
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      const isSection = trimmed === '[[IgnoredVulns]]';
+      const isKeyValue = /^(id|reason)\s*=\s*".*"$/.test(trimmed);
+      expect(isSection || isKeyValue).toBe(true);
+    }
+  });
+
+  it('should have valid GHSA ID format for every entry', () => {
+    const idMatches = content.match(/^id\s*=\s*"(.+)"/gm) || [];
+    expect(idMatches.length).toBeGreaterThan(0);
+
+    for (const match of idMatches) {
+      const id = match.replace(/^id\s*=\s*"/, '').replace(/"$/, '');
+      expect(id).toMatch(/^GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}$/);
+    }
+  });
+
+  it('should have a reason for every GHSA entry', () => {
+    const ids = (content.match(/^id\s*=\s*"/gm) || []).length;
+    const reasons = (content.match(/^reason\s*=\s*"/gm) || []).length;
+    expect(ids).toBe(reasons);
+  });
+
+  it('should have each [[IgnoredVulns]] block contain exactly one id and one reason', () => {
+    // Split by section headers and validate each block
+    const blocks = content.split('[[IgnoredVulns]]').slice(1); // skip header
+    expect(blocks.length).toBeGreaterThan(0);
+
+    for (const block of blocks) {
+      const lines = block.split('\n').filter(l => l.trim() && !l.trim().startsWith('#'));
+      const idLines = lines.filter(l => l.trim().startsWith('id'));
+      const reasonLines = lines.filter(l => l.trim().startsWith('reason'));
+
+      expect(idLines).toHaveLength(1);
+      expect(reasonLines).toHaveLength(1);
+    }
+  });
+
+  it('should have no duplicate GHSA IDs', () => {
+    const idMatches = content.match(/^id\s*=\s*"(.+)"/gm) || [];
+    const ids = idMatches.map(m => m.replace(/^id\s*=\s*"/, '').replace(/"$/, ''));
+    const unique = new Set(ids);
+    expect(ids.length).toBe(unique.size);
+  });
+
+  it('should have a header with analysis date and issue reference', () => {
+    expect(content).toContain('Analysis date:');
+    expect(content).toContain('Related issue:');
+    expect(content).toContain('issues/1800');
+  });
+});

--- a/tests/unit/osv-scanner-config.test.ts
+++ b/tests/unit/osv-scanner-config.test.ts
@@ -7,10 +7,10 @@
  */
 
 import { describe, expect, it, beforeAll } from '@jest/globals';
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
-const OSV_SCANNER_PATH = path.resolve(__dirname, '../../osv-scanner.toml');
+const OSV_SCANNER_PATH = path.join(process.cwd(), 'osv-scanner.toml');
 
 describe('OSV Scanner Configuration', () => {
   let content: string;


### PR DESCRIPTION
## Summary
- **Dismissed all 20 open Dependabot alerts** with documented reasons via API — 18 as `not_used` (dev-only or dead code), 2 as `tolerable_risk` (path-to-regexp, mitigated by localhost binding + static routes)
- **Added `osv-scanner.toml`** with 18 GHSA ignore entries so OpenSSF Scorecard respects the same triage (Scorecard queries OSV.dev independently of Dependabot)
- **Added `.github/workflows/dependency-review.yml`** to gate future PRs on runtime-scope vulnerabilities at moderate+ severity

## Alert Breakdown

| Package | Alerts | Dismissal | Reason |
|---|---|---|---|
| handlebars | 7 | `not_used` | Dev dep (ts-jest transitive) |
| tar | 6 | `not_used` | Dead code (install-mcp→giget, never imported) |
| picomatch | 3 | `not_used` | Dev dep (jest/eslint transitive) |
| lodash | 2 | `not_used` | Dev dep (archiver transitive, test-only) |
| path-to-regexp | 2 | `tolerable_risk` | Localhost-only, static routes, no user-controlled routing |

## Test plan
- [ ] Verify GitHub Security tab shows 0 open Dependabot alerts
- [ ] Verify `osv-scanner.toml` is valid TOML and all GHSA IDs match the dismissed alerts
- [ ] Verify dependency-review workflow triggers on a test PR

Closes #1800

🤖 Generated with [Claude Code](https://claude.com/claude-code)