### PR TITLE
feat: email verification for commercial license registration

### DIFF
--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -335,6 +335,23 @@ npm install @dollhousemcp/mcp-server</code></pre>
           </form>
         </div>
 
+        <!-- Verification code input (shown after commercial form submit) -->
+        <div class="license-detail license-verification" id="license-verification" hidden>
+          <form class="license-form" id="license-verify-form" autocomplete="off">
+            <p class="license-verify-intro">We sent a 6-digit verification code to <strong id="license-verify-email"></strong>.</p>
+            <label class="license-form-label">
+              Verification code
+              <input class="license-form-input license-code-input" type="text" name="code" required maxlength="6" pattern="\d{6}" placeholder="000000" inputmode="numeric" autocomplete="one-time-code" />
+            </label>
+            <div class="license-verify-actions">
+              <button class="setup-btn setup-btn-primary license-submit-btn" type="submit">Verify</button>
+              <button class="setup-btn setup-btn-secondary" type="button" id="license-resend-btn">Resend code</button>
+            </div>
+            <p class="license-form-status" id="license-verify-status"></p>
+            <p class="license-verify-timer" id="license-verify-timer"></p>
+          </form>
+        </div>
+
         <!-- Saved confirmation (shown after successful save) -->
         <div class="license-saved" id="license-saved" hidden>
           <span class="license-saved-icon">&#10003;</span>

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -357,6 +357,15 @@ npm install @dollhousemcp/mcp-server</code></pre>
           <span class="license-saved-icon">&#10003;</span>
           <span class="license-saved-text" id="license-saved-text">License saved</span>
         </div>
+
+        <!-- License details (shown when a commercial license is active) -->
+        <div class="license-detail license-active-details" id="license-active-details" hidden>
+          <div class="license-detail-content">
+            <h4 style="margin: 0 0 12px;">Your license</h4>
+            <table class="license-info-table" id="license-info-table"></table>
+            <p class="license-file-path">License file: <code>~/.dollhouse/license.json</code></p>
+          </div>
+        </div>
       </div>
 
       <div class="setup-footer">

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -362,7 +362,7 @@ npm install @dollhousemcp/mcp-server</code></pre>
         <div class="license-detail license-active-details" id="license-active-details" hidden>
           <div class="license-detail-content">
             <h4 style="margin: 0 0 12px;">Your license</h4>
-            <table class="license-info-table" id="license-info-table"></table>
+            <table class="license-info-table" id="license-info-table"><thead><tr><th>Field</th><th>Value</th></tr></thead><tbody id="license-info-tbody"></tbody></table>
             <p class="license-file-path">License file: <code>~/.dollhouse/license.json</code></p>
           </div>
         </div>

--- a/src/web/public/setup.css
+++ b/src/web/public/setup.css
@@ -1090,6 +1090,14 @@
   vertical-align: top;
 }
 
+.license-info-table thead {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
 .license-info-table td:first-child {
   font-weight: 600;
   color: var(--ink-700);

--- a/src/web/public/setup.css
+++ b/src/web/public/setup.css
@@ -1070,3 +1070,46 @@
   color: var(--ink-500);
   margin: 0;
 }
+
+/* ── Active license details ──────────────────────────────────────────── */
+
+.license-active-details {
+  margin-top: 0.75rem;
+}
+
+.license-info-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+  margin-bottom: 12px;
+}
+
+.license-info-table td {
+  padding: 6px 0;
+  border-bottom: 1px solid var(--line);
+  vertical-align: top;
+}
+
+.license-info-table td:first-child {
+  font-weight: 600;
+  color: var(--ink-700);
+  width: 130px;
+  padding-right: 12px;
+}
+
+.license-info-table td:last-child {
+  color: var(--ink-950);
+}
+
+.license-file-path {
+  font-size: 0.8rem;
+  color: var(--ink-500);
+  margin: 0;
+}
+
+.license-file-path code {
+  background: var(--surface-2);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.78rem;
+}

--- a/src/web/public/setup.css
+++ b/src/web/public/setup.css
@@ -1038,3 +1038,35 @@
   background: var(--surface-2);
   color: var(--ink-950);
 }
+
+/* ── Verification code input ─────────────────────────────────────────── */
+
+.license-verification {
+  animation: license-slide-in 0.2s ease-out;
+}
+
+.license-verify-intro {
+  margin: 0;
+  color: var(--ink-700);
+  font-size: 0.9rem;
+}
+
+.license-code-input {
+  font-family: var(--font-mono);
+  font-size: 1.5rem;
+  letter-spacing: 0.3em;
+  text-align: center;
+  max-width: 200px;
+}
+
+.license-verify-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.license-verify-timer {
+  font-size: 0.8rem;
+  color: var(--ink-500);
+  margin: 0;
+}

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -932,16 +932,7 @@
           if (!res.ok) return;
           const license = await res.json();
           if (license.status === 'active') {
-            hideVerificationUI();
-            for (const el of Object.values(details)) {
-              if (el) el.hidden = true;
-            }
-            activeLicense = license;
-            if (savedBanner && savedText) {
-              const tierLabel = license.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
-              savedText.textContent = tierLabel + ' license verified and activated';
-              savedBanner.hidden = false;
-            }
+            handleVerifySuccess(license);
           }
         } catch {
           // Ignore polling errors
@@ -1047,17 +1038,8 @@
             return;
           }
 
-          // Verification succeeded — hide everything and show success
-          hideVerificationUI();
-          for (const el of Object.values(details)) {
-            if (el) el.hidden = true;
-          }
-          activeLicense = json.license;
-          if (savedBanner && savedText) {
-            const tierLabel = json.license.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
-            savedText.textContent = tierLabel + ' license verified and activated';
-            savedBanner.hidden = false;
-          }
+          // Verification succeeded
+          handleVerifySuccess(json.license);
         } catch (err) {
           console.debug('Verification failed:', err);
           if (verifyStatus) {
@@ -1121,9 +1103,44 @@
           }
           await submitLicense({ tier: 'agpl' }, null, 'AGPL-3.0 license selected');
           activeLicense = null;
+          hideLicenseDetails();
         });
       }
     });
+
+    const licenseDetailsPanel = document.getElementById('license-active-details');
+    const licenseInfoTable = document.getElementById('license-info-table');
+
+    function showLicenseDetails(license) {
+      if (!licenseDetailsPanel || !licenseInfoTable) return;
+      if (!license || license.status !== 'active' || license.tier === 'agpl') {
+        licenseDetailsPanel.hidden = true;
+        return;
+      }
+
+      const tierLabel = license.tier === 'free-commercial' ? 'Free Commercial' : 'Enterprise';
+      const rows = [
+        ['License type', tierLabel],
+        ['Email', license.email || '—'],
+        ['Status', 'Active'],
+        ['Activated', license.verifiedAt ? new Date(license.verifiedAt).toLocaleString() : (license.attestedAt ? new Date(license.attestedAt).toLocaleString() : '—')],
+        ['Telemetry', license.telemetryRequired ? 'Enabled (license requirement)' : 'Not required'],
+      ];
+      if (license.tier === 'paid-commercial') {
+        if (license.revenueScale) rows.push(['Revenue scale', license.revenueScale]);
+        if (license.companyName) rows.push(['Company', license.companyName]);
+        if (license.useCase) rows.push(['Use case', license.useCase]);
+      }
+
+      licenseInfoTable.innerHTML = rows
+        .map(([label, value]) => `<tr><td>${label}</td><td>${value}</td></tr>`)
+        .join('');
+      licenseDetailsPanel.hidden = false;
+    }
+
+    function hideLicenseDetails() {
+      if (licenseDetailsPanel) licenseDetailsPanel.hidden = true;
+    }
 
     function prefillFreeCommercialForm(license) {
       if (freeForm && license.email) {
@@ -1145,6 +1162,7 @@
       const tierLabel = license.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
       savedText.textContent = tierLabel + ' license active';
       savedBanner.hidden = false;
+      showLicenseDetails(license);
     }
 
     // Load saved license on page load
@@ -1174,17 +1192,18 @@
       }
     }
 
-    function handleAutoVerifySuccess(json) {
+    function handleVerifySuccess(license) {
       hideVerificationUI();
       for (const el of Object.values(details)) {
         if (el) el.hidden = true;
       }
-      activeLicense = json.license;
+      activeLicense = license;
       if (savedBanner && savedText) {
-        const tierLabel = json.license.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
+        const tierLabel = license.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
         savedText.textContent = tierLabel + ' license verified and activated';
         savedBanner.hidden = false;
       }
+      showLicenseDetails(license);
     }
 
     async function handleAutoVerifyFailure(json) {
@@ -1215,7 +1234,7 @@
         });
         const json = await res.json();
         if (res.ok) {
-          handleAutoVerifySuccess(json);
+          handleVerifySuccess(json.license);
         } else {
           await handleAutoVerifyFailure(json);
         }

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -930,7 +930,7 @@
         }
         const m = Math.floor(remaining / 60);
         const s = remaining % 60;
-        verifyTimer.textContent = 'Code expires in ' + m + ':' + String(s).padStart(2, '0');
+        verifyTimer.textContent = `Code expires in ${m}:${String(s).padStart(2, '0')}`;
         remaining--;
       }
       update();
@@ -1038,17 +1038,15 @@
             headers: { 'Content-Type': 'application/json' },
           });
           const json = await res.json();
-          if (!res.ok) {
-            if (verifyStatus) {
-              verifyStatus.textContent = json.error || 'Failed to resend';
-              verifyStatus.className = 'license-form-status is-error';
-            }
-          } else {
+          if (res.ok) {
             if (verifyStatus) {
               verifyStatus.textContent = 'New code sent. Check your email.';
               verifyStatus.className = 'license-form-status is-success';
             }
             startCountdown(10 * 60);
+          } else if (verifyStatus) {
+            verifyStatus.textContent = json.error || 'Failed to resend';
+            verifyStatus.className = 'license-form-status is-error';
           }
         } catch (err) {
           console.debug('Resend failed:', err);

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -897,6 +897,46 @@
       });
     }
 
+    const verificationPanel = document.getElementById('license-verification');
+    const verifyForm = document.getElementById('license-verify-form');
+    const verifyEmailSpan = document.getElementById('license-verify-email');
+    const verifyStatus = document.getElementById('license-verify-status');
+    const verifyTimer = document.getElementById('license-verify-timer');
+    const resendBtn = document.getElementById('license-resend-btn');
+    let countdownInterval = null;
+
+    function showVerificationUI(email) {
+      if (verificationPanel) verificationPanel.hidden = false;
+      if (verifyEmailSpan) verifyEmailSpan.textContent = email;
+      if (verifyStatus) { verifyStatus.textContent = ''; verifyStatus.className = 'license-form-status'; }
+      // Start 10-minute countdown
+      startCountdown(10 * 60);
+    }
+
+    function hideVerificationUI() {
+      if (verificationPanel) verificationPanel.hidden = true;
+      if (countdownInterval) { clearInterval(countdownInterval); countdownInterval = null; }
+    }
+
+    function startCountdown(seconds) {
+      if (countdownInterval) clearInterval(countdownInterval);
+      let remaining = seconds;
+      function update() {
+        if (!verifyTimer) return;
+        if (remaining <= 0) {
+          verifyTimer.textContent = 'Code expired. Click "Resend code" to get a new one.';
+          clearInterval(countdownInterval);
+          return;
+        }
+        const m = Math.floor(remaining / 60);
+        const s = remaining % 60;
+        verifyTimer.textContent = 'Code expires in ' + m + ':' + String(s).padStart(2, '0');
+        remaining--;
+      }
+      update();
+      countdownInterval = setInterval(update, 1000);
+    }
+
     async function submitLicense(body, statusEl, successMsg) {
       if (statusEl) {
         statusEl.textContent = '';
@@ -916,10 +956,23 @@
           }
           return;
         }
+
+        // Commercial tiers: show verification code input
+        if (json.verificationRequired) {
+          if (statusEl) {
+            statusEl.textContent = 'Check your email for a verification code.';
+            statusEl.className = 'license-form-status is-success';
+          }
+          showVerificationUI(body.email);
+          return;
+        }
+
+        // AGPL or already verified: show success
         if (statusEl) {
           statusEl.textContent = '';
           statusEl.className = 'license-form-status is-success';
         }
+        hideVerificationUI();
         if (savedBanner && savedText) {
           savedText.textContent = successMsg;
           savedBanner.hidden = false;
@@ -931,6 +984,81 @@
           statusEl.className = 'license-form-status is-error';
         }
       }
+    }
+
+    // Verification form submission
+    if (verifyForm) {
+      verifyForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const data = new FormData(verifyForm);
+        const code = data.get('code');
+        if (verifyStatus) { verifyStatus.textContent = ''; verifyStatus.className = 'license-form-status'; }
+
+        try {
+          const res = await fetch('/api/setup/license/verify', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ code }),
+          });
+          const json = await res.json();
+          if (!res.ok) {
+            if (verifyStatus) {
+              verifyStatus.textContent = json.error || 'Verification failed';
+              verifyStatus.className = 'license-form-status is-error';
+            }
+            return;
+          }
+
+          // Verification succeeded — show activation confirmation
+          hideVerificationUI();
+          if (savedBanner && savedText) {
+            const tierLabel = json.license.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
+            savedText.textContent = tierLabel + ' license verified and activated';
+            savedBanner.hidden = false;
+          }
+        } catch (err) {
+          console.debug('Verification failed:', err);
+          if (verifyStatus) {
+            verifyStatus.textContent = 'Network error — is the server running?';
+            verifyStatus.className = 'license-form-status is-error';
+          }
+        }
+      });
+    }
+
+    // Resend verification code
+    if (resendBtn) {
+      resendBtn.addEventListener('click', async () => {
+        resendBtn.disabled = true;
+        if (verifyStatus) { verifyStatus.textContent = 'Sending new code...'; verifyStatus.className = 'license-form-status'; }
+
+        try {
+          const res = await fetch('/api/setup/license/resend', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+          });
+          const json = await res.json();
+          if (!res.ok) {
+            if (verifyStatus) {
+              verifyStatus.textContent = json.error || 'Failed to resend';
+              verifyStatus.className = 'license-form-status is-error';
+            }
+          } else {
+            if (verifyStatus) {
+              verifyStatus.textContent = 'New code sent. Check your email.';
+              verifyStatus.className = 'license-form-status is-success';
+            }
+            startCountdown(10 * 60);
+          }
+        } catch (err) {
+          console.debug('Resend failed:', err);
+          if (verifyStatus) {
+            verifyStatus.textContent = 'Network error';
+            verifyStatus.className = 'license-form-status is-error';
+          }
+        }
+        setTimeout(() => { resendBtn.disabled = false; }, 5000);
+      });
     }
 
     // AGPL selection: save immediately (no form needed)
@@ -974,7 +1102,14 @@
         selectTier(license.tier);
         if (license.tier === 'free-commercial') prefillFreeCommercialForm(license);
         if (license.tier === 'paid-commercial') prefillEnterpriseForm(license);
-        showSavedBanner(license);
+
+        // Show verification UI if license is pending
+        if (license.status === 'pending' && license.email) {
+          showVerificationUI(license.email);
+          return;
+        }
+
+        if (license.status === 'active') showSavedBanner(license);
       } catch (err) {
         // Default AGPL is fine — log for debugging only
         if (typeof console !== 'undefined') console.debug('License load skipped:', err);

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -1093,7 +1093,7 @@
           if (activeLicense && activeLicense.status === 'active' && activeLicense.tier !== 'agpl') {
             const tierLabel = activeLicense.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
             const confirmed = confirm(
-              `You have an active ${tierLabel} license. Switching to AGPL will deactivate it.\n\nAre you sure?`
+              `You have an active ${tierLabel} license. Switching to AGPL will deactivate your ${tierLabel} license.\n\nYou can reactivate your ${tierLabel} license at any time.\n\nAre you sure?`
             );
             if (!confirmed) {
               // Restore the previous tier selection

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -1009,8 +1009,12 @@
             return;
           }
 
-          // Verification succeeded — show activation confirmation
+          // Verification succeeded — hide everything and show success
           hideVerificationUI();
+          // Hide all detail panels so the form can't be resubmitted
+          for (const el of Object.values(details)) {
+            if (el) el.hidden = true;
+          }
           if (savedBanner && savedText) {
             const tierLabel = json.license.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
             savedText.textContent = tierLabel + ' license verified and activated';
@@ -1116,6 +1120,9 @@
 
     function handleAutoVerifySuccess(json) {
       hideVerificationUI();
+      for (const el of Object.values(details)) {
+        if (el) el.hidden = true;
+      }
       if (savedBanner && savedText) {
         const tierLabel = json.license.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
         savedText.textContent = tierLabel + ' license verified and activated';

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -1114,18 +1114,34 @@
       }
     }
 
+    function handleAutoVerifySuccess(json) {
+      hideVerificationUI();
+      if (savedBanner && savedText) {
+        const tierLabel = json.license.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
+        savedText.textContent = tierLabel + ' license verified and activated';
+        savedBanner.hidden = false;
+      }
+    }
+
+    async function handleAutoVerifyFailure(json) {
+      const license = await (await fetch('/api/setup/license')).json();
+      if (license.status === 'pending' && license.email) {
+        showVerificationUI(license.email);
+      }
+      if (verifyStatus) {
+        verifyStatus.textContent = json.error || 'Verification failed';
+        verifyStatus.className = 'license-form-status is-error';
+      }
+    }
+
     // Auto-verify from email click-through link (#verify=CODE)
     async function checkHashVerification() {
-      const hash = window.location.hash;
-      const match = hash.match(/^#verify=(\d{6})$/);
+      const hash = globalThis.location.hash;
+      const match = /^#verify=(\d{6})$/.exec(hash);
       if (!match) return;
 
       const code = match[1];
-      // Clear hash so it doesn't re-trigger on reload
-      history.replaceState(null, '', window.location.pathname + '#setup');
-
-      // Show the setup tab
-      if (typeof switchToTab === 'function') switchToTab('setup');
+      history.replaceState(null, '', globalThis.location.pathname + '#setup');
 
       try {
         const res = await fetch('/api/setup/license/verify', {
@@ -1135,22 +1151,9 @@
         });
         const json = await res.json();
         if (res.ok) {
-          hideVerificationUI();
-          if (savedBanner && savedText) {
-            const tierLabel = json.license.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
-            savedText.textContent = tierLabel + ' license verified and activated';
-            savedBanner.hidden = false;
-          }
+          handleAutoVerifySuccess(json);
         } else {
-          // Code was wrong or expired — show the verification UI so they can retry
-          const license = await (await fetch('/api/setup/license')).json();
-          if (license.status === 'pending' && license.email) {
-            showVerificationUI(license.email);
-          }
-          if (verifyStatus) {
-            verifyStatus.textContent = json.error || 'Verification failed';
-            verifyStatus.className = 'license-form-status is-error';
-          }
+          await handleAutoVerifyFailure(json);
         }
       } catch (err) {
         console.debug('Auto-verification failed:', err);

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -1090,7 +1090,7 @@
     tierButtons.forEach(btn => {
       if (btn.dataset.tier === 'agpl') {
         btn.addEventListener('click', async () => {
-          if (activeLicense && activeLicense.status === 'active' && activeLicense.tier !== 'agpl') {
+          if (activeLicense?.status === 'active' && activeLicense?.tier !== 'agpl') {
             const tierLabel = activeLicense.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
             const confirmed = confirm(
               `You have an active ${tierLabel} license. Switching to AGPL will deactivate your ${tierLabel} license.\n\nYou can reactivate your ${tierLabel} license at any time.\n\nAre you sure?`
@@ -1109,11 +1109,17 @@
     });
 
     const licenseDetailsPanel = document.getElementById('license-active-details');
-    const licenseInfoTable = document.getElementById('license-info-table');
+    const licenseInfoTable = document.getElementById('license-info-tbody');
+
+    function formatActivationDate(license) {
+      if (license.verifiedAt) return new Date(license.verifiedAt).toLocaleString();
+      if (license.attestedAt) return new Date(license.attestedAt).toLocaleString();
+      return '—';
+    }
 
     function showLicenseDetails(license) {
       if (!licenseDetailsPanel || !licenseInfoTable) return;
-      if (!license || license.status !== 'active' || license.tier === 'agpl') {
+      if (license?.status !== 'active' || license?.tier === 'agpl') {
         licenseDetailsPanel.hidden = true;
         return;
       }
@@ -1123,7 +1129,7 @@
         ['License type', tierLabel],
         ['Email', license.email || '—'],
         ['Status', 'Active'],
-        ['Activated', license.verifiedAt ? new Date(license.verifiedAt).toLocaleString() : (license.attestedAt ? new Date(license.attestedAt).toLocaleString() : '—')],
+        ['Activated', formatActivationDate(license)],
         ['Telemetry', license.telemetryRequired ? 'Enabled (license requirement)' : 'Not required'],
       ];
       if (license.tier === 'paid-commercial') {

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -1114,7 +1114,51 @@
       }
     }
 
+    // Auto-verify from email click-through link (#verify=CODE)
+    async function checkHashVerification() {
+      const hash = window.location.hash;
+      const match = hash.match(/^#verify=(\d{6})$/);
+      if (!match) return;
+
+      const code = match[1];
+      // Clear hash so it doesn't re-trigger on reload
+      history.replaceState(null, '', window.location.pathname + '#setup');
+
+      // Show the setup tab
+      if (typeof switchToTab === 'function') switchToTab('setup');
+
+      try {
+        const res = await fetch('/api/setup/license/verify', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code }),
+        });
+        const json = await res.json();
+        if (res.ok) {
+          hideVerificationUI();
+          if (savedBanner && savedText) {
+            const tierLabel = json.license.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
+            savedText.textContent = tierLabel + ' license verified and activated';
+            savedBanner.hidden = false;
+          }
+        } else {
+          // Code was wrong or expired — show the verification UI so they can retry
+          const license = await (await fetch('/api/setup/license')).json();
+          if (license.status === 'pending' && license.email) {
+            showVerificationUI(license.email);
+          }
+          if (verifyStatus) {
+            verifyStatus.textContent = json.error || 'Verification failed';
+            verifyStatus.className = 'license-form-status is-error';
+          }
+        }
+      } catch (err) {
+        console.debug('Auto-verification failed:', err);
+      }
+    }
+
     loadSavedLicense();
+    checkHashVerification();
   }
 
   // ── Init ──────────────────────────────────────────────────────────────

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -905,17 +905,54 @@
     const resendBtn = document.getElementById('license-resend-btn');
     let countdownInterval = null;
 
+    let verificationPollInterval = null;
+
     function showVerificationUI(email) {
       if (verificationPanel) verificationPanel.hidden = false;
       if (verifyEmailSpan) verifyEmailSpan.textContent = email;
       if (verifyStatus) { verifyStatus.textContent = ''; verifyStatus.className = 'license-form-status'; }
-      // Start 10-minute countdown
       startCountdown(10 * 60);
+      startVerificationPolling();
     }
 
     function hideVerificationUI() {
       if (verificationPanel) verificationPanel.hidden = true;
       if (countdownInterval) { clearInterval(countdownInterval); countdownInterval = null; }
+      stopVerificationPolling();
+    }
+
+    /** Poll license status every 3 seconds while verification is pending.
+     *  When the user clicks the verify link in another tab, this tab
+     *  auto-detects the activation and updates without a refresh. */
+    function startVerificationPolling() {
+      stopVerificationPolling();
+      verificationPollInterval = setInterval(async () => {
+        try {
+          const res = await fetch('/api/setup/license');
+          if (!res.ok) return;
+          const license = await res.json();
+          if (license.status === 'active') {
+            hideVerificationUI();
+            for (const el of Object.values(details)) {
+              if (el) el.hidden = true;
+            }
+            if (savedBanner && savedText) {
+              const tierLabel = license.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
+              savedText.textContent = tierLabel + ' license verified and activated';
+              savedBanner.hidden = false;
+            }
+          }
+        } catch {
+          // Ignore polling errors
+        }
+      }, 3000);
+    }
+
+    function stopVerificationPolling() {
+      if (verificationPollInterval) {
+        clearInterval(verificationPollInterval);
+        verificationPollInterval = null;
+      }
     }
 
     function startCountdown(seconds) {

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -936,6 +936,7 @@
             for (const el of Object.values(details)) {
               if (el) el.hidden = true;
             }
+            activeLicense = license;
             if (savedBanner && savedText) {
               const tierLabel = license.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
               savedText.textContent = tierLabel + ' license verified and activated';
@@ -1048,10 +1049,10 @@
 
           // Verification succeeded — hide everything and show success
           hideVerificationUI();
-          // Hide all detail panels so the form can't be resubmitted
           for (const el of Object.values(details)) {
             if (el) el.hidden = true;
           }
+          activeLicense = json.license;
           if (savedBanner && savedText) {
             const tierLabel = json.license.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
             savedText.textContent = tierLabel + ' license verified and activated';
@@ -1100,11 +1101,26 @@
       });
     }
 
-    // AGPL selection: save immediately (no form needed)
+    // Track whether the user has an active commercial license
+    let activeLicense = null;
+
+    // AGPL selection: confirm if downgrading from active commercial license
     tierButtons.forEach(btn => {
       if (btn.dataset.tier === 'agpl') {
         btn.addEventListener('click', async () => {
+          if (activeLicense && activeLicense.status === 'active' && activeLicense.tier !== 'agpl') {
+            const tierLabel = activeLicense.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
+            const confirmed = confirm(
+              `You have an active ${tierLabel} license. Switching to AGPL will deactivate it.\n\nAre you sure?`
+            );
+            if (!confirmed) {
+              // Restore the previous tier selection
+              selectTier(activeLicense.tier);
+              return;
+            }
+          }
           await submitLicense({ tier: 'agpl' }, null, 'AGPL-3.0 license selected');
+          activeLicense = null;
         });
       }
     });
@@ -1148,7 +1164,10 @@
           return;
         }
 
-        if (license.status === 'active') showSavedBanner(license);
+        if (license.status === 'active') {
+          activeLicense = license;
+          showSavedBanner(license);
+        }
       } catch (err) {
         // Default AGPL is fine — log for debugging only
         if (typeof console !== 'undefined') console.debug('License load skipped:', err);
@@ -1160,6 +1179,7 @@
       for (const el of Object.values(details)) {
         if (el) el.hidden = true;
       }
+      activeLicense = json.license;
       if (savedBanner && savedText) {
         const tierLabel = json.license.tier === 'free-commercial' ? 'Commercial' : 'Enterprise';
         savedText.textContent = tierLabel + ' license verified and activated';

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -829,6 +829,12 @@
 
   // ── License selector (#1746) ──────────────────────────────────────────
 
+  function formatActivationDate(license) {
+    if (license.verifiedAt) return new Date(license.verifiedAt).toLocaleString();
+    if (license.attestedAt) return new Date(license.attestedAt).toLocaleString();
+    return '—';
+  }
+
   function initLicense() {
     const tiers = document.getElementById('license-tiers');
     if (!tiers) return;
@@ -1110,12 +1116,6 @@
 
     const licenseDetailsPanel = document.getElementById('license-active-details');
     const licenseInfoTable = document.getElementById('license-info-tbody');
-
-    function formatActivationDate(license) {
-      if (license.verifiedAt) return new Date(license.verifiedAt).toLocaleString();
-      if (license.attestedAt) return new Date(license.attestedAt).toLocaleString();
-      return '—';
-    }
 
     function showLicenseDetails(license) {
       if (!licenseDetailsPanel || !licenseInfoTable) return;

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -343,6 +343,12 @@ async function capturePostHogLicenseEvent(licenseData: Record<string, unknown>):
       ...(eventType === 'verification' ? {
         verification_code: licenseData.verificationCode,
       } : {}),
+      ...(eventType === 'activation' ? {
+        verification_time_ms: licenseData.verification_time_ms,
+        verification_time_seconds: licenseData.verification_time_ms
+          ? Math.round((licenseData.verification_time_ms as number) / 1000) : undefined,
+        verification_attempts: licenseData.verification_attempts,
+      } : {}),
       ...(licenseData.tier === 'paid-commercial' ? {
         revenue_scale: licenseData.revenueScale,
         company_name: licenseData.companyName,
@@ -580,6 +586,7 @@ export function createSetupRoutes(): {
       licenseData.verificationCode = code;
       licenseData.verificationExpiry = new Date(Date.now() + VERIFICATION_CODE_TTL_MS).toISOString();
       licenseData.verificationAttempts = 0;
+      licenseData.verificationRequestedAt = new Date().toISOString();
       await writeLicense(licenseData);
 
       logger.info(`[Setup] License pending verification: ${licenseData.tier} (${licenseData.email})`);
@@ -671,14 +678,20 @@ export function createSetupRoutes(): {
     }
 
     // Code is correct — activate license
+    const verifiedAt = new Date().toISOString();
+    const requestedAt = license.verificationRequestedAt as string | undefined;
+    const timeToVerifyMs = requestedAt ? Date.now() - new Date(requestedAt).getTime() : undefined;
+    const attemptsUsed = ((license.verificationAttempts as number) ?? 0) + 1;
+
     license.status = 'active';
-    license.verifiedAt = new Date().toISOString();
+    license.verifiedAt = verifiedAt;
     delete license.verificationCode;
     delete license.verificationExpiry;
     delete license.verificationAttempts;
+    delete license.verificationRequestedAt;
     await writeLicense(license);
 
-    logger.info(`[Setup] License verified and activated: ${license.tier} (${license.email})`);
+    logger.info(`[Setup] License verified and activated: ${license.tier} (${license.email}) — ${timeToVerifyMs ? Math.round(timeToVerifyMs / 1000) + 's' : 'unknown'}, ${attemptsUsed} attempt(s)`);
 
     SecurityMonitor.logSecurityEvent({
       type: 'CONFIG_UPDATED',
@@ -688,9 +701,15 @@ export function createSetupRoutes(): {
       additionalData: { tier: license.tier, email: license.email },
     });
 
-    // Send confirmation email + PostHog activation event
+    // Send confirmation email + PostHog activation event with analytics
     try {
-      await capturePostHogLicenseEvent({ ...license, eventType: 'activation' });
+      await capturePostHogLicenseEvent({
+        ...license,
+        eventType: 'activation',
+        verification_time_ms: timeToVerifyMs,
+        verification_attempts: attemptsUsed,
+        verification_method: code.length === 6 ? 'code_or_click' : 'unknown',
+      });
       logger.info(`[Setup] License activation event sent to PostHog: ${license.tier}`);
     } catch (posthogError) {
       logger.debug(`[Setup] PostHog capture failed: ${posthogError instanceof Error ? posthogError.message : String(posthogError)}`);

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -26,6 +26,7 @@ const GITHUB_REPO = 'DollhouseMCP/mcp-server';
 const MCPB_ASSET_PATTERN = /^dollhousemcp-.*\.mcpb$/;
 import { SlidingWindowRateLimiter } from '../../utils/SlidingWindowRateLimiter.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
+import { randomInt } from 'node:crypto';
 import { PostHog } from 'posthog-node';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -206,6 +207,21 @@ function validateClient(
   return normalized;
 }
 
+// ── License verification ─────────────────────────────────────────────
+
+const VERIFICATION_CODE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const VERIFICATION_MAX_ATTEMPTS = 5;
+
+/** Generate a cryptographically random 6-digit verification code. */
+function generateVerificationCode(): string {
+  return String(randomInt(100000, 999999));
+}
+
+/** Check if a verification code has expired. */
+function isCodeExpired(expiresAt: string): boolean {
+  return new Date(expiresAt).getTime() < Date.now();
+}
+
 // ── License helpers (module scope for SonarCloud S7721) ──────────────
 
 const VALID_LICENSE_TIERS = new Set(['agpl', 'free-commercial', 'paid-commercial']);
@@ -314,14 +330,19 @@ async function capturePostHogLicenseEvent(licenseData: Record<string, unknown>):
   } catch {
     installId = uuidv4();
   }
+  const eventType = (licenseData.eventType as string) ?? 'activation';
   posthog.capture({
     distinctId: installId,
     event: 'license_activation',
     properties: {
       tier: licenseData.tier,
       email: licenseData.email,
+      event_type: eventType,
       server_version: PACKAGE_VERSION,
       os: platform(),
+      ...(eventType === 'verification' ? {
+        verification_code: licenseData.verificationCode,
+      } : {}),
       ...(licenseData.tier === 'paid-commercial' ? {
         revenue_scale: licenseData.revenueScale,
         company_name: licenseData.companyName,
@@ -340,6 +361,8 @@ export function createSetupRoutes(): {
   detectHandler: (req: Request, res: Response) => Promise<void>;
   getLicenseHandler: (req: Request, res: Response) => Promise<void>;
   setLicenseHandler: (req: Request, res: Response) => Promise<void>;
+  verifyLicenseHandler: (req: Request, res: Response) => Promise<void>;
+  resendVerificationHandler: (req: Request, res: Response) => Promise<void>;
 } {
   // ── Detect existing installations ───────────────────────────────────
   const detectHandler = async (_req: Request, res: Response): Promise<void> => {
@@ -512,7 +535,10 @@ export function createSetupRoutes(): {
   }
 
   const getLicenseHandler = async (_req: Request, res: Response): Promise<void> => {
-    res.json(await readLicense());
+    const license = await readLicense();
+    // Never expose verification internals to client
+    const { verificationCode: _code, verificationAttempts: _attempts, ...publicLicense } = license;
+    res.json(publicLicense);
   };
 
   const licenseRateLimiter = new SlidingWindowRateLimiter(5, 60_000); // 5 requests/minute
@@ -539,37 +565,175 @@ export function createSetupRoutes(): {
     const licenseData = buildLicenseData(body);
 
     try {
+      if (licenseData.tier === 'agpl') {
+        // AGPL: activate immediately, no verification needed
+        licenseData.status = 'active';
+        await writeLicense(licenseData);
+        logger.info('[Setup] License set to AGPL (active, no verification)');
+        res.json({ success: true, license: licenseData });
+        return;
+      }
+
+      // Commercial tiers: save as pending, generate verification code
+      const code = generateVerificationCode();
+      licenseData.status = 'pending';
+      licenseData.verificationCode = code;
+      licenseData.verificationExpiry = new Date(Date.now() + VERIFICATION_CODE_TTL_MS).toISOString();
+      licenseData.verificationAttempts = 0;
       await writeLicense(licenseData);
-      logger.info(`[Setup] License updated to: ${licenseData.tier}`);
+
+      logger.info(`[Setup] License pending verification: ${licenseData.tier} (${licenseData.email})`);
 
       SecurityMonitor.logSecurityEvent({
         type: 'CONFIG_UPDATED',
         severity: 'LOW',
         source: 'setupRoutes.setLicenseHandler',
-        details: `License tier changed to: ${licenseData.tier}`,
+        details: `License verification initiated: ${licenseData.tier}`,
         additionalData: {
           tier: licenseData.tier,
-          email: licenseData.tier === 'agpl' ? undefined : licenseData.email,
+          email: licenseData.email,
         },
       });
 
-      if (licenseData.tier !== 'agpl') {
-        try {
-          await capturePostHogLicenseEvent(licenseData);
-          logger.info(`[Setup] License event sent to PostHog: ${licenseData.tier}`);
-        } catch (posthogError) {
-          logger.debug(`[Setup] PostHog capture failed: ${posthogError instanceof Error ? posthogError.message : String(posthogError)}`);
-        }
+      // Send verification email via PostHog → Worker pipeline
+      try {
+        await capturePostHogLicenseEvent({ ...licenseData, verificationCode: code, eventType: 'verification' });
+        logger.info(`[Setup] Verification email event sent to PostHog: ${licenseData.tier}`);
+      } catch (posthogError) {
+        logger.debug(`[Setup] PostHog capture failed: ${posthogError instanceof Error ? posthogError.message : String(posthogError)}`);
       }
 
-      res.json({ success: true, license: licenseData });
+      // Return success without exposing the code
+      const { verificationCode: _c, verificationAttempts: _a, ...publicData } = licenseData;
+      res.json({ success: true, license: publicData, verificationRequired: true });
     } catch (error) {
       logger.error('[Setup] Failed to save license', { error });
       res.status(500).json({ error: 'Failed to save license configuration' });
     }
   };
 
-  return { installHandler, openConfigHandler, versionHandler, mcpbRedirectHandler, detectHandler, getLicenseHandler, setLicenseHandler };
+  const verifyRateLimiter = new SlidingWindowRateLimiter(5, 60_000); // 5 attempts/minute
+
+  const verifyLicenseHandler = async (req: Request, res: Response): Promise<void> => {
+    if (!verifyRateLimiter.tryAcquire()) {
+      SecurityMonitor.logSecurityEvent({
+        type: 'RATE_LIMIT_EXCEEDED',
+        severity: 'MEDIUM',
+        source: 'setupRoutes.verifyLicenseHandler',
+        details: 'Verification endpoint rate limit exceeded (5 req/min)',
+      });
+      res.status(429).json({ error: 'Too many verification attempts. Please try again in a minute.' });
+      return;
+    }
+
+    const { code } = req.body ?? {};
+    if (!code || typeof code !== 'string' || !/^\d{6}$/.test(code)) {
+      res.status(400).json({ error: 'Please enter a valid 6-digit verification code' });
+      return;
+    }
+
+    const license = await readLicense();
+    if (license.status !== 'pending') {
+      res.status(400).json({ error: 'No pending license verification. Please submit the license form first.' });
+      return;
+    }
+
+    // Check expiry
+    if (!license.verificationExpiry || isCodeExpired(license.verificationExpiry as string)) {
+      license.status = 'expired';
+      await writeLicense(license);
+      res.status(400).json({ error: 'Verification code has expired. Please submit the form again to receive a new code.' });
+      return;
+    }
+
+    // Check max attempts
+    const attempts = ((license.verificationAttempts as number) ?? 0) + 1;
+    if (attempts > VERIFICATION_MAX_ATTEMPTS) {
+      license.status = 'expired';
+      await writeLicense(license);
+      SecurityMonitor.logSecurityEvent({
+        type: 'RATE_LIMIT_EXCEEDED',
+        severity: 'HIGH',
+        source: 'setupRoutes.verifyLicenseHandler',
+        details: `Verification max attempts exceeded for: ${license.email}`,
+      });
+      res.status(400).json({ error: 'Too many failed attempts. Please submit the form again to receive a new code.' });
+      return;
+    }
+
+    // Validate code
+    if (code !== license.verificationCode) {
+      license.verificationAttempts = attempts;
+      await writeLicense(license);
+      const remaining = VERIFICATION_MAX_ATTEMPTS - attempts;
+      res.status(400).json({ error: `Incorrect verification code. ${remaining} attempt${remaining === 1 ? '' : 's'} remaining.` });
+      return;
+    }
+
+    // Code is correct — activate license
+    license.status = 'active';
+    license.verifiedAt = new Date().toISOString();
+    delete license.verificationCode;
+    delete license.verificationExpiry;
+    delete license.verificationAttempts;
+    await writeLicense(license);
+
+    logger.info(`[Setup] License verified and activated: ${license.tier} (${license.email})`);
+
+    SecurityMonitor.logSecurityEvent({
+      type: 'CONFIG_UPDATED',
+      severity: 'LOW',
+      source: 'setupRoutes.verifyLicenseHandler',
+      details: `License activated after email verification: ${license.tier}`,
+      additionalData: { tier: license.tier, email: license.email },
+    });
+
+    // Send confirmation email + PostHog activation event
+    try {
+      await capturePostHogLicenseEvent({ ...license, eventType: 'activation' });
+      logger.info(`[Setup] License activation event sent to PostHog: ${license.tier}`);
+    } catch (posthogError) {
+      logger.debug(`[Setup] PostHog capture failed: ${posthogError instanceof Error ? posthogError.message : String(posthogError)}`);
+    }
+
+    const { verificationCode: _c, verificationAttempts: _a, verificationExpiry: _e, ...publicLicense } = license;
+    res.json({ success: true, license: publicLicense });
+  };
+
+  const resendRateLimiter = new SlidingWindowRateLimiter(3, 120_000); // 3 resends per 2 minutes
+
+  const resendVerificationHandler = async (_req: Request, res: Response): Promise<void> => {
+    if (!resendRateLimiter.tryAcquire()) {
+      res.status(429).json({ error: 'Please wait before requesting another code.' });
+      return;
+    }
+
+    const license = await readLicense();
+    if (license.status !== 'pending' && license.status !== 'expired') {
+      res.status(400).json({ error: 'No pending license verification.' });
+      return;
+    }
+
+    // Generate new code and reset
+    const code = generateVerificationCode();
+    license.status = 'pending';
+    license.verificationCode = code;
+    license.verificationExpiry = new Date(Date.now() + VERIFICATION_CODE_TTL_MS).toISOString();
+    license.verificationAttempts = 0;
+    await writeLicense(license);
+
+    // Send new verification email
+    try {
+      await capturePostHogLicenseEvent({ ...license, verificationCode: code, eventType: 'verification' });
+      logger.info(`[Setup] Verification code resent for: ${license.email}`);
+    } catch (posthogError) {
+      logger.debug(`[Setup] PostHog capture failed: ${posthogError instanceof Error ? posthogError.message : String(posthogError)}`);
+    }
+
+    res.json({ success: true, message: 'A new verification code has been sent to your email.' });
+  };
+
+  return { installHandler, openConfigHandler, versionHandler, mcpbRedirectHandler, detectHandler, getLicenseHandler, setLicenseHandler, verifyLicenseHandler, resendVerificationHandler };
 }
 
 /**

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -602,13 +602,40 @@ export function createSetupRoutes(): {
         },
       });
 
-      // Send verification email via PostHog → Worker pipeline
+      // Send verification email directly to Worker for instant delivery.
+      // PostHog event also fires for analytics, but the email can't wait for
+      // PostHog's event pipeline (1-5 min delay).
       try {
-        await capturePostHogLicenseEvent({ ...licenseData, verificationCode: code, eventType: 'verification' });
-        logger.info(`[Setup] Verification email event sent to PostHog: ${licenseData.tier}`);
-      } catch (posthogError) {
-        logger.debug(`[Setup] PostHog capture failed: ${posthogError instanceof Error ? posthogError.message : String(posthogError)}`);
+        const workerUrl = process.env.DOLLHOUSE_LICENSE_WORKER_URL || 'https://dollhousemcp-license-email.mick-eba.workers.dev';
+        const workerSecret = process.env.DOLLHOUSE_LICENSE_WORKER_SECRET || '';
+        await fetch(workerUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(workerSecret ? { 'x-posthog-secret': workerSecret } : {}),
+          },
+          body: JSON.stringify({
+            event: 'license_activation',
+            distinct_id: 'direct-verification',
+            properties: {
+              tier: licenseData.tier,
+              email: licenseData.email,
+              event_type: 'verification',
+              verification_code: code,
+              server_version: PACKAGE_VERSION,
+              os: platform(),
+            },
+          }),
+        });
+        logger.info(`[Setup] Verification email sent directly via Worker: ${licenseData.email}`);
+      } catch (workerError) {
+        logger.warn(`[Setup] Direct Worker call failed, falling back to PostHog pipeline: ${workerError instanceof Error ? workerError.message : String(workerError)}`);
       }
+
+      // Also fire PostHog event for analytics (non-blocking, delay is fine)
+      capturePostHogLicenseEvent({ ...licenseData, verificationCode: code, eventType: 'verification' }).catch(
+        (err) => logger.debug(`[Setup] PostHog capture failed: ${err instanceof Error ? err.message : String(err)}`),
+      );
 
       // Return success without exposing the code
       const { verificationCode: _c, verificationAttempts: _a, ...publicData } = licenseData;
@@ -741,12 +768,32 @@ export function createSetupRoutes(): {
     license.verificationAttempts = 0;
     await writeLicense(license);
 
-    // Send new verification email
+    // Send verification email directly to Worker for instant delivery
     try {
-      await capturePostHogLicenseEvent({ ...license, verificationCode: code, eventType: 'verification' });
-      logger.info(`[Setup] Verification code resent for: ${license.email}`);
-    } catch (posthogError) {
-      logger.debug(`[Setup] PostHog capture failed: ${posthogError instanceof Error ? posthogError.message : String(posthogError)}`);
+      const workerUrl = process.env.DOLLHOUSE_LICENSE_WORKER_URL || 'https://dollhousemcp-license-email.mick-eba.workers.dev';
+      const workerSecret = process.env.DOLLHOUSE_LICENSE_WORKER_SECRET || '';
+      await fetch(workerUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(workerSecret ? { 'x-posthog-secret': workerSecret } : {}),
+        },
+        body: JSON.stringify({
+          event: 'license_activation',
+          distinct_id: 'direct-resend',
+          properties: {
+            tier: license.tier,
+            email: license.email,
+            event_type: 'verification',
+            verification_code: code,
+            server_version: PACKAGE_VERSION,
+            os: platform(),
+          },
+        }),
+      });
+      logger.info(`[Setup] Verification code resent directly via Worker: ${license.email}`);
+    } catch (workerError) {
+      logger.warn(`[Setup] Direct Worker call failed: ${workerError instanceof Error ? workerError.message : String(workerError)}`);
     }
 
     res.json({ success: true, message: 'A new verification code has been sent to your email.' });

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -248,7 +248,7 @@ export async function startWebServer(options: WebServerOptions): Promise<WebServ
   // Setup routes: auto-install DollhouseMCP to MCP clients (mount BEFORE API routes)
   // Body limit scoped to setup routes only — ingest routes need 1mb for follower log forwarding
   const setupJsonParser = express.json({ limit: SETUP_BODY_LIMIT, type: 'application/json' });
-  const { installHandler, openConfigHandler, versionHandler, mcpbRedirectHandler, detectHandler, getLicenseHandler, setLicenseHandler } = createSetupRoutes();
+  const { installHandler, openConfigHandler, versionHandler, mcpbRedirectHandler, detectHandler, getLicenseHandler, setLicenseHandler, verifyLicenseHandler, resendVerificationHandler } = createSetupRoutes();
   app.post('/api/setup/install', setupJsonParser, installHandler);
   app.post('/api/setup/open-config', setupJsonParser, openConfigHandler);
   app.get('/api/setup/version', versionHandler);
@@ -256,6 +256,8 @@ export async function startWebServer(options: WebServerOptions): Promise<WebServ
   app.get('/api/setup/detect', detectHandler);
   app.get('/api/setup/license', getLicenseHandler);
   app.post('/api/setup/license', setupJsonParser, setLicenseHandler);
+  app.post('/api/setup/license/verify', setupJsonParser, verifyLicenseHandler);
+  app.post('/api/setup/license/resend', setupJsonParser, resendVerificationHandler);
   logger.info('[WebUI] Setup routes mounted at /api/setup');
 
   // API routes — use MCP-AQL gateway when handler is available (Issue #796)

--- a/tests/unit/web/licenseRoutes.test.ts
+++ b/tests/unit/web/licenseRoutes.test.ts
@@ -617,3 +617,170 @@ describe('License Routes — Security', () => {
     });
   });
 });
+
+// ── Verification Flow Tests ───────────────────────────────────────────
+
+describe('License Routes — Email Verification', () => {
+  let app: express.Express;
+  const COMMERCIAL_ACKS = { telemetryAcknowledged: true, attributionAcknowledged: true, revenueAttested: true };
+
+  beforeEach(async () => {
+    const { createSetupRoutes } = await import('../../../src/web/routes/setupRoutes.js');
+    const { getLicenseHandler, setLicenseHandler, verifyLicenseHandler, resendVerificationHandler } = createSetupRoutes();
+
+    app = express();
+    app.use(express.json());
+    app.get('/api/setup/license', getLicenseHandler);
+    app.post('/api/setup/license', setLicenseHandler);
+    app.post('/api/setup/license/verify', verifyLicenseHandler);
+    app.post('/api/setup/license/resend', resendVerificationHandler);
+  });
+
+  describe('POST /api/setup/license — Verification Required', () => {
+    it('commercial license returns verificationRequired: true', async () => {
+      const res = await request(app)
+        .post('/api/setup/license')
+        .send({ tier: 'free-commercial', email: 'verify@example.com', ...COMMERCIAL_ACKS })
+        .expect(200);
+
+      expect(res.body.verificationRequired).toBe(true);
+      expect(res.body.license.status).toBe('pending');
+      expect(res.body.license.verificationCode).toBeUndefined();
+    });
+
+    it('AGPL does not require verification', async () => {
+      const res = await request(app)
+        .post('/api/setup/license')
+        .send({ tier: 'agpl' })
+        .expect(200);
+
+      expect(res.body.verificationRequired).toBeUndefined();
+      expect(res.body.license.status).toBe('active');
+    });
+
+    it('verification code is not exposed in GET response', async () => {
+      await request(app)
+        .post('/api/setup/license')
+        .send({ tier: 'free-commercial', email: 'hidden@example.com', ...COMMERCIAL_ACKS })
+        .expect(200);
+
+      const getRes = await request(app)
+        .get('/api/setup/license')
+        .expect(200);
+
+      expect(getRes.body.verificationCode).toBeUndefined();
+      expect(getRes.body.verificationAttempts).toBeUndefined();
+      expect(getRes.body.status).toBe('pending');
+    });
+  });
+
+  describe('POST /api/setup/license/verify', () => {
+    async function setupPendingLicense(): Promise<string> {
+      await request(app)
+        .post('/api/setup/license')
+        .send({ tier: 'free-commercial', email: 'verify@example.com', ...COMMERCIAL_ACKS })
+        .expect(200);
+
+      const raw = await readFile(LICENSE_PATH, 'utf-8');
+      return JSON.parse(raw).verificationCode;
+    }
+
+    it('activates license with correct code', async () => {
+      const code = await setupPendingLicense();
+
+      const res = await request(app)
+        .post('/api/setup/license/verify')
+        .send({ code })
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.license.status).toBe('active');
+      expect(res.body.license.verifiedAt).toBeDefined();
+      expect(res.body.license.verificationCode).toBeUndefined();
+    });
+
+    it('rejects incorrect code with remaining attempts', async () => {
+      await setupPendingLicense();
+
+      const res = await request(app)
+        .post('/api/setup/license/verify')
+        .send({ code: '000000' })
+        .expect(400);
+
+      expect(res.body.error).toContain('Incorrect');
+      expect(res.body.error).toContain('remaining');
+    });
+
+    it('rejects non-6-digit code', async () => {
+      await setupPendingLicense();
+
+      await request(app).post('/api/setup/license/verify').send({ code: 'abc' }).expect(400);
+      await request(app).post('/api/setup/license/verify').send({ code: '12345' }).expect(400);
+      await request(app).post('/api/setup/license/verify').send({ code: '1234567' }).expect(400);
+    });
+
+    it('rejects when no pending license exists', async () => {
+      await request(app)
+        .post('/api/setup/license')
+        .send({ tier: 'agpl' })
+        .expect(200);
+
+      const res = await request(app)
+        .post('/api/setup/license/verify')
+        .send({ code: '123456' })
+        .expect(400);
+
+      expect(res.body.error).toContain('No pending');
+    });
+
+    it('invalidates after max attempts exceeded', async () => {
+      await setupPendingLicense();
+
+      for (let i = 0; i < 5; i++) {
+        await request(app)
+          .post('/api/setup/license/verify')
+          .send({ code: '000000' });
+      }
+
+      const res = await request(app)
+        .post('/api/setup/license/verify')
+        .send({ code: '000000' });
+
+      // Accept 400 (max attempts) or 429 (rate limit) — both block the attempt
+      expect([400, 429]).toContain(res.status);
+    });
+  });
+
+  describe('POST /api/setup/license/resend', () => {
+    it('generates a new code for pending license', async () => {
+      await request(app)
+        .post('/api/setup/license')
+        .send({ tier: 'free-commercial', email: 'resend@example.com', ...COMMERCIAL_ACKS })
+        .expect(200);
+
+      const res = await request(app)
+        .post('/api/setup/license/resend')
+        .send({})
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+
+      const raw = await readFile(LICENSE_PATH, 'utf-8');
+      const license = JSON.parse(raw);
+      expect(license.verificationCode).toBeDefined();
+      expect(license.verificationCode).toHaveLength(6);
+    });
+
+    it('rejects when no pending license', async () => {
+      await request(app)
+        .post('/api/setup/license')
+        .send({ tier: 'agpl' })
+        .expect(200);
+
+      await request(app)
+        .post('/api/setup/license/resend')
+        .send({})
+        .expect(400);
+    });
+  });
+});

--- a/tests/unit/web/licenseRoutes.test.ts
+++ b/tests/unit/web/licenseRoutes.test.ts
@@ -674,17 +674,17 @@ describe('License Routes — Email Verification', () => {
     });
   });
 
+  async function setupPendingLicense(): Promise<string> {
+    await request(app)
+      .post('/api/setup/license')
+      .send({ tier: 'free-commercial', email: 'verify@example.com', ...COMMERCIAL_ACKS })
+      .expect(200);
+
+    const raw = await readFile(LICENSE_PATH, 'utf-8');
+    return JSON.parse(raw).verificationCode;
+  }
+
   describe('POST /api/setup/license/verify', () => {
-    async function setupPendingLicense(): Promise<string> {
-      await request(app)
-        .post('/api/setup/license')
-        .send({ tier: 'free-commercial', email: 'verify@example.com', ...COMMERCIAL_ACKS })
-        .expect(200);
-
-      const raw = await readFile(LICENSE_PATH, 'utf-8');
-      return JSON.parse(raw).verificationCode;
-    }
-
     it('activates license with correct code', async () => {
       const code = await setupPendingLicense();
 

--- a/workers/license-email/src/index.ts
+++ b/workers/license-email/src/index.ts
@@ -297,25 +297,45 @@ interface EmailParams {
   env: Env;
 }
 
-async function sendEmail(params: EmailParams): Promise<void> {
-  const response = await fetch('https://api.resend.com/emails', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${params.env.RESEND_API_KEY}`,
-    },
-    body: JSON.stringify({
-      from: `${params.from.name} <${params.from.email}>`,
-      to: [params.to],
-      reply_to: params.replyTo,
-      subject: params.subject,
-      html: params.html,
-    }),
-  });
+const MAX_RETRIES = 3;
+const INITIAL_BACKOFF_MS = 500;
 
-  if (!response.ok) {
+async function sendEmail(params: EmailParams): Promise<void> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      const backoff = INITIAL_BACKOFF_MS * Math.pow(2, attempt - 1);
+      await new Promise(resolve => setTimeout(resolve, backoff));
+    }
+
+    const response = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${params.env.RESEND_API_KEY}`,
+      },
+      body: JSON.stringify({
+        from: `${params.from.name} <${params.from.email}>`,
+        to: [params.to],
+        reply_to: params.replyTo,
+        subject: params.subject,
+        html: params.html,
+      }),
+    });
+
+    if (response.ok) return;
+
     const text = await response.text();
-    console.error(`Resend API error (${response.status}):`, text);
-    throw new Error('Email delivery failed');
+    console.error(`Resend API error (attempt ${attempt + 1}/${MAX_RETRIES + 1}, status ${response.status}):`, text);
+
+    // Don't retry on client errors (400, 401, 403, 422) — only server/rate errors
+    if (response.status < 500 && response.status !== 429) {
+      throw new Error('Email delivery failed');
+    }
+
+    lastError = new Error('Email delivery failed');
   }
+
+  throw lastError ?? new Error('Email delivery failed');
 }

--- a/workers/license-email/src/index.ts
+++ b/workers/license-email/src/index.ts
@@ -180,12 +180,12 @@ function buildVerificationEmail(
   <div style="background: #fefce8; border: 1px solid #fde68a; border-radius: 8px; padding: 20px; margin: 24px 0;">
     <p style="margin: 0 0 12px; font-size: 15px; font-weight: 600; color: #92400e; text-align: center;">Reading this on your phone or another device?</p>
     <p style="margin: 0 0 12px; font-size: 14px; color: #78716c; text-align: center;">Copy this code and paste it into the Setup page on your computer:</p>
-    <div style="background: #ffffff; border: 2px solid #e2e8f0; border-radius: 12px; padding: 16px; text-align: center;">
-      <a href="mailto:?subject=DollhouseMCP%20Verification%20Code&amp;body=${code}" style="text-decoration: none;">
-        <p style="margin: 0; font-size: 36px; font-weight: 700; letter-spacing: 10px; color: #1a1a2e; font-family: monospace;">${code}</p>
-      </a>
-      <p style="margin: 8px 0 0; font-size: 12px; color: #94a3b8;">Tap the code to share it, or long-press to copy</p>
-    </div>
+    <table role="presentation" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
+      <tr>
+        <td style="background: #ffffff; border: 2px solid #e2e8f0; border-radius: 12px; padding: 18px 28px; text-align: center; font-size: 36px; font-weight: 700; letter-spacing: 10px; color: #1a1a2e; font-family: monospace;">${code.split('').join(' ')}</td>
+      </tr>
+    </table>
+    <p style="margin: 10px 0 0; font-size: 13px; color: #78716c; text-align: center;">Type this code on the DollhouseMCP Setup page on your computer</p>
   </div>
 
   <p style="color: #64748b; font-size: 13px;">This link and code expire in 10 minutes. If you didn't request this, you can safely ignore this email.</p>

--- a/workers/license-email/src/index.ts
+++ b/workers/license-email/src/index.ts
@@ -169,13 +169,23 @@ function buildVerificationEmail(
   <h2 style="color: #1a1a2e;">Verify your email address</h2>
   <p>You're registering a <strong>${esc(props.tier === 'paid-commercial' ? 'Enterprise' : 'Commercial')}</strong> license for DollhouseMCP.</p>
 
-  <div style="text-align: center; margin: 24px 0;">
-    <a href="${verifyUrl}" style="display: inline-block; background: #3b82f6; color: #ffffff; font-weight: 600; font-size: 16px; padding: 14px 32px; border-radius: 8px; text-decoration: none;">Verify my email</a>
+  <div style="background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 8px; padding: 20px; margin: 24px 0;">
+    <p style="margin: 0 0 12px; font-size: 15px; font-weight: 600; color: #1e40af; text-align: center;">On the same computer where DollhouseMCP is installed?</p>
+    <div style="text-align: center;">
+      <a href="${verifyUrl}" style="display: inline-block; background: #3b82f6; color: #ffffff; font-weight: 600; font-size: 16px; padding: 14px 32px; border-radius: 8px; text-decoration: none;">Verify my email</a>
+    </div>
+    <p style="color: #64748b; font-size: 13px; margin: 10px 0 0; text-align: center;">This button opens your DollhouseMCP console and verifies automatically.</p>
   </div>
 
-  <p style="color: #64748b; font-size: 13px; text-align: center;">Or enter this code manually on the Setup page:</p>
-  <div style="background: #f8fafc; border: 2px solid #e2e8f0; border-radius: 12px; padding: 16px; margin: 12px 0; text-align: center;">
-    <p style="margin: 0; font-size: 32px; font-weight: 700; letter-spacing: 8px; color: #1a1a2e; font-family: monospace;">${code}</p>
+  <div style="background: #fefce8; border: 1px solid #fde68a; border-radius: 8px; padding: 20px; margin: 24px 0;">
+    <p style="margin: 0 0 12px; font-size: 15px; font-weight: 600; color: #92400e; text-align: center;">Reading this on your phone or another device?</p>
+    <p style="margin: 0 0 12px; font-size: 14px; color: #78716c; text-align: center;">Copy this code and paste it into the Setup page on your computer:</p>
+    <div style="background: #ffffff; border: 2px solid #e2e8f0; border-radius: 12px; padding: 16px; text-align: center;">
+      <a href="mailto:?subject=DollhouseMCP%20Verification%20Code&amp;body=${code}" style="text-decoration: none;">
+        <p style="margin: 0; font-size: 36px; font-weight: 700; letter-spacing: 10px; color: #1a1a2e; font-family: monospace;">${code}</p>
+      </a>
+      <p style="margin: 8px 0 0; font-size: 12px; color: #94a3b8;">Tap the code to share it, or long-press to copy</p>
+    </div>
   </div>
 
   <p style="color: #64748b; font-size: 13px;">This link and code expire in 10 minutes. If you didn't request this, you can safely ignore this email.</p>

--- a/workers/license-email/src/index.ts
+++ b/workers/license-email/src/index.ts
@@ -35,6 +35,8 @@ interface PostHogEvent {
   properties: {
     tier: 'free-commercial' | 'paid-commercial';
     email: string;
+    event_type?: 'verification' | 'activation';
+    verification_code?: string;
     server_version?: string;
     os?: string;
     revenue_scale?: string;
@@ -69,39 +71,56 @@ export default {
       return new Response('Ignored: not a license_activation event', { status: 200 });
     }
 
-    const { tier, email } = event.properties;
+    const { tier, email, event_type, verification_code } = event.properties;
     if (!email || !tier) {
       return new Response('Missing required fields: tier, email', { status: 400 });
     }
 
-    const { subject, html } = tier === 'paid-commercial'
-      ? buildEnterpriseEmail(event.properties, env)
-      : buildCommercialEmail(event.properties, env);
-
     try {
-      await sendEmail({
-        from: { name: env.FROM_NAME, email: env.FROM_EMAIL },
-        to: email,
-        replyTo: env.REPLY_TO,
-        subject,
-        html,
-        env,
-      });
-
-      // For Enterprise, also notify the sales team
-      if (tier === 'paid-commercial') {
-        const salesNotification = buildSalesNotification(event.properties);
+      if (event_type === 'verification') {
+        // Step 1: Send verification code email
+        if (!verification_code) {
+          return new Response('Missing verification_code for verification event', { status: 400 });
+        }
+        const verificationEmail = buildVerificationEmail(event.properties, env);
         await sendEmail({
           from: { name: env.FROM_NAME, email: env.FROM_EMAIL },
-          to: env.REPLY_TO,
-          replyTo: email,
-          subject: salesNotification.subject,
-          html: salesNotification.html,
+          to: email,
+          replyTo: env.REPLY_TO,
+          subject: verificationEmail.subject,
+          html: verificationEmail.html,
           env,
         });
+      } else {
+        // Step 2: Send confirmation email (after verification succeeds)
+        const { subject, html } = tier === 'paid-commercial'
+          ? buildEnterpriseEmail(event.properties, env)
+          : buildCommercialEmail(event.properties, env);
+
+        await sendEmail({
+          from: { name: env.FROM_NAME, email: env.FROM_EMAIL },
+          to: email,
+          replyTo: env.REPLY_TO,
+          subject,
+          html,
+          env,
+        });
+
+        // For Enterprise, also notify the sales team
+        if (tier === 'paid-commercial') {
+          const salesNotification = buildSalesNotification(event.properties);
+          await sendEmail({
+            from: { name: env.FROM_NAME, email: env.FROM_EMAIL },
+            to: env.REPLY_TO,
+            replyTo: email,
+            subject: salesNotification.subject,
+            html: salesNotification.html,
+            env,
+          });
+        }
       }
 
-      return new Response(JSON.stringify({ success: true, tier, email }), {
+      return new Response(JSON.stringify({ success: true, tier, email, event_type: event_type ?? 'activation' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       });
@@ -129,6 +148,34 @@ function esc(str: string | undefined | null): string {
 }
 
 // ── Email templates ──────────────────────────────────────────────────
+
+function buildVerificationEmail(
+  props: PostHogEvent['properties'],
+  env: Env,
+): { subject: string; html: string } {
+  const code = esc(props.verification_code);
+  return {
+    subject: `DollhouseMCP — Your verification code is ${code}`,
+    html: `
+<!DOCTYPE html>
+<html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a2e; max-width: 600px; margin: 0 auto; padding: 24px;">
+  <h2 style="color: #1a1a2e;">Verify your email address</h2>
+  <p>You're registering a <strong>${esc(props.tier === 'paid-commercial' ? 'Enterprise' : 'Commercial')}</strong> license for DollhouseMCP.</p>
+
+  <div style="background: #f8fafc; border: 2px solid #e2e8f0; border-radius: 12px; padding: 24px; margin: 24px 0; text-align: center;">
+    <p style="margin: 0 0 8px; font-size: 14px; color: #64748b;">Your verification code:</p>
+    <p style="margin: 0; font-size: 36px; font-weight: 700; letter-spacing: 8px; color: #1a1a2e; font-family: monospace;">${code}</p>
+  </div>
+
+  <p>Enter this code on the DollhouseMCP Setup page to complete your license registration.</p>
+  <p style="color: #64748b; font-size: 13px;">This code expires in 10 minutes. If you didn't request this, you can safely ignore this email.</p>
+
+  <hr style="border: none; border-top: 1px solid #e2e8f0; margin: 24px 0;">
+  <p style="font-size: 12px; color: #64748b;">DollhouseMCP &mdash; AI customization through modular elements<br>
+  <a href="https://github.com/DollhouseMCP/mcp-server" style="color: #3b82f6;">github.com/DollhouseMCP/mcp-server</a></p>
+</body></html>`,
+  };
+}
 
 function buildCommercialEmail(
   props: PostHogEvent['properties'],

--- a/workers/license-email/src/index.ts
+++ b/workers/license-email/src/index.ts
@@ -46,13 +46,56 @@ interface PostHogEvent {
   timestamp?: string;
 }
 
+/** Handle verification event: send verification code email. */
+async function handleVerification(props: PostHogEvent['properties'], env: Env): Promise<void> {
+  if (!props.verification_code) {
+    throw new Error('Missing verification_code for verification event');
+  }
+  const verificationEmail = buildVerificationEmail(props, env);
+  await sendEmail({
+    from: { name: env.FROM_NAME, email: env.FROM_EMAIL },
+    to: props.email,
+    replyTo: env.REPLY_TO,
+    subject: verificationEmail.subject,
+    html: verificationEmail.html,
+    env,
+  });
+}
+
+/** Handle activation event: send confirmation email (+ sales notification for Enterprise). */
+async function handleActivation(props: PostHogEvent['properties'], env: Env): Promise<void> {
+  const { subject, html } = props.tier === 'paid-commercial'
+    ? buildEnterpriseEmail(props, env)
+    : buildCommercialEmail(props, env);
+
+  await sendEmail({
+    from: { name: env.FROM_NAME, email: env.FROM_EMAIL },
+    to: props.email,
+    replyTo: env.REPLY_TO,
+    subject,
+    html,
+    env,
+  });
+
+  if (props.tier === 'paid-commercial') {
+    const salesNotification = buildSalesNotification(props);
+    await sendEmail({
+      from: { name: env.FROM_NAME, email: env.FROM_EMAIL },
+      to: env.REPLY_TO,
+      replyTo: props.email,
+      subject: salesNotification.subject,
+      html: salesNotification.html,
+      env,
+    });
+  }
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     if (request.method !== 'POST') {
       return new Response('Method not allowed', { status: 405 });
     }
 
-    // Validate PostHog webhook secret
     if (env.POSTHOG_WEBHOOK_SECRET) {
       const secret = request.headers.get('x-posthog-secret');
       if (secret !== env.POSTHOG_WEBHOOK_SECRET) {
@@ -71,53 +114,16 @@ export default {
       return new Response('Ignored: not a license_activation event', { status: 200 });
     }
 
-    const { tier, email, event_type, verification_code } = event.properties;
+    const { tier, email, event_type } = event.properties;
     if (!email || !tier) {
       return new Response('Missing required fields: tier, email', { status: 400 });
     }
 
     try {
       if (event_type === 'verification') {
-        // Step 1: Send verification code email
-        if (!verification_code) {
-          return new Response('Missing verification_code for verification event', { status: 400 });
-        }
-        const verificationEmail = buildVerificationEmail(event.properties, env);
-        await sendEmail({
-          from: { name: env.FROM_NAME, email: env.FROM_EMAIL },
-          to: email,
-          replyTo: env.REPLY_TO,
-          subject: verificationEmail.subject,
-          html: verificationEmail.html,
-          env,
-        });
+        await handleVerification(event.properties, env);
       } else {
-        // Step 2: Send confirmation email (after verification succeeds)
-        const { subject, html } = tier === 'paid-commercial'
-          ? buildEnterpriseEmail(event.properties, env)
-          : buildCommercialEmail(event.properties, env);
-
-        await sendEmail({
-          from: { name: env.FROM_NAME, email: env.FROM_EMAIL },
-          to: email,
-          replyTo: env.REPLY_TO,
-          subject,
-          html,
-          env,
-        });
-
-        // For Enterprise, also notify the sales team
-        if (tier === 'paid-commercial') {
-          const salesNotification = buildSalesNotification(event.properties);
-          await sendEmail({
-            from: { name: env.FROM_NAME, email: env.FROM_EMAIL },
-            to: env.REPLY_TO,
-            replyTo: email,
-            subject: salesNotification.subject,
-            html: salesNotification.html,
-            env,
-          });
-        }
+        await handleActivation(event.properties, env);
       }
 
       return new Response(JSON.stringify({ success: true, tier, email, event_type: event_type ?? 'activation' }), {

--- a/workers/license-email/src/index.ts
+++ b/workers/license-email/src/index.ts
@@ -160,21 +160,25 @@ function buildVerificationEmail(
   env: Env,
 ): { subject: string; html: string } {
   const code = esc(props.verification_code);
+  const verifyUrl = `http://dollhouse.localhost:41715#verify=${code}`;
   return {
-    subject: `DollhouseMCP — Your verification code is ${code}`,
+    subject: `DollhouseMCP — Verify your email to activate your license`,
     html: `
 <!DOCTYPE html>
 <html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a2e; max-width: 600px; margin: 0 auto; padding: 24px;">
   <h2 style="color: #1a1a2e;">Verify your email address</h2>
   <p>You're registering a <strong>${esc(props.tier === 'paid-commercial' ? 'Enterprise' : 'Commercial')}</strong> license for DollhouseMCP.</p>
 
-  <div style="background: #f8fafc; border: 2px solid #e2e8f0; border-radius: 12px; padding: 24px; margin: 24px 0; text-align: center;">
-    <p style="margin: 0 0 8px; font-size: 14px; color: #64748b;">Your verification code:</p>
-    <p style="margin: 0; font-size: 36px; font-weight: 700; letter-spacing: 8px; color: #1a1a2e; font-family: monospace;">${code}</p>
+  <div style="text-align: center; margin: 24px 0;">
+    <a href="${verifyUrl}" style="display: inline-block; background: #3b82f6; color: #ffffff; font-weight: 600; font-size: 16px; padding: 14px 32px; border-radius: 8px; text-decoration: none;">Verify my email</a>
   </div>
 
-  <p>Enter this code on the DollhouseMCP Setup page to complete your license registration.</p>
-  <p style="color: #64748b; font-size: 13px;">This code expires in 10 minutes. If you didn't request this, you can safely ignore this email.</p>
+  <p style="color: #64748b; font-size: 13px; text-align: center;">Or enter this code manually on the Setup page:</p>
+  <div style="background: #f8fafc; border: 2px solid #e2e8f0; border-radius: 12px; padding: 16px; margin: 12px 0; text-align: center;">
+    <p style="margin: 0; font-size: 32px; font-weight: 700; letter-spacing: 8px; color: #1a1a2e; font-family: monospace;">${code}</p>
+  </div>
+
+  <p style="color: #64748b; font-size: 13px;">This link and code expire in 10 minutes. If you didn't request this, you can safely ignore this email.</p>
 
   <hr style="border: none; border-top: 1px solid #e2e8f0; margin: 24px 0;">
   <p style="font-size: 12px; color: #64748b;">DollhouseMCP &mdash; AI customization through modular elements<br>

--- a/workers/license-email/src/index.ts
+++ b/workers/license-email/src/index.ts
@@ -180,12 +180,18 @@ function buildVerificationEmail(
   <div style="background: #fefce8; border: 1px solid #fde68a; border-radius: 8px; padding: 20px; margin: 24px 0;">
     <p style="margin: 0 0 12px; font-size: 15px; font-weight: 600; color: #92400e; text-align: center;">Reading this on your phone or another device?</p>
     <p style="margin: 0 0 12px; font-size: 14px; color: #78716c; text-align: center;">Copy this code and paste it into the Setup page on your computer:</p>
-    <table role="presentation" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
       <tr>
-        <td style="background: #ffffff; border: 2px solid #e2e8f0; border-radius: 12px; padding: 18px 28px; text-align: center; font-size: 36px; font-weight: 700; letter-spacing: 10px; color: #1a1a2e; font-family: monospace;">${code.split('').join(' ')}</td>
+        <td align="center">
+          <table role="presentation" cellpadding="0" cellspacing="0">
+            <tr>
+              <td style="background: #ffffff; border: 2px solid #e2e8f0; border-radius: 12px; padding: 16px 32px; font-size: 32px; font-weight: 700; letter-spacing: 8px; color: #1a1a2e; font-family: 'Courier New', Courier, monospace; white-space: nowrap;">${code}</td>
+            </tr>
+          </table>
+        </td>
       </tr>
     </table>
-    <p style="margin: 10px 0 0; font-size: 13px; color: #78716c; text-align: center;">Type this code on the DollhouseMCP Setup page on your computer</p>
+    <p style="margin: 10px 0 0; font-size: 13px; color: #78716c; text-align: center;">Long-press the code to copy it, then paste on the Setup page</p>
   </div>
 
   <p style="color: #64748b; font-size: 13px;">This link and code expire in 10 minutes. If you didn't request this, you can safely ignore this email.</p>


### PR DESCRIPTION
## Summary

Commercial and Enterprise license registrations now require email verification before activation, with instant email delivery and a polished multi-device UX.

## Verification Flow

1. User submits license form → license saved as `status: 'pending'`
2. Server calls Cloudflare Worker directly → verification email arrives instantly
3. Email has two clear sections:
   - **Blue box**: "On the same computer?" → click-through verify button (auto-verifies)
   - **Yellow box**: "On your phone?" → 6-digit code to type manually
4. Original tab polls every 3s — auto-updates when verified from another tab
5. After verification → license details panel shows type, email, activation date, file path

## Security

- 6-digit codes via `crypto.randomInt` (CSPRNG), 10-minute TTL
- Codes never exposed in API responses
- 5 max attempts before invalidation, 5 req/min rate limit on verify
- 3 resends per 2 min rate limit
- Exponential backoff retry (3x) on Resend API failures
- SecurityMonitor audit logging for all verification events
- Confirmation dialog when downgrading from active Commercial to AGPL

## New Endpoints

- `POST /api/setup/license/verify` — validates code, activates license
- `POST /api/setup/license/resend` — generates new code, resets TTL

## Instant Email Delivery

- Server calls Worker directly via `fetch()` (bypasses PostHog pipeline delay)
- PostHog event still fires non-blocking for analytics
- Requires `DOLLHOUSE_LICENSE_WORKER_URL` and `DOLLHOUSE_LICENSE_WORKER_SECRET` env vars

## Verification Analytics (PostHog)

- `verification_time_ms` / `verification_time_seconds`: time from code request to verify
- `verification_attempts`: how many tries (1 = first try / click-through)
- `event_type`: `verification` (code sent) vs `activation` (verified)

## License Details Panel

After activation, shows: license type, email, status, activation date, telemetry status, enterprise details, and file path (`~/.dollhouse/license.json`)

## AGPL Downgrade Protection

Switching from active Commercial to AGPL shows confirmation: "You have an active Commercial license. Switching to AGPL will deactivate your Commercial license. You can reactivate your Commercial license at any time."

## Test plan

- [x] 46 license API tests (10 verification flow tests)
- [x] 25 Worker email template tests
- [x] 71 total license tests passing
- [x] 9,651 full suite tests passing
- [x] Manual end-to-end: form → instant email → click verify → both tabs update
- [x] Manual: phone email → copy code → paste → verify
- [x] Manual: AGPL downgrade confirmation dialog

Closes #1830

🤖 Generated with [Claude Code](https://claude.com/claude-code)