### PR TITLE
fix(ux): clarify Setup heading — Connect DollhouseMCP to your AI client

### DIFF
--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -61,7 +61,7 @@
           <span class="setup-status-dot"></span>
           <span>DollhouseMCP is running on your machine</span>
         </div>
-        <h2 class="setup-hero-title">Connect your AI client</h2>
+        <h2 class="setup-hero-title">Connect DollhouseMCP to your AI client</h2>
         <p class="setup-hero-sub">Pick your platform below. Click <strong>Install Now</strong> to auto-configure, or copy the config manually.</p>
       </div>
 


### PR DESCRIPTION
## Summary

Changes "Connect your AI client" to "Connect DollhouseMCP to your AI client" on the Setup tab heading.

Users were confused, thinking they were being asked to install Claude Desktop/Cursor/etc. rather than add DollhouseMCP to those clients.

Closes #1827

🤖 Generated with [Claude Code](https://claude.com/claude-code)