### PR TITLE
feat(setup): add release channel selector (Stable / RC / Beta)

### DIFF
--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -62,7 +62,7 @@
           <span>DollhouseMCP is running on your machine</span>
         </div>
         <h2 class="setup-hero-title">Connect DollhouseMCP to your AI client</h2>
-        <p class="setup-hero-sub">Pick your platform below. Click <strong>Install Now</strong> to auto-configure, or copy the config manually.</p>
+        <p class="setup-hero-sub">Pick your platform below. Click <strong>Configure Now</strong> to connect, or copy the config manually.</p>
       </div>
 
       <fieldset class="setup-method-toggle" id="setup-method-toggle">
@@ -132,10 +132,10 @@ npm install @dollhousemcp/mcp-server</code></pre>
       <!-- Claude Desktop -->
       <section class="setup-panel is-active" role="tabpanel" id="setup-panel-claude-desktop" aria-labelledby="setup-tab-claude-desktop">
         <div class="setup-method setup-method-primary">
-          <h3>Auto-install <span class="setup-method-badge setup-badge">auto-updating</span></h3>
+          <h3>Auto-configure <span class="setup-method-badge setup-badge">auto-updating</span></h3>
           <p class="setup-method-desc">Pulls the latest version of DollhouseMCP on every startup. Uses <code>npx @latest</code> under the hood. Restart Claude Desktop after.</p>
           <div class="setup-install-row">
-            <button class="setup-btn setup-btn-primary setup-install-btn" type="button" data-install-client="claude">Install Now</button>
+            <button class="setup-btn setup-btn-primary setup-install-btn" type="button" data-install-client="claude">Configure Now</button>
             <span class="setup-install-status" data-install-status="claude"></span>
           </div>
         </div>
@@ -172,10 +172,10 @@ npm install @dollhousemcp/mcp-server</code></pre>
       <!-- Claude Code -->
       <section class="setup-panel" role="tabpanel" id="setup-panel-claude-code" aria-labelledby="setup-tab-claude-code" hidden>
         <div class="setup-method setup-method-primary">
-          <h3>Auto-install <span class="setup-method-badge setup-badge">auto-updating</span></h3>
+          <h3>Auto-configure <span class="setup-method-badge setup-badge">auto-updating</span></h3>
           <p class="setup-method-desc">Adds DollhouseMCP to Claude Code, pulling the latest version on every startup.</p>
           <div class="setup-install-row">
-            <button class="setup-btn setup-btn-primary setup-install-btn" type="button" data-install-client="claude-code">Install Now</button>
+            <button class="setup-btn setup-btn-primary setup-install-btn" type="button" data-install-client="claude-code">Configure Now</button>
             <span class="setup-install-status" data-install-status="claude-code"></span>
           </div>
         </div>
@@ -382,7 +382,7 @@ npm install @dollhousemcp/mcp-server</code></pre>
         <p>Full documentation for all platforms (Continue, Docker, local LLMs) in the
           <a href="https://github.com/DollhouseMCP/mcp-server/blob/main/docs/guides/quick-start.md" target="_blank" rel="noopener">quick start guide</a>.
         </p>
-        <p>Auto-install powered by <a href="https://github.com/supermemoryai/install-mcp" target="_blank" rel="noopener">install-mcp</a> by <a href="https://github.com/dhravyashah" target="_blank" rel="noopener">Dhravya Shah</a>.</p>
+        <p>Auto-configure powered by <a href="https://github.com/supermemoryai/install-mcp" target="_blank" rel="noopener">install-mcp</a> by <a href="https://github.com/dhravyashah" target="_blank" rel="noopener">Dhravya Shah</a>.</p>
       </div>
     </div>
   </div>

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -79,7 +79,7 @@
 
       <fieldset class="setup-channel-toggle" id="setup-channel-toggle">
         <legend class="setup-channel-legend">Release channel</legend>
-        <select id="setup-channel-select" class="setup-channel-select">
+        <select id="setup-channel-select" class="setup-channel-select" aria-describedby="setup-channel-hint">
           <option value="latest" selected>Stable</option>
           <option value="rc">Release Candidate</option>
           <option value="beta">Beta</option>

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -77,6 +77,16 @@
         </button>
       </fieldset>
 
+      <fieldset class="setup-channel-toggle" id="setup-channel-toggle">
+        <legend class="setup-channel-legend">Release channel</legend>
+        <select id="setup-channel-select" class="setup-channel-select">
+          <option value="latest" selected>Stable</option>
+          <option value="rc">Release Candidate</option>
+          <option value="beta">Beta</option>
+        </select>
+        <span class="setup-channel-hint" id="setup-channel-hint">Recommended for most users.</span>
+      </fieldset>
+
       <!-- Pinned install prereq (hidden by default, shown when pinned selected) -->
       <div class="setup-pinned-prereq" id="setup-pinned-prereq" hidden>
         <div class="setup-method">

--- a/src/web/public/setup.css
+++ b/src/web/public/setup.css
@@ -115,6 +115,45 @@
   color: var(--signal);
 }
 
+/* ── Channel selector ──────────────────────────────────────────────────── */
+
+.setup-channel-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border: none;
+  padding: 0;
+  margin: 0 0 1.2rem;
+}
+
+.setup-channel-legend {
+  font-family: var(--font-heading);
+  font-size: var(--step--1);
+  font-weight: 600;
+  color: var(--ink-700);
+}
+
+.setup-channel-select {
+  appearance: auto;
+  padding: 0.35rem 0.6rem;
+  border: 2px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  font-size: var(--step--1);
+  color: var(--ink-950);
+  cursor: pointer;
+}
+
+.setup-channel-select:focus {
+  border-color: var(--signal);
+  outline: none;
+}
+
+.setup-channel-hint {
+  font-size: var(--step--1);
+  color: var(--ink-500);
+}
+
 .setup-pinned-prereq {
   margin-bottom: 1.2rem;
 }

--- a/src/web/public/setup.css
+++ b/src/web/public/setup.css
@@ -126,6 +126,10 @@
   margin: 0 0 1.2rem;
 }
 
+.setup-channel-toggle[hidden] {
+  display: none;
+}
+
 .setup-channel-legend {
   font-family: var(--font-heading);
   font-size: var(--step--1);

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -39,8 +39,8 @@
   const npxCmd = (tag) => `npx -y ${PKG}@${tag}`;
 
   /** Build all platform configs for a given pinned version */
-  function buildConfigs(version, channel) {
-    const ch = channel || 'latest';
+  function buildConfigs(version, channel = 'latest') {
+    const ch = channel;
     const result = {};
     for (const { id, rootKey, cli, toml } of PLATFORMS) {
       const entry = {
@@ -140,6 +140,7 @@
 
   // ── Channel selector ──────────────────────────────────────────────────
 
+  /** User-facing descriptions for each release channel, shown below the selector. */
   const CHANNEL_HINTS = {
     latest: 'Recommended for most users.',
     rc: 'Preview of the next stable release. May have minor issues.',

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -39,24 +39,25 @@
   const npxCmd = (tag) => `npx -y ${PKG}@${tag}`;
 
   /** Build all platform configs for a given pinned version */
-  function buildConfigs(version) {
+  function buildConfigs(version, channel) {
+    const ch = channel || 'latest';
     const result = {};
     for (const { id, rootKey, cli, toml } of PLATFORMS) {
       const entry = {
         npx: cli
-          ? { code: `${cli} mcp add dollhousemcp -- ${npxCmd('latest')}`, isTerminal: true }
-          : jsonConfig(rootKey, npxCmd('latest')),
+          ? { code: `${cli} mcp add dollhousemcp -- ${npxCmd(ch)}`, isTerminal: true }
+          : jsonConfig(rootKey, npxCmd(ch)),
         global: cli
           ? { code: `${cli} mcp add dollhousemcp -- ${npxCmd(version)}`, isTerminal: true }
           : jsonConfig(rootKey, npxCmd(version)),
       };
       if (cli) {
-        entry.npxJson = jsonConfig(rootKey, npxCmd('latest'));
+        entry.npxJson = jsonConfig(rootKey, npxCmd(ch));
         entry.globalJson = jsonConfig(rootKey, npxCmd(version));
       }
       if (toml) {
         const tomlBlock = (tag) => `[mcp_servers.dollhousemcp]\ncommand = "npx"\nargs = ["-y", "${PKG}@${tag}"]`;
-        entry.npxToml = { code: tomlBlock('latest') };
+        entry.npxToml = { code: tomlBlock(ch) };
         entry.globalToml = { code: tomlBlock(version) };
       }
       result[id] = entry;
@@ -66,7 +67,8 @@
 
   // Start with a placeholder version, update once we fetch from server
   let pinnedVersion = 'latest';
-  let configs = buildConfigs(pinnedVersion);
+  let currentChannel = 'latest';
+  let configs = buildConfigs(pinnedVersion, currentChannel);
 
   // ── Current method state ──────────────────────────────────────────────
 
@@ -133,6 +135,28 @@
 
     buttons.forEach((btn) => {
       btn.addEventListener('click', () => handleToggle(btn));
+    });
+  };
+
+  // ── Channel selector ──────────────────────────────────────────────────
+
+  const CHANNEL_HINTS = {
+    latest: 'Recommended for most users.',
+    rc: 'Preview of the next stable release. May have minor issues.',
+    beta: 'Cutting-edge features. May be unstable.',
+  };
+
+  const initChannelSelector = () => {
+    const select = document.getElementById('setup-channel-select');
+    const hint = document.getElementById('setup-channel-hint');
+    if (!select) return;
+
+    select.addEventListener('change', () => {
+      currentChannel = select.value;
+      if (hint) hint.textContent = CHANNEL_HINTS[currentChannel] || '';
+      configs = buildConfigs(pinnedVersion, currentChannel);
+      updateAllConfigs(currentMethod);
+      updateInstallButtonLabels();
     });
   };
 
@@ -285,9 +309,10 @@
     const isPinned = currentMethod === 'global' && pinnedVersion && pinnedVersion !== 'latest';
 
     // Update Install buttons
+    const channelLabel = currentChannel === 'latest' ? '' : ` (${currentChannel})`;
     document.querySelectorAll('.setup-install-btn').forEach((btn) => {
       if (btn.classList.contains('is-success') || btn.classList.contains('is-match')) return;
-      btn.textContent = isPinned ? `Install v${pinnedVersion}` : 'Install Now';
+      btn.textContent = isPinned ? `Install v${pinnedVersion}` : `Install Now${channelLabel}`;
     });
 
     // Update auto-install badges and descriptions
@@ -331,6 +356,8 @@
       const payload = { client };
       if (currentMethod === 'global' && pinnedVersion && pinnedVersion !== 'latest') {
         payload.version = pinnedVersion;
+      } else if (currentChannel !== 'latest') {
+        payload.channel = currentChannel;
       }
 
       const res = await DollhouseAuth.apiFetch('/api/setup/install', {
@@ -524,8 +551,8 @@
       pinnedVersion = data.latest?.version || data.running?.version || pinnedVersion;
       if (pinnedVersion === 'latest') return;
 
-      // Rebuild configs with real version
-      configs = buildConfigs(pinnedVersion);
+      // Rebuild configs with real version and current channel
+      configs = buildConfigs(pinnedVersion, currentChannel);
 
       // Update prereq section
       const versionLabel = document.getElementById('pinned-version-label');
@@ -1259,6 +1286,7 @@
   renderGeneratedPanels();
   highlightOSPaths(os);
   initMethodToggle();
+  initChannelSelector();
   initPlatformTabs();
   initCopyButtons();
   initInstallButtons();

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -113,6 +113,7 @@
     // Cache DOM elements queried on every toggle click
     const prereq = document.getElementById('setup-pinned-prereq');
     const mcpbSection = document.getElementById('setup-mcpb-section');
+    const channelToggle = document.getElementById('setup-channel-toggle');
 
     const handleToggle = (btn) => {
       const method = btn.dataset.method;
@@ -127,6 +128,7 @@
 
       if (prereq) prereq.hidden = method !== 'global';
       if (mcpbSection) mcpbSection.hidden = method !== 'global';
+      if (channelToggle) channelToggle.hidden = method === 'global';
 
       updateAllConfigs(method);
       updateInstallButtonLabels();

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -138,6 +138,11 @@
     buttons.forEach((btn) => {
       btn.addEventListener('click', () => handleToggle(btn));
     });
+
+    // Sync initial visibility — if the browser restored a non-default
+    // active button (e.g. pinned was selected before reload), apply
+    // the hidden state now without waiting for a click.
+    if (channelToggle) channelToggle.hidden = currentMethod === 'global';
   };
 
   // ── Channel selector ──────────────────────────────────────────────────

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -313,7 +313,7 @@
     const channelLabel = currentChannel === 'latest' ? '' : ` (${currentChannel})`;
     document.querySelectorAll('.setup-install-btn').forEach((btn) => {
       if (btn.classList.contains('is-success') || btn.classList.contains('is-match')) return;
-      btn.textContent = isPinned ? `Install v${pinnedVersion}` : `Install Now${channelLabel}`;
+      btn.textContent = isPinned ? `Configure v${pinnedVersion}` : `Configure Now${channelLabel}`;
     });
 
     // Update auto-install badges and descriptions
@@ -337,7 +337,7 @@
 
   // ── Install buttons ────────────────────────────────────────────────────
 
-  /** Handle Install Now button click */
+  /** Handle Configure Now button click */
   const handleInstallClick = async (btn) => {
     const client = btn.dataset.installClient;
     if (!client) return;
@@ -346,7 +346,7 @@
     const originalText = btn.textContent;
 
     btn.disabled = true;
-    btn.textContent = 'Installing...';
+    btn.textContent = 'Configuring...';
     btn.classList.add('is-loading');
     if (status) {
       status.textContent = '';
@@ -708,7 +708,7 @@
       installBtn.classList.add('is-match');
     } else {
       const isPinned = currentMethod === 'global' && pinnedVersion && pinnedVersion !== 'latest';
-      installBtn.textContent = isPinned ? `Install v${pinnedVersion}` : 'Install Now';
+      installBtn.textContent = isPinned ? `Configure v${pinnedVersion}` : 'Configure Now';
       installBtn.disabled = false;
       installBtn.classList.remove('is-match');
     }
@@ -779,12 +779,12 @@
   const openBtnHtml = (openClient) =>
     openClient ? ` <button class="setup-open-btn" type="button" data-open-client="${openClient}">Open config file</button>` : '';
 
-  /** Build the Install Now + CLI terminal command section */
+  /** Build the Configure Now + CLI terminal command section */
   const renderInstallSection = (p) => {
     let html = '';
     if (p.installClient) {
       html += '<div class="setup-method setup-method-primary">';
-      html += `<div class="setup-install-row"><button class="setup-btn setup-btn-primary setup-install-btn" type="button" data-install-client="${p.installClient}">Install Now</button>`;
+      html += `<div class="setup-install-row"><button class="setup-btn setup-btn-primary setup-install-btn" type="button" data-install-client="${p.installClient}">Configure Now</button>`;
       html += `<span class="setup-install-status" data-install-status="${p.installClient}"></span></div>`;
     }
     if (p.cli) {

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -441,21 +441,26 @@ export function createSetupRoutes(): {
     const normalizedClient = validateClient(req, res, ALLOWED_CLIENTS);
     if (!normalizedClient) return;
 
-    // Validate version if provided — must be semver-like (no shell injection)
-    const { version } = req.body as { version?: string };
+    // Validate version or channel if provided — must be semver-like or a known channel (no shell injection)
+    const ALLOWED_CHANNELS = new Set(['latest', 'beta', 'rc']);
+    const { version, channel } = req.body as { version?: string; channel?: string };
     const normalizedVersion = version ? UnicodeValidator.normalize(version).normalizedContent : undefined;
     if (normalizedVersion && !/^\d+\.\d+\.\d+/.test(normalizedVersion)) {
       res.status(400).json({ error: 'Invalid version format. Expected semver (e.g., 2.0.2)' });
       return;
     }
+    // Channel overrides version for auto-updating installs (beta, rc, latest)
+    const effectiveVersion = channel && ALLOWED_CHANNELS.has(channel) && channel !== 'latest'
+      ? channel
+      : normalizedVersion;
 
-    const tag = normalizedVersion ? `@${normalizedVersion}` : '@latest';
+    const tag = effectiveVersion ? `@${effectiveVersion}` : '@latest';
     logger.info(`[Setup] Installing DollhouseMCP${tag} to client: ${normalizedClient}`);
 
     try {
-      const output = await runInstallMcp(normalizedClient, normalizedVersion);
+      const output = await runInstallMcp(normalizedClient, effectiveVersion);
       logger.info(`[Setup] Successfully installed to ${normalizedClient}`);
-      res.json({ success: true, output, client: normalizedClient, version: normalizedVersion || 'latest' });
+      res.json({ success: true, output, client: normalizedClient, version: effectiveVersion || 'latest' });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       logger.warn(`[Setup] Install failed for ${normalizedClient}: ${message}`);

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -55,6 +55,9 @@ const ALLOWED_CLIENTS = new Set([
   'codex',
 ]);
 
+/** Allowed release channels for the install endpoint. */
+const ALLOWED_INSTALL_CHANNELS: ReadonlySet<string> = new Set(['latest', 'beta', 'rc']);
+
 /** Rate limit: 5 installs per minute */
 const installLimiter = new SlidingWindowRateLimiter(5, 60_000);
 
@@ -442,16 +445,17 @@ export function createSetupRoutes(): {
     if (!normalizedClient) return;
 
     // Validate version or channel if provided — must be semver-like or a known channel (no shell injection)
-    const ALLOWED_CHANNELS = new Set(['latest', 'beta', 'rc']);
     const { version, channel } = req.body as { version?: string; channel?: string };
     const normalizedVersion = version ? UnicodeValidator.normalize(version).normalizedContent : undefined;
     if (normalizedVersion && !/^\d+\.\d+\.\d+/.test(normalizedVersion)) {
       res.status(400).json({ error: 'Invalid version format. Expected semver (e.g., 2.0.2)' });
       return;
     }
-    // Channel overrides version for auto-updating installs (beta, rc, latest)
-    const effectiveVersion = channel && ALLOWED_CHANNELS.has(channel) && channel !== 'latest'
-      ? channel
+    // Channel overrides version for auto-updating installs (beta, rc, latest).
+    // Normalize and validate against the allowlist to prevent injection.
+    const normalizedChannel = channel ? UnicodeValidator.normalize(channel).normalizedContent : undefined;
+    const effectiveVersion = normalizedChannel && ALLOWED_INSTALL_CHANNELS.has(normalizedChannel) && normalizedChannel !== 'latest'
+      ? normalizedChannel
       : normalizedVersion;
 
     const tag = effectiveVersion ? `@${effectiveVersion}` : '@latest';

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -358,17 +358,17 @@ describe('Setup Tab — HTML Content Integrity', () => {
     });
   });
 
-  describe('Install Now buttons (static panels)', () => {
-    it('has Install Now for claude (in HTML)', () => {
+  describe('Configure Now buttons (static panels)', () => {
+    it('has Configure Now for claude (in HTML)', () => {
       expect(html).toContain('data-install-client="claude"');
     });
 
-    it('has Install Now for claude-code (in HTML)', () => {
+    it('has Configure Now for claude-code (in HTML)', () => {
       expect(html).toContain('data-install-client="claude-code"');
     });
   });
 
-  describe('Install Now buttons (generated panels)', () => {
+  describe('Configure Now buttons (generated panels)', () => {
     it('JS PLATFORMS registry defines installClient for generated platforms', () => {
       const generatedWithInstall = ['cursor', 'vscode', 'codex', 'gemini-cli', 'windsurf', 'cline'];
       for (const client of generatedWithInstall) {
@@ -648,7 +648,7 @@ describe('Setup Tab — JavaScript Integrity', () => {
 
     it('shows channel label on install button when non-stable', () => {
       expect(js).toContain("channelLabel");
-      expect(js).toContain("`Install Now${channelLabel}`");
+      expect(js).toContain("`Configure Now${channelLabel}`");
     });
 
     it('updates hint text on channel change', () => {
@@ -786,7 +786,7 @@ describe('Setup Tab — Regressions', () => {
   });
 
   describe('UX copy quality', () => {
-    it('auto-install leads with action not mechanism', () => {
+    it('auto-configure leads with action not mechanism', () => {
       // "Pulls the latest version" should come before "Uses npx"
       const pullsIdx = html.indexOf('Pulls the latest version');
       const usesNpxIdx = html.indexOf('Uses <code>npx @latest</code>');
@@ -964,7 +964,7 @@ describe('Setup Tab — Regressions', () => {
 
     it('JS updates button label to show pinned version', () => {
       expect(js).toContain('updateInstallButtonLabels');
-      expect(js).toContain('Install v${pinnedVersion}');
+      expect(js).toContain('Configure v${pinnedVersion}');
     });
   });
 
@@ -1188,7 +1188,7 @@ describe('Setup Tab — Generated Panel DOM Validation', () => {
     }
   });
 
-  it('platforms with installClient have an Install Now button', () => {
+  it('platforms with installClient have a Configure Now button', () => {
     const withInstall = ['cursor', 'vscode', 'codex', 'gemini', 'windsurf', 'cline'];
     for (const p of withInstall) {
       const panel = document.getElementById('setup-panel-' + p);
@@ -1198,7 +1198,7 @@ describe('Setup Tab — Generated Panel DOM Validation', () => {
     }
   });
 
-  it('LM Studio does not have an Install Now button', () => {
+  it('LM Studio does not have a Configure Now button', () => {
     const panel = document.getElementById('setup-panel-lmstudio');
     const btn = panel?.querySelector('.setup-install-btn');
     expect(btn).toBeNull();

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -115,6 +115,41 @@ describe('Setup Routes — API Endpoints', () => {
       }
     });
 
+    it('accepts channel parameter for release channel installs', async () => {
+      const res = await request(app)
+        .post('/api/setup/install')
+        .send({ client: 'claude', channel: 'beta' });
+
+      // Should not get 400 — channel is valid
+      expect(res.status).not.toBe(400);
+    });
+
+    it('accepts rc channel parameter', async () => {
+      const res = await request(app)
+        .post('/api/setup/install')
+        .send({ client: 'claude', channel: 'rc' });
+
+      expect(res.status).not.toBe(400);
+    });
+
+    it('ignores invalid channel values (falls back to latest)', async () => {
+      const res = await request(app)
+        .post('/api/setup/install')
+        .send({ client: 'claude', channel: 'nightly' });
+
+      // Invalid channel is silently ignored, not rejected — falls back to @latest
+      expect(res.status).not.toBe(400);
+    });
+
+    it('ignores channel with shell injection attempt', async () => {
+      const res = await request(app)
+        .post('/api/setup/install')
+        .send({ client: 'claude', channel: '; rm -rf /' });
+
+      // Invalid channel ignored, falls back to @latest — no 500
+      expect(res.status).not.toBe(500);
+    });
+
     it('normalizes client name to lowercase', async () => {
       const res = await request(app)
         .post('/api/setup/install')
@@ -495,6 +530,38 @@ describe('Setup Tab — HTML Content Integrity', () => {
     });
   });
 
+  describe('Release channel selector', () => {
+    it('has channel selector fieldset', () => {
+      expect(html).toContain('id="setup-channel-toggle"');
+    });
+
+    it('has channel select dropdown', () => {
+      expect(html).toContain('id="setup-channel-select"');
+    });
+
+    it('has Stable, Release Candidate, and Beta options', () => {
+      expect(html).toContain('value="latest"');
+      expect(html).toContain('value="rc"');
+      expect(html).toContain('value="beta"');
+      expect(html).toContain('>Stable<');
+      expect(html).toContain('>Release Candidate<');
+      expect(html).toContain('>Beta<');
+    });
+
+    it('defaults to Stable', () => {
+      expect(html).toContain('value="latest" selected');
+    });
+
+    it('has accessible hint text linked via aria-describedby', () => {
+      expect(html).toContain('aria-describedby="setup-channel-hint"');
+      expect(html).toContain('id="setup-channel-hint"');
+    });
+
+    it('has Release channel legend', () => {
+      expect(html).toContain('Release channel');
+    });
+  });
+
   describe('Verify section', () => {
     it('has verification prompt', () => {
       expect(html).toContain('What DollhouseMCP tools do you have available?');
@@ -555,6 +622,40 @@ describe('Setup Tab — JavaScript Integrity', () => {
     });
   });
 
+  describe('Channel selector logic', () => {
+    it('tracks currentChannel state', () => {
+      expect(js).toContain("let currentChannel = 'latest'");
+    });
+
+    it('has channel hints for all three channels', () => {
+      expect(js).toContain('CHANNEL_HINTS');
+      expect(js).toContain("latest:");
+      expect(js).toContain("rc:");
+      expect(js).toContain("beta:");
+    });
+
+    it('buildConfigs accepts channel parameter with default', () => {
+      expect(js).toMatch(/function buildConfigs\(version,\s*channel\s*=\s*'latest'\)/);
+    });
+
+    it('passes channel to buildConfigs on selector change', () => {
+      expect(js).toContain("configs = buildConfigs(pinnedVersion, currentChannel)");
+    });
+
+    it('sends channel in install payload when non-stable', () => {
+      expect(js).toContain('payload.channel = currentChannel');
+    });
+
+    it('shows channel label on install button when non-stable', () => {
+      expect(js).toContain("channelLabel");
+      expect(js).toContain("`Install Now${channelLabel}`");
+    });
+
+    it('updates hint text on channel change', () => {
+      expect(js).toContain("hint.textContent = CHANNEL_HINTS[currentChannel]");
+    });
+  });
+
   describe('Functions', () => {
     it('exports OS detection', () => {
       expect(js).toContain('detectOS');
@@ -562,6 +663,10 @@ describe('Setup Tab — JavaScript Integrity', () => {
 
     it('exports method toggle init', () => {
       expect(js).toContain('initMethodToggle');
+    });
+
+    it('exports channel selector init', () => {
+      expect(js).toContain('initChannelSelector');
     });
 
     it('exports platform tabs init', () => {
@@ -627,6 +732,17 @@ describe('Setup Tab — CSS Integrity', () => {
   it('has responsive styles', () => {
     expect(css).toContain('@media');
     expect(css).toContain('max-width: 640px');
+  });
+
+  it('defines channel selector styles', () => {
+    expect(css).toContain('.setup-channel-toggle');
+    expect(css).toContain('.setup-channel-select');
+    expect(css).toContain('.setup-channel-hint');
+    expect(css).toContain('.setup-channel-legend');
+  });
+
+  it('channel select has focus state', () => {
+    expect(css).toContain('.setup-channel-select:focus');
   });
 });
 
@@ -849,6 +965,42 @@ describe('Setup Tab — Regressions', () => {
     it('JS updates button label to show pinned version', () => {
       expect(js).toContain('updateInstallButtonLabels');
       expect(js).toContain('Install v${pinnedVersion}');
+    });
+  });
+
+  describe('Channel selector regression', () => {
+    it('channel selector initializes after method toggle', () => {
+      const methodIdx = js.indexOf('initMethodToggle()');
+      const channelIdx = js.indexOf('initChannelSelector()');
+      expect(methodIdx).toBeGreaterThan(-1);
+      expect(channelIdx).toBeGreaterThan(-1);
+      expect(channelIdx).toBeGreaterThan(methodIdx);
+    });
+
+    it('channel defaults to latest on page load', () => {
+      expect(js).toContain("let currentChannel = 'latest'");
+    });
+
+    it('no hardcoded @beta or @rc package references in source', () => {
+      expect(js).not.toContain('@dollhousemcp/mcp-server@rc');
+      expect(js).not.toContain('@dollhousemcp/mcp-server@beta');
+    });
+
+    it('channel selector updates configs on change', () => {
+      expect(js).toContain('updateAllConfigs(currentMethod)');
+    });
+
+    it('backend allowlists channel values', () => {
+      const ts = readFileSync(join(process.cwd(), 'src/web/routes/setupRoutes.ts'), 'utf-8');
+      expect(ts).toContain("ALLOWED_INSTALL_CHANNELS");
+      expect(ts).toContain("'latest'");
+      expect(ts).toContain("'beta'");
+      expect(ts).toContain("'rc'");
+    });
+
+    it('backend normalizes channel input', () => {
+      const ts = readFileSync(join(process.cwd(), 'src/web/routes/setupRoutes.ts'), 'utf-8');
+      expect(ts).toContain('UnicodeValidator.normalize(channel)');
     });
   });
 

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -744,6 +744,11 @@ describe('Setup Tab — CSS Integrity', () => {
   it('channel select has focus state', () => {
     expect(css).toContain('.setup-channel-select:focus');
   });
+
+  it('channel toggle has hidden attribute override to prevent display:flex conflict', () => {
+    expect(css).toContain('.setup-channel-toggle[hidden]');
+    expect(css).toContain('display: none');
+  });
 });
 
 // ── Regression tests ──────────────────────────────────────────────────
@@ -1001,6 +1006,11 @@ describe('Setup Tab — Regressions', () => {
     it('backend normalizes channel input', () => {
       const ts = readFileSync(join(process.cwd(), 'src/web/routes/setupRoutes.ts'), 'utf-8');
       expect(ts).toContain('UnicodeValidator.normalize(channel)');
+    });
+
+    it('channel selector hidden on init when pinned mode is active', () => {
+      // The init sync line must apply hidden state without waiting for a click
+      expect(js).toContain("channelToggle.hidden = currentMethod === 'global'");
     });
   });
 

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -728,8 +728,8 @@ describe('Setup Tab — Regressions', () => {
       expect(js).toContain('pinned-local-cmd');
     });
 
-    it('rebuilds configs with fetched version', () => {
-      expect(js).toContain('configs = buildConfigs(pinnedVersion)');
+    it('rebuilds configs with fetched version and channel', () => {
+      expect(js).toContain('configs = buildConfigs(pinnedVersion, currentChannel)');
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds a release channel dropdown (Stable / RC / Beta) to the Setup tab
- Selecting a channel updates all generated configs to use the corresponding npm dist-tag (`@latest`, `@rc`, `@beta`)
- Backend accepts `channel` parameter in install payload, allowlisted to `latest`, `beta`, `rc`
- Install buttons show the channel label when non-stable (e.g. "Install Now (beta)")

Partial fix for #1835 (Phase 2 — setup wizard channel selection).  
Phase 1 (CI auto-tagging) and Phase 3 (channel switching without re-setup) remain open.

## Test plan

- [ ] Open Setup tab, verify "Release channel" dropdown appears between method toggle and platform tabs
- [ ] Select "Beta" — verify config JSON changes from `@latest` to `@beta`
- [ ] Select "Release Candidate" — verify config shows `@rc`
- [ ] Select "Stable" — verify config returns to `@latest`
- [ ] Verify hint text updates for each selection
- [ ] Install button shows "(beta)" or "(rc)" suffix when non-stable
- [ ] Pinned version mode still works independently of channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)