### PR TITLE
fix(setup): hide activation form when commercial license is active

### DIFF
--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -893,7 +893,7 @@
       // Show/hide detail panels. If the selected tier has an active license,
       // keep the form hidden — showLicenseDetails() will display the details
       // card instead (#1841).
-      var hideForm = activeLicense?.status === 'active' && activeLicense?.tier === tier && tier !== 'agpl';
+      const hideForm = activeLicense?.status === 'active' && activeLicense?.tier === tier && tier !== 'agpl';
       for (const [key, el] of Object.entries(details)) {
         if (el) el.hidden = key !== tier || hideForm;
       }
@@ -1165,7 +1165,7 @@
       }
 
       // Hide the activation form for the active tier — the details panel replaces it (#1841)
-      var activeForm = details[license.tier];
+      const activeForm = details[license.tier];
       if (activeForm) activeForm.hidden = true;
 
       const tierLabel = license.tier === 'free-commercial' ? 'Free Commercial' : 'Enterprise';

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -890,10 +890,14 @@
         btn.classList.toggle('is-selected', selected);
         btn.setAttribute('aria-pressed', String(selected));
       });
-      // Show/hide detail panels
+      // Show/hide detail panels. If the selected tier has an active license,
+      // keep the form hidden — showLicenseDetails() will display the details
+      // card instead (#1841).
+      var hideForm = activeLicense?.status === 'active' && activeLicense?.tier === tier && tier !== 'agpl';
       for (const [key, el] of Object.entries(details)) {
-        if (el) el.hidden = key !== tier;
+        if (el) el.hidden = key !== tier || hideForm;
       }
+      if (hideForm) showLicenseDetails(activeLicense);
       // Hide saved banner when switching
       if (savedBanner) savedBanner.hidden = true;
     }
@@ -1137,9 +1141,9 @@
               `You have an active ${tierLabel} license. Switching to AGPL will deactivate your ${tierLabel} license.\n\nYou can reactivate your ${tierLabel} license at any time.\n\nAre you sure?`
             );
             if (!confirmed) {
-              // Restore the previous tier selection and re-hide the form
+              // Restore the previous tier selection (selectTier handles
+              // re-hiding the form when activeLicense is set)
               selectTier(activeLicense.tier);
-              showLicenseDetails(activeLicense);
               return;
             }
           }

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -1159,6 +1159,10 @@
         return;
       }
 
+      // Hide the activation form for the active tier — the details panel replaces it (#1841)
+      var activeForm = details[license.tier];
+      if (activeForm) activeForm.hidden = true;
+
       const tierLabel = license.tier === 'free-commercial' ? 'Free Commercial' : 'Enterprise';
       const rows = [
         ['License type', tierLabel],

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -1137,8 +1137,9 @@
               `You have an active ${tierLabel} license. Switching to AGPL will deactivate your ${tierLabel} license.\n\nYou can reactivate your ${tierLabel} license at any time.\n\nAre you sure?`
             );
             if (!confirmed) {
-              // Restore the previous tier selection
+              // Restore the previous tier selection and re-hide the form
               selectTier(activeLicense.tier);
+              showLicenseDetails(activeLicense);
               return;
             }
           }

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -1123,6 +1123,87 @@ describe('Setup Tab — Regressions', () => {
   });
 });
 
+// ── License form visibility regression (#1841) ──────────────────────────
+// Ensures the activation form is hidden when a commercial license is active,
+// and restored correctly during tier switching.
+
+describe('Setup Tab — License Form Visibility (#1841)', () => {
+  let js: string;
+  let html: string;
+
+  beforeAll(async () => {
+    js = await readFileAsync(join(PUBLIC_DIR, 'setup.js'), 'utf-8');
+    html = await readFileAsync(join(PUBLIC_DIR, 'index.html'), 'utf-8');
+  });
+
+  describe('HTML structure', () => {
+    it('has license detail panels for free-commercial and paid-commercial', () => {
+      expect(html).toContain('id="license-detail-free-commercial"');
+      expect(html).toContain('id="license-detail-paid-commercial"');
+    });
+
+    it('has license active details panel', () => {
+      expect(html).toContain('id="license-active-details"');
+    });
+
+    it('license active details panel is hidden by default', () => {
+      const match = /id="license-active-details"[^>]*/.exec(html);
+      expect(match?.[0]).toContain('hidden');
+    });
+  });
+
+  describe('JS: showLicenseDetails hides activation form', () => {
+    it('hides the activation form for the active tier', () => {
+      expect(js).toContain('const activeForm = details[license.tier]');
+      expect(js).toContain('activeForm.hidden = true');
+    });
+
+    it('uses const not var for activeForm', () => {
+      expect(js).not.toMatch(/var activeForm\b/);
+    });
+  });
+
+  describe('JS: selectTier handles active license', () => {
+    it('checks activeLicense when selecting a tier', () => {
+      expect(js).toContain("activeLicense?.status === 'active'");
+      expect(js).toContain("activeLicense?.tier === tier");
+    });
+
+    it('calls showLicenseDetails when returning to active tier', () => {
+      // selectTier must call showLicenseDetails(activeLicense) when hideForm is true
+      expect(js).toContain('if (hideForm) showLicenseDetails(activeLicense)');
+    });
+
+    it('uses const not var for hideForm', () => {
+      expect(js).not.toMatch(/var hideForm\b/);
+    });
+  });
+
+  describe('JS: AGPL downgrade cancel restores state', () => {
+    it('calls selectTier on cancel to restore previous tier', () => {
+      expect(js).toContain('selectTier(activeLicense.tier)');
+    });
+
+    it('does not need separate showLicenseDetails call on cancel (selectTier handles it)', () => {
+      // The AGPL cancel path should NOT have its own showLicenseDetails call
+      // because selectTier now handles it centrally
+      const agplSection = js.slice(
+        js.indexOf('AGPL selection: confirm'),
+        js.indexOf('const licenseDetailsPanel')
+      );
+      const showDetailsCount = (agplSection.match(/showLicenseDetails/g) || []).length;
+      expect(showDetailsCount).toBe(0);
+    });
+  });
+
+  describe('JS: loadSavedLicense shows details on page load', () => {
+    it('calls showSavedBanner which calls showLicenseDetails', () => {
+      expect(js).toContain('showSavedBanner(license)');
+      expect(js).toContain('showLicenseDetails(license)');
+    });
+  });
+});
+
 // ── Generated panel DOM validation ────────────────────────────────────
 // Uses JSDOM to execute setup.js against the actual HTML template,
 // then validates the rendered DOM output programmatically.


### PR DESCRIPTION
## Summary

- When a commercial license is already active, the activation form (email, checkboxes, Activate button) is now hidden
- The "Your license" details card replaces it cleanly
- Switching to a different tier (e.g., clicking AGPL) restores the form via the existing `selectTier()` logic

Closes #1841

## Test plan

- [ ] With active commercial license: Setup tab shows details card only, no form
- [ ] Click AGPL tier: confirmation dialog appears, form restores if cancelled
- [ ] Fresh install (no license): form appears normally
- [ ] Verify after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)