### PR TITLE
feat(config): unify console port configuration (config → env → default)

### DIFF
--- a/src/config/ConfigManager.ts
+++ b/src/config/ConfigManager.ts
@@ -291,6 +291,23 @@ export class ConfigManager {
   private readonly fileOperations: IFileOperationsService;
   private os: typeof os;
 
+  /**
+   * Extract console.port from raw YAML config content without full
+   * ConfigManager initialization. Uses FAILSAFE_SCHEMA for security
+   * (no code execution). Returns undefined if not found or invalid.
+   */
+  static readPortFromYaml(yamlContent: string): number | undefined {
+    try {
+      const parsed = yaml.load(yamlContent, { schema: yaml.FAILSAFE_SCHEMA }) as Record<string, any> | null;
+      const raw = parsed?.console?.port;
+      if (raw === undefined || raw === null) return undefined;
+      const port = Number(raw);
+      return Number.isFinite(port) ? port : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
   constructor(fileOperations: IFileOperationsService, osModule: typeof os) {
     this.fileOperations = fileOperations;
     this.os = osModule;

--- a/src/config/ConfigManager.ts
+++ b/src/config/ConfigManager.ts
@@ -237,7 +237,13 @@ export interface LicenseConfig {
 }
 
 export interface ConsoleConfig {
-  /** Web console port. Overridden by DOLLHOUSE_WEB_CONSOLE_PORT env var or --port CLI flag. */
+  /**
+   * Web console port (1024–65535). Resolution hierarchy:
+   *   1. --port CLI flag (standalone --web mode only)
+   *   2. This config value (~/.dollhouse/config.yml → console.port)
+   *   3. DOLLHOUSE_WEB_CONSOLE_PORT env var
+   *   4. Default: 41715
+   */
   port: number;
 }
 

--- a/src/config/ConfigManager.ts
+++ b/src/config/ConfigManager.ts
@@ -236,6 +236,18 @@ export interface LicenseConfig {
   useCase?: string;          // Paid commercial: required
 }
 
+/** Branded type for validated port numbers (1024–65535). */
+export type PortNumber = number & { readonly __brand: 'PortNumber' };
+
+/** Validate and brand a port number. Returns undefined if invalid. */
+export function validatePort(value: unknown): PortNumber | undefined {
+  const num = typeof value === 'string' ? Number(value) : value;
+  if (typeof num !== 'number' || !Number.isFinite(num)) return undefined;
+  const port = Math.floor(num);
+  if (port < 1024 || port > 65535) return undefined;
+  return port as PortNumber;
+}
+
 export interface ConsoleConfig {
   /**
    * Web console port (1024–65535). Resolution hierarchy:
@@ -673,6 +685,18 @@ export class ConfigManager {
     
     // SECURITY: Validate path to prevent prototype pollution
     validatePropertyPath(path, 'path');
+
+    // Runtime validation for known typed settings (#1840)
+    if (path === 'console.port') {
+      const validated = validatePort(value);
+      if (!validated) {
+        return {
+          success: false,
+          message: `Invalid port: ${value}. Must be an integer between 1024 and 65535.`,
+        };
+      }
+      value = validated;
+    }
 
     const keys = path.split('.');
     let current: any = this.config;

--- a/src/config/ConfigManager.ts
+++ b/src/config/ConfigManager.ts
@@ -236,6 +236,11 @@ export interface LicenseConfig {
   useCase?: string;          // Paid commercial: required
 }
 
+export interface ConsoleConfig {
+  /** Web console port. Overridden by DOLLHOUSE_WEB_CONSOLE_PORT env var or --port CLI flag. */
+  port: number;
+}
+
 export interface SourcePriorityConfigData {
   order: string[];  // Array of 'local' | 'github' | 'collection'
   stop_on_first: boolean;
@@ -255,6 +260,7 @@ export interface DollhouseConfig {
   autoLoad: AutoLoadConfig;
   retentionPolicy: RetentionPolicyConfig;
   license: LicenseConfig;
+  console: ConsoleConfig;
   source_priority?: SourcePriorityConfigData;
 }
 
@@ -396,6 +402,9 @@ export class ConfigManager {
       },
       license: {
         tier: 'agpl'
+      },
+      console: {
+        port: 41715
       },
       /**
        * Retention Policy Configuration (Issue #51)

--- a/src/di/Container.ts
+++ b/src/di/Container.ts
@@ -993,6 +993,10 @@ export class DollhouseContainer {
       const mcpAqlHandler = this.tryResolve<MCPAQLHandler>('mcpAqlHandler');
       const logManager = this.resolve<LogManager>('LogManager');
 
+      // Resolve console port: config file → env var → default (#1840)
+      const configManager = this.resolve<ConfigManager>('ConfigManager');
+      const configPort = configManager.getSetting<number>('console.port');
+
       const { startUnifiedConsole } = await import('../web/console/UnifiedConsole.js');
       const result = await startUnifiedConsole({
         sessionId,
@@ -1002,6 +1006,7 @@ export class DollhouseContainer {
         mcpAqlHandler,
         registerLogSink: (sink) => logManager.registerSink(sink),
         wireSSEBroadcasts: (webResult, mSink) => this.wireSSEBroadcasts(webResult, mSink),
+        port: configPort,
       });
 
       logger.info(`[Container] Web console started as ${result.role}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -859,13 +859,16 @@ if ((isDirectExecution || isNpxExecution || isCliExecution) && (!isTest || isTes
       if (!resolvedPort) {
         try {
           const { readFile } = await import('node:fs/promises');
-          const yaml = await import('js-yaml');
           const configPath = path.join(os.homedir(), '.dollhouse', 'config.yml');
           const raw = await readFile(configPath, 'utf8');
-          const parsed = yaml.load(raw, { schema: yaml.FAILSAFE_SCHEMA }) as any;
-          const configPort = parsed?.console?.port ? Number(parsed.console.port) : undefined;
-          if (configPort && configPort >= 1024 && configPort <= 65535) {
-            resolvedPort = configPort;
+          // Security: size-limit config file (64KB max, matching SecureYamlParser)
+          // and use ConfigManager's YAML loading which applies FAILSAFE_SCHEMA.
+          if (raw.length <= 64 * 1024) {
+            const { ConfigManager } = await import('./config/ConfigManager.js');
+            const configPort = ConfigManager.readPortFromYaml(raw);
+            if (configPort && configPort >= 1024 && configPort <= 65535) {
+              resolvedPort = configPort;
+            }
           }
         } catch {
           // Config file not available — fall through to env var default

--- a/src/index.ts
+++ b/src/index.ts
@@ -795,8 +795,9 @@ if ((isDirectExecution || isNpxExecution || isCliExecution) && (!isTest || isTes
 
     (async () => {
       const portfolioDir = path.join(os.homedir(), '.dollhouse', 'portfolio');
+      // CLI flag parsed early; config file resolved after container bootstrap (#1840)
       const portArg = process.argv.find(a => a.startsWith('--port='));
-      const port = portArg ? parseInt(portArg.split('=')[1], 10) : undefined;
+      const cliPort = portArg ? parseInt(portArg.split('=')[1], 10) : undefined;
       const noBrowser = process.argv.includes('--no-open');
 
       let mcpAqlHandler;
@@ -853,8 +854,26 @@ if ((isDirectExecution || isNpxExecution || isCliExecution) && (!isTest || isTes
         console.error('[DollhouseMCP] Failed to initialize console token store — Auth tab will be non-functional', err);
       }
 
+      // Resolve port: CLI flag → config file → env var → default (#1840)
+      let resolvedPort = cliPort;
+      if (!resolvedPort) {
+        try {
+          const { readFile } = await import('node:fs/promises');
+          const yaml = await import('js-yaml');
+          const configPath = path.join(os.homedir(), '.dollhouse', 'config.yml');
+          const raw = await readFile(configPath, 'utf8');
+          const parsed = yaml.load(raw, { schema: yaml.FAILSAFE_SCHEMA }) as any;
+          const configPort = parsed?.console?.port ? Number(parsed.console.port) : undefined;
+          if (configPort && configPort >= 1024 && configPort <= 65535) {
+            resolvedPort = configPort;
+          }
+        } catch {
+          // Config file not available — fall through to env var default
+        }
+      }
+
       const { startWebServer } = await import('./web/server.js');
-      await startWebServer({ portfolioDir, port, openBrowser: !noBrowser, mcpAqlHandler, memorySink, metricsSink, additionalRouters: [ingestResult.router], tokenStore });
+      await startWebServer({ portfolioDir, port: resolvedPort, openBrowser: !noBrowser, mcpAqlHandler, memorySink, metricsSink, additionalRouters: [ingestResult.router], tokenStore });
 
       // Listen for quit commands on stdin (standalone --web mode only).
       // In MCP stdio mode, stdin is consumed by the JSON-RPC transport.

--- a/src/index.ts
+++ b/src/index.ts
@@ -789,11 +789,20 @@ async function resolvePortFromConfig(): Promise<number | undefined> {
     const { readFile } = await import('node:fs/promises');
     const configPath = path.join(os.homedir(), '.dollhouse', 'config.yml');
     const raw = await readFile(configPath, 'utf8');
-    if (raw.length > 64 * 1024) return undefined; // 64KB size limit
-    const { ConfigManager } = await import('./config/ConfigManager.js');
-    const configPort = ConfigManager.readPortFromYaml(raw);
-    return configPort && configPort >= 1024 && configPort <= 65535 ? configPort : undefined;
+    if (raw.length > 64 * 1024) {
+      logger.debug('[PortConfig] Config file exceeds 64KB — skipping');
+      return undefined;
+    }
+    const { ConfigManager, validatePort } = await import('./config/ConfigManager.js');
+    const configPort = validatePort(ConfigManager.readPortFromYaml(raw));
+    if (configPort) {
+      logger.debug(`[PortConfig] Resolved port ${configPort} from config file`);
+      return configPort;
+    }
+    logger.debug('[PortConfig] No valid port in config file — using env/default');
+    return undefined;
   } catch {
+    logger.debug('[PortConfig] Config file not found — using env/default');
     return undefined;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -779,6 +779,25 @@ async function startServerWithRetry(retriesLeft = STARTUP_DELAYS.length): Promis
   }
 }
 
+/**
+ * Resolve the console port from config file, with range validation.
+ * Used by standalone --web mode when no CLI --port flag is provided.
+ * Returns undefined if the config file is missing or the port is invalid.
+ */
+async function resolvePortFromConfig(): Promise<number | undefined> {
+  try {
+    const { readFile } = await import('node:fs/promises');
+    const configPath = path.join(os.homedir(), '.dollhouse', 'config.yml');
+    const raw = await readFile(configPath, 'utf8');
+    if (raw.length > 64 * 1024) return undefined; // 64KB size limit
+    const { ConfigManager } = await import('./config/ConfigManager.js');
+    const configPort = ConfigManager.readPortFromYaml(raw);
+    return configPort && configPort >= 1024 && configPort <= 65535 ? configPort : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 if ((isDirectExecution || isNpxExecution || isCliExecution) && (!isTest || isTestMode)) {
   // Issue #704: --web flag starts the portfolio web UI instead of MCP server
   const isWebMode = process.argv.includes('--web');
@@ -797,7 +816,7 @@ if ((isDirectExecution || isNpxExecution || isCliExecution) && (!isTest || isTes
       const portfolioDir = path.join(os.homedir(), '.dollhouse', 'portfolio');
       // CLI flag parsed early; config file resolved after container bootstrap (#1840)
       const portArg = process.argv.find(a => a.startsWith('--port='));
-      const cliPort = portArg ? parseInt(portArg.split('=')[1], 10) : undefined;
+      const cliPort = portArg ? Number.parseInt(portArg.split('=')[1], 10) : undefined;
       const noBrowser = process.argv.includes('--no-open');
 
       let mcpAqlHandler;
@@ -855,25 +874,7 @@ if ((isDirectExecution || isNpxExecution || isCliExecution) && (!isTest || isTes
       }
 
       // Resolve port: CLI flag → config file → env var → default (#1840)
-      let resolvedPort = cliPort;
-      if (!resolvedPort) {
-        try {
-          const { readFile } = await import('node:fs/promises');
-          const configPath = path.join(os.homedir(), '.dollhouse', 'config.yml');
-          const raw = await readFile(configPath, 'utf8');
-          // Security: size-limit config file (64KB max, matching SecureYamlParser)
-          // and use ConfigManager's YAML loading which applies FAILSAFE_SCHEMA.
-          if (raw.length <= 64 * 1024) {
-            const { ConfigManager } = await import('./config/ConfigManager.js');
-            const configPort = ConfigManager.readPortFromYaml(raw);
-            if (configPort && configPort >= 1024 && configPort <= 65535) {
-              resolvedPort = configPort;
-            }
-          }
-        } catch {
-          // Config file not available — fall through to env var default
-        }
-      }
+      const resolvedPort = cliPort || await resolvePortFromConfig();
 
       const { startWebServer } = await import('./web/server.js');
       await startWebServer({ portfolioDir, port: resolvedPort, openBrowser: !noBrowser, mcpAqlHandler, memorySink, metricsSink, additionalRouters: [ingestResult.router], tokenStore });

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -136,6 +136,8 @@ export async function warnIfLegacyConsolePresent(
 export async function startUnifiedConsole(options: UnifiedConsoleOptions): Promise<UnifiedConsoleResult> {
   // Resolve port: options (config file) → env var → default
   const consolePort = options.port || DEFAULT_CONSOLE_PORT;
+  logger.debug(`[UnifiedConsole] Port resolved: ${consolePort}` +
+    (options.port ? ' (from config file)' : ` (from env/default)`));
 
   // Legacy-leader detection (#1794) — warn the user if a pre-auth
   // DollhouseMCP console is running alongside this authenticated one.

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -36,12 +36,13 @@ import { ConsoleTokenStore } from './consoleToken.js';
 import { env } from '../../config/env.js';
 
 /**
- * Port for the unified console leader — single source of truth is the
- * `DOLLHOUSE_WEB_CONSOLE_PORT` env var (defaulted in `src/config/env.ts`).
- * Kept as a local const so the constant name still shows up in this file
- * and in log output, but every runtime reference flows through env.
+ * Default console port from the env var. Used as fallback when no port
+ * is provided via config file or options. The resolution hierarchy is:
+ *   1. options.port (from config file, resolved by the DI container)
+ *   2. DOLLHOUSE_WEB_CONSOLE_PORT env var
+ *   3. 41715 (hardcoded default in env.ts)
  */
-const CONSOLE_PORT = env.DOLLHOUSE_WEB_CONSOLE_PORT;
+const DEFAULT_CONSOLE_PORT = env.DOLLHOUSE_WEB_CONSOLE_PORT;
 
 /**
  * Options for starting the unified console.
@@ -61,6 +62,8 @@ export interface UnifiedConsoleOptions {
   registerLogSink: (sink: { write(entry: UnifiedLogEntry): void; flush(): Promise<void>; close(): Promise<void> }) => void;
   /** Callback to wire SSE broadcasts after web server starts */
   wireSSEBroadcasts: (webResult: { logBroadcast?: (entry: UnifiedLogEntry) => void; metricsOnSnapshot?: (snapshot: MetricSnapshot) => void }, metricsSink?: MemoryMetricsSink) => void;
+  /** Console port override from config file. Falls back to env var if not provided. */
+  port?: number;
 }
 
 /**
@@ -131,14 +134,17 @@ export async function warnIfLegacyConsolePresent(
  * or sets up event forwarding (follower).
  */
 export async function startUnifiedConsole(options: UnifiedConsoleOptions): Promise<UnifiedConsoleResult> {
+  // Resolve port: options (config file) → env var → default
+  const consolePort = options.port || DEFAULT_CONSOLE_PORT;
+
   // Legacy-leader detection (#1794) — warn the user if a pre-auth
   // DollhouseMCP console is running alongside this authenticated one.
   // They will coexist fine because of port + lock + token file isolation,
   // but the user should know both exist so the differing security posture
   // between them doesn't look like a bug.
-  await warnIfLegacyConsolePresent(CONSOLE_PORT);
+  await warnIfLegacyConsolePresent(consolePort);
 
-  let election = await electLeader(options.sessionId, CONSOLE_PORT);
+  let election = await electLeader(options.sessionId, consolePort);
 
   // If we lost the election, check if the leader is actually running a web console.
   // An MCP stdio process may hold leadership but not serve web routes.
@@ -146,12 +152,12 @@ export async function startUnifiedConsole(options: UnifiedConsoleOptions): Promi
   if (election.role === 'follower') {
     const reachable = await isLeaderWebConsoleReachable(election.leaderInfo);
     if (!reachable) {
-      election = await forceClaimLeadership(options.sessionId, CONSOLE_PORT);
+      election = await forceClaimLeadership(options.sessionId, consolePort);
     }
   }
 
   if (election.role === 'leader') {
-    return startAsLeader(options, election);
+    return startAsLeader(options, election, consolePort);
   } else {
     return startAsFollower(options, election);
   }
@@ -159,12 +165,13 @@ export async function startUnifiedConsole(options: UnifiedConsoleOptions): Promi
 
 /**
  * Start as the console leader.
- * Binds the configured web console port (see `DOLLHOUSE_WEB_CONSOLE_PORT`
- * in `src/config/env.ts`), mounts all routes including ingestion, starts heartbeat.
+ * Binds the resolved console port (config file → env var → default),
+ * mounts all routes including ingestion, starts heartbeat.
  */
 async function startAsLeader(
   options: UnifiedConsoleOptions,
   election: ElectionResult,
+  consolePort: number = DEFAULT_CONSOLE_PORT,
 ): Promise<UnifiedConsoleResult> {
   const { startWebServer } = await import('../server.js');
   const { pickRandomPuppetName } = await import('./SessionNames.js');
@@ -204,7 +211,7 @@ async function startAsLeader(
     portfolioDir: options.portfolioDir,
     memorySink: options.memorySink,
     metricsSink: options.metricsSink,
-    port: CONSOLE_PORT,
+    port: consolePort,
     additionalRouters: [ingestResult.router],
     tokenStore,
     ...(options.mcpAqlHandler ? { mcpAqlHandler: options.mcpAqlHandler } : {}),
@@ -234,14 +241,14 @@ async function startAsLeader(
   registerLeaderCleanup();
 
   logger.info('[UnifiedConsole] Leader started', {
-    sessionId: options.sessionId, port: CONSOLE_PORT, pid: process.pid,
+    sessionId: options.sessionId, port: consolePort, pid: process.pid,
     role: 'leader', ingestRoutes: ['/api/ingest/logs', '/api/ingest/metrics', '/api/ingest/session', '/api/sessions'],
   });
 
   return {
     role: 'leader',
     election,
-    port: CONSOLE_PORT,
+    port: consolePort,
     cleanup: async () => {
       stopHeartbeat();
     },

--- a/tests/unit/config/consolePort.test.ts
+++ b/tests/unit/config/consolePort.test.ts
@@ -171,8 +171,8 @@ describe('Console port configuration (#1840)', () => {
       expect(validatePort('abc')).toBeUndefined();
       expect(validatePort(null)).toBeUndefined();
       expect(validatePort(undefined)).toBeUndefined();
-      expect(validatePort(NaN)).toBeUndefined();
-      expect(validatePort(Infinity)).toBeUndefined();
+      expect(validatePort(Number.NaN)).toBeUndefined();
+      expect(validatePort(Number.POSITIVE_INFINITY)).toBeUndefined();
     });
 
     it('floors fractional ports', () => {

--- a/tests/unit/config/consolePort.test.ts
+++ b/tests/unit/config/consolePort.test.ts
@@ -111,10 +111,9 @@ describe('Console port configuration (#1840)', () => {
       expect(source).toContain('ConfigManager.readPortFromYaml');
     });
 
-    it('validates config port is in valid range (1024-65535)', async () => {
+    it('validates config port via validatePort()', async () => {
       const source = await readFile(join(SRC, 'src/index.ts'), 'utf8');
-      expect(source).toContain('configPort >= 1024');
-      expect(source).toContain('configPort <= 65535');
+      expect(source).toContain('validatePort(ConfigManager.readPortFromYaml');
     });
 
     it('size-limits config file before parsing (64KB)', async () => {
@@ -131,6 +130,82 @@ describe('Console port configuration (#1840)', () => {
       const source = await readFile(join(SRC, 'src/index.ts'), 'utf8');
       // cliPort || resolvePortFromConfig() — CLI checked first via ||
       expect(source).toContain('cliPort || await resolvePortFromConfig()');
+    });
+  });
+
+  // ── validatePort branded type ───────────────────────────────────────
+
+  describe('validatePort()', () => {
+    let validatePort: (value: unknown) => number | undefined;
+
+    beforeAll(async () => {
+      const mod = await import('../../../src/config/ConfigManager.js');
+      validatePort = mod.validatePort;
+    });
+
+    it('accepts valid port numbers', () => {
+      expect(validatePort(41715)).toBe(41715);
+      expect(validatePort(1024)).toBe(1024);
+      expect(validatePort(65535)).toBe(65535);
+      expect(validatePort(8080)).toBe(8080);
+    });
+
+    it('accepts string port numbers', () => {
+      expect(validatePort('9000')).toBe(9000);
+      expect(validatePort('41715')).toBe(41715);
+    });
+
+    it('rejects privileged ports', () => {
+      expect(validatePort(80)).toBeUndefined();
+      expect(validatePort(443)).toBeUndefined();
+      expect(validatePort(0)).toBeUndefined();
+      expect(validatePort(1023)).toBeUndefined();
+    });
+
+    it('rejects ports above max', () => {
+      expect(validatePort(65536)).toBeUndefined();
+      expect(validatePort(70000)).toBeUndefined();
+    });
+
+    it('rejects non-numeric values', () => {
+      expect(validatePort('abc')).toBeUndefined();
+      expect(validatePort(null)).toBeUndefined();
+      expect(validatePort(undefined)).toBeUndefined();
+      expect(validatePort(NaN)).toBeUndefined();
+      expect(validatePort(Infinity)).toBeUndefined();
+    });
+
+    it('floors fractional ports', () => {
+      expect(validatePort(8080.7)).toBe(8080);
+    });
+  });
+
+  // ── Runtime validation in updateSetting ────────────────────────────────
+
+  describe('updateSetting runtime validation for console.port', () => {
+    it('ConfigManager validates console.port on set', async () => {
+      const source = await readFile(join(SRC, 'src/config/ConfigManager.ts'), 'utf8');
+      expect(source).toContain("path === 'console.port'");
+      expect(source).toContain('validatePort(value)');
+      expect(source).toContain('Invalid port');
+    });
+  });
+
+  // ── Debug logging ─────────────────────────────────────────────────────
+
+  describe('port resolution debug logging', () => {
+    it('resolvePortFromConfig logs resolution steps', async () => {
+      const source = await readFile(join(SRC, 'src/index.ts'), 'utf8');
+      expect(source).toContain('[PortConfig] Resolved port');
+      expect(source).toContain('[PortConfig] No valid port');
+      expect(source).toContain('[PortConfig] Config file not found');
+    });
+
+    it('UnifiedConsole logs resolved port source', async () => {
+      const source = await readFile(join(SRC, 'src/web/console/UnifiedConsole.ts'), 'utf8');
+      expect(source).toContain('[UnifiedConsole] Port resolved');
+      expect(source).toContain('from config file');
+      expect(source).toContain('from env/default');
     });
   });
 

--- a/tests/unit/config/consolePort.test.ts
+++ b/tests/unit/config/consolePort.test.ts
@@ -95,9 +95,9 @@ describe('Console port configuration (#1840)', () => {
       expect(source).toContain('cliPort');
     });
 
-    it('reads config file for port when no CLI flag', async () => {
+    it('reads config file for port via ConfigManager.readPortFromYaml', async () => {
       const source = await readFile(join(SRC, 'src/index.ts'), 'utf8');
-      expect(source).toContain("parsed?.console?.port");
+      expect(source).toContain('ConfigManager.readPortFromYaml');
     });
 
     it('validates config port is in valid range (1024-65535)', async () => {
@@ -106,9 +106,9 @@ describe('Console port configuration (#1840)', () => {
       expect(source).toContain('configPort <= 65535');
     });
 
-    it('uses FAILSAFE_SCHEMA for secure YAML parsing', async () => {
+    it('size-limits config file before parsing (64KB)', async () => {
       const source = await readFile(join(SRC, 'src/index.ts'), 'utf8');
-      expect(source).toContain('FAILSAFE_SCHEMA');
+      expect(source).toContain('raw.length <= 64 * 1024');
     });
 
     it('passes resolvedPort to startWebServer', async () => {
@@ -118,59 +118,62 @@ describe('Console port configuration (#1840)', () => {
 
     it('CLI flag takes precedence over config file', async () => {
       const source = await readFile(join(SRC, 'src/index.ts'), 'utf8');
-      // cliPort is checked first, config file only if !cliPort
       const cliIdx = source.indexOf('let resolvedPort = cliPort');
-      const configIdx = source.indexOf("parsed?.console?.port");
+      const configIdx = source.indexOf('ConfigManager.readPortFromYaml');
       expect(cliIdx).toBeGreaterThan(-1);
       expect(configIdx).toBeGreaterThan(cliIdx);
     });
   });
 
-  // ── YAML parsing edge cases ────────────────────────────────────────────
+  // ── ConfigManager.readPortFromYaml ───────────────────────────────────
 
-  describe('YAML port parsing edge cases', () => {
-    it('handles valid port number', async () => {
-      const yaml = await import('js-yaml');
-      const parsed = yaml.load('console:\n  port: 9000\n', { schema: yaml.FAILSAFE_SCHEMA }) as any;
-      const port = Number(parsed?.console?.port);
-      expect(port).toBe(9000);
-      expect(port >= 1024 && port <= 65535).toBe(true);
+  describe('ConfigManager.readPortFromYaml', () => {
+    let readPortFromYaml: (yaml: string) => number | undefined;
+
+    beforeAll(async () => {
+      const { ConfigManager } = await import('../../../src/config/ConfigManager.js');
+      readPortFromYaml = ConfigManager.readPortFromYaml;
     });
 
-    it('rejects non-numeric port', async () => {
-      const yaml = await import('js-yaml');
-      const parsed = yaml.load('console:\n  port: "abc"\n', { schema: yaml.FAILSAFE_SCHEMA }) as any;
-      const port = Number(parsed?.console?.port);
-      expect(Number.isNaN(port)).toBe(true);
-      expect(port >= 1024 && port <= 65535).toBe(false);
+    it('parses valid port number', () => {
+      expect(readPortFromYaml('console:\n  port: 9000\n')).toBe(9000);
     });
 
-    it('rejects privileged port', async () => {
-      const yaml = await import('js-yaml');
-      const parsed = yaml.load('console:\n  port: 80\n', { schema: yaml.FAILSAFE_SCHEMA }) as any;
-      const port = Number(parsed?.console?.port);
-      expect(port >= 1024 && port <= 65535).toBe(false);
+    it('parses default port', () => {
+      expect(readPortFromYaml('console:\n  port: 41715\n')).toBe(41715);
     });
 
-    it('rejects port above max', async () => {
-      const yaml = await import('js-yaml');
-      const parsed = yaml.load('console:\n  port: 70000\n', { schema: yaml.FAILSAFE_SCHEMA }) as any;
-      const port = Number(parsed?.console?.port);
-      expect(port >= 1024 && port <= 65535).toBe(false);
+    it('returns undefined for non-numeric port', () => {
+      expect(readPortFromYaml('console:\n  port: abc\n')).toBeUndefined();
     });
 
-    it('handles missing console section', async () => {
-      const yaml = await import('js-yaml');
-      const parsed = yaml.load('user:\n  name: test\n', { schema: yaml.FAILSAFE_SCHEMA }) as any;
-      const port = parsed?.console?.port ? Number(parsed.console.port) : undefined;
-      expect(port).toBeUndefined();
+    it('returns undefined for missing console section', () => {
+      expect(readPortFromYaml('user:\n  name: test\n')).toBeUndefined();
     });
 
-    it('handles empty config file', async () => {
-      const yaml = await import('js-yaml');
-      const parsed = yaml.load('', { schema: yaml.FAILSAFE_SCHEMA }) as any;
-      const port = parsed?.console?.port ? Number(parsed?.console?.port) : undefined;
-      expect(port).toBeUndefined();
+    it('returns undefined for empty config', () => {
+      expect(readPortFromYaml('')).toBeUndefined();
+    });
+
+    it('returns undefined for malformed YAML', () => {
+      expect(readPortFromYaml('{{{')).toBeUndefined();
+    });
+
+    it('returns port below valid range (caller must validate)', () => {
+      // readPortFromYaml returns the number; range validation is the caller's job
+      const port = readPortFromYaml('console:\n  port: 80\n');
+      expect(port).toBe(80);
+    });
+
+    it('returns port above valid range (caller must validate)', () => {
+      const port = readPortFromYaml('console:\n  port: 70000\n');
+      expect(port).toBe(70000);
+    });
+
+    it('uses FAILSAFE_SCHEMA (no code execution)', async () => {
+      const source = await readFile(join(SRC, 'src/config/ConfigManager.ts'), 'utf8');
+      expect(source).toContain('readPortFromYaml');
+      expect(source).toContain('FAILSAFE_SCHEMA');
     });
   });
 

--- a/tests/unit/config/consolePort.test.ts
+++ b/tests/unit/config/consolePort.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for console port configuration hierarchy (#1840).
+ *
+ * Verifies the resolution order:
+ *   1. CLI flag (--port=N) — standalone --web mode only
+ *   2. Config file (~/.dollhouse/config.yml → console.port)
+ *   3. DOLLHOUSE_WEB_CONSOLE_PORT env var
+ *   4. Default: 41715
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const SRC = process.cwd();
+
+describe('Console port configuration (#1840)', () => {
+
+  // ── Config schema ──────────────────────────────────────────────────────
+
+  describe('ConfigManager schema', () => {
+    it('defines ConsoleConfig interface with port field', async () => {
+      const source = await readFile(join(SRC, 'src/config/ConfigManager.ts'), 'utf8');
+      expect(source).toContain('export interface ConsoleConfig');
+      expect(source).toContain('port: number');
+    });
+
+    it('DollhouseConfig includes console property', async () => {
+      const source = await readFile(join(SRC, 'src/config/ConfigManager.ts'), 'utf8');
+      expect(source).toContain('console: ConsoleConfig');
+    });
+
+    it('default config sets console.port to 41715', async () => {
+      const source = await readFile(join(SRC, 'src/config/ConfigManager.ts'), 'utf8');
+      expect(source).toMatch(/console:\s*\{\s*\n\s*port:\s*41715/);
+    });
+
+    it('documents the resolution hierarchy in the interface', async () => {
+      const source = await readFile(join(SRC, 'src/config/ConfigManager.ts'), 'utf8');
+      expect(source).toContain('--port CLI flag');
+      expect(source).toContain('DOLLHOUSE_WEB_CONSOLE_PORT env var');
+      expect(source).toContain('Default: 41715');
+    });
+  });
+
+  // ── Container wiring ──────────────────────────────────────────────────
+
+  describe('Container passes config port to UnifiedConsole', () => {
+    it('resolves port from ConfigManager', async () => {
+      const source = await readFile(join(SRC, 'src/di/Container.ts'), 'utf8');
+      expect(source).toContain("getSetting<number>('console.port')");
+    });
+
+    it('passes resolved port in UnifiedConsole options', async () => {
+      const source = await readFile(join(SRC, 'src/di/Container.ts'), 'utf8');
+      expect(source).toContain('port: configPort');
+    });
+  });
+
+  // ── UnifiedConsole port resolution ─────────────────────────────────────
+
+  describe('UnifiedConsole accepts port option', () => {
+    it('options interface has port field', async () => {
+      const source = await readFile(join(SRC, 'src/web/console/UnifiedConsole.ts'), 'utf8');
+      expect(source).toContain('port?: number');
+    });
+
+    it('resolves port with fallback to DEFAULT_CONSOLE_PORT', async () => {
+      const source = await readFile(join(SRC, 'src/web/console/UnifiedConsole.ts'), 'utf8');
+      expect(source).toContain('options.port || DEFAULT_CONSOLE_PORT');
+    });
+
+    it('passes resolved port to startAsLeader', async () => {
+      const source = await readFile(join(SRC, 'src/web/console/UnifiedConsole.ts'), 'utf8');
+      expect(source).toContain('startAsLeader(options, election, consolePort)');
+    });
+
+    it('startAsLeader uses consolePort for web server binding', async () => {
+      const source = await readFile(join(SRC, 'src/web/console/UnifiedConsole.ts'), 'utf8');
+      expect(source).toContain('port: consolePort,');
+    });
+
+    it('DEFAULT_CONSOLE_PORT reads from env var', async () => {
+      const source = await readFile(join(SRC, 'src/web/console/UnifiedConsole.ts'), 'utf8');
+      expect(source).toContain('DEFAULT_CONSOLE_PORT = env.DOLLHOUSE_WEB_CONSOLE_PORT');
+    });
+  });
+
+  // ── Standalone --web mode CLI integration ──────────────────────────────
+
+  describe('standalone --web mode port resolution', () => {
+    it('parses --port CLI flag', async () => {
+      const source = await readFile(join(SRC, 'src/index.ts'), 'utf8');
+      expect(source).toContain("startsWith('--port=')");
+      expect(source).toContain('cliPort');
+    });
+
+    it('reads config file for port when no CLI flag', async () => {
+      const source = await readFile(join(SRC, 'src/index.ts'), 'utf8');
+      expect(source).toContain("parsed?.console?.port");
+    });
+
+    it('validates config port is in valid range (1024-65535)', async () => {
+      const source = await readFile(join(SRC, 'src/index.ts'), 'utf8');
+      expect(source).toContain('configPort >= 1024');
+      expect(source).toContain('configPort <= 65535');
+    });
+
+    it('uses FAILSAFE_SCHEMA for secure YAML parsing', async () => {
+      const source = await readFile(join(SRC, 'src/index.ts'), 'utf8');
+      expect(source).toContain('FAILSAFE_SCHEMA');
+    });
+
+    it('passes resolvedPort to startWebServer', async () => {
+      const source = await readFile(join(SRC, 'src/index.ts'), 'utf8');
+      expect(source).toContain('port: resolvedPort');
+    });
+
+    it('CLI flag takes precedence over config file', async () => {
+      const source = await readFile(join(SRC, 'src/index.ts'), 'utf8');
+      // cliPort is checked first, config file only if !cliPort
+      const cliIdx = source.indexOf('let resolvedPort = cliPort');
+      const configIdx = source.indexOf("parsed?.console?.port");
+      expect(cliIdx).toBeGreaterThan(-1);
+      expect(configIdx).toBeGreaterThan(cliIdx);
+    });
+  });
+
+  // ── YAML parsing edge cases ────────────────────────────────────────────
+
+  describe('YAML port parsing edge cases', () => {
+    it('handles valid port number', async () => {
+      const yaml = await import('js-yaml');
+      const parsed = yaml.load('console:\n  port: 9000\n', { schema: yaml.FAILSAFE_SCHEMA }) as any;
+      const port = Number(parsed?.console?.port);
+      expect(port).toBe(9000);
+      expect(port >= 1024 && port <= 65535).toBe(true);
+    });
+
+    it('rejects non-numeric port', async () => {
+      const yaml = await import('js-yaml');
+      const parsed = yaml.load('console:\n  port: "abc"\n', { schema: yaml.FAILSAFE_SCHEMA }) as any;
+      const port = Number(parsed?.console?.port);
+      expect(Number.isNaN(port)).toBe(true);
+      expect(port >= 1024 && port <= 65535).toBe(false);
+    });
+
+    it('rejects privileged port', async () => {
+      const yaml = await import('js-yaml');
+      const parsed = yaml.load('console:\n  port: 80\n', { schema: yaml.FAILSAFE_SCHEMA }) as any;
+      const port = Number(parsed?.console?.port);
+      expect(port >= 1024 && port <= 65535).toBe(false);
+    });
+
+    it('rejects port above max', async () => {
+      const yaml = await import('js-yaml');
+      const parsed = yaml.load('console:\n  port: 70000\n', { schema: yaml.FAILSAFE_SCHEMA }) as any;
+      const port = Number(parsed?.console?.port);
+      expect(port >= 1024 && port <= 65535).toBe(false);
+    });
+
+    it('handles missing console section', async () => {
+      const yaml = await import('js-yaml');
+      const parsed = yaml.load('user:\n  name: test\n', { schema: yaml.FAILSAFE_SCHEMA }) as any;
+      const port = parsed?.console?.port ? Number(parsed.console.port) : undefined;
+      expect(port).toBeUndefined();
+    });
+
+    it('handles empty config file', async () => {
+      const yaml = await import('js-yaml');
+      const parsed = yaml.load('', { schema: yaml.FAILSAFE_SCHEMA }) as any;
+      const port = parsed?.console?.port ? Number(parsed?.console?.port) : undefined;
+      expect(port).toBeUndefined();
+    });
+  });
+
+  // ── EADDRINUSE regression ──────────────────────────────────────────────
+
+  describe('port conflict handling (never kills processes)', () => {
+    it('detects EADDRINUSE gracefully', async () => {
+      const source = await readFile(join(SRC, 'src/web/server.ts'), 'utf8');
+      expect(source).toContain("err.code === 'EADDRINUSE'");
+    });
+
+    it('logs and opens existing console on conflict', async () => {
+      const source = await readFile(join(SRC, 'src/web/server.ts'), 'utf8');
+      expect(source).toContain('opening existing console');
+    });
+
+    it('never kills processes on the configured port', async () => {
+      const source = await readFile(join(SRC, 'src/web/server.ts'), 'utf8');
+      expect(source).not.toContain('process.kill');
+    });
+
+    it('resolves promise on conflict (does not throw)', async () => {
+      const source = await readFile(join(SRC, 'src/web/server.ts'), 'utf8');
+      // The error handler calls resolve(), not reject()
+      const errorSection = source.slice(
+        source.indexOf("httpServer.on('error'"),
+        source.indexOf('});', source.indexOf("httpServer.on('error'")) + 10,
+      );
+      expect(errorSection).toContain('resolve()');
+      expect(errorSection).not.toContain('reject(');
+    });
+  });
+});

--- a/tests/unit/config/consolePort.test.ts
+++ b/tests/unit/config/consolePort.test.ts
@@ -100,7 +100,13 @@ describe('Console port configuration (#1840)', () => {
       expect(source).toContain('cliPort');
     });
 
-    it('reads config file for port via ConfigManager.readPortFromYaml', async () => {
+    it('uses resolvePortFromConfig helper function', async () => {
+      const source = await readFile(join(SRC, 'src/index.ts'), 'utf8');
+      expect(source).toContain('async function resolvePortFromConfig');
+      expect(source).toContain('resolvePortFromConfig()');
+    });
+
+    it('resolvePortFromConfig uses ConfigManager.readPortFromYaml', async () => {
       const source = await readFile(join(SRC, 'src/index.ts'), 'utf8');
       expect(source).toContain('ConfigManager.readPortFromYaml');
     });
@@ -113,7 +119,7 @@ describe('Console port configuration (#1840)', () => {
 
     it('size-limits config file before parsing (64KB)', async () => {
       const source = await readFile(join(SRC, 'src/index.ts'), 'utf8');
-      expect(source).toContain('raw.length <= 64 * 1024');
+      expect(source).toContain('raw.length > 64 * 1024');
     });
 
     it('passes resolvedPort to startWebServer', async () => {
@@ -123,10 +129,8 @@ describe('Console port configuration (#1840)', () => {
 
     it('CLI flag takes precedence over config file', async () => {
       const source = await readFile(join(SRC, 'src/index.ts'), 'utf8');
-      const cliIdx = source.indexOf('let resolvedPort = cliPort');
-      const configIdx = source.indexOf('ConfigManager.readPortFromYaml');
-      expect(cliIdx).toBeGreaterThan(-1);
-      expect(configIdx).toBeGreaterThan(cliIdx);
+      // cliPort || resolvePortFromConfig() — CLI checked first via ||
+      expect(source).toContain('cliPort || await resolvePortFromConfig()');
     });
   });
 

--- a/tests/unit/config/consolePort.test.ts
+++ b/tests/unit/config/consolePort.test.ts
@@ -32,7 +32,12 @@ describe('Console port configuration (#1840)', () => {
 
     it('default config sets console.port to 41715', async () => {
       const source = await readFile(join(SRC, 'src/config/ConfigManager.ts'), 'utf8');
-      expect(source).toMatch(/console:\s*\{\s*\n\s*port:\s*41715/);
+      expect(source).toContain('port: 41715');
+      // Verify it's inside the console section
+      const consoleIdx = source.indexOf("console: {");
+      const portIdx = source.indexOf('port: 41715', consoleIdx);
+      expect(consoleIdx).toBeGreaterThan(-1);
+      expect(portIdx).toBeGreaterThan(consoleIdx);
     });
 
     it('documents the resolution hierarchy in the interface', async () => {


### PR DESCRIPTION
## Summary

- Adds `console.port` to config file schema (`~/.dollhouse/config.yml`)
- Port resolution hierarchy: config file → env var → default (41715)
- Container reads config and passes resolved port to UnifiedConsole
- Existing `dollhouse_config` MCP tool works automatically:
  - `dollhouse_config get console.port` → returns current port
  - `dollhouse_config set console.port 9000` → persists to config file
- EADDRINUSE handling unchanged: graceful fallback, never kills processes

Closes #1840

## Test plan

- [ ] Default behavior unchanged: console starts on 41715
- [ ] `dollhouse_config get console.port` returns 41715
- [ ] After `dollhouse_config set console.port 9000`, restart → console binds to 9000
- [ ] `DOLLHOUSE_WEB_CONSOLE_PORT=8080` env var overrides config file
- [ ] `--port=7777` CLI flag overrides both
- [ ] Port conflict: graceful "existing instance" message, no process killing

🤖 Generated with [Claude Code](https://claude.com/claude-code)