### PR TITLE
fix: npx one-liner silently exits on fresh machines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.9",
+  "version": "2.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.9",
+      "version": "2.0.11",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"
@@ -11699,7 +11699,7 @@
     },
     "packages/safety": {
       "name": "@dollhousemcp/safety",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "transport": {
         "type": "stdio"
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -749,7 +749,13 @@ export class DollhouseMCPServer implements IToolHandler {
 // isDirectExecution missed the dist/index.js suffix and the server never started.
 const rawScriptPath = process.argv?.[1] ?? '';
 let scriptPath = rawScriptPath ? path.normalize(rawScriptPath) : '';
-try { scriptPath = realpathSync(scriptPath); } catch { /* symlink target missing — use original */ }
+try {
+  scriptPath = realpathSync(scriptPath);
+} catch {
+  if (process.env.DOLLHOUSE_DEBUG) {
+    console.error(`[DEBUG] Symlink resolution failed for ${rawScriptPath} — using original path`);
+  }
+}
 const isDirectExecution =
   scriptPath.endsWith(`${path.sep}dist${path.sep}index.js`) ||
   scriptPath.endsWith(`${path.sep}src${path.sep}index.ts`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -793,7 +793,8 @@ async function startServerWithRetry(retriesLeft = STARTUP_DELAYS.length): Promis
     }
     // Final failure - minimal error message for security
     // Note: Using console.error here is intentional as it's the final error before exit
-    console.error("[DollhouseMCP] Server startup failed", error); // Added error object
+    console.error("[DollhouseMCP] Server startup failed",
+      process.env.DOLLHOUSE_DEBUG ? error : (error as Error).message || 'unknown error');
     process.exit(1);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
 import { env } from './config/env.js';
 
 import * as path from 'path';
+import { realpathSync } from 'node:fs';
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { ErrorHandler } from "./utils/ErrorHandler.js";
@@ -742,12 +743,24 @@ export class DollhouseMCPServer implements IToolHandler {
 
 // Only start the server if this file is being run directly (not imported by tests)
 // Handle different execution methods (direct, npx, CLI)
-const scriptPath = process.argv?.[1] ? path.normalize(process.argv[1]) : '';
+//
+// Bug fix: npx creates symlinks in .bin/ (e.g. .bin/mcp-server → dist/index.js).
+// Node.js keeps the symlink path in process.argv[1], so without resolving it,
+// isDirectExecution missed the dist/index.js suffix and the server never started.
+const rawScriptPath = process.argv?.[1] ?? '';
+let scriptPath = rawScriptPath ? path.normalize(rawScriptPath) : '';
+try { scriptPath = realpathSync(scriptPath); } catch { /* symlink target missing — use original */ }
 const isDirectExecution =
   scriptPath.endsWith(`${path.sep}dist${path.sep}index.js`) ||
   scriptPath.endsWith(`${path.sep}src${path.sep}index.ts`);
-const isNpxExecution = process.env.npm_execpath?.includes('npx');
-const isCliExecution = process.argv[1]?.endsWith('/dollhousemcp') || process.argv[1]?.endsWith('\\dollhousemcp');
+// Modern npm (v7+) runs npx as "npm exec" — npm_execpath may point to
+// npm-cli.js instead of npx-cli.js. Detect both legacy and modern npx.
+const isNpxExecution =
+  process.env.npm_execpath?.includes('npx') ||
+  process.env.npm_command === 'exec';
+// Match all registered bin entry names from package.json "bin" field
+const binName = path.basename(rawScriptPath);
+const isCliExecution = binName === 'dollhousemcp' || binName === 'mcp-server';
 const isTest = process.env.JEST_WORKER_ID; // This is set when Jest runs tests
 const isTestMode = process.env.TEST_MODE === 'true'; // Check for TEST_MODE environment variable
 const dollhouseDebugFlag = process.env.DOLLHOUSE_DEBUG?.toLowerCase();

--- a/tests/unit/execution-detection.test.ts
+++ b/tests/unit/execution-detection.test.ts
@@ -3,7 +3,7 @@
  * Verifies that the server correctly identifies different execution methods
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
 
 /**
@@ -137,7 +137,7 @@ describe('Execution Detection Logic', () => {
 
     test('should detect dollhousemcp bin entry on Windows', () => {
       if (path.sep !== '\\') return; // path.basename only splits on native separator
-      const { isCliExecution } = detectExecution('C:\\Users\\user\\AppData\\Roaming\\npm\\dollhousemcp', {});
+      const { isCliExecution } = detectExecution(String.raw`C:\Users\user\AppData\Roaming\npm\dollhousemcp`, {});
       expect(isCliExecution).toBe(true);
     });
 
@@ -148,7 +148,7 @@ describe('Execution Detection Logic', () => {
 
     test('should detect mcp-server bin entry on Windows', () => {
       if (path.sep !== '\\') return; // path.basename only splits on native separator
-      const { isCliExecution } = detectExecution('C:\\Users\\user\\AppData\\Roaming\\npm\\mcp-server', {});
+      const { isCliExecution } = detectExecution(String.raw`C:\Users\user\AppData\Roaming\npm\mcp-server`, {});
       expect(isCliExecution).toBe(true);
     });
 

--- a/tests/unit/execution-detection.test.ts
+++ b/tests/unit/execution-detection.test.ts
@@ -3,21 +3,44 @@
  * Verifies that the server correctly identifies different execution methods
  */
 
+import * as path from 'path';
 import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+
+/**
+ * Helper: reproduce the detection logic from index.ts so tests stay in sync.
+ * When the detection logic changes in index.ts, update this helper to match.
+ */
+function detectExecution(argv1: string, env: Record<string, string | undefined>) {
+  const rawScriptPath = argv1 ?? '';
+  // In tests we skip realpathSync — symlink resolution is tested separately
+  const scriptPath = rawScriptPath ? path.normalize(rawScriptPath) : '';
+  const isDirectExecution =
+    scriptPath.endsWith(`${path.sep}dist${path.sep}index.js`) ||
+    scriptPath.endsWith(`${path.sep}src${path.sep}index.ts`);
+  const isNpxExecution =
+    (env.npm_execpath?.includes('npx') ?? false) ||
+    env.npm_command === 'exec';
+  const binName = path.basename(rawScriptPath);
+  const isCliExecution = binName === 'dollhousemcp' || binName === 'mcp-server';
+  const isTest = env.JEST_WORKER_ID;
+  return { isDirectExecution, isNpxExecution, isCliExecution, isTest };
+}
 
 describe('Execution Detection Logic', () => {
   // Save original values
   const originalArgv1 = process.argv[1];
   const originalNpmExecPath = process.env.npm_execpath;
+  const originalNpmCommand = process.env.npm_command;
   const originalJestWorkerId = process.env.JEST_WORKER_ID;
-  
+
   beforeEach(() => {
     // Reset to clean state
     process.argv[1] = '/path/to/dist/index.js';
     delete process.env.npm_execpath;
+    delete process.env.npm_command;
     delete process.env.JEST_WORKER_ID;
   });
-  
+
   afterEach(() => {
     // Restore original values
     process.argv[1] = originalArgv1;
@@ -26,191 +49,209 @@ describe('Execution Detection Logic', () => {
     } else {
       delete process.env.npm_execpath;
     }
+    if (originalNpmCommand) {
+      process.env.npm_command = originalNpmCommand;
+    } else {
+      delete process.env.npm_command;
+    }
     if (originalJestWorkerId) {
       process.env.JEST_WORKER_ID = originalJestWorkerId;
     }
   });
 
   describe('Direct Execution Detection', () => {
-    test('should detect direct node execution', () => {
-      // Simulate direct execution
-      process.argv[1] = '/path/to/dist/index.js';
-      delete process.env.npm_execpath;
-      
-      const isDirectExecution = !process.env.npm_execpath;
+    test('should detect dist/index.js execution', () => {
+      const { isDirectExecution } = detectExecution('/path/to/dist/index.js', {});
       expect(isDirectExecution).toBe(true);
     });
-    
-    test('should not detect direct execution when npm_execpath is set', () => {
-      process.env.npm_execpath = '/usr/local/bin/npm';
-      
-      const isDirectExecution = !process.env.npm_execpath;
+
+    test('should detect src/index.ts execution', () => {
+      const { isDirectExecution } = detectExecution('/path/to/src/index.ts', {});
+      expect(isDirectExecution).toBe(true);
+    });
+
+    test('should not match arbitrary paths', () => {
+      const { isDirectExecution } = detectExecution('/path/to/node_modules/.bin/mcp-server', {});
       expect(isDirectExecution).toBe(false);
     });
   });
 
   describe('NPX Execution Detection', () => {
-    test('should detect npx execution', () => {
-      process.env.npm_execpath = '/usr/local/bin/npx';
-      
-      const isNpxExecution = (process.env.npm_execpath as any)?.includes('npx') || false;
+    test('should detect legacy npx (npm_execpath contains npx)', () => {
+      const { isNpxExecution } = detectExecution('/path/to/dist/index.js', {
+        npm_execpath: '/usr/local/bin/npx',
+      });
       expect(isNpxExecution).toBe(true);
     });
-    
-    test('should detect npx in various paths', () => {
+
+    test('should detect npx in various legacy paths', () => {
       const npxPaths = [
         '/usr/local/bin/npx',
         '/opt/homebrew/bin/npx',
         'C:\\Program Files\\nodejs\\npx.cmd',
-        '/home/user/.npm/bin/npx'
+        '/home/user/.npm/bin/npx',
+        '/usr/local/lib/node_modules/npm/bin/npx-cli.js',
       ];
-      
-      npxPaths.forEach(path => {
-        process.env.npm_execpath = path;
-        const isNpxExecution = (process.env.npm_execpath as any)?.includes('npx') || false;
+
+      npxPaths.forEach(p => {
+        const { isNpxExecution } = detectExecution('/any', { npm_execpath: p });
         expect(isNpxExecution).toBe(true);
       });
     });
-    
+
+    test('should detect modern npx (npm v7+ uses npm_command=exec)', () => {
+      const { isNpxExecution } = detectExecution('/any', {
+        npm_execpath: '/usr/local/lib/node_modules/npm/bin/npm-cli.js',
+        npm_command: 'exec',
+      });
+      expect(isNpxExecution).toBe(true);
+    });
+
+    test('should detect modern npx even without npm_execpath', () => {
+      const { isNpxExecution } = detectExecution('/any', {
+        npm_command: 'exec',
+      });
+      expect(isNpxExecution).toBe(true);
+    });
+
     test('should not detect npx when using npm directly', () => {
-      process.env.npm_execpath = '/usr/local/bin/npm';
-      
-      const isNpxExecution = (process.env.npm_execpath as any)?.includes('npx') || false;
+      const { isNpxExecution } = detectExecution('/any', {
+        npm_execpath: '/usr/local/lib/node_modules/npm/bin/npm-cli.js',
+      });
+      expect(isNpxExecution).toBe(false);
+    });
+
+    test('should not detect npx with unrelated npm_command', () => {
+      const { isNpxExecution } = detectExecution('/any', {
+        npm_command: 'install',
+      });
       expect(isNpxExecution).toBe(false);
     });
   });
 
   describe('CLI Execution Detection', () => {
-    test('should detect CLI execution on Unix-like systems', () => {
-      process.argv[1] = '/usr/local/bin/dollhousemcp';
-      
-      const isCliExecution = process.argv[1]?.endsWith('/dollhousemcp') || process.argv[1]?.endsWith('\\dollhousemcp') || false;
+    test('should detect dollhousemcp bin entry on Unix', () => {
+      const { isCliExecution } = detectExecution('/usr/local/bin/dollhousemcp', {});
       expect(isCliExecution).toBe(true);
     });
-    
-    test('should detect CLI execution on Windows', () => {
-      process.argv[1] = 'C:\\Users\\user\\AppData\\Roaming\\npm\\dollhousemcp';
-      
-      const isCliExecution = process.argv[1]?.endsWith('/dollhousemcp') || process.argv[1]?.endsWith('\\dollhousemcp') || false;
+
+    test('should detect dollhousemcp bin entry on Windows', () => {
+      if (path.sep !== '\\') return; // path.basename only splits on native separator
+      const { isCliExecution } = detectExecution('C:\\Users\\user\\AppData\\Roaming\\npm\\dollhousemcp', {});
       expect(isCliExecution).toBe(true);
     });
-    
-    test('should detect CLI in various installation paths', () => {
+
+    test('should detect mcp-server bin entry on Unix', () => {
+      const { isCliExecution } = detectExecution('/usr/local/bin/mcp-server', {});
+      expect(isCliExecution).toBe(true);
+    });
+
+    test('should detect mcp-server bin entry on Windows', () => {
+      if (path.sep !== '\\') return; // path.basename only splits on native separator
+      const { isCliExecution } = detectExecution('C:\\Users\\user\\AppData\\Roaming\\npm\\mcp-server', {});
+      expect(isCliExecution).toBe(true);
+    });
+
+    test('should detect mcp-server in npx .bin directory', () => {
+      const { isCliExecution } = detectExecution('/home/user/.npm/_npx/abc123/node_modules/.bin/mcp-server', {});
+      expect(isCliExecution).toBe(true);
+    });
+
+    test('should detect dollhousemcp in npx .bin directory', () => {
+      const { isCliExecution } = detectExecution('/home/user/.npm/_npx/abc123/node_modules/.bin/dollhousemcp', {});
+      expect(isCliExecution).toBe(true);
+    });
+
+    test('should detect CLI in various Unix installation paths', () => {
       const cliPaths = [
         '/usr/local/bin/dollhousemcp',
         '/opt/homebrew/bin/dollhousemcp',
-        'C:\\Program Files\\nodejs\\dollhousemcp',
         '/home/user/.npm/bin/dollhousemcp',
-        'C:\\Users\\user\\AppData\\Roaming\\npm\\dollhousemcp'
+        '/usr/local/bin/mcp-server',
+        '/opt/homebrew/bin/mcp-server',
+        '/home/user/.npm/bin/mcp-server',
       ];
-      
-      cliPaths.forEach(path => {
-        process.argv[1] = path;
-        const isCliExecution = process.argv[1]?.endsWith('/dollhousemcp') || process.argv[1]?.endsWith('\\dollhousemcp') || false;
+
+      cliPaths.forEach(p => {
+        const { isCliExecution } = detectExecution(p, {});
         expect(isCliExecution).toBe(true);
       });
     });
-    
-    test('should not detect CLI when running index.js directly', () => {
-      process.argv[1] = '/path/to/dist/index.js';
-      
-      const isCliExecution = process.argv[1]?.endsWith('/dollhousemcp') || process.argv[1]?.endsWith('\\dollhousemcp') || false;
+
+    test('should not detect CLI when running dist/index.js directly', () => {
+      const { isCliExecution } = detectExecution('/path/to/dist/index.js', {});
       expect(isCliExecution).toBe(false);
     });
   });
 
   describe('Test Environment Detection', () => {
     test('should detect test environment', () => {
-      process.env.JEST_WORKER_ID = '1';
-      
-      const isTest = process.env.JEST_WORKER_ID;
+      const { isTest } = detectExecution('/any', { JEST_WORKER_ID: '1' });
       expect(isTest).toBeTruthy();
     });
-    
+
     test('should not detect test environment in production', () => {
-      delete process.env.JEST_WORKER_ID;
-      
-      const isTest = process.env.JEST_WORKER_ID;
+      const { isTest } = detectExecution('/any', {});
       expect(isTest).toBeFalsy();
     });
   });
 
-  describe('Execution Environment Object', () => {
-    test('should correctly populate execution environment', () => {
-      process.env.npm_execpath = '/usr/local/bin/npx';
-      process.argv[1] = '/usr/local/bin/dollhousemcp';
-      
-      const EXECUTION_ENV = {
-        isNpx: process.env.npm_execpath?.includes('npx') || false,
-        isCli: process.argv[1]?.endsWith('/dollhousemcp') || false,
-        isDirect: !process.env.npm_execpath,
-        cwd: process.cwd(),
-        scriptPath: process.argv[1],
-      };
-      
-      expect(EXECUTION_ENV.isNpx).toBe(true);
-      expect(EXECUTION_ENV.isCli).toBe(true);
-      expect(EXECUTION_ENV.isDirect).toBe(false);
-      expect(EXECUTION_ENV.cwd).toBe(process.cwd());
-      expect(EXECUTION_ENV.scriptPath).toBe('/usr/local/bin/dollhousemcp');
+  describe('Server Startup Decision (integration scenarios)', () => {
+    test('npx @dollhousemcp/mcp-server — .bin/mcp-server symlink (the original bug)', () => {
+      // This is the exact scenario that was broken: npx runs .bin/mcp-server,
+      // Node keeps the symlink path in argv[1], and none of the old checks matched.
+      const { isDirectExecution, isNpxExecution, isCliExecution } = detectExecution(
+        '/home/user/.npm/_npx/abc123/node_modules/.bin/mcp-server',
+        {},
+      );
+      // isDirectExecution is false (no symlink resolution in test helper),
+      // but isCliExecution catches the mcp-server bin name
+      const shouldStart = isDirectExecution || isNpxExecution || isCliExecution;
+      expect(shouldStart).toBe(true);
+      expect(isCliExecution).toBe(true);
+    });
+
+    test('npx @dollhousemcp/mcp-server with modern npm (npm_command=exec)', () => {
+      const { isNpxExecution } = detectExecution(
+        '/home/user/.npm/_npx/abc123/node_modules/.bin/mcp-server',
+        { npm_command: 'exec' },
+      );
+      expect(isNpxExecution).toBe(true);
+    });
+
+    test('direct node dist/index.js execution', () => {
+      const { isDirectExecution } = detectExecution('/path/to/dist/index.js', {});
+      expect(isDirectExecution).toBe(true);
+    });
+
+    test('global install running dollhousemcp', () => {
+      const { isCliExecution } = detectExecution('/usr/local/bin/dollhousemcp', {});
+      expect(isCliExecution).toBe(true);
+    });
+
+    test('should not start server in test environment', () => {
+      const { isDirectExecution, isNpxExecution, isCliExecution, isTest } = detectExecution(
+        '/path/to/dist/index.js',
+        { JEST_WORKER_ID: '1' },
+      );
+      const shouldStart = (isDirectExecution || isNpxExecution || isCliExecution) && !isTest;
+      expect(shouldStart).toBe(false);
     });
   });
 
   describe('Progressive Retry Delays', () => {
     test('should use progressive delays for retries', () => {
       const STARTUP_DELAYS = [10, 50, 100, 200];
-      
+
       expect(STARTUP_DELAYS).toHaveLength(4);
-      expect(STARTUP_DELAYS[0]).toBe(10);  // Fast initial retry
-      expect(STARTUP_DELAYS[1]).toBe(50);  // Original delay
-      expect(STARTUP_DELAYS[2]).toBe(100); // Slower for slow machines
-      expect(STARTUP_DELAYS[3]).toBe(200); // Final attempt
-      
-      // Verify delays are progressive
+      expect(STARTUP_DELAYS[0]).toBe(10);
+      expect(STARTUP_DELAYS[1]).toBe(50);
+      expect(STARTUP_DELAYS[2]).toBe(100);
+      expect(STARTUP_DELAYS[3]).toBe(200);
+
       for (let i = 1; i < STARTUP_DELAYS.length; i++) {
         expect(STARTUP_DELAYS[i]).toBeGreaterThan(STARTUP_DELAYS[i - 1]);
       }
-    });
-  });
-
-  describe('Server Startup Decision', () => {
-    test('should start server for direct execution when not in test', () => {
-      delete process.env.npm_execpath;
-      delete process.env.JEST_WORKER_ID;
-      process.argv[1] = '/path/to/dist/index.js';
-      
-      const isDirectExecution = !process.env.npm_execpath;
-      const isNpxExecution = (process.env.npm_execpath as any)?.includes('npx') || false;
-      const isCliExecution = process.argv[1]?.endsWith('/dollhousemcp') || false;
-      const isTest = process.env.JEST_WORKER_ID;
-      
-      const shouldStart = (isDirectExecution || isNpxExecution || isCliExecution) && !isTest;
-      expect(shouldStart).toBe(true);
-    });
-    
-    test('should start server for npx execution when not in test', () => {
-      process.env.npm_execpath = '/usr/local/bin/npx';
-      delete process.env.JEST_WORKER_ID;
-      
-      const isDirectExecution = !process.env.npm_execpath;
-      const isNpxExecution = (process.env.npm_execpath as any)?.includes('npx') || false;
-      const isCliExecution = process.argv[1]?.endsWith('/dollhousemcp') || false;
-      const isTest = process.env.JEST_WORKER_ID;
-      
-      const shouldStart = (isDirectExecution || isNpxExecution || isCliExecution) && !isTest;
-      expect(shouldStart).toBe(true);
-    });
-    
-    test('should not start server in test environment', () => {
-      process.env.JEST_WORKER_ID = '1';
-      
-      const isDirectExecution = !process.env.npm_execpath;
-      const isNpxExecution = (process.env.npm_execpath as any)?.includes('npx') || false;
-      const isCliExecution = process.argv[1]?.endsWith('/dollhousemcp') || false;
-      const isTest = process.env.JEST_WORKER_ID;
-      
-      const shouldStart = (isDirectExecution || isNpxExecution || isCliExecution) && !isTest;
-      expect(shouldStart).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Critical onboarding bug**: `npx @dollhousemcp/mcp-server@latest --web` silently exits with no output on fresh machines
- Root cause: execution detection missed the `mcp-server` bin entry name and failed on modern npm (v7+)
- Three-layer fix: symlink resolution, modern npx detection, and bin name matching
- Version bump to 2.0.11

## Root Cause

When npx runs `@dollhousemcp/mcp-server`, Node.js sets `process.argv[1]` to the symlink path (`.bin/mcp-server`), not the resolved target (`dist/index.js`). All three execution checks failed:

| Check | Expected | Got |
|---|---|---|
| `isDirectExecution` | path ending in `dist/index.js` | `.bin/mcp-server` |
| `isNpxExecution` | `npm_execpath` containing 'npx' | `undefined` (modern npm v7+) |
| `isCliExecution` | path ending in `dollhousemcp` | `mcp-server` |

The `if` guard on line 810 evaluated to `false`, so the server startup code never ran. The process loaded all modules, found nothing to do, and exited cleanly.

## Fix

1. **`realpathSync`** resolves `.bin/mcp-server` → `dist/index.js` so `isDirectExecution` matches
2. **`npm_command === 'exec'`** detects modern npx (npm v7+ uses "npm exec" internally)
3. **`path.basename` matching** catches both `dollhousemcp` and `mcp-server` bin entries

## Test plan

- [x] 25 unit tests pass (updated to cover mcp-server bin name, modern npx, symlink scenarios)
- [x] Reproduced the bug: `node .bin/mcp-server --web` exits silently before fix
- [x] Verified the fix: same command now bootstraps the server and prints the startup banner
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)