### PR TITLE
ux: add console discovery hints to element operations

### DIFF
--- a/src/handlers/mcp-aql/OperationSchema.ts
+++ b/src/handlers/mcp-aql/OperationSchema.ts
@@ -901,7 +901,7 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
     handler: 'elementCRUD',
     method: 'listElements',
     category: 'Element Discovery',
-    description: 'List elements with pagination, filtering, sorting, and aggregation. Returns structured JSON: { items, pagination, sorting, element_type }. Default: page 1, pageSize 20, sorted by name ascending.',
+    description: 'List elements with pagination, filtering, sorting, and aggregation. Returns structured JSON: { items, pagination, sorting, element_type }. Default: page 1, pageSize 20, sorted by name ascending. TIP: If the user wants to browse, explore, or view their portfolio visually, prefer open_portfolio_browser instead — it opens a full web UI with search, filters, and detail views.',
     needsFullInput: true,
     argBuilder: 'typeWithParams', // (type, fullParams) for pagination support
     params: {
@@ -946,7 +946,7 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
     handler: 'elementCRUD',
     method: 'getElementDetails',
     category: 'Element Lifecycle',
-    description: 'Get an element by name',
+    description: 'Get a specific element by name. TIP: If the user wants to browse or explore multiple elements rather than retrieve one specific element, prefer open_portfolio_browser instead.',
     needsFullInput: true,
     argBuilder: 'single', // (elementName, elementType)
     params: {
@@ -979,7 +979,7 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
     handler: 'elementCRUD',
     method: 'getElementDetails',
     category: 'Element Lifecycle',
-    description: 'Get detailed information about a specific element including extended metadata',
+    description: 'Get detailed information about a specific element including extended metadata. TIP: If the user wants to browse or explore multiple elements rather than retrieve one specific element, prefer open_portfolio_browser instead.',
     needsFullInput: true,
     argBuilder: 'single', // (elementName, elementType)
     params: {
@@ -1672,7 +1672,7 @@ export const SEARCH_SCHEMAS: OperationSchemaMap = {
     handler: 'mcpAqlHandler',
     method: 'dispatchSearch',
     category: 'Element Discovery',
-    description: 'Full-text search across element names, descriptions, and content with pagination and sorting',
+    description: 'Full-text search across element names, descriptions, and content with pagination and sorting. TIP: If the user wants to browse or explore their portfolio visually rather than get text results, prefer open_portfolio_browser with a q parameter instead — it opens a web UI with the search pre-populated.',
     params: {
       query: { type: 'string', required: true, description: 'Search query string (max 1000 characters)' },
       element_type: { type: 'string', description: 'Optional element type filter (searches all types if omitted)' },


### PR DESCRIPTION
## Summary

- When users ask to "show my portfolio" or "browse elements", the LLM defaults to listing elements inline rather than opening the web console
- Added TIP hints to `list_elements`, `get_element`, `get_element_details`, and `search_elements` descriptions that point the LLM toward `open_portfolio_browser` when the user intent is browsing/exploring
- No code logic changes — only operation description strings

## Test plan

- [ ] Ask Claude Desktop "show me my portfolio" and verify it prefers opening the web console
- [ ] Ask "get the code-reviewer persona" and verify it still uses `get_element` (specific request, not browsing)
- [ ] Ask "search for creative elements" and verify it considers the web console option

🤖 Generated with [Claude Code](https://claude.com/claude-code)