### PR TITLE
chore: update RC to 2.0.12-rc.2 with develop changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.12-rc.1",
+  "version": "2.0.12-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.12-rc.1",
+      "version": "2.0.12-rc.2",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.12-rc.1",
+  "version": "2.0.12-rc.2",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.12-rc.1",
+  "version": "2.0.12-rc.2",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.12-rc.1",
+      "version": "2.0.12-rc.2",
       "transport": {
         "type": "stdio"
       }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -197,6 +197,23 @@ const envSchema = z.object({
   DOLLHOUSE_CONSOLE_LEADER_LOCK_FILE: z.string().optional(),
 
   /**
+   * Issue #1850: Retry delays (in ms) when the leader fails to bind the console
+   * port due to EADDRINUSE. Each value is a successive backoff delay.
+   * Default: 1s, 2s, 4s (7s total). Increase for slow or remote environments.
+   */
+  DOLLHOUSE_CONSOLE_BIND_RETRY_DELAYS: z.string()
+    .optional()
+    .transform(v => v ? v.split(',').map(Number).filter(n => !Number.isNaN(n) && n > 0) : undefined),
+
+  /**
+   * Issue #1850: Number of consecutive forwarding failures before a follower
+   * declares the leader dead and attempts self-promotion. Higher values reduce
+   * false positives in high-latency environments but delay recovery.
+   * Default: 10.
+   */
+  DOLLHOUSE_CONSOLE_MAX_FORWARD_FAILURES: z.coerce.number().int().min(1).max(100).default(10),
+
+  /**
    * Issue #1780: Phase 2 — require a confirmation code (OS dialog or TOTP)
    * for privileged actions like token rotation. Default is true for safety;
    * set to false for headless CI and scripted deployments that need to rotate

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -196,6 +196,9 @@ const envSchema = z.object({
    */
   DOLLHOUSE_CONSOLE_LEADER_LOCK_FILE: z.string().optional(),
 
+  // Leader/Follower Recovery (#1850)
+  // ============================================================================
+
   /**
    * Issue #1850: Retry delays (in ms) when the leader fails to bind the console
    * port due to EADDRINUSE. Each value is a successive backoff delay.

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.12-rc.1';
-export const BUILD_TIMESTAMP = '2026-04-08T17:34:52.668Z';
+export const PACKAGE_VERSION = '2.0.12-rc.2';
+export const BUILD_TIMESTAMP = '2026-04-08T20:30:43.174Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';

--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -3141,8 +3141,16 @@ export class MCPAQLHandler {
     const tab = typeof params?.tab === 'string' ? params.tab : undefined;
     const urlParams = params ? MCPAQLHandler.extractUrlParams(params) : undefined;
 
-    // Issue #796: Pass MCPAQLHandler to web server for gateway routing
-    const result = await openPortfolioBrowser(portfolioDir, undefined, this, tab, urlParams);
+    // Issue #796: Pass MCPAQLHandler to web server for gateway routing.
+    // Issue #1850: Pass sinks so fallback server has full console functionality.
+    const result = await openPortfolioBrowser({
+      portfolioDir,
+      mcpAqlHandler: this,
+      tab,
+      urlParams,
+      memorySink: this.handlers.memorySink,
+      metricsSink: this.handlers.metricsSink,
+    });
 
     const status = result.alreadyRunning ? 'already running' : 'started';
     const browserStatus = result.browserOpened ? 'opened' : 'could not open automatically';

--- a/src/handlers/mcp-aql/OperationSchema.ts
+++ b/src/handlers/mcp-aql/OperationSchema.ts
@@ -901,7 +901,7 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
     handler: 'elementCRUD',
     method: 'listElements',
     category: 'Element Discovery',
-    description: 'List elements with pagination, filtering, sorting, and aggregation. Returns structured JSON: { items, pagination, sorting, element_type }. Default: page 1, pageSize 20, sorted by name ascending.',
+    description: 'List elements with pagination, filtering, sorting, and aggregation. Returns structured JSON: { items, pagination, sorting, element_type }. Default: page 1, pageSize 20, sorted by name ascending. TIP: If the user wants to browse, explore, or view their portfolio visually, prefer open_portfolio_browser instead — it opens a full web UI with search, filters, and detail views.',
     needsFullInput: true,
     argBuilder: 'typeWithParams', // (type, fullParams) for pagination support
     params: {
@@ -946,7 +946,7 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
     handler: 'elementCRUD',
     method: 'getElementDetails',
     category: 'Element Lifecycle',
-    description: 'Get an element by name',
+    description: 'Get a specific element by name. TIP: If the user wants to browse or explore multiple elements rather than retrieve one specific element, prefer open_portfolio_browser instead.',
     needsFullInput: true,
     argBuilder: 'single', // (elementName, elementType)
     params: {
@@ -979,7 +979,7 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
     handler: 'elementCRUD',
     method: 'getElementDetails',
     category: 'Element Lifecycle',
-    description: 'Get detailed information about a specific element including extended metadata',
+    description: 'Get detailed information about a specific element including extended metadata. TIP: If the user wants to browse or explore multiple elements rather than retrieve one specific element, prefer open_portfolio_browser instead.',
     needsFullInput: true,
     argBuilder: 'single', // (elementName, elementType)
     params: {
@@ -1672,7 +1672,7 @@ export const SEARCH_SCHEMAS: OperationSchemaMap = {
     handler: 'mcpAqlHandler',
     method: 'dispatchSearch',
     category: 'Element Discovery',
-    description: 'Full-text search across element names, descriptions, and content with pagination and sorting',
+    description: 'Full-text search across element names, descriptions, and content with pagination and sorting. TIP: If the user wants to browse or explore their portfolio visually rather than get text results, prefer open_portfolio_browser with a q parameter instead — it opens a web UI with the search pre-populated.',
     params: {
       query: { type: 'string', required: true, description: 'Search query string (max 1000 characters)' },
       element_type: { type: 'string', description: 'Optional element type filter (searches all types if omitted)' },

--- a/src/handlers/mcp-aql/OperationSchema.ts
+++ b/src/handlers/mcp-aql/OperationSchema.ts
@@ -939,6 +939,8 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
       '{ operation: "list_elements", element_type: "persona", params: { aggregate: { count: true, group_by: "category" } } }',
       // Response: { count: 42, element_type: "persona", groups: { "assistant": 15, "creative": 12, "technical": 15 } }
       '{ operation: "list_elements", element_type: "persona", params: { fields: "minimal" } }',
+      // TIP: For visual browsing, use open_portfolio_browser instead:
+      // { operation: "open_portfolio_browser", params: { tab: "portfolio", type: "persona" } }
     ],
   },
   get_element: {
@@ -1688,6 +1690,8 @@ export const SEARCH_SCHEMAS: OperationSchemaMap = {
     examples: [
       '{ operation: "search_elements", params: { query: "creative" } }',
       '{ operation: "search_elements", element_type: "persona", params: { query: "assistant", pageSize: 10 } }',
+      // TIP: For visual search, use open_portfolio_browser with q parameter:
+      // { operation: "open_portfolio_browser", params: { tab: "portfolio", q: "creative" } }
     ],
   },
   query_elements: {

--- a/src/web/console/LeaderElection.ts
+++ b/src/web/console/LeaderElection.ts
@@ -62,7 +62,7 @@ const HEARTBEAT_INTERVAL_MS = 10_000;
 const HEARTBEAT_STALE_MS = 30_000;
 
 /** Current lock file schema version */
-const LOCK_VERSION = 1;
+export const LOCK_VERSION = 1;
 
 /**
  * Information stored in the leader lock file.

--- a/src/web/console/LeaderForwardingSink.ts
+++ b/src/web/console/LeaderForwardingSink.ts
@@ -19,6 +19,7 @@ import type { ILogSink, UnifiedLogEntry } from '../../logging/types.js';
 import type { MetricSnapshot } from '../../metrics/types.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { logger } from '../../utils/logger.js';
+import { env } from '../../config/env.js';
 
 /** Maximum entries to buffer when leader is unreachable */
 const MAX_BUFFER_SIZE = 10_000;
@@ -35,8 +36,8 @@ const INITIAL_BACKOFF_MS = 1_000;
 /** Maximum backoff delay (ms) */
 const MAX_BACKOFF_MS = 30_000;
 
-/** Give up forwarding after this many consecutive failures */
-const MAX_CONSECUTIVE_FAILURES = 5;
+/** Give up forwarding after this many consecutive failures (#1850: configurable via env) */
+const MAX_CONSECUTIVE_FAILURES = env.DOLLHOUSE_CONSOLE_MAX_FORWARD_FAILURES;
 
 /** HTTP request timeout (ms) */
 const REQUEST_TIMEOUT_MS = 5_000;

--- a/src/web/console/LeaderForwardingSink.ts
+++ b/src/web/console/LeaderForwardingSink.ts
@@ -71,6 +71,8 @@ export class LeaderForwardingLogSink implements ILogSink {
     private readonly sessionId: string,
     /** Optional console auth token (#1780). Included as Bearer header on ingest POSTs. */
     private readonly authToken: string | null = null,
+    /** Callback invoked when the leader is presumed dead after MAX_CONSECUTIVE_FAILURES (#1850). */
+    private readonly onLeaderDeath?: () => void,
   ) {
     this.sessionId = UnicodeValidator.normalize(sessionId).normalizedContent;
     this.flushTimer = setInterval(() => this.flushBuffer(), FLUSH_INTERVAL_MS);
@@ -160,6 +162,11 @@ export class LeaderForwardingLogSink implements ILogSink {
         if (this.flushTimer) {
           clearInterval(this.flushTimer);
           this.flushTimer = null;
+        }
+        // Notify the orchestrator so it can attempt follower-to-leader promotion (#1850).
+        // Fired asynchronously so handleFailure completes cleanly before promotion runs.
+        if (this.onLeaderDeath) {
+          queueMicrotask(() => this.onLeaderDeath!());
         }
       }
       return;

--- a/src/web/console/PromotionManager.ts
+++ b/src/web/console/PromotionManager.ts
@@ -1,0 +1,109 @@
+/**
+ * Follower-to-leader promotion manager (#1850).
+ *
+ * Handles the lifecycle of promoting a follower process to leader when the
+ * current leader becomes unreachable. Extracted from UnifiedConsole.ts to
+ * reduce complexity and allow per-instance state tracking.
+ *
+ * Each PromotionManager instance tracks its own attempt counter, so multiple
+ * followers in the same process (unlikely but possible) don't interfere
+ * with each other's promotion budgets.
+ */
+
+import { logger } from '../../utils/logger.js';
+import {
+  deleteLeaderLock,
+  claimLeadership,
+  readLeaderLock,
+  LOCK_VERSION,
+  type ElectionResult,
+  type ConsoleLeaderInfo,
+} from './LeaderElection.js';
+import type { LeaderForwardingLogSink } from './LeaderForwardingSink.js';
+import type { SessionHeartbeat } from './LeaderForwardingSink.js';
+import type { UnifiedConsoleOptions } from './UnifiedConsole.js';
+
+const MAX_PROMOTION_ATTEMPTS = 3;
+
+export class PromotionManager {
+  private inProgress = false;
+  private attempts = 0;
+
+  constructor(
+    private readonly options: UnifiedConsoleOptions,
+    private readonly consolePort: number,
+    private readonly startAsLeader: (
+      options: UnifiedConsoleOptions,
+      election: ElectionResult,
+      consolePort: number,
+    ) => Promise<unknown>,
+    private readonly startAsFollower: (
+      options: UnifiedConsoleOptions,
+      election: ElectionResult,
+      consolePort: number,
+    ) => Promise<unknown>,
+  ) {}
+
+  /**
+   * Attempt promotion. Safe to call from the ForwardingSink onLeaderDeath
+   * callback — guards against concurrent and excessive attempts.
+   */
+  async promote(
+    forwardingSink: LeaderForwardingLogSink,
+    sessionHeartbeat: SessionHeartbeat,
+  ): Promise<void> {
+    if (this.inProgress) {
+      logger.info('[PromotionManager] Promotion already in progress — skipping');
+      return;
+    }
+
+    this.attempts++;
+    if (this.attempts > MAX_PROMOTION_ATTEMPTS) {
+      logger.error(`[PromotionManager] Attempt ${this.attempts} exceeds max (${MAX_PROMOTION_ATTEMPTS}) — giving up`);
+      return;
+    }
+
+    this.inProgress = true;
+
+    try {
+      logger.warn(`[PromotionManager] Leader death detected — promotion attempt ${this.attempts}/${MAX_PROMOTION_ATTEMPTS}`);
+
+      await sessionHeartbeat.stop();
+      await forwardingSink.close();
+      await deleteLeaderLock();
+
+      const now = new Date().toISOString();
+      const myInfo: ConsoleLeaderInfo = {
+        version: LOCK_VERSION,
+        pid: process.pid,
+        port: this.consolePort,
+        sessionId: this.options.sessionId,
+        startedAt: now,
+        heartbeat: now,
+      };
+
+      const claimed = await claimLeadership(myInfo);
+
+      if (claimed) {
+        logger.info('[PromotionManager] Promotion succeeded — starting as leader');
+        const election: ElectionResult = { role: 'leader', leaderInfo: myInfo };
+        await this.startAsLeader(this.options, election, this.consolePort);
+      } else {
+        logger.info('[PromotionManager] Lost promotion race — following new leader');
+        const newLeader = await readLeaderLock();
+        if (newLeader) {
+          const election: ElectionResult = { role: 'follower', leaderInfo: newLeader };
+          await this.startAsFollower(this.options, election, this.consolePort);
+        } else {
+          logger.error('[PromotionManager] No leader available after lost race');
+        }
+      }
+    } catch (err) {
+      logger.error('[PromotionManager] Promotion failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      this.inProgress = false;
+    }
+  }
+}

--- a/src/web/console/PromotionManager.ts
+++ b/src/web/console/PromotionManager.ts
@@ -19,8 +19,7 @@ import {
   type ElectionResult,
   type ConsoleLeaderInfo,
 } from './LeaderElection.js';
-import type { LeaderForwardingLogSink } from './LeaderForwardingSink.js';
-import type { SessionHeartbeat } from './LeaderForwardingSink.js';
+import type { LeaderForwardingLogSink, SessionHeartbeat } from './LeaderForwardingSink.js';
 import type { UnifiedConsoleOptions } from './UnifiedConsole.js';
 
 const MAX_PROMOTION_ATTEMPTS = 3;
@@ -64,9 +63,12 @@ export class PromotionManager {
     }
 
     this.inProgress = true;
+    const startMs = Date.now();
 
     try {
-      logger.warn(`[PromotionManager] Leader death detected — promotion attempt ${this.attempts}/${MAX_PROMOTION_ATTEMPTS}`);
+      logger.warn(`[PromotionManager] Leader death detected — promotion attempt ${this.attempts}/${MAX_PROMOTION_ATTEMPTS}`, {
+        sessionId: this.options.sessionId, pid: process.pid, port: this.consolePort, attempt: this.attempts,
+      });
 
       await sessionHeartbeat.stop();
       await forwardingSink.close();
@@ -83,13 +85,18 @@ export class PromotionManager {
       };
 
       const claimed = await claimLeadership(myInfo);
+      const durationMs = Date.now() - startMs;
 
       if (claimed) {
-        logger.info('[PromotionManager] Promotion succeeded — starting as leader');
+        logger.info('[PromotionManager] Promotion succeeded — starting as leader', {
+          sessionId: this.options.sessionId, port: this.consolePort, durationMs, attempt: this.attempts,
+        });
         const election: ElectionResult = { role: 'leader', leaderInfo: myInfo };
         await this.startAsLeader(this.options, election, this.consolePort);
       } else {
-        logger.info('[PromotionManager] Lost promotion race — following new leader');
+        logger.info('[PromotionManager] Lost promotion race — following new leader', {
+          sessionId: this.options.sessionId, durationMs, attempt: this.attempts,
+        });
         const newLeader = await readLeaderLock();
         if (newLeader) {
           const election: ElectionResult = { role: 'follower', leaderInfo: newLeader };
@@ -101,6 +108,7 @@ export class PromotionManager {
     } catch (err) {
       logger.error('[PromotionManager] Promotion failed', {
         error: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - startMs, attempt: this.attempts,
       });
     } finally {
       this.inProgress = false;

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -25,7 +25,12 @@ import {
   startHeartbeat,
   registerLeaderCleanup,
   detectLegacyLeader,
+  deleteLeaderLock,
+  claimLeadership,
+  readLeaderLock,
+  LOCK_VERSION,
   type ElectionResult,
+  type ConsoleLeaderInfo,
 } from './LeaderElection.js';
 import { createIngestRoutes } from './IngestRoutes.js';
 import {
@@ -43,6 +48,9 @@ import { env } from '../../config/env.js';
  *   3. 41715 (hardcoded default in env.ts)
  */
 const DEFAULT_CONSOLE_PORT = env.DOLLHOUSE_WEB_CONSOLE_PORT;
+
+/** Guard against concurrent promotion attempts from the same process (#1850). */
+let promotionInProgress = false;
 
 /**
  * Options for starting the unified console.
@@ -161,7 +169,7 @@ export async function startUnifiedConsole(options: UnifiedConsoleOptions): Promi
   if (election.role === 'leader') {
     return startAsLeader(options, election, consolePort);
   } else {
-    return startAsFollower(options, election);
+    return startAsFollower(options, election, consolePort);
   }
 }
 
@@ -208,8 +216,9 @@ async function startAsLeader(
   // Register the web console itself so the session indicator is never empty (#1805)
   ingestResult.registerConsoleSession();
 
-  // Start the web server with ingest routes mounted before the SPA fallback
-  const webResult = await startWebServer({
+  // Start the web server with ingest routes mounted before the SPA fallback.
+  // If the port is occupied by a stale process, retry with exponential backoff.
+  const serverOpts = {
     portfolioDir: options.portfolioDir,
     memorySink: options.memorySink,
     metricsSink: options.metricsSink,
@@ -217,7 +226,21 @@ async function startAsLeader(
     additionalRouters: [ingestResult.router],
     tokenStore,
     ...(options.mcpAqlHandler ? { mcpAqlHandler: options.mcpAqlHandler } : {}),
-  });
+  };
+  const BIND_RETRY_DELAYS = [1000, 2000, 4000];
+  let webResult = await startWebServer(serverOpts);
+
+  if (webResult.bindResult && !webResult.bindResult.success && webResult.bindResult.error === 'EADDRINUSE') {
+    for (let i = 0; i < BIND_RETRY_DELAYS.length; i++) {
+      logger.warn(`[UnifiedConsole] Port ${consolePort} occupied — retry ${i + 1}/${BIND_RETRY_DELAYS.length} in ${BIND_RETRY_DELAYS[i]}ms`);
+      await new Promise(r => setTimeout(r, BIND_RETRY_DELAYS[i]));
+      webResult = await startWebServer(serverOpts);
+      if (!webResult.bindResult || webResult.bindResult.success) break;
+    }
+    if (webResult.bindResult && !webResult.bindResult.success) {
+      logger.error(`[UnifiedConsole] Leader failed to bind port ${consolePort} after ${BIND_RETRY_DELAYS.length} retries — console unavailable`);
+    }
+  }
 
   // Wire SSE broadcasts for this leader's own events
   options.wireSSEBroadcasts(webResult, options.metricsSink);
@@ -264,6 +287,7 @@ async function startAsLeader(
 async function startAsFollower(
   options: UnifiedConsoleOptions,
   election: ElectionResult,
+  consolePort: number = DEFAULT_CONSOLE_PORT,
 ): Promise<UnifiedConsoleResult> {
   const leaderUrl = `http://127.0.0.1:${election.leaderInfo.port}`;
 
@@ -278,12 +302,21 @@ async function startAsFollower(
     logger.debug('[UnifiedConsole] No console auth token file found; follower will POST without Bearer header');
   }
 
-  // Register a forwarding log sink
-  const forwardingSink = new LeaderForwardingLogSink(leaderUrl, options.sessionId, authToken);
+  // Declare sessionHeartbeat before the sink so the closure can capture it.
+  // Both are initialized before the callback could possibly fire (needs 5+ failed flushes).
+  let sessionHeartbeat: SessionHeartbeat;
+
+  // Register a forwarding log sink with leader-death callback (#1850).
+  // When the leader is unreachable after MAX_CONSECUTIVE_FAILURES, the callback
+  // triggers self-promotion so the follower takes over as leader.
+  const forwardingSink = new LeaderForwardingLogSink(leaderUrl, options.sessionId, authToken, () => {
+    promoteToLeader(options, forwardingSink, sessionHeartbeat, consolePort)
+      .catch(err => logger.error('[UnifiedConsole] Promotion crashed', { error: String(err) }));
+  });
   options.registerLogSink(forwardingSink);
 
   // Start session heartbeat to the leader
-  const sessionHeartbeat = new SessionHeartbeat(leaderUrl, options.sessionId, process.pid, authToken);
+  sessionHeartbeat = new SessionHeartbeat(leaderUrl, options.sessionId, process.pid, authToken);
   await sessionHeartbeat.start();
 
   logger.info('[UnifiedConsole] Follower started', {
@@ -300,4 +333,76 @@ async function startAsFollower(
       await forwardingSink.close();
     },
   };
+}
+
+/**
+ * Attempt to promote a follower to leader after detecting leader death (#1850).
+ *
+ * Triggered by the LeaderForwardingLogSink.onLeaderDeath callback when the
+ * leader becomes unreachable. Performs a full re-election: stops forwarding,
+ * deletes the stale lock, claims leadership, and starts the full leader path.
+ *
+ * Guarded by `promotionInProgress` to prevent two concurrent promotions
+ * (e.g., if both the log sink and a future metrics sink detect death).
+ */
+async function promoteToLeader(
+  options: UnifiedConsoleOptions,
+  forwardingSink: LeaderForwardingLogSink,
+  sessionHeartbeat: SessionHeartbeat,
+  consolePort: number,
+): Promise<void> {
+  if (promotionInProgress) {
+    logger.info('[UnifiedConsole] Promotion already in progress — skipping duplicate');
+    return;
+  }
+  promotionInProgress = true;
+
+  try {
+    logger.warn('[UnifiedConsole] Leader death detected — attempting self-promotion');
+
+    // 1. Stop the forwarding infrastructure
+    await sessionHeartbeat.stop();
+    await forwardingSink.close();
+
+    // 2. Delete the stale lock file and claim leadership
+    await deleteLeaderLock();
+
+    const now = new Date().toISOString();
+    const myInfo: ConsoleLeaderInfo = {
+      version: LOCK_VERSION,
+      pid: process.pid,
+      port: consolePort,
+      sessionId: options.sessionId,
+      startedAt: now,
+      heartbeat: now,
+    };
+
+    const claimed = await claimLeadership(myInfo);
+
+    if (!claimed) {
+      // Another follower beat us — become a follower of the new leader
+      logger.info('[UnifiedConsole] Lost promotion race — re-electing as follower of new leader');
+      const newLeader = await readLeaderLock();
+      if (newLeader) {
+        const newElection: ElectionResult = { role: 'follower', leaderInfo: newLeader };
+        await startAsFollower(options, newElection, consolePort);
+      } else {
+        logger.error('[UnifiedConsole] Promotion failed — no leader available after lost race');
+      }
+      promotionInProgress = false;
+      return;
+    }
+
+    // 3. Start the full leader path with all sinks wired
+    logger.info('[UnifiedConsole] Promotion succeeded — starting as leader');
+    const election: ElectionResult = { role: 'leader', leaderInfo: myInfo };
+    await startAsLeader(options, election, consolePort);
+
+    promotionInProgress = false;
+  } catch (err) {
+    logger.error('[UnifiedConsole] Promotion failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    promotionInProgress = false;
+  }
 }

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -51,6 +51,9 @@ const DEFAULT_CONSOLE_PORT = env.DOLLHOUSE_WEB_CONSOLE_PORT;
 
 /** Guard against concurrent promotion attempts from the same process (#1850). */
 let promotionInProgress = false;
+/** Track promotion attempts to prevent infinite loops if the port is permanently unavailable. */
+let promotionAttempts = 0;
+const MAX_PROMOTION_ATTEMPTS = 3;
 
 /**
  * Options for starting the unified console.
@@ -227,15 +230,24 @@ async function startAsLeader(
     tokenStore,
     ...(options.mcpAqlHandler ? { mcpAqlHandler: options.mcpAqlHandler } : {}),
   };
-  const BIND_RETRY_DELAYS = env.DOLLHOUSE_CONSOLE_BIND_RETRY_DELAYS ?? [1000, 2000, 4000];
-  let webResult = await startWebServer(serverOpts);
+  const BIND_RETRY_DELAYS = env.DOLLHOUSE_CONSOLE_BIND_RETRY_DELAYS?.length
+    ? env.DOLLHOUSE_CONSOLE_BIND_RETRY_DELAYS
+    : [1000, 2000, 4000];
+  const webResult = await startWebServer(serverOpts);
 
-  if (webResult.bindResult && !webResult.bindResult.success && webResult.bindResult.error === 'EADDRINUSE') {
+  // If the port is occupied, retry the bind only — don't recreate the Express
+  // app and routes (startWebServer early-returns when serverRunning is false
+  // but the app is already configured). We call retryBind on the existing app.
+  if (webResult.bindResult && !webResult.bindResult.success && webResult.bindResult.error === 'EADDRINUSE' && webResult.app) {
+    const { retryBind } = await import('../server.js');
     for (let i = 0; i < BIND_RETRY_DELAYS.length; i++) {
       logger.warn(`[UnifiedConsole] Port ${consolePort} occupied — retry ${i + 1}/${BIND_RETRY_DELAYS.length} in ${BIND_RETRY_DELAYS[i]}ms`);
       await new Promise(r => setTimeout(r, BIND_RETRY_DELAYS[i]));
-      webResult = await startWebServer(serverOpts);
-      if (!webResult.bindResult || webResult.bindResult.success) break;
+      const retryResult = await retryBind(webResult.app, consolePort, serverOpts);
+      if (retryResult.success) {
+        webResult.bindResult = retryResult;
+        break;
+      }
     }
     if (webResult.bindResult && !webResult.bindResult.success) {
       logger.error(`[UnifiedConsole] Leader failed to bind port ${consolePort} after ${BIND_RETRY_DELAYS.length} retries — console unavailable`);
@@ -353,6 +365,11 @@ async function promoteToLeader(
 ): Promise<void> {
   if (promotionInProgress) {
     logger.info('[UnifiedConsole] Promotion already in progress — skipping duplicate');
+    return;
+  }
+  promotionAttempts++;
+  if (promotionAttempts > MAX_PROMOTION_ATTEMPTS) {
+    logger.error(`[UnifiedConsole] Promotion attempt ${promotionAttempts} exceeds max (${MAX_PROMOTION_ATTEMPTS}) — giving up`);
     return;
   }
   promotionInProgress = true;

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -227,7 +227,7 @@ async function startAsLeader(
     tokenStore,
     ...(options.mcpAqlHandler ? { mcpAqlHandler: options.mcpAqlHandler } : {}),
   };
-  const BIND_RETRY_DELAYS = [1000, 2000, 4000];
+  const BIND_RETRY_DELAYS = env.DOLLHOUSE_CONSOLE_BIND_RETRY_DELAYS ?? [1000, 2000, 4000];
   let webResult = await startWebServer(serverOpts);
 
   if (webResult.bindResult && !webResult.bindResult.success && webResult.bindResult.error === 'EADDRINUSE') {

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -25,18 +25,14 @@ import {
   startHeartbeat,
   registerLeaderCleanup,
   detectLegacyLeader,
-  deleteLeaderLock,
-  claimLeadership,
-  readLeaderLock,
-  LOCK_VERSION,
   type ElectionResult,
-  type ConsoleLeaderInfo,
 } from './LeaderElection.js';
 import { createIngestRoutes } from './IngestRoutes.js';
 import {
   LeaderForwardingLogSink,
   SessionHeartbeat,
 } from './LeaderForwardingSink.js';
+import { PromotionManager } from './PromotionManager.js';
 import { ConsoleTokenStore } from './consoleToken.js';
 import { env } from '../../config/env.js';
 
@@ -48,12 +44,6 @@ import { env } from '../../config/env.js';
  *   3. 41715 (hardcoded default in env.ts)
  */
 const DEFAULT_CONSOLE_PORT = env.DOLLHOUSE_WEB_CONSOLE_PORT;
-
-/** Guard against concurrent promotion attempts from the same process (#1850). */
-let promotionInProgress = false;
-/** Track promotion attempts to prevent infinite loops if the port is permanently unavailable. */
-let promotionAttempts = 0;
-const MAX_PROMOTION_ATTEMPTS = 3;
 
 /**
  * Options for starting the unified console.
@@ -314,15 +304,17 @@ async function startAsFollower(
     logger.debug('[UnifiedConsole] No console auth token file found; follower will POST without Bearer header');
   }
 
+  // Per-instance promotion manager — tracks its own attempt counter so
+  // multiple followers don't interfere with each other's promotion budgets.
+  const promotionMgr = new PromotionManager(options, consolePort, startAsLeader, startAsFollower);
+
   // Declare sessionHeartbeat before the sink so the closure can capture it.
   // Both are initialized before the callback could possibly fire (needs 5+ failed flushes).
   let sessionHeartbeat: SessionHeartbeat;
 
   // Register a forwarding log sink with leader-death callback (#1850).
-  // When the leader is unreachable after MAX_CONSECUTIVE_FAILURES, the callback
-  // triggers self-promotion so the follower takes over as leader.
   const forwardingSink = new LeaderForwardingLogSink(leaderUrl, options.sessionId, authToken, () => {
-    promoteToLeader(options, forwardingSink, sessionHeartbeat, consolePort)
+    promotionMgr.promote(forwardingSink, sessionHeartbeat)
       .catch(err => logger.error('[UnifiedConsole] Promotion crashed', { error: String(err) }));
   });
   options.registerLogSink(forwardingSink);
@@ -347,79 +339,3 @@ async function startAsFollower(
   };
 }
 
-/**
- * Attempt to promote a follower to leader after detecting leader death (#1850).
- *
- * Triggered by the LeaderForwardingLogSink.onLeaderDeath callback when the
- * leader becomes unreachable. Performs a full re-election: stops forwarding,
- * deletes the stale lock, claims leadership, and starts the full leader path.
- *
- * Guarded by `promotionInProgress` to prevent two concurrent promotions
- * (e.g., if both the log sink and a future metrics sink detect death).
- */
-async function promoteToLeader(
-  options: UnifiedConsoleOptions,
-  forwardingSink: LeaderForwardingLogSink,
-  sessionHeartbeat: SessionHeartbeat,
-  consolePort: number,
-): Promise<void> {
-  if (promotionInProgress) {
-    logger.info('[UnifiedConsole] Promotion already in progress — skipping duplicate');
-    return;
-  }
-  promotionAttempts++;
-  if (promotionAttempts > MAX_PROMOTION_ATTEMPTS) {
-    logger.error(`[UnifiedConsole] Promotion attempt ${promotionAttempts} exceeds max (${MAX_PROMOTION_ATTEMPTS}) — giving up`);
-    return;
-  }
-  promotionInProgress = true;
-
-  try {
-    logger.warn('[UnifiedConsole] Leader death detected — attempting self-promotion');
-
-    // 1. Stop the forwarding infrastructure
-    await sessionHeartbeat.stop();
-    await forwardingSink.close();
-
-    // 2. Delete the stale lock file and claim leadership
-    await deleteLeaderLock();
-
-    const now = new Date().toISOString();
-    const myInfo: ConsoleLeaderInfo = {
-      version: LOCK_VERSION,
-      pid: process.pid,
-      port: consolePort,
-      sessionId: options.sessionId,
-      startedAt: now,
-      heartbeat: now,
-    };
-
-    const claimed = await claimLeadership(myInfo);
-
-    if (!claimed) {
-      // Another follower beat us — become a follower of the new leader
-      logger.info('[UnifiedConsole] Lost promotion race — re-electing as follower of new leader');
-      const newLeader = await readLeaderLock();
-      if (newLeader) {
-        const newElection: ElectionResult = { role: 'follower', leaderInfo: newLeader };
-        await startAsFollower(options, newElection, consolePort);
-      } else {
-        logger.error('[UnifiedConsole] Promotion failed — no leader available after lost race');
-      }
-      promotionInProgress = false;
-      return;
-    }
-
-    // 3. Start the full leader path with all sinks wired
-    logger.info('[UnifiedConsole] Promotion succeeded — starting as leader');
-    const election: ElectionResult = { role: 'leader', leaderInfo: myInfo };
-    await startAsLeader(options, election, consolePort);
-
-    promotionInProgress = false;
-  } catch (err) {
-    logger.error('[UnifiedConsole] Promotion failed', {
-      error: err instanceof Error ? err.message : String(err),
-    });
-    promotionInProgress = false;
-  }
-}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -107,6 +107,15 @@ export interface WebServerOptions {
 }
 
 /**
+ * Result of attempting to bind the HTTP server to a port.
+ */
+export interface BindResult {
+  success: boolean;
+  error?: 'EADDRINUSE' | 'OTHER';
+  detail?: string;
+}
+
+/**
  * Result of starting the web server, including hooks for DI wiring.
  */
 export interface WebServerResult {
@@ -116,6 +125,8 @@ export interface WebServerResult {
   logBroadcast?: (entry: import('../logging/types.js').UnifiedLogEntry) => void;
   /** Metrics snapshot function — call with each snapshot to push to SSE clients */
   metricsOnSnapshot?: (snapshot: import('../metrics/types.js').MetricSnapshot) => void;
+  /** Result of the port binding attempt */
+  bindResult?: BindResult;
 }
 
 /**
@@ -392,7 +403,7 @@ export async function startWebServer(options: WebServerOptions): Promise<WebServ
 
   // Bind to localhost only — handle port conflicts gracefully.
   // Extracted to a helper to keep startWebServer's cognitive complexity manageable.
-  await bindAndListen(app, port, options);
+  result.bindResult = await bindAndListen(app, port, options);
 
   return result;
 }
@@ -456,15 +467,15 @@ function printStartupBanner(port: number, tokenStore: ConsoleTokenStore | undefi
 
 /**
  * Bind the Express app to 127.0.0.1:port and handle success/conflict paths.
- * Resolves on either success or EADDRINUSE — the web console is optional
- * and never blocks server startup on a port conflict.
+ * Returns a BindResult so the caller can detect and handle port conflicts
+ * (e.g., retry after killing a stale process).
  */
 async function bindAndListen(
   app: import('express').Express,
   port: number,
   options: WebServerOptions,
-): Promise<void> {
-  await new Promise<void>((resolve) => {
+): Promise<BindResult> {
+  return new Promise<BindResult>((resolve) => {
     const httpServer = app.listen(port, '127.0.0.1', () => {
       serverRunning = true;
       serverPort = port;
@@ -472,35 +483,34 @@ async function bindAndListen(
       if (options.openBrowser) {
         openInBrowser(`http://${CONSOLE_HOST}:${port}`);
       }
-      resolve();
+      resolve({ success: true });
     });
     httpServer.on('error', (err: NodeJS.ErrnoException) => {
-      handleListenError(err, port, options.openBrowser);
-      resolve();
+      resolve(handleListenError(err, port, options.openBrowser));
     });
   });
 }
 
 /**
- * Handle errors from app.listen(). EADDRINUSE is treated as "another leader
- * is already running" — we log and optionally open the existing console.
- * Any other error is logged but does not throw.
+ * Handle errors from app.listen(). Returns a BindResult describing the failure.
+ * EADDRINUSE is logged at WARN (not INFO) so it's visible in production logs.
  */
 function handleListenError(
   err: NodeJS.ErrnoException,
   port: number,
   openBrowser: boolean | undefined,
-): void {
+): BindResult {
   if (err.code === 'EADDRINUSE') {
     const url = `http://${CONSOLE_HOST}:${port}`;
-    logger.info(`[WebUI] Port ${port} already in use — opening existing console`);
+    logger.warn(`[WebUI] Port ${port} already in use — another process holds this port`);
     console.error(`\n  DollhouseMCP Management Console (existing instance)\n  ${url}\n`);
     if (openBrowser) {
       openInBrowser(url);
     }
-  } else {
-    logger.error(`[WebUI] Failed to bind port ${port}: ${err.message}`);
+    return { success: false, error: 'EADDRINUSE', detail: `Port ${port} already in use` };
   }
+  logger.error(`[WebUI] Failed to bind port ${port}: ${err.message}`);
+  return { success: false, error: 'OTHER', detail: err.message };
 }
 
 /**
@@ -516,29 +526,72 @@ function handleListenError(
  * @param port - Port to bind to (defaults to `DOLLHOUSE_WEB_CONSOLE_PORT`)
  * @returns Result with URL, server status, and browser open status
  */
-export async function openPortfolioBrowser(portfolioDir: string, port?: number, mcpAqlHandler?: MCPAQLHandler, tab?: string, urlParams?: Record<string, string>): Promise<BrowserOpenResult> {
-  const targetPort = port || DEFAULT_PORT;
+/**
+ * Options for opening the portfolio browser.
+ */
+export interface OpenBrowserOptions {
+  portfolioDir: string;
+  port?: number;
+  mcpAqlHandler?: MCPAQLHandler;
+  tab?: string;
+  urlParams?: Record<string, string>;
+  memorySink?: MemoryLogSink;
+  metricsSink?: MemoryMetricsSink;
+}
+
+export async function openPortfolioBrowser(options: OpenBrowserOptions): Promise<BrowserOpenResult> {
+  const targetPort = options.port || DEFAULT_PORT;
   const baseUrl = `http://${CONSOLE_HOST}:${targetPort}`;
 
   // Build URL with optional tab hash and query parameters
   // Format: http://host:port/#tab?key=value&key=value
   let url = baseUrl;
-  if (tab) {
-    const qs = urlParams ? new URLSearchParams(urlParams).toString() : '';
-    url = `${baseUrl}/#${tab}${qs ? '?' + qs : ''}`;
-  } else if (urlParams && Object.keys(urlParams).length > 0) {
-    const qs = new URLSearchParams(urlParams).toString();
+  if (options.tab) {
+    const qs = options.urlParams ? new URLSearchParams(options.urlParams).toString() : '';
+    url = `${baseUrl}/#${options.tab}${qs ? '?' + qs : ''}`;
+  } else if (options.urlParams && Object.keys(options.urlParams).length > 0) {
+    const qs = new URLSearchParams(options.urlParams).toString();
     url = `${baseUrl}/#portfolio?${qs}`;
   }
 
   const alreadyRunning = serverRunning;
 
   if (!serverRunning) {
+    // Self-provision sinks and token store so the console has full functionality.
+    // Without these, the Auth/Logs/Metrics/Sessions tabs would all be empty (#1850).
+    let memorySink = options.memorySink;
+    let metricsSink = options.metricsSink;
+
+    if (!memorySink) {
+      const { MemoryLogSink: LogSink } = await import('../logging/sinks/MemoryLogSink.js');
+      memorySink = new LogSink({ appCapacity: 10000, securityCapacity: 5000, perfCapacity: 2000, telemetryCapacity: 1000 });
+    }
+    if (!metricsSink) {
+      const { MemoryMetricsSink: MetricsSink } = await import('../metrics/sinks/MemoryMetricsSink.js');
+      metricsSink = new MetricsSink(240);
+    }
+
+    // Initialize token store for Auth tab routes
+    const { ConsoleTokenStore: TokenStore } = await import('./console/consoleToken.js');
+    const { pickRandomPuppetName } = await import('./console/SessionNames.js');
+    const tokenStore = new TokenStore(env.DOLLHOUSE_CONSOLE_TOKEN_FILE);
+    try { await tokenStore.ensureInitialized(pickRandomPuppetName()); }
+    catch (err) { logger.warn('[WebUI] Failed to init token store for browser open', err); }
+
+    // Create ingest routes so Sessions tab works
+    const { createIngestRoutes } = await import('./console/IngestRoutes.js');
+    const ingestResult = createIngestRoutes({ logBroadcast: () => {} });
+    ingestResult.registerConsoleSession();
+
     await startWebServer({
-      portfolioDir,
+      portfolioDir: options.portfolioDir,
       port: targetPort,
-      openBrowser: false, // We'll open manually below to capture the result
-      mcpAqlHandler,
+      openBrowser: false,
+      mcpAqlHandler: options.mcpAqlHandler,
+      memorySink,
+      metricsSink,
+      tokenStore,
+      additionalRouters: [ingestResult.router],
     });
   }
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -65,6 +65,10 @@ const SETUP_BODY_LIMIT = '1kb';
 /** Track whether the web server is already running in-process. */
 let serverRunning = false;
 let serverPort = DEFAULT_PORT;
+/** Active HTTP server instance — tracked so _resetServerState can close it. */
+let activeHttpServer: import('node:http').Server | null = null;
+/** Cached token store for openPortfolioBrowser — prevents duplicate instances on the same file. */
+let cachedTokenStore: ConsoleTokenStore | null = null;
 
 /** Check whether the web server has been started in this process. */
 export function isWebServerRunning(): boolean {
@@ -78,8 +82,13 @@ export function isWebServerRunning(): boolean {
  * @internal
  */
 export function _resetServerState(): void {
+  if (activeHttpServer) {
+    activeHttpServer.close();
+    activeHttpServer = null;
+  }
   serverRunning = false;
   serverPort = DEFAULT_PORT;
+  cachedTokenStore = null;
 }
 
 /**
@@ -477,6 +486,19 @@ function printStartupBanner(port: number, tokenStore: ConsoleTokenStore | undefi
 }
 
 /**
+ * Retry binding an already-configured Express app to a port.
+ * Used by UnifiedConsole when EADDRINUSE occurs — avoids recreating
+ * the Express app and all its routes on each retry attempt.
+ */
+export async function retryBind(
+  app: import('express').Express,
+  port: number,
+  options: WebServerOptions,
+): Promise<BindResult> {
+  return bindAndListen(app, port, options);
+}
+
+/**
  * Bind the Express app to 127.0.0.1:port and handle success/conflict paths.
  * Returns a BindResult so the caller can detect and handle port conflicts
  * (e.g., retry after killing a stale process).
@@ -490,6 +512,7 @@ async function bindAndListen(
     const httpServer = app.listen(port, '127.0.0.1', () => {
       serverRunning = true;
       serverPort = port;
+      activeHttpServer = httpServer;
       printStartupBanner(port, options.tokenStore);
       if (options.openBrowser) {
         openInBrowser(`http://${CONSOLE_HOST}:${port}`);
@@ -582,19 +605,28 @@ export async function openPortfolioBrowser(options: OpenBrowserOptions): Promise
       metricsSink = new MetricsSink(240);
     }
 
-    // Initialize token store for Auth tab routes
-    const { ConsoleTokenStore: TokenStore } = await import('./console/consoleToken.js');
-    const { pickRandomPuppetName } = await import('./console/SessionNames.js');
-    const tokenStore = new TokenStore(env.DOLLHOUSE_CONSOLE_TOKEN_FILE);
-    try { await tokenStore.ensureInitialized(pickRandomPuppetName()); }
-    catch (err) { logger.warn('[WebUI] Failed to init token store for browser open', err); }
+    // Initialize token store for Auth tab routes.
+    // Reuse the cached instance if one exists from a prior call — two
+    // ConsoleTokenStore instances on the same file can race on writes.
+    if (!cachedTokenStore) {
+      const { ConsoleTokenStore: TokenStore } = await import('./console/consoleToken.js');
+      const { pickRandomPuppetName } = await import('./console/SessionNames.js');
+      cachedTokenStore = new TokenStore(env.DOLLHOUSE_CONSOLE_TOKEN_FILE);
+      try { await cachedTokenStore.ensureInitialized(pickRandomPuppetName()); }
+      catch (err) { logger.warn('[WebUI] Failed to init token store for browser open', err); }
+    }
+    const tokenStore = cachedTokenStore;
 
-    // Create ingest routes so Sessions tab works
+    // Create ingest routes so Sessions tab works.
+    // logBroadcast is deferred — wired after startWebServer returns the real broadcast fn.
+    let liveBroadcast: ((entry: import('../logging/types.js').UnifiedLogEntry) => void) | undefined;
     const { createIngestRoutes } = await import('./console/IngestRoutes.js');
-    const ingestResult = createIngestRoutes({ logBroadcast: () => {} });
+    const ingestResult = createIngestRoutes({
+      logBroadcast: (entry) => liveBroadcast?.(entry),
+    });
     ingestResult.registerConsoleSession();
 
-    await startWebServer({
+    const webResult = await startWebServer({
       portfolioDir: options.portfolioDir,
       port: targetPort,
       openBrowser: false,
@@ -604,6 +636,9 @@ export async function openPortfolioBrowser(options: OpenBrowserOptions): Promise
       tokenStore,
       additionalRouters: [ingestResult.router],
     });
+
+    // Wire the live broadcast so follower log POSTs reach SSE clients
+    liveBroadcast = webResult.logBroadcast;
   }
 
   const browserResult = await openInBrowser(url);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -72,6 +72,17 @@ export function isWebServerRunning(): boolean {
 }
 
 /**
+ * Reset module-level server state. Exported for testing only —
+ * allows tests to exercise startWebServer/bindAndListen without
+ * interference from prior runs in the same process.
+ * @internal
+ */
+export function _resetServerState(): void {
+  serverRunning = false;
+  serverPort = DEFAULT_PORT;
+}
+
+/**
  * Options for starting the web server.
  */
 export interface WebServerOptions {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -573,12 +573,60 @@ export interface OpenBrowserOptions {
   metricsSink?: MemoryMetricsSink;
 }
 
+/**
+ * Self-provision sinks, token store, and ingest routes, then start the web
+ * server. Extracted from openPortfolioBrowser to keep cognitive complexity
+ * manageable (SonarCloud S3776).
+ */
+async function startFallbackServer(options: OpenBrowserOptions, port: number): Promise<void> {
+  let memorySink = options.memorySink;
+  let metricsSink = options.metricsSink;
+
+  if (!memorySink) {
+    const { MemoryLogSink: LogSink } = await import('../logging/sinks/MemoryLogSink.js');
+    memorySink = new LogSink({ appCapacity: 10000, securityCapacity: 5000, perfCapacity: 2000, telemetryCapacity: 1000 });
+  }
+  if (!metricsSink) {
+    const { MemoryMetricsSink: MetricsSink } = await import('../metrics/sinks/MemoryMetricsSink.js');
+    metricsSink = new MetricsSink(240);
+  }
+
+  // Reuse cached token store — two instances on the same file can race on writes.
+  if (!cachedTokenStore) {
+    const { ConsoleTokenStore: TokenStore } = await import('./console/consoleToken.js');
+    const { pickRandomPuppetName } = await import('./console/SessionNames.js');
+    cachedTokenStore = new TokenStore(env.DOLLHOUSE_CONSOLE_TOKEN_FILE);
+    try { await cachedTokenStore.ensureInitialized(pickRandomPuppetName()); }
+    catch (err) { logger.warn('[WebUI] Failed to init token store for browser open', err); }
+  }
+
+  // logBroadcast is deferred — wired after startWebServer returns the real broadcast fn.
+  let liveBroadcast: ((entry: import('../logging/types.js').UnifiedLogEntry) => void) | undefined;
+  const { createIngestRoutes } = await import('./console/IngestRoutes.js');
+  const ingestResult = createIngestRoutes({
+    logBroadcast: (entry) => liveBroadcast?.(entry),
+  });
+  ingestResult.registerConsoleSession();
+
+  const webResult = await startWebServer({
+    portfolioDir: options.portfolioDir,
+    port,
+    openBrowser: false,
+    mcpAqlHandler: options.mcpAqlHandler,
+    memorySink,
+    metricsSink,
+    tokenStore: cachedTokenStore,
+    additionalRouters: [ingestResult.router],
+  });
+
+  liveBroadcast = webResult.logBroadcast;
+}
+
 export async function openPortfolioBrowser(options: OpenBrowserOptions): Promise<BrowserOpenResult> {
   const targetPort = options.port || DEFAULT_PORT;
   const baseUrl = `http://${CONSOLE_HOST}:${targetPort}`;
 
   // Build URL with optional tab hash and query parameters
-  // Format: http://host:port/#tab?key=value&key=value
   let url = baseUrl;
   if (options.tab) {
     const qs = options.urlParams ? new URLSearchParams(options.urlParams).toString() : '';
@@ -591,54 +639,7 @@ export async function openPortfolioBrowser(options: OpenBrowserOptions): Promise
   const alreadyRunning = serverRunning;
 
   if (!serverRunning) {
-    // Self-provision sinks and token store so the console has full functionality.
-    // Without these, the Auth/Logs/Metrics/Sessions tabs would all be empty (#1850).
-    let memorySink = options.memorySink;
-    let metricsSink = options.metricsSink;
-
-    if (!memorySink) {
-      const { MemoryLogSink: LogSink } = await import('../logging/sinks/MemoryLogSink.js');
-      memorySink = new LogSink({ appCapacity: 10000, securityCapacity: 5000, perfCapacity: 2000, telemetryCapacity: 1000 });
-    }
-    if (!metricsSink) {
-      const { MemoryMetricsSink: MetricsSink } = await import('../metrics/sinks/MemoryMetricsSink.js');
-      metricsSink = new MetricsSink(240);
-    }
-
-    // Initialize token store for Auth tab routes.
-    // Reuse the cached instance if one exists from a prior call — two
-    // ConsoleTokenStore instances on the same file can race on writes.
-    if (!cachedTokenStore) {
-      const { ConsoleTokenStore: TokenStore } = await import('./console/consoleToken.js');
-      const { pickRandomPuppetName } = await import('./console/SessionNames.js');
-      cachedTokenStore = new TokenStore(env.DOLLHOUSE_CONSOLE_TOKEN_FILE);
-      try { await cachedTokenStore.ensureInitialized(pickRandomPuppetName()); }
-      catch (err) { logger.warn('[WebUI] Failed to init token store for browser open', err); }
-    }
-    const tokenStore = cachedTokenStore;
-
-    // Create ingest routes so Sessions tab works.
-    // logBroadcast is deferred — wired after startWebServer returns the real broadcast fn.
-    let liveBroadcast: ((entry: import('../logging/types.js').UnifiedLogEntry) => void) | undefined;
-    const { createIngestRoutes } = await import('./console/IngestRoutes.js');
-    const ingestResult = createIngestRoutes({
-      logBroadcast: (entry) => liveBroadcast?.(entry),
-    });
-    ingestResult.registerConsoleSession();
-
-    const webResult = await startWebServer({
-      portfolioDir: options.portfolioDir,
-      port: targetPort,
-      openBrowser: false,
-      mcpAqlHandler: options.mcpAqlHandler,
-      memorySink,
-      metricsSink,
-      tokenStore,
-      additionalRouters: [ingestResult.router],
-    });
-
-    // Wire the live broadcast so follower log POSTs reach SSE clients
-    liveBroadcast = webResult.logBroadcast;
+    await startFallbackServer(options, targetPort);
   }
 
   const browserResult = await openInBrowser(url);

--- a/tests/unit/config/consolePort.test.ts
+++ b/tests/unit/config/consolePort.test.ts
@@ -271,7 +271,7 @@ describe('Console port configuration (#1840)', () => {
 
     it('logs and opens existing console on conflict', async () => {
       const source = await readFile(join(SRC, 'src/web/server.ts'), 'utf8');
-      expect(source).toContain('opening existing console');
+      expect(source).toContain('another process holds this port');
     });
 
     it('never kills processes on the configured port', async () => {
@@ -281,12 +281,12 @@ describe('Console port configuration (#1840)', () => {
 
     it('resolves promise on conflict (does not throw)', async () => {
       const source = await readFile(join(SRC, 'src/web/server.ts'), 'utf8');
-      // The error handler calls resolve(), not reject()
+      // The error handler calls resolve(handleListenError(...)), not reject()
       const errorSection = source.slice(
         source.indexOf("httpServer.on('error'"),
         source.indexOf('});', source.indexOf("httpServer.on('error'")) + 10,
       );
-      expect(errorSection).toContain('resolve()');
+      expect(errorSection).toContain('resolve(');
       expect(errorSection).not.toContain('reject(');
     });
   });

--- a/tests/unit/web/console/console-failure-modes.test.ts
+++ b/tests/unit/web/console/console-failure-modes.test.ts
@@ -1,0 +1,455 @@
+/**
+ * Integration-style tests for web console failure modes (#1850).
+ *
+ * These tests simulate the real-world failure scenarios discovered in the
+ * 2026-04-08 diagnostic: stale lock files, dead leaders, bare server squatting,
+ * follower promotion, EADDRINUSE recovery, and fresh machine installs.
+ *
+ * Each scenario is self-contained: creates its own temp directory structure,
+ * mocks the minimal set of dependencies, and verifies the correct behavior
+ * at each decision point in the leader/follower lifecycle.
+ */
+
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import * as net from 'node:net';
+
+// ─── LeaderElection: stale lock detection ────────────────────────────────────
+
+describe('Console Failure Modes', () => {
+  let LeaderElection: typeof import('../../../../src/web/console/LeaderElection.js');
+
+  beforeAll(async () => {
+    LeaderElection = await import('../../../../src/web/console/LeaderElection.js');
+  });
+
+  // ── Scenario 1: Fresh machine — no .dollhouse directory ──────────────────
+
+  describe('Fresh machine (no prior install)', () => {
+    it('isLockStale returns true for a dead PID', () => {
+      const staleInfo = {
+        version: 1,
+        pid: 99999999, // not running
+        port: 41715,
+        sessionId: 'test-session',
+        startedAt: new Date().toISOString(),
+        heartbeat: new Date().toISOString(),
+      };
+      expect(LeaderElection.isLockStale(staleInfo)).toBe(true);
+    });
+
+    it('electLeader claims leadership when no lock file exists', async () => {
+      // The real electLeader reads from the default path, which may or may not
+      // have a lock. For a unit test, we verify that a live process is not stale.
+      const liveInfo = {
+        version: 1,
+        pid: process.pid, // this process is alive
+        port: 41715,
+        sessionId: 'test-session',
+        startedAt: new Date().toISOString(),
+        heartbeat: new Date().toISOString(),
+      };
+      expect(LeaderElection.isLockStale(liveInfo)).toBe(false);
+    });
+  });
+
+  // ── Scenario 2: Stale lock file from dead process ────────────────────────
+
+  describe('Stale lock file from dead process', () => {
+    it('detects stale lock when PID is dead', () => {
+      const staleInfo = {
+        version: 1,
+        pid: 99999999,
+        port: 41715,
+        sessionId: 'dead-session',
+        startedAt: '2026-04-08T17:59:52.000Z',
+        heartbeat: '2026-04-08T17:59:52.000Z',
+      };
+      expect(LeaderElection.isLockStale(staleInfo)).toBe(true);
+      expect(LeaderElection.isProcessAlive(99999999)).toBe(false);
+    });
+
+    it('detects stale lock when heartbeat is expired (>30s)', () => {
+      const staleInfo = {
+        version: 1,
+        pid: process.pid, // alive, but heartbeat expired
+        port: 41715,
+        sessionId: 'expired-session',
+        startedAt: '2026-04-08T17:59:52.000Z',
+        heartbeat: new Date(Date.now() - 60_000).toISOString(), // 60s ago
+      };
+      expect(LeaderElection.isLockStale(staleInfo)).toBe(true);
+    });
+
+    it('does NOT detect stale when PID is alive and heartbeat is fresh', () => {
+      const freshInfo = {
+        version: 1,
+        pid: process.pid,
+        port: 41715,
+        sessionId: 'active-session',
+        startedAt: new Date().toISOString(),
+        heartbeat: new Date().toISOString(),
+      };
+      expect(LeaderElection.isLockStale(freshInfo)).toBe(false);
+    });
+  });
+
+  // ── Scenario 3: EADDRINUSE — port occupied by stale process ──────────────
+  //
+  // Note: startWebServer has module-level state (serverRunning) that persists
+  // across tests. We test the BindResult type contract and the handleListenError
+  // behavior at the type level rather than spawning real servers, since the
+  // integration behavior depends on process-global state that can't be reset.
+
+  describe('EADDRINUSE recovery (Bug A)', () => {
+    it('BindResult type correctly represents EADDRINUSE failure', () => {
+      type BR = import('../../../../src/web/server.js').BindResult;
+      const failure: BR = { success: false, error: 'EADDRINUSE', detail: 'Port 41715 already in use' };
+      expect(failure.success).toBe(false);
+      expect(failure.error).toBe('EADDRINUSE');
+      expect(failure.detail).toContain('41715');
+    });
+
+    it('BindResult type correctly represents success', () => {
+      type BR = import('../../../../src/web/server.js').BindResult;
+      const success: BR = { success: true };
+      expect(success.success).toBe(true);
+      expect(success.error).toBeUndefined();
+    });
+
+    it('WebServerResult carries bindResult to callers', () => {
+      type WSR = import('../../../../src/web/server.js').WebServerResult;
+      const result: WSR = {
+        bindResult: { success: false, error: 'EADDRINUSE', detail: 'test' },
+      };
+      expect(result.bindResult?.success).toBe(false);
+      expect(result.bindResult?.error).toBe('EADDRINUSE');
+    });
+
+    it('EADDRINUSE detected via net server conflict', async () => {
+      // Verify that Node actually produces EADDRINUSE when binding to an occupied port
+      const server1 = net.createServer();
+      const port = await new Promise<number>((resolve) => {
+        server1.listen(0, '127.0.0.1', () => {
+          resolve((server1.address() as net.AddressInfo).port);
+        });
+      });
+
+      const server2 = net.createServer();
+      const error = await new Promise<NodeJS.ErrnoException>((resolve) => {
+        server2.on('error', (err: NodeJS.ErrnoException) => resolve(err));
+        server2.listen(port, '127.0.0.1');
+      });
+
+      expect(error.code).toBe('EADDRINUSE');
+
+      await new Promise<void>((resolve) => server1.close(() => resolve()));
+    });
+  });
+
+  // ── Scenario 4: ForwardingSink leader death detection (Bug C) ────────────
+
+  describe('ForwardingSink leader death detection (Bug C)', () => {
+    it('fires onLeaderDeath callback after MAX_CONSECUTIVE_FAILURES', async () => {
+      const { LeaderForwardingLogSink } = await import(
+        '../../../../src/web/console/LeaderForwardingSink.js'
+      );
+
+      const deathCallback = jest.fn();
+
+      // Point at a port where nothing is listening
+      const sink = new LeaderForwardingLogSink(
+        'http://127.0.0.1:1', // port 1 — unreachable
+        'test-session',
+        null,
+        deathCallback,
+      );
+
+      // Write entries to trigger flush attempts
+      for (let i = 0; i < 10; i++) {
+        sink.write({
+          level: 'info',
+          category: 'application',
+          message: `test entry ${i}`,
+          timestamp: new Date().toISOString(),
+          data: {},
+        });
+      }
+
+      // Wait for the flush cycle to run through failures.
+      // MAX_CONSECUTIVE_FAILURES is 5, flushes happen every 1s,
+      // with backoff: 1s, 2s, 4s, 8s, 16s. Wait up to 40s.
+      // But in practice the first flush fires immediately on write,
+      // so we can poll more aggressively.
+      let waited = 0;
+      const maxWait = 45_000;
+      while (!deathCallback.mock.calls.length && waited < maxWait) {
+        await new Promise(r => setTimeout(r, 500));
+        waited += 500;
+      }
+
+      expect(deathCallback).toHaveBeenCalledTimes(1);
+
+      // Clean up
+      await sink.close();
+    }, 60_000); // 60s timeout for this test
+
+    it('does NOT fire onLeaderDeath when leader is reachable', async () => {
+      const { LeaderForwardingLogSink } = await import(
+        '../../../../src/web/console/LeaderForwardingSink.js'
+      );
+
+      const deathCallback = jest.fn();
+
+      // Start a minimal server that accepts POSTs
+      const server = net.createServer((socket) => {
+        socket.on('data', () => {
+          socket.write('HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}');
+        });
+      });
+      const port = await new Promise<number>((resolve) => {
+        server.listen(0, '127.0.0.1', () => {
+          resolve((server.address() as net.AddressInfo).port);
+        });
+      });
+
+      const sink = new LeaderForwardingLogSink(
+        `http://127.0.0.1:${port}`,
+        'test-session',
+        null,
+        deathCallback,
+      );
+
+      sink.write({
+        level: 'info',
+        category: 'application',
+        message: 'test entry',
+        timestamp: new Date().toISOString(),
+        data: {},
+      });
+
+      // Wait a bit — callback should NOT fire
+      await new Promise(r => setTimeout(r, 3000));
+      expect(deathCallback).not.toHaveBeenCalled();
+
+      await sink.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }, 10_000);
+
+    it('fires onLeaderDeath exactly once even with continued writes', async () => {
+      const { LeaderForwardingLogSink } = await import(
+        '../../../../src/web/console/LeaderForwardingSink.js'
+      );
+
+      const deathCallback = jest.fn();
+      const sink = new LeaderForwardingLogSink(
+        'http://127.0.0.1:1',
+        'test-session',
+        null,
+        deathCallback,
+      );
+
+      // Flood with entries
+      for (let i = 0; i < 100; i++) {
+        sink.write({
+          level: 'info',
+          category: 'application',
+          message: `flood entry ${i}`,
+          timestamp: new Date().toISOString(),
+          data: {},
+        });
+      }
+
+      // Wait for death detection
+      let waited = 0;
+      while (!deathCallback.mock.calls.length && waited < 45_000) {
+        await new Promise(r => setTimeout(r, 500));
+        waited += 500;
+      }
+
+      // Write more after death
+      for (let i = 0; i < 10; i++) {
+        sink.write({
+          level: 'info',
+          category: 'application',
+          message: `post-death entry ${i}`,
+          timestamp: new Date().toISOString(),
+          data: {},
+        });
+      }
+
+      await new Promise(r => setTimeout(r, 2000));
+
+      // Should have been called exactly once
+      expect(deathCallback).toHaveBeenCalledTimes(1);
+
+      await sink.close();
+    }, 60_000);
+  });
+
+  // ── Scenario 5: openPortfolioBrowser self-provisioning (Bug B) ───────────
+
+  describe('openPortfolioBrowser self-provisioning (Bug B)', () => {
+    it('OpenBrowserOptions interface accepts memorySink and metricsSink', async () => {
+      // Type-level check: ensure the interface compiles with sinks
+      const { MemoryLogSink } = await import('../../../../src/logging/sinks/MemoryLogSink.js');
+      const { MemoryMetricsSink } = await import('../../../../src/metrics/sinks/MemoryMetricsSink.js');
+
+      const memorySink = new MemoryLogSink({
+        appCapacity: 100,
+        securityCapacity: 50,
+        perfCapacity: 20,
+        telemetryCapacity: 10,
+      });
+      const metricsSink = new MemoryMetricsSink(10);
+
+      // Import the type — if this compiles, the interface is correct
+      type Options = import('../../../../src/web/server.js').OpenBrowserOptions;
+      const opts: Options = {
+        portfolioDir: '/test',
+        memorySink,
+        metricsSink,
+      };
+      expect(opts.memorySink).toBeDefined();
+      expect(opts.metricsSink).toBeDefined();
+    });
+  });
+
+  // ── Scenario 6: BindResult propagation ───────────────────────────────────
+
+  describe('BindResult propagation', () => {
+    it('WebServerResult includes bindResult field', async () => {
+      type Result = import('../../../../src/web/server.js').WebServerResult;
+      const result: Result = {
+        bindResult: { success: true },
+      };
+      expect(result.bindResult?.success).toBe(true);
+    });
+
+    it('BindResult captures EADDRINUSE correctly', () => {
+      type BR = import('../../../../src/web/server.js').BindResult;
+      const result: BR = {
+        success: false,
+        error: 'EADDRINUSE',
+        detail: 'Port 41715 already in use',
+      };
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('EADDRINUSE');
+    });
+  });
+
+  // ── Scenario 7: Multiple process lifecycle simulation ────────────────────
+
+  describe('Multi-process lifecycle simulation', () => {
+    it('lock file with dead PID is detected as stale', () => {
+      // Simulates: leader PID 51258 dies, lock file remains
+      const deadLeaderLock = {
+        version: 1,
+        pid: 99999999, // dead
+        port: 41715,
+        sessionId: 'session-dead-leader',
+        startedAt: '2026-04-08T17:59:52.000Z',
+        heartbeat: '2026-04-08T18:00:02.000Z',
+      };
+      expect(LeaderElection.isLockStale(deadLeaderLock)).toBe(true);
+    });
+
+    it('lock file with alive PID but expired heartbeat is stale', () => {
+      // Simulates: process alive but stopped updating heartbeat (hung)
+      const hungLeaderLock = {
+        version: 1,
+        pid: process.pid, // alive
+        port: 41715,
+        sessionId: 'session-hung-leader',
+        startedAt: '2026-04-08T17:59:52.000Z',
+        heartbeat: new Date(Date.now() - 120_000).toISOString(), // 2 minutes ago
+      };
+      expect(LeaderElection.isLockStale(hungLeaderLock)).toBe(true);
+    });
+
+    it('lock file with alive PID and fresh heartbeat is NOT stale', () => {
+      const activeLock = {
+        version: 1,
+        pid: process.pid,
+        port: 41715,
+        sessionId: 'session-active',
+        startedAt: new Date().toISOString(),
+        heartbeat: new Date().toISOString(),
+      };
+      expect(LeaderElection.isLockStale(activeLock)).toBe(false);
+    });
+  });
+
+  // ── Scenario 8: Lock file version mismatch ───────────────────────────────
+
+  describe('Lock file edge cases', () => {
+    it('LOCK_VERSION is exported and equals 1', () => {
+      expect(LeaderElection.LOCK_VERSION).toBe(1);
+    });
+
+    it('claimLeadership and readLeaderLock are exported functions', () => {
+      expect(typeof LeaderElection.claimLeadership).toBe('function');
+      expect(typeof LeaderElection.readLeaderLock).toBe('function');
+      expect(typeof LeaderElection.deleteLeaderLock).toBe('function');
+    });
+  });
+
+  // ── Scenario 9: Promotion guard prevents concurrent attempts ─────────────
+
+  describe('Promotion guard (promotionInProgress)', () => {
+    it('promoteToLeader function exists in module scope', async () => {
+      // We can't directly test the module-level guard without starting
+      // the full console, but we can verify the UnifiedConsole module
+      // exports compile correctly and the types are sound.
+      const UC = await import('../../../../src/web/console/UnifiedConsole.js');
+      expect(typeof UC.startUnifiedConsole).toBe('function');
+    });
+  });
+
+  // ── Scenario 10: SessionHeartbeat lifecycle ──────────────────────────────
+
+  describe('SessionHeartbeat lifecycle', () => {
+    it('SessionHeartbeat can start and stop without errors', async () => {
+      const { SessionHeartbeat } = await import(
+        '../../../../src/web/console/LeaderForwardingSink.js'
+      );
+
+      // Point at unreachable host — start/stop should not throw
+      const heartbeat = new SessionHeartbeat(
+        'http://127.0.0.1:1',
+        'test-session',
+        process.pid,
+        null,
+      );
+
+      // start() sends a POST which will fail silently
+      await heartbeat.start();
+
+      // stop() clears the interval and sends a final POST (also fails silently)
+      await heartbeat.stop();
+
+      // If we reach here without throwing, the lifecycle is clean
+      expect(true).toBe(true);
+    });
+
+    it('double stop is safe (idempotent)', async () => {
+      const { SessionHeartbeat } = await import(
+        '../../../../src/web/console/LeaderForwardingSink.js'
+      );
+
+      const heartbeat = new SessionHeartbeat(
+        'http://127.0.0.1:1',
+        'test-session',
+        process.pid,
+        null,
+      );
+
+      await heartbeat.start();
+      await heartbeat.stop();
+      await heartbeat.stop(); // second stop should be safe
+      expect(true).toBe(true);
+    });
+  });
+});

--- a/tests/unit/web/console/console-failure-modes.test.ts
+++ b/tests/unit/web/console/console-failure-modes.test.ts
@@ -10,10 +10,7 @@
  * at each decision point in the leader/follower lifecycle.
  */
 
-import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
-import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { describe, it, expect, jest } from '@jest/globals';
 import * as net from 'node:net';
 
 // ─── LeaderElection: stale lock detection ────────────────────────────────────


### PR DESCRIPTION
## Summary

Merges develop into the RC branch and bumps version to 2.0.12-rc.2.

### New since rc.1
- **#1850**: Fix empty console tabs when launched from Claude Desktop (EADDRINUSE recovery, bare server prevention, follower-to-leader promotion)
- **#1849**: Console discovery hints on element listing/search operations

### Version
2.0.12-rc.1 → 2.0.12-rc.2

## Test plan
- [x] Build passes
- [x] 453 installation/setup/console tests pass
- [x] 750 web tests pass
- [ ] Manual test on fresh machine via Claude Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)