### PR TITLE
fix: kill stale processes squatting on console port (#1850)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.11-rc.1] - 2026-04-08
+
+Release candidate for v2.0.11 — console auth, permissions, licensing, port 41715, channel selector
+
 ## [Unreleased] — Phase 2 authenticated console
 
 ### Breaking: Web console default port moved from 3939 → 41715

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.10",
+  "version": "2.0.11-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.10",
+      "version": "2.0.11-rc.1",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.12-rc.1",
+  "version": "2.0.12-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.12-rc.1",
+      "version": "2.0.12-rc.2",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.11-rc.1",
+  "version": "2.0.12-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.11-rc.1",
+      "version": "2.0.12-rc.1",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.11-rc.1",
+  "version": "2.0.12-rc.1",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.12-rc.1",
+  "version": "2.0.12-rc.2",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.10",
+  "version": "2.0.11-rc.1",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.12-rc.1",
+  "version": "2.0.12-rc.2",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.12-rc.1",
+      "version": "2.0.12-rc.2",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.10",
+  "version": "2.0.11-rc.1",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.10",
+      "version": "2.0.11-rc.1",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.11-rc.1",
+  "version": "2.0.12-rc.1",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.11-rc.1",
+      "version": "2.0.12-rc.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -196,6 +196,9 @@ const envSchema = z.object({
    */
   DOLLHOUSE_CONSOLE_LEADER_LOCK_FILE: z.string().optional(),
 
+  // Leader/Follower Recovery (#1850)
+  // ============================================================================
+
   /**
    * Issue #1850: Retry delays (in ms) when the leader fails to bind the console
    * port due to EADDRINUSE. Each value is a successive backoff delay.

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -1,0 +1,9 @@
+/**
+ * Auto-generated file - DO NOT EDIT
+ * Generated at build time by scripts/generate-version.js
+ */
+
+export const PACKAGE_VERSION = '2.0.12-rc.1';
+export const BUILD_TIMESTAMP = '2026-04-08T17:34:52.668Z';
+export const BUILD_TYPE: 'npm' | 'git' = 'git';
+export const PACKAGE_NAME = '@dollhousemcp/mcp-server';

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.12-rc.1';
-export const BUILD_TIMESTAMP = '2026-04-08T17:34:52.668Z';
+export const PACKAGE_VERSION = '2.0.12-rc.2';
+export const BUILD_TIMESTAMP = '2026-04-08T20:30:43.174Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';

--- a/src/handlers/mcp-aql/OperationSchema.ts
+++ b/src/handlers/mcp-aql/OperationSchema.ts
@@ -939,6 +939,8 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
       '{ operation: "list_elements", element_type: "persona", params: { aggregate: { count: true, group_by: "category" } } }',
       // Response: { count: 42, element_type: "persona", groups: { "assistant": 15, "creative": 12, "technical": 15 } }
       '{ operation: "list_elements", element_type: "persona", params: { fields: "minimal" } }',
+      // TIP: For visual browsing, use open_portfolio_browser instead:
+      // { operation: "open_portfolio_browser", params: { tab: "portfolio", type: "persona" } }
     ],
   },
   get_element: {
@@ -1688,6 +1690,8 @@ export const SEARCH_SCHEMAS: OperationSchemaMap = {
     examples: [
       '{ operation: "search_elements", params: { query: "creative" } }',
       '{ operation: "search_elements", element_type: "persona", params: { query: "assistant", pageSize: 10 } }',
+      // TIP: For visual search, use open_portfolio_browser with q parameter:
+      // { operation: "open_portfolio_browser", params: { tab: "portfolio", q: "creative" } }
     ],
   },
   query_elements: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -749,7 +749,13 @@ export class DollhouseMCPServer implements IToolHandler {
 // isDirectExecution missed the dist/index.js suffix and the server never started.
 const rawScriptPath = process.argv?.[1] ?? '';
 let scriptPath = rawScriptPath ? path.normalize(rawScriptPath) : '';
-try { scriptPath = realpathSync(scriptPath); } catch { /* symlink target missing — use original */ }
+try {
+  scriptPath = realpathSync(scriptPath);
+} catch {
+  if (process.env.DOLLHOUSE_DEBUG) {
+    console.error(`[DEBUG] Symlink resolution failed for ${rawScriptPath} — using original path`);
+  }
+}
 const isDirectExecution =
   scriptPath.endsWith(`${path.sep}dist${path.sep}index.js`) ||
   scriptPath.endsWith(`${path.sep}src${path.sep}index.ts`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -793,7 +793,8 @@ async function startServerWithRetry(retriesLeft = STARTUP_DELAYS.length): Promis
     }
     // Final failure - minimal error message for security
     // Note: Using console.error here is intentional as it's the final error before exit
-    console.error("[DollhouseMCP] Server startup failed", error); // Added error object
+    console.error("[DollhouseMCP] Server startup failed",
+      process.env.DOLLHOUSE_DEBUG ? error : (error as Error).message || 'unknown error');
     process.exit(1);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
 import { env } from './config/env.js';
 
 import * as path from 'path';
+import { realpathSync } from 'node:fs';
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { ErrorHandler } from "./utils/ErrorHandler.js";
@@ -742,12 +743,24 @@ export class DollhouseMCPServer implements IToolHandler {
 
 // Only start the server if this file is being run directly (not imported by tests)
 // Handle different execution methods (direct, npx, CLI)
-const scriptPath = process.argv?.[1] ? path.normalize(process.argv[1]) : '';
+//
+// Bug fix: npx creates symlinks in .bin/ (e.g. .bin/mcp-server → dist/index.js).
+// Node.js keeps the symlink path in process.argv[1], so without resolving it,
+// isDirectExecution missed the dist/index.js suffix and the server never started.
+const rawScriptPath = process.argv?.[1] ?? '';
+let scriptPath = rawScriptPath ? path.normalize(rawScriptPath) : '';
+try { scriptPath = realpathSync(scriptPath); } catch { /* symlink target missing — use original */ }
 const isDirectExecution =
   scriptPath.endsWith(`${path.sep}dist${path.sep}index.js`) ||
   scriptPath.endsWith(`${path.sep}src${path.sep}index.ts`);
-const isNpxExecution = process.env.npm_execpath?.includes('npx');
-const isCliExecution = process.argv[1]?.endsWith('/dollhousemcp') || process.argv[1]?.endsWith('\\dollhousemcp');
+// Modern npm (v7+) runs npx as "npm exec" — npm_execpath may point to
+// npm-cli.js instead of npx-cli.js. Detect both legacy and modern npx.
+const isNpxExecution =
+  process.env.npm_execpath?.includes('npx') ||
+  process.env.npm_command === 'exec';
+// Match all registered bin entry names from package.json "bin" field
+const binName = path.basename(rawScriptPath);
+const isCliExecution = binName === 'dollhousemcp' || binName === 'mcp-server';
 const isTest = process.env.JEST_WORKER_ID; // This is set when Jest runs tests
 const isTestMode = process.env.TEST_MODE === 'true'; // Check for TEST_MODE environment variable
 const dollhouseDebugFlag = process.env.DOLLHOUSE_DEBUG?.toLowerCase();

--- a/src/web/console/PromotionManager.ts
+++ b/src/web/console/PromotionManager.ts
@@ -1,0 +1,109 @@
+/**
+ * Follower-to-leader promotion manager (#1850).
+ *
+ * Handles the lifecycle of promoting a follower process to leader when the
+ * current leader becomes unreachable. Extracted from UnifiedConsole.ts to
+ * reduce complexity and allow per-instance state tracking.
+ *
+ * Each PromotionManager instance tracks its own attempt counter, so multiple
+ * followers in the same process (unlikely but possible) don't interfere
+ * with each other's promotion budgets.
+ */
+
+import { logger } from '../../utils/logger.js';
+import {
+  deleteLeaderLock,
+  claimLeadership,
+  readLeaderLock,
+  LOCK_VERSION,
+  type ElectionResult,
+  type ConsoleLeaderInfo,
+} from './LeaderElection.js';
+import type { LeaderForwardingLogSink } from './LeaderForwardingSink.js';
+import type { SessionHeartbeat } from './LeaderForwardingSink.js';
+import type { UnifiedConsoleOptions } from './UnifiedConsole.js';
+
+const MAX_PROMOTION_ATTEMPTS = 3;
+
+export class PromotionManager {
+  private inProgress = false;
+  private attempts = 0;
+
+  constructor(
+    private readonly options: UnifiedConsoleOptions,
+    private readonly consolePort: number,
+    private readonly startAsLeader: (
+      options: UnifiedConsoleOptions,
+      election: ElectionResult,
+      consolePort: number,
+    ) => Promise<unknown>,
+    private readonly startAsFollower: (
+      options: UnifiedConsoleOptions,
+      election: ElectionResult,
+      consolePort: number,
+    ) => Promise<unknown>,
+  ) {}
+
+  /**
+   * Attempt promotion. Safe to call from the ForwardingSink onLeaderDeath
+   * callback — guards against concurrent and excessive attempts.
+   */
+  async promote(
+    forwardingSink: LeaderForwardingLogSink,
+    sessionHeartbeat: SessionHeartbeat,
+  ): Promise<void> {
+    if (this.inProgress) {
+      logger.info('[PromotionManager] Promotion already in progress — skipping');
+      return;
+    }
+
+    this.attempts++;
+    if (this.attempts > MAX_PROMOTION_ATTEMPTS) {
+      logger.error(`[PromotionManager] Attempt ${this.attempts} exceeds max (${MAX_PROMOTION_ATTEMPTS}) — giving up`);
+      return;
+    }
+
+    this.inProgress = true;
+
+    try {
+      logger.warn(`[PromotionManager] Leader death detected — promotion attempt ${this.attempts}/${MAX_PROMOTION_ATTEMPTS}`);
+
+      await sessionHeartbeat.stop();
+      await forwardingSink.close();
+      await deleteLeaderLock();
+
+      const now = new Date().toISOString();
+      const myInfo: ConsoleLeaderInfo = {
+        version: LOCK_VERSION,
+        pid: process.pid,
+        port: this.consolePort,
+        sessionId: this.options.sessionId,
+        startedAt: now,
+        heartbeat: now,
+      };
+
+      const claimed = await claimLeadership(myInfo);
+
+      if (claimed) {
+        logger.info('[PromotionManager] Promotion succeeded — starting as leader');
+        const election: ElectionResult = { role: 'leader', leaderInfo: myInfo };
+        await this.startAsLeader(this.options, election, this.consolePort);
+      } else {
+        logger.info('[PromotionManager] Lost promotion race — following new leader');
+        const newLeader = await readLeaderLock();
+        if (newLeader) {
+          const election: ElectionResult = { role: 'follower', leaderInfo: newLeader };
+          await this.startAsFollower(this.options, election, this.consolePort);
+        } else {
+          logger.error('[PromotionManager] No leader available after lost race');
+        }
+      }
+    } catch (err) {
+      logger.error('[PromotionManager] Promotion failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      this.inProgress = false;
+    }
+  }
+}

--- a/src/web/console/PromotionManager.ts
+++ b/src/web/console/PromotionManager.ts
@@ -19,8 +19,7 @@ import {
   type ElectionResult,
   type ConsoleLeaderInfo,
 } from './LeaderElection.js';
-import type { LeaderForwardingLogSink } from './LeaderForwardingSink.js';
-import type { SessionHeartbeat } from './LeaderForwardingSink.js';
+import type { LeaderForwardingLogSink, SessionHeartbeat } from './LeaderForwardingSink.js';
 import type { UnifiedConsoleOptions } from './UnifiedConsole.js';
 
 const MAX_PROMOTION_ATTEMPTS = 3;
@@ -64,9 +63,12 @@ export class PromotionManager {
     }
 
     this.inProgress = true;
+    const startMs = Date.now();
 
     try {
-      logger.warn(`[PromotionManager] Leader death detected — promotion attempt ${this.attempts}/${MAX_PROMOTION_ATTEMPTS}`);
+      logger.warn(`[PromotionManager] Leader death detected — promotion attempt ${this.attempts}/${MAX_PROMOTION_ATTEMPTS}`, {
+        sessionId: this.options.sessionId, pid: process.pid, port: this.consolePort, attempt: this.attempts,
+      });
 
       await sessionHeartbeat.stop();
       await forwardingSink.close();
@@ -83,13 +85,18 @@ export class PromotionManager {
       };
 
       const claimed = await claimLeadership(myInfo);
+      const durationMs = Date.now() - startMs;
 
       if (claimed) {
-        logger.info('[PromotionManager] Promotion succeeded — starting as leader');
+        logger.info('[PromotionManager] Promotion succeeded — starting as leader', {
+          sessionId: this.options.sessionId, port: this.consolePort, durationMs, attempt: this.attempts,
+        });
         const election: ElectionResult = { role: 'leader', leaderInfo: myInfo };
         await this.startAsLeader(this.options, election, this.consolePort);
       } else {
-        logger.info('[PromotionManager] Lost promotion race — following new leader');
+        logger.info('[PromotionManager] Lost promotion race — following new leader', {
+          sessionId: this.options.sessionId, durationMs, attempt: this.attempts,
+        });
         const newLeader = await readLeaderLock();
         if (newLeader) {
           const election: ElectionResult = { role: 'follower', leaderInfo: newLeader };
@@ -101,6 +108,7 @@ export class PromotionManager {
     } catch (err) {
       logger.error('[PromotionManager] Promotion failed', {
         error: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - startMs, attempt: this.attempts,
       });
     } finally {
       this.inProgress = false;

--- a/src/web/console/StaleProcessRecovery.ts
+++ b/src/web/console/StaleProcessRecovery.ts
@@ -47,7 +47,7 @@ export async function findPidOnPort(port: number): Promise<number | null> {
       const { stdout, stderr } = await execFileAsync(cmd.bin, cmd.args, { timeout: 1000 });
       // fuser outputs to stderr on some systems
       const output = (stdout || stderr || '').trim();
-      const pids = output.split(/[\s\n]+/).map(Number).filter(n => !Number.isNaN(n) && n > 0);
+      const pids = output.split(/\s+/).map(Number).filter(n => !Number.isNaN(n) && n > 0);
       const otherPid = pids.find(p => p !== process.pid);
       if (otherPid) return otherPid;
     } catch {

--- a/src/web/console/StaleProcessRecovery.ts
+++ b/src/web/console/StaleProcessRecovery.ts
@@ -59,18 +59,25 @@ export async function killStaleProcess(pid: number, port: number): Promise<boole
   const { promisify } = await import('node:util');
   const execFileAsync = promisify(execFileCb);
 
+  // Security verification flow — three checks must pass before we kill:
+  // 1. Process must be owned by the current OS user (prevents cross-user kills)
+  // 2. Command line must match a DollhouseMCP binary path (prevents killing other services)
+  // 3. If both fail or ps can't run, we refuse — safe default is to not kill
   try {
     const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'user=,command='], { timeout: 1000 });
+
+    // Check 1: User ownership — only kill our own processes
     const currentUser = (await import('node:os')).userInfo().username;
     if (!stdout.trim().startsWith(currentUser)) {
-      logger.warn(`[WebUI] Port ${port} held by different user (pid ${pid}) — not killing`);
+      await logger.warn(`[WebUI] Port ${port} held by different user (pid ${pid}) — not killing`);
       return false;
     }
+
+    // Check 2: Binary identity — must be .bin/mcp-server, .bin/dollhousemcp,
+    // /bin/dollhousemcp (global install), or dist/index.js (direct node execution).
+    // NOT just 'mcp-server' anywhere in the path — that would match Jest workers
+    // running from within the mcp-server project directory.
     const cmdLine = stdout.trim();
-    // Check that the process is actually running a DollhouseMCP binary, not just
-    // a process whose working directory contains 'mcp-server' (e.g., a test runner).
-    // Match: .bin/dollhousemcp, .bin/mcp-server, /bin/dollhousemcp, dist/index.js,
-    // or 'node ... --web' with dist/index.js in the arguments.
     const isDollhouseBin = /(?:^|\/)dollhousemcp(?:\s|$)/.test(cmdLine) ||
       cmdLine.includes('.bin/dollhousemcp');
     const isMcpServerBin = cmdLine.includes('.bin/mcp-server') ||
@@ -81,7 +88,8 @@ export async function killStaleProcess(pid: number, port: number): Promise<boole
     }
     await logger.debug(`[WebUI] Verified stale process ${pid} is DollhouseMCP`, { cmdLine });
   } catch (err) {
-    logger.debug(`[WebUI] Cannot verify process ${pid} — skipping kill`, {
+    // Check 3: If we can't verify, don't kill — safe default
+    await logger.debug(`[WebUI] Cannot verify process ${pid} — skipping kill`, {
       error: err instanceof Error ? err.message : String(err),
     });
     return false;

--- a/src/web/console/StaleProcessRecovery.ts
+++ b/src/web/console/StaleProcessRecovery.ts
@@ -69,11 +69,12 @@ export async function killStaleProcess(pid: number, port: number): Promise<boole
     const cmdLine = stdout.trim();
     // Check that the process is actually running a DollhouseMCP binary, not just
     // a process whose working directory contains 'mcp-server' (e.g., a test runner).
-    // We look for the binary names in .bin/ paths or as standalone commands.
-    const isDollhouseBin = /\bdollhousemcp\b/.test(cmdLine) && cmdLine.includes('.bin/dollhousemcp');
-    const isMcpServerBin = /\bmcp-server\b/.test(cmdLine) && (
-      cmdLine.includes('.bin/mcp-server') || cmdLine.includes('dist/index.js')
-    );
+    // Match: .bin/dollhousemcp, .bin/mcp-server, /bin/dollhousemcp, dist/index.js,
+    // or 'node ... --web' with dist/index.js in the arguments.
+    const isDollhouseBin = /(?:^|\/)dollhousemcp(?:\s|$)/.test(cmdLine) ||
+      cmdLine.includes('.bin/dollhousemcp');
+    const isMcpServerBin = cmdLine.includes('.bin/mcp-server') ||
+      cmdLine.includes('dist/index.js');
     if (!isDollhouseBin && !isMcpServerBin) {
       await logger.warn(`[WebUI] Port ${port} held by non-DollhouseMCP process (pid ${pid}) — not killing`, { cmdLine });
       return false;

--- a/src/web/console/StaleProcessRecovery.ts
+++ b/src/web/console/StaleProcessRecovery.ts
@@ -37,13 +37,24 @@ export async function findPidOnPort(port: number): Promise<number | null> {
   const { execFile: execFileCb } = await import('node:child_process');
   const { promisify } = await import('node:util');
   const execFileAsync = promisify(execFileCb);
-  try {
-    const { stdout } = await execFileAsync('lsof', ['-ti', `:${port}`], { timeout: 1000 });
-    const pids = stdout.trim().split('\n').map(Number).filter(n => !Number.isNaN(n) && n > 0);
-    return pids.find(p => p !== process.pid) ?? null;
-  } catch {
-    return null;
+
+  // Try lsof first (macOS + most Linux), fall back to fuser (minimal Linux/Docker)
+  for (const cmd of [
+    { bin: 'lsof', args: ['-ti', `:${port}`] },
+    { bin: 'fuser', args: [`${port}/tcp`] },
+  ]) {
+    try {
+      const { stdout, stderr } = await execFileAsync(cmd.bin, cmd.args, { timeout: 1000 });
+      // fuser outputs to stderr on some systems
+      const output = (stdout || stderr || '').trim();
+      const pids = output.split(/[\s\n]+/).map(Number).filter(n => !Number.isNaN(n) && n > 0);
+      const otherPid = pids.find(p => p !== process.pid);
+      if (otherPid) return otherPid;
+    } catch {
+      continue; // command not found or no results — try next
+    }
   }
+  return null;
 }
 
 /**

--- a/src/web/console/StaleProcessRecovery.ts
+++ b/src/web/console/StaleProcessRecovery.ts
@@ -1,0 +1,133 @@
+/**
+ * Stale process detection and recovery (#1850).
+ *
+ * Finds and kills zombie DollhouseMCP processes that squat on the console
+ * port after their session has ended. Used by bindAndListen in server.ts
+ * when EADDRINUSE occurs.
+ *
+ * Extracted to a standalone module so it can be tested without importing
+ * the full Express server and its dependency chain.
+ */
+
+// Use lazy import for logger to avoid pulling in the full env.ts/config chain
+// at module load time. This keeps the module independently testable.
+let _logger: typeof import('../../utils/logger.js').logger | null = null;
+async function getLogger() {
+  if (!_logger) {
+    try { _logger = (await import('../../utils/logger.js')).logger; }
+    catch { /* fallback below */ }
+  }
+  return _logger;
+}
+const logger = {
+  warn: async (...args: unknown[]) => { const l = await getLogger(); l ? l.warn(args[0] as string, args[1]) : console.error('[WARN]', ...args); },
+  info: async (...args: unknown[]) => { const l = await getLogger(); l ? l.info(args[0] as string, args[1]) : console.error('[INFO]', ...args); },
+  debug: async (...args: unknown[]) => { const l = await getLogger(); l ? l.debug(args[0] as string, args[1]) : void 0; },
+};
+
+/**
+ * Find the PID of the process listening on a given port.
+ * Uses lsof on macOS/Linux. Returns null if not found or on error.
+ *
+ * Timeout: 1s — lsof on localhost is typically <100ms. The 1s ceiling
+ * handles slow NFS-mounted /dev/fd or overloaded CI runners without
+ * delaying startup noticeably.
+ */
+export async function findPidOnPort(port: number): Promise<number | null> {
+  const { execFile: execFileCb } = await import('node:child_process');
+  const { promisify } = await import('node:util');
+  const execFileAsync = promisify(execFileCb);
+  try {
+    const { stdout } = await execFileAsync('lsof', ['-ti', `:${port}`], { timeout: 1000 });
+    const pids = stdout.trim().split('\n').map(Number).filter(n => !Number.isNaN(n) && n > 0);
+    return pids.find(p => p !== process.pid) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Kill a stale process holding a port. Sends SIGTERM, waits briefly,
+ * then SIGKILL if still alive. Only kills DollhouseMCP processes
+ * (verified by checking the command line and user ownership).
+ *
+ * Timeout: 1s for ps verification. Kill wait: 300ms × 10 polls = 3s
+ * before escalating to SIGKILL. Total worst case: ~4s.
+ */
+export async function killStaleProcess(pid: number, port: number): Promise<boolean> {
+  const { execFile: execFileCb } = await import('node:child_process');
+  const { promisify } = await import('node:util');
+  const execFileAsync = promisify(execFileCb);
+
+  try {
+    const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'user=,command='], { timeout: 1000 });
+    const currentUser = (await import('node:os')).userInfo().username;
+    if (!stdout.trim().startsWith(currentUser)) {
+      logger.warn(`[WebUI] Port ${port} held by different user (pid ${pid}) — not killing`);
+      return false;
+    }
+    const cmdLine = stdout.trim();
+    // Check that the process is actually running a DollhouseMCP binary, not just
+    // a process whose working directory contains 'mcp-server' (e.g., a test runner).
+    // We look for the binary names in .bin/ paths or as standalone commands.
+    const isDollhouseBin = /\bdollhousemcp\b/.test(cmdLine) && cmdLine.includes('.bin/dollhousemcp');
+    const isMcpServerBin = /\bmcp-server\b/.test(cmdLine) && (
+      cmdLine.includes('.bin/mcp-server') || cmdLine.includes('dist/index.js')
+    );
+    if (!isDollhouseBin && !isMcpServerBin) {
+      await logger.warn(`[WebUI] Port ${port} held by non-DollhouseMCP process (pid ${pid}) — not killing`, { cmdLine });
+      return false;
+    }
+    await logger.debug(`[WebUI] Verified stale process ${pid} is DollhouseMCP`, { cmdLine });
+  } catch (err) {
+    logger.debug(`[WebUI] Cannot verify process ${pid} — skipping kill`, {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+
+  try {
+    process.kill(pid, 'SIGTERM');
+    logger.warn(`[WebUI] Sent SIGTERM to stale process ${pid} on port ${port}`);
+    for (let i = 0; i < 10; i++) {
+      await new Promise(r => setTimeout(r, 300));
+      try { process.kill(pid, 0); } catch { return true; }
+    }
+    process.kill(pid, 'SIGKILL');
+    logger.warn(`[WebUI] Sent SIGKILL to stale process ${pid} on port ${port}`);
+    await new Promise(r => setTimeout(r, 500));
+    return true;
+  } catch {
+    return true; // process already dead
+  }
+}
+
+/**
+ * Detect and recover from a stale process squatting on the port.
+ * Compares the port holder's PID against the leader lock file to determine
+ * if it's a squatter. Returns true if the squatter was killed.
+ *
+ * Timeouts: lsof 1s, ps 1s, SIGTERM wait 3s — max ~5s total.
+ */
+export async function recoverStalePort(port: number): Promise<boolean> {
+  const stalePid = await findPidOnPort(port);
+  if (!stalePid) return false;
+
+  try {
+    const { readLeaderLock } = await import('./LeaderElection.js');
+    const lock = await readLeaderLock();
+    if (lock?.pid === stalePid && lock?.port === port && lock.pid !== process.pid) {
+      logger.warn(`[WebUI] Port ${port} held by legitimate leader (pid ${stalePid}) — not killing`);
+      return false;
+    }
+  } catch {
+    // Can't read lock file — treat port holder as squatter
+  }
+
+  const killed = await killStaleProcess(stalePid, port);
+  if (killed) {
+    logger.info(`[WebUI] Stale process ${stalePid} removed from port ${port}`);
+    await new Promise(r => setTimeout(r, 500));
+  }
+  return killed;
+}

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -220,28 +220,12 @@ async function startAsLeader(
     tokenStore,
     ...(options.mcpAqlHandler ? { mcpAqlHandler: options.mcpAqlHandler } : {}),
   };
-  const BIND_RETRY_DELAYS = env.DOLLHOUSE_CONSOLE_BIND_RETRY_DELAYS?.length
-    ? env.DOLLHOUSE_CONSOLE_BIND_RETRY_DELAYS
-    : [1000, 2000, 4000];
+  // bindAndListen now handles EADDRINUSE by finding and killing the stale
+  // process on the port, then retrying. No external retry loop needed.
   const webResult = await startWebServer(serverOpts);
 
-  // If the port is occupied, retry the bind only — don't recreate the Express
-  // app and routes (startWebServer early-returns when serverRunning is false
-  // but the app is already configured). We call retryBind on the existing app.
-  if (webResult.bindResult && !webResult.bindResult.success && webResult.bindResult.error === 'EADDRINUSE' && webResult.app) {
-    const { retryBind } = await import('../server.js');
-    for (let i = 0; i < BIND_RETRY_DELAYS.length; i++) {
-      logger.warn(`[UnifiedConsole] Port ${consolePort} occupied — retry ${i + 1}/${BIND_RETRY_DELAYS.length} in ${BIND_RETRY_DELAYS[i]}ms`);
-      await new Promise(r => setTimeout(r, BIND_RETRY_DELAYS[i]));
-      const retryResult = await retryBind(webResult.app, consolePort, serverOpts);
-      if (retryResult.success) {
-        webResult.bindResult = retryResult;
-        break;
-      }
-    }
-    if (webResult.bindResult && !webResult.bindResult.success) {
-      logger.error(`[UnifiedConsole] Leader failed to bind port ${consolePort} after ${BIND_RETRY_DELAYS.length} retries — console unavailable`);
-    }
+  if (webResult.bindResult && !webResult.bindResult.success) {
+    logger.error(`[UnifiedConsole] Leader failed to bind port ${consolePort} — console unavailable`);
   }
 
   // Wire SSE broadcasts for this leader's own events

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -25,18 +25,14 @@ import {
   startHeartbeat,
   registerLeaderCleanup,
   detectLegacyLeader,
-  deleteLeaderLock,
-  claimLeadership,
-  readLeaderLock,
-  LOCK_VERSION,
   type ElectionResult,
-  type ConsoleLeaderInfo,
 } from './LeaderElection.js';
 import { createIngestRoutes } from './IngestRoutes.js';
 import {
   LeaderForwardingLogSink,
   SessionHeartbeat,
 } from './LeaderForwardingSink.js';
+import { PromotionManager } from './PromotionManager.js';
 import { ConsoleTokenStore } from './consoleToken.js';
 import { env } from '../../config/env.js';
 
@@ -48,12 +44,6 @@ import { env } from '../../config/env.js';
  *   3. 41715 (hardcoded default in env.ts)
  */
 const DEFAULT_CONSOLE_PORT = env.DOLLHOUSE_WEB_CONSOLE_PORT;
-
-/** Guard against concurrent promotion attempts from the same process (#1850). */
-let promotionInProgress = false;
-/** Track promotion attempts to prevent infinite loops if the port is permanently unavailable. */
-let promotionAttempts = 0;
-const MAX_PROMOTION_ATTEMPTS = 3;
 
 /**
  * Options for starting the unified console.
@@ -314,15 +304,17 @@ async function startAsFollower(
     logger.debug('[UnifiedConsole] No console auth token file found; follower will POST without Bearer header');
   }
 
+  // Per-instance promotion manager — tracks its own attempt counter so
+  // multiple followers don't interfere with each other's promotion budgets.
+  const promotionMgr = new PromotionManager(options, consolePort, startAsLeader, startAsFollower);
+
   // Declare sessionHeartbeat before the sink so the closure can capture it.
   // Both are initialized before the callback could possibly fire (needs 5+ failed flushes).
   let sessionHeartbeat: SessionHeartbeat;
 
   // Register a forwarding log sink with leader-death callback (#1850).
-  // When the leader is unreachable after MAX_CONSECUTIVE_FAILURES, the callback
-  // triggers self-promotion so the follower takes over as leader.
   const forwardingSink = new LeaderForwardingLogSink(leaderUrl, options.sessionId, authToken, () => {
-    promoteToLeader(options, forwardingSink, sessionHeartbeat, consolePort)
+    promotionMgr.promote(forwardingSink, sessionHeartbeat)
       .catch(err => logger.error('[UnifiedConsole] Promotion crashed', { error: String(err) }));
   });
   options.registerLogSink(forwardingSink);
@@ -347,79 +339,3 @@ async function startAsFollower(
   };
 }
 
-/**
- * Attempt to promote a follower to leader after detecting leader death (#1850).
- *
- * Triggered by the LeaderForwardingLogSink.onLeaderDeath callback when the
- * leader becomes unreachable. Performs a full re-election: stops forwarding,
- * deletes the stale lock, claims leadership, and starts the full leader path.
- *
- * Guarded by `promotionInProgress` to prevent two concurrent promotions
- * (e.g., if both the log sink and a future metrics sink detect death).
- */
-async function promoteToLeader(
-  options: UnifiedConsoleOptions,
-  forwardingSink: LeaderForwardingLogSink,
-  sessionHeartbeat: SessionHeartbeat,
-  consolePort: number,
-): Promise<void> {
-  if (promotionInProgress) {
-    logger.info('[UnifiedConsole] Promotion already in progress — skipping duplicate');
-    return;
-  }
-  promotionAttempts++;
-  if (promotionAttempts > MAX_PROMOTION_ATTEMPTS) {
-    logger.error(`[UnifiedConsole] Promotion attempt ${promotionAttempts} exceeds max (${MAX_PROMOTION_ATTEMPTS}) — giving up`);
-    return;
-  }
-  promotionInProgress = true;
-
-  try {
-    logger.warn('[UnifiedConsole] Leader death detected — attempting self-promotion');
-
-    // 1. Stop the forwarding infrastructure
-    await sessionHeartbeat.stop();
-    await forwardingSink.close();
-
-    // 2. Delete the stale lock file and claim leadership
-    await deleteLeaderLock();
-
-    const now = new Date().toISOString();
-    const myInfo: ConsoleLeaderInfo = {
-      version: LOCK_VERSION,
-      pid: process.pid,
-      port: consolePort,
-      sessionId: options.sessionId,
-      startedAt: now,
-      heartbeat: now,
-    };
-
-    const claimed = await claimLeadership(myInfo);
-
-    if (!claimed) {
-      // Another follower beat us — become a follower of the new leader
-      logger.info('[UnifiedConsole] Lost promotion race — re-electing as follower of new leader');
-      const newLeader = await readLeaderLock();
-      if (newLeader) {
-        const newElection: ElectionResult = { role: 'follower', leaderInfo: newLeader };
-        await startAsFollower(options, newElection, consolePort);
-      } else {
-        logger.error('[UnifiedConsole] Promotion failed — no leader available after lost race');
-      }
-      promotionInProgress = false;
-      return;
-    }
-
-    // 3. Start the full leader path with all sinks wired
-    logger.info('[UnifiedConsole] Promotion succeeded — starting as leader');
-    const election: ElectionResult = { role: 'leader', leaderInfo: myInfo };
-    await startAsLeader(options, election, consolePort);
-
-    promotionInProgress = false;
-  } catch (err) {
-    logger.error('[UnifiedConsole] Promotion failed', {
-      error: err instanceof Error ? err.message : String(err),
-    });
-    promotionInProgress = false;
-  }
-}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -485,71 +485,9 @@ function printStartupBanner(port: number, tokenStore: ConsoleTokenStore | undefi
   console.error(`  Type "q" or "quit" to exit.\n`);
 }
 
-/**
- * Find the PID of the process listening on a given port.
- * Uses lsof on macOS/Linux. Returns null if not found or on error.
- */
-async function findPidOnPort(port: number): Promise<number | null> {
-  const { execFile: execFileCb } = await import('node:child_process');
-  const { promisify } = await import('node:util');
-  const execFileAsync = promisify(execFileCb);
-  try {
-    // lsof -ti :port returns just the PID(s) listening on the port
-    const { stdout } = await execFileAsync('lsof', ['-ti', `:${port}`], { timeout: 1000 });
-    const pids = stdout.trim().split('\n').map(Number).filter(n => !Number.isNaN(n) && n > 0);
-    // Return the first PID that isn't us
-    return pids.find(p => p !== process.pid) ?? null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Kill a stale process holding a port. Sends SIGTERM, waits briefly,
- * then SIGKILL if still alive. Only kills DollhouseMCP processes
- * (verified by checking the command line).
- */
-async function killStaleProcess(pid: number, port: number): Promise<boolean> {
-  const { execFile: execFileCb } = await import('node:child_process');
-  const { promisify } = await import('node:util');
-  const execFileAsync = promisify(execFileCb);
-
-  // Safety check: only kill DollhouseMCP processes, not random services on the port
-  try {
-    const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'user=,command='], { timeout: 1000 });
-    // Only kill processes owned by the current user AND running DollhouseMCP
-    const currentUser = (await import('node:os')).userInfo().username;
-    if (!stdout.trim().startsWith(currentUser)) {
-      logger.warn(`[WebUI] Port ${port} held by different user (pid ${pid}) — not killing`);
-      return false;
-    }
-    const cmdLine = stdout.trim();
-    if (!cmdLine.includes('dollhousemcp') && !cmdLine.includes('mcp-server')) {
-      logger.warn(`[WebUI] Port ${port} held by non-DollhouseMCP process (pid ${pid}) — not killing`, { cmdLine });
-      return false;
-    }
-    logger.debug(`[WebUI] Verified stale process ${pid} is DollhouseMCP`, { cmdLine });
-  } catch {
-    return false; // can't verify, don't kill
-  }
-
-  try {
-    process.kill(pid, 'SIGTERM');
-    logger.warn(`[WebUI] Sent SIGTERM to stale process ${pid} on port ${port}`);
-    // Wait for the process to die
-    for (let i = 0; i < 10; i++) {
-      await new Promise(r => setTimeout(r, 300));
-      try { process.kill(pid, 0); } catch { return true; } // process is dead
-    }
-    // Still alive after 3s — force kill
-    process.kill(pid, 'SIGKILL');
-    logger.warn(`[WebUI] Sent SIGKILL to stale process ${pid} on port ${port}`);
-    await new Promise(r => setTimeout(r, 500));
-    return true;
-  } catch {
-    return true; // process already dead
-  }
-}
+// Stale process recovery — extracted to StaleProcessRecovery.ts for independent testing (#1850).
+import { recoverStalePort } from './console/StaleProcessRecovery.js';
+export { findPidOnPort, killStaleProcess, recoverStalePort } from './console/StaleProcessRecovery.js';
 
 /**
  * Attempt a single port bind. Returns a BindResult without any recovery logic.
@@ -579,37 +517,6 @@ function attemptBind(
       }
     });
   });
-}
-
-/**
- * Detect and recover from a stale process squatting on the port.
- * Compares the port holder's PID against the leader lock file to determine
- * if it's a squatter. Returns true if the squatter was killed.
- *
- * Timeouts: lsof 1s, ps 1s, SIGTERM wait 3s — max ~5s total.
- */
-async function recoverStalePort(port: number): Promise<boolean> {
-  const stalePid = await findPidOnPort(port);
-  if (!stalePid) return false;
-
-  // Check lock file — if the port holder IS the elected leader, don't kill
-  try {
-    const { readLeaderLock } = await import('./console/LeaderElection.js');
-    const lock = await readLeaderLock();
-    if (lock?.pid === stalePid && lock?.port === port && lock.pid !== process.pid) {
-      logger.warn(`[WebUI] Port ${port} held by legitimate leader (pid ${stalePid}) — not killing`);
-      return false;
-    }
-  } catch {
-    // Can't read lock file — treat port holder as squatter
-  }
-
-  const killed = await killStaleProcess(stalePid, port);
-  if (killed) {
-    logger.info(`[WebUI] Stale process ${stalePid} removed from port ${port}`);
-    await new Promise(r => setTimeout(r, 500)); // brief pause for port release
-  }
-  return killed;
 }
 
 /**

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -495,7 +495,7 @@ async function findPidOnPort(port: number): Promise<number | null> {
   const execFileAsync = promisify(execFileCb);
   try {
     // lsof -ti :port returns just the PID(s) listening on the port
-    const { stdout } = await execFileAsync('lsof', ['-ti', `:${port}`], { timeout: 3000 });
+    const { stdout } = await execFileAsync('lsof', ['-ti', `:${port}`], { timeout: 1000 });
     const pids = stdout.trim().split('\n').map(Number).filter(n => !Number.isNaN(n) && n > 0);
     // Return the first PID that isn't us
     return pids.find(p => p !== process.pid) ?? null;
@@ -516,17 +516,19 @@ async function killStaleProcess(pid: number, port: number): Promise<boolean> {
 
   // Safety check: only kill DollhouseMCP processes, not random services on the port
   try {
-    const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'user=,command='], { timeout: 3000 });
+    const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'user=,command='], { timeout: 1000 });
     // Only kill processes owned by the current user AND running DollhouseMCP
     const currentUser = (await import('node:os')).userInfo().username;
     if (!stdout.trim().startsWith(currentUser)) {
       logger.warn(`[WebUI] Port ${port} held by different user (pid ${pid}) — not killing`);
       return false;
     }
-    if (!stdout.includes('dollhousemcp') && !stdout.includes('mcp-server')) {
-      logger.warn(`[WebUI] Port ${port} held by non-DollhouseMCP process (pid ${pid}) — not killing`);
+    const cmdLine = stdout.trim();
+    if (!cmdLine.includes('dollhousemcp') && !cmdLine.includes('mcp-server')) {
+      logger.warn(`[WebUI] Port ${port} held by non-DollhouseMCP process (pid ${pid}) — not killing`, { cmdLine });
       return false;
     }
+    logger.debug(`[WebUI] Verified stale process ${pid} is DollhouseMCP`, { cmdLine });
   } catch {
     return false; // can't verify, don't kill
   }
@@ -550,15 +552,14 @@ async function killStaleProcess(pid: number, port: number): Promise<boolean> {
 }
 
 /**
- * Bind the Express app to 127.0.0.1:port. On EADDRINUSE, attempt to find
- * and kill the stale DollhouseMCP process holding the port, then retry once.
+ * Attempt a single port bind. Returns a BindResult without any recovery logic.
  */
-async function bindAndListen(
+function attemptBind(
   app: import('express').Express,
   port: number,
   options: WebServerOptions,
 ): Promise<BindResult> {
-  const attempt = (): Promise<BindResult> => new Promise<BindResult>((resolve) => {
+  return new Promise<BindResult>((resolve) => {
     const httpServer = app.listen(port, '127.0.0.1', () => {
       serverRunning = true;
       serverPort = port;
@@ -578,45 +579,58 @@ async function bindAndListen(
       }
     });
   });
+}
 
-  const result = await attempt();
-
-  if (result.success || result.error !== 'EADDRINUSE') {
-    return result;
-  }
-
-  // Port is occupied — check if it's a stale DollhouseMCP process.
-  // Compare the PID on the port against the lock file PID. If they differ
-  // (or the lock file is absent/stale), the port holder is a squatter.
+/**
+ * Detect and recover from a stale process squatting on the port.
+ * Compares the port holder's PID against the leader lock file to determine
+ * if it's a squatter. Returns true if the squatter was killed.
+ *
+ * Timeouts: lsof 1s, ps 1s, SIGTERM wait 3s — max ~5s total.
+ */
+async function recoverStalePort(port: number): Promise<boolean> {
   const stalePid = await findPidOnPort(port);
-  if (stalePid) {
-    let isSquatter = true;
-    try {
-      const { readLeaderLock } = await import('./console/LeaderElection.js');
-      const lock = await readLeaderLock();
-      if (lock && lock.pid === stalePid && lock.port === port) {
-        // The lock file agrees this PID should be on this port — it's a legitimate leader.
-        // Only kill it if the lock file PID is actually us (we won election but can't bind).
-        isSquatter = lock.pid !== process.pid;
-      }
-    } catch {
-      // Can't read lock file — treat as squatter
-    }
+  if (!stalePid) return false;
 
-    if (isSquatter) {
-      const killed = await killStaleProcess(stalePid, port);
-      if (killed) {
-        logger.info(`[WebUI] Stale process ${stalePid} removed from port ${port} — retrying bind`);
-        await new Promise(r => setTimeout(r, 500));
-        const retryResult = await attempt();
-        if (retryResult.success) return retryResult;
-      }
-    } else {
+  // Check lock file — if the port holder IS the elected leader, don't kill
+  try {
+    const { readLeaderLock } = await import('./console/LeaderElection.js');
+    const lock = await readLeaderLock();
+    if (lock?.pid === stalePid && lock?.port === port && lock.pid !== process.pid) {
       logger.warn(`[WebUI] Port ${port} held by legitimate leader (pid ${stalePid}) — not killing`);
+      return false;
     }
+  } catch {
+    // Can't read lock file — treat port holder as squatter
   }
 
-  // Still can't bind — log and fall through
+  const killed = await killStaleProcess(stalePid, port);
+  if (killed) {
+    logger.info(`[WebUI] Stale process ${stalePid} removed from port ${port}`);
+    await new Promise(r => setTimeout(r, 500)); // brief pause for port release
+  }
+  return killed;
+}
+
+/**
+ * Bind the Express app to 127.0.0.1:port. On EADDRINUSE, attempt to find
+ * and kill the stale DollhouseMCP process holding the port, then retry once.
+ */
+async function bindAndListen(
+  app: import('express').Express,
+  port: number,
+  options: WebServerOptions,
+): Promise<BindResult> {
+  const result = await attemptBind(app, port, options);
+  if (result.success || result.error !== 'EADDRINUSE') return result;
+
+  // Port occupied — attempt stale process recovery and retry
+  if (await recoverStalePort(port)) {
+    const retryResult = await attemptBind(app, port, options);
+    if (retryResult.success) return retryResult;
+  }
+
+  // Still can't bind — fall through with warning
   logger.warn(`[WebUI] Port ${port} already in use — another process holds this port`);
   console.error(`\n  DollhouseMCP Management Console (existing instance)\n  http://${CONSOLE_HOST}:${port}\n`);
   if (options.openBrowser) {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -486,29 +486,79 @@ function printStartupBanner(port: number, tokenStore: ConsoleTokenStore | undefi
 }
 
 /**
- * Retry binding an already-configured Express app to a port.
- * Used by UnifiedConsole when EADDRINUSE occurs — avoids recreating
- * the Express app and all its routes on each retry attempt.
+ * Find the PID of the process listening on a given port.
+ * Uses lsof on macOS/Linux. Returns null if not found or on error.
  */
-export async function retryBind(
-  app: import('express').Express,
-  port: number,
-  options: WebServerOptions,
-): Promise<BindResult> {
-  return bindAndListen(app, port, options);
+async function findPidOnPort(port: number): Promise<number | null> {
+  const { execFile: execFileCb } = await import('node:child_process');
+  const { promisify } = await import('node:util');
+  const execFileAsync = promisify(execFileCb);
+  try {
+    // lsof -ti :port returns just the PID(s) listening on the port
+    const { stdout } = await execFileAsync('lsof', ['-ti', `:${port}`], { timeout: 3000 });
+    const pids = stdout.trim().split('\n').map(Number).filter(n => !Number.isNaN(n) && n > 0);
+    // Return the first PID that isn't us
+    return pids.find(p => p !== process.pid) ?? null;
+  } catch {
+    return null;
+  }
 }
 
 /**
- * Bind the Express app to 127.0.0.1:port and handle success/conflict paths.
- * Returns a BindResult so the caller can detect and handle port conflicts
- * (e.g., retry after killing a stale process).
+ * Kill a stale process holding a port. Sends SIGTERM, waits briefly,
+ * then SIGKILL if still alive. Only kills DollhouseMCP processes
+ * (verified by checking the command line).
+ */
+async function killStaleProcess(pid: number, port: number): Promise<boolean> {
+  const { execFile: execFileCb } = await import('node:child_process');
+  const { promisify } = await import('node:util');
+  const execFileAsync = promisify(execFileCb);
+
+  // Safety check: only kill DollhouseMCP processes, not random services on the port
+  try {
+    const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'user=,command='], { timeout: 3000 });
+    // Only kill processes owned by the current user AND running DollhouseMCP
+    const currentUser = (await import('node:os')).userInfo().username;
+    if (!stdout.trim().startsWith(currentUser)) {
+      logger.warn(`[WebUI] Port ${port} held by different user (pid ${pid}) — not killing`);
+      return false;
+    }
+    if (!stdout.includes('dollhousemcp') && !stdout.includes('mcp-server')) {
+      logger.warn(`[WebUI] Port ${port} held by non-DollhouseMCP process (pid ${pid}) — not killing`);
+      return false;
+    }
+  } catch {
+    return false; // can't verify, don't kill
+  }
+
+  try {
+    process.kill(pid, 'SIGTERM');
+    logger.warn(`[WebUI] Sent SIGTERM to stale process ${pid} on port ${port}`);
+    // Wait for the process to die
+    for (let i = 0; i < 10; i++) {
+      await new Promise(r => setTimeout(r, 300));
+      try { process.kill(pid, 0); } catch { return true; } // process is dead
+    }
+    // Still alive after 3s — force kill
+    process.kill(pid, 'SIGKILL');
+    logger.warn(`[WebUI] Sent SIGKILL to stale process ${pid} on port ${port}`);
+    await new Promise(r => setTimeout(r, 500));
+    return true;
+  } catch {
+    return true; // process already dead
+  }
+}
+
+/**
+ * Bind the Express app to 127.0.0.1:port. On EADDRINUSE, attempt to find
+ * and kill the stale DollhouseMCP process holding the port, then retry once.
  */
 async function bindAndListen(
   app: import('express').Express,
   port: number,
   options: WebServerOptions,
 ): Promise<BindResult> {
-  return new Promise<BindResult>((resolve) => {
+  const attempt = (): Promise<BindResult> => new Promise<BindResult>((resolve) => {
     const httpServer = app.listen(port, '127.0.0.1', () => {
       serverRunning = true;
       serverPort = port;
@@ -520,31 +570,59 @@ async function bindAndListen(
       resolve({ success: true });
     });
     httpServer.on('error', (err: NodeJS.ErrnoException) => {
-      resolve(handleListenError(err, port, options.openBrowser));
+      if (err.code === 'EADDRINUSE') {
+        resolve({ success: false, error: 'EADDRINUSE', detail: `Port ${port} already in use` });
+      } else {
+        logger.error(`[WebUI] Failed to bind port ${port}: ${err.message}`);
+        resolve({ success: false, error: 'OTHER', detail: err.message });
+      }
     });
   });
-}
 
-/**
- * Handle errors from app.listen(). Returns a BindResult describing the failure.
- * EADDRINUSE is logged at WARN (not INFO) so it's visible in production logs.
- */
-function handleListenError(
-  err: NodeJS.ErrnoException,
-  port: number,
-  openBrowser: boolean | undefined,
-): BindResult {
-  if (err.code === 'EADDRINUSE') {
-    const url = `http://${CONSOLE_HOST}:${port}`;
-    logger.warn(`[WebUI] Port ${port} already in use — another process holds this port`);
-    console.error(`\n  DollhouseMCP Management Console (existing instance)\n  ${url}\n`);
-    if (openBrowser) {
-      openInBrowser(url);
-    }
-    return { success: false, error: 'EADDRINUSE', detail: `Port ${port} already in use` };
+  const result = await attempt();
+
+  if (result.success || result.error !== 'EADDRINUSE') {
+    return result;
   }
-  logger.error(`[WebUI] Failed to bind port ${port}: ${err.message}`);
-  return { success: false, error: 'OTHER', detail: err.message };
+
+  // Port is occupied — check if it's a stale DollhouseMCP process.
+  // Compare the PID on the port against the lock file PID. If they differ
+  // (or the lock file is absent/stale), the port holder is a squatter.
+  const stalePid = await findPidOnPort(port);
+  if (stalePid) {
+    let isSquatter = true;
+    try {
+      const { readLeaderLock } = await import('./console/LeaderElection.js');
+      const lock = await readLeaderLock();
+      if (lock && lock.pid === stalePid && lock.port === port) {
+        // The lock file agrees this PID should be on this port — it's a legitimate leader.
+        // Only kill it if the lock file PID is actually us (we won election but can't bind).
+        isSquatter = lock.pid !== process.pid;
+      }
+    } catch {
+      // Can't read lock file — treat as squatter
+    }
+
+    if (isSquatter) {
+      const killed = await killStaleProcess(stalePid, port);
+      if (killed) {
+        logger.info(`[WebUI] Stale process ${stalePid} removed from port ${port} — retrying bind`);
+        await new Promise(r => setTimeout(r, 500));
+        const retryResult = await attempt();
+        if (retryResult.success) return retryResult;
+      }
+    } else {
+      logger.warn(`[WebUI] Port ${port} held by legitimate leader (pid ${stalePid}) — not killing`);
+    }
+  }
+
+  // Still can't bind — log and fall through
+  logger.warn(`[WebUI] Port ${port} already in use — another process holds this port`);
+  console.error(`\n  DollhouseMCP Management Console (existing instance)\n  http://${CONSOLE_HOST}:${port}\n`);
+  if (options.openBrowser) {
+    openInBrowser(`http://${CONSOLE_HOST}:${port}`);
+  }
+  return result;
 }
 
 /**

--- a/tests/integration/console-lifecycle.test.ts
+++ b/tests/integration/console-lifecycle.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Integration tests for console lifecycle (#1850).
+ *
+ * Tests the full leader election → server startup → port recovery flow
+ * using real filesystem state (temp directories), real net.Server
+ * instances, and real lock files.
+ *
+ * These tests reproduce the actual failure scenarios from the 2026-04-08
+ * diagnostic: stale lock files, bare server squatting, EADDRINUSE
+ * recovery, and follower re-election.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import * as net from 'node:net';
+import { mkdtemp, writeFile, readFile, rm, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const p = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(p));
+    });
+  });
+}
+
+function listenOnPort(port?: number): Promise<{ server: net.Server; port: number }> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.listen(port ?? 0, '127.0.0.1', () => {
+      resolve({ server, port: (server.address() as net.AddressInfo).port });
+    });
+  });
+}
+
+function closeServer(server: net.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe('Console Lifecycle Integration (#1850)', () => {
+  let tempDir: string;
+  let runDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'dollhouse-lifecycle-test-'));
+    runDir = join(tempDir, 'run');
+    await mkdir(runDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // ── Leader election state ─────────────────────────────────────────────
+
+  describe('Leader election lock file lifecycle', () => {
+    it('creates a valid lock file with required fields', async () => {
+      const lockPath = join(runDir, 'console-leader.auth.lock');
+      const lockData = {
+        version: 1,
+        pid: process.pid,
+        port: 41715,
+        sessionId: 'test-session-abc',
+        startedAt: new Date().toISOString(),
+        heartbeat: new Date().toISOString(),
+      };
+      await writeFile(lockPath, JSON.stringify(lockData, null, 2));
+
+      const raw = JSON.parse(await readFile(lockPath, 'utf8'));
+      expect(raw.version).toBe(1);
+      expect(raw.pid).toBe(process.pid);
+      expect(raw.port).toBe(41715);
+      expect(raw.sessionId).toBe('test-session-abc');
+      expect(raw.startedAt).toBeDefined();
+      expect(raw.heartbeat).toBeDefined();
+    });
+
+    it('detects stale lock file when PID is dead', async () => {
+      const LeaderElection = await import('../../src/web/console/LeaderElection.js');
+      const staleLock = {
+        version: 1,
+        pid: 99999999,
+        port: 41715,
+        sessionId: 'dead-leader',
+        startedAt: '2026-04-08T17:59:52.000Z',
+        heartbeat: '2026-04-08T17:59:52.000Z',
+      };
+      expect(LeaderElection.isLockStale(staleLock)).toBe(true);
+    });
+
+    it('detects stale lock file when heartbeat is expired', async () => {
+      const LeaderElection = await import('../../src/web/console/LeaderElection.js');
+      const staleLock = {
+        version: 1,
+        pid: process.pid, // alive, but heartbeat old
+        port: 41715,
+        sessionId: 'hung-leader',
+        startedAt: new Date().toISOString(),
+        heartbeat: new Date(Date.now() - 60_000).toISOString(), // 60s ago
+      };
+      expect(LeaderElection.isLockStale(staleLock)).toBe(true);
+    });
+
+    it('does not flag a healthy lock as stale', async () => {
+      const LeaderElection = await import('../../src/web/console/LeaderElection.js');
+      const freshLock = {
+        version: 1,
+        pid: process.pid,
+        port: 41715,
+        sessionId: 'active-leader',
+        startedAt: new Date().toISOString(),
+        heartbeat: new Date().toISOString(),
+      };
+      expect(LeaderElection.isLockStale(freshLock)).toBe(false);
+    });
+  });
+
+  // ── Port squatting scenario ───────────────────────────────────────────
+
+  describe('Port squatting and recovery', () => {
+    it('EADDRINUSE occurs when a zombie holds the port', async () => {
+      // Simulate: zombie process holds port
+      const { server: zombie, port } = await listenOnPort();
+
+      try {
+        // New server tries to bind the same port
+        const error = await new Promise<NodeJS.ErrnoException>((resolve) => {
+          const newServer = net.createServer();
+          newServer.on('error', (err: NodeJS.ErrnoException) => resolve(err));
+          newServer.listen(port, '127.0.0.1');
+        });
+        expect(error.code).toBe('EADDRINUSE');
+      } finally {
+        await closeServer(zombie);
+      }
+    });
+
+    it('port is available after zombie is killed', async () => {
+      const { server: zombie, port } = await listenOnPort();
+
+      // Kill the zombie (simulate our recovery)
+      await closeServer(zombie);
+
+      // Now we can bind
+      const { server: newServer, port: newPort } = await listenOnPort(port);
+      expect(newPort).toBe(port);
+      await closeServer(newServer);
+    });
+
+    it('lock file PID mismatch identifies squatter', async () => {
+      const lockPath = join(runDir, 'console-leader.auth.lock');
+      const port = await getFreePort();
+
+      // Lock file says PID 12345 is the leader
+      await writeFile(lockPath, JSON.stringify({
+        version: 1,
+        pid: 12345,
+        port,
+        sessionId: 'old-leader',
+        startedAt: new Date().toISOString(),
+        heartbeat: new Date().toISOString(),
+      }, null, 2));
+
+      // But PID 99999 is on the port — that's a squatter
+      const lock = JSON.parse(await readFile(lockPath, 'utf8'));
+      const portHolderPid = 99999;
+      expect(lock.pid).not.toBe(portHolderPid);
+      // This mismatch is what recoverStalePort uses to decide to kill
+    });
+  });
+
+  // ── Token store initialization ────────────────────────────────────────
+
+  describe('Token store on fresh and existing installations', () => {
+    it('creates token file on first run', async () => {
+      const tokenPath = join(runDir, 'console-token.auth.json');
+      const { ConsoleTokenStore } = await import('../../src/web/console/consoleToken.js');
+      const store = new ConsoleTokenStore(tokenPath);
+      const token = await store.ensureInitialized('TestPuppet');
+
+      expect(token).toBeDefined();
+      expect(token.name).toContain('TestPuppet');
+      expect(token.kind).toBe('console');
+
+      // File should exist on disk
+      const raw = JSON.parse(await readFile(tokenPath, 'utf8'));
+      expect(raw.version).toBe(1);
+      expect(raw.tokens.length).toBeGreaterThan(0);
+    });
+
+    it('reads existing token file on subsequent run', async () => {
+      const tokenPath = join(runDir, 'console-token.auth.json');
+      const { ConsoleTokenStore } = await import('../../src/web/console/consoleToken.js');
+
+      // First run creates
+      const store1 = new ConsoleTokenStore(tokenPath);
+      const token1 = await store1.ensureInitialized('FirstRun');
+
+      // Second run reads existing
+      const store2 = new ConsoleTokenStore(tokenPath);
+      const token2 = await store2.ensureInitialized('SecondRun');
+
+      // Should return the same token, not create a new one
+      expect(token2.id).toBe(token1.id);
+    });
+  });
+
+  // ── Multiple process simulation ───────────────────────────────────────
+
+  describe('Multiple process port contention', () => {
+    it('second server gets EADDRINUSE while first holds the port', async () => {
+      const { server: first, port } = await listenOnPort();
+      const errors: string[] = [];
+
+      try {
+        // Attempt 3 more servers on the same port — all should fail
+        for (let i = 0; i < 3; i++) {
+          const err = await new Promise<NodeJS.ErrnoException>((resolve) => {
+            const s = net.createServer();
+            s.on('error', (e: NodeJS.ErrnoException) => resolve(e));
+            s.listen(port, '127.0.0.1');
+          });
+          errors.push(err.code || 'unknown');
+        }
+
+        expect(errors).toEqual(['EADDRINUSE', 'EADDRINUSE', 'EADDRINUSE']);
+      } finally {
+        await closeServer(first);
+      }
+    });
+
+    it('stale port files accumulate without cleanup', async () => {
+      // Simulate: multiple sessions write port files
+      for (let i = 0; i < 5; i++) {
+        await writeFile(join(runDir, `permission-server-${10000 + i}.port`), '41715');
+      }
+      await writeFile(join(runDir, 'permission-server.port'), '41715');
+
+      // All 6 files exist — this is the accumulation problem
+      const { readdir } = await import('node:fs/promises');
+      const files = await readdir(runDir);
+      const portFiles = files.filter(f => f.includes('permission-server'));
+      expect(portFiles.length).toBe(6);
+    });
+  });
+
+  // ── ForwardingSink leader death detection ──────────────────────────────
+
+  describe('ForwardingSink detects leader death', () => {
+    it('fires onLeaderDeath after consecutive failures', async () => {
+      const { LeaderForwardingLogSink } = await import(
+        '../../src/web/console/LeaderForwardingSink.js'
+      );
+
+      const deathCallback = jest.fn();
+      // Point at an unreachable port
+      const sink = new LeaderForwardingLogSink(
+        'http://127.0.0.1:1',
+        'test-follower',
+        null,
+        deathCallback,
+      );
+
+      // Write entries to trigger flush attempts
+      for (let i = 0; i < 10; i++) {
+        sink.write({
+          level: 'info',
+          category: 'application',
+          message: `entry ${i}`,
+          timestamp: new Date().toISOString(),
+          data: {},
+        });
+      }
+
+      // Wait for death detection (backoff cycle)
+      let waited = 0;
+      while (!deathCallback.mock.calls.length && waited < 45_000) {
+        await new Promise(r => setTimeout(r, 500));
+        waited += 500;
+      }
+
+      expect(deathCallback).toHaveBeenCalledTimes(1);
+      await sink.close();
+    }, 60000);
+  });
+
+  // ── Binary path detection end-to-end ──────────────────────────────────
+
+  describe('Binary path detection with real ps output', () => {
+    if (process.platform !== 'win32') {
+      it('current process does NOT match DollhouseMCP binary pattern', async () => {
+        const { execFile } = await import('node:child_process');
+        const { promisify } = await import('node:util');
+        const exec = promisify(execFile);
+
+        const { stdout } = await exec('ps', ['-p', String(process.pid), '-o', 'command='], { timeout: 1000 });
+        const cmdLine = stdout.trim();
+
+        // Jest worker should NOT match the DollhouseMCP binary patterns
+        const isDollhouseBin = /(?:^|\/)dollhousemcp(?:\s|$)/.test(cmdLine) ||
+          cmdLine.includes('.bin/dollhousemcp');
+        const isMcpServerBin = cmdLine.includes('.bin/mcp-server') ||
+          cmdLine.includes('dist/index.js');
+
+        expect(isDollhouseBin || isMcpServerBin).toBe(false);
+      });
+    }
+  });
+});

--- a/tests/integration/console-lifecycle.test.ts
+++ b/tests/integration/console-lifecycle.test.ts
@@ -308,4 +308,155 @@ describe('Console Lifecycle Integration (#1850)', () => {
       });
     }
   });
+
+  // ── End-to-end: port recovery after zombie kill ───────────────────────
+
+  describe('End-to-end port recovery', () => {
+    it('recoverStalePort returns false for a non-DollhouseMCP server (full flow)', async () => {
+      const Recovery = await import('../../src/web/console/StaleProcessRecovery.js');
+
+      // Start a plain TCP server to occupy a port (simulates a zombie)
+      const { server, port } = await listenOnPort();
+      try {
+        // recoverStalePort should find the PID but refuse to kill (not DollhouseMCP)
+        const recovered = await Recovery.recoverStalePort(port);
+        expect(recovered).toBe(false);
+
+        // The server must still be alive — recovery didn't kill it
+        const addr = server.address();
+        expect(addr).not.toBeNull();
+      } finally {
+        await closeServer(server);
+      }
+    });
+
+    it('port is bindable after manual server close (simulates successful kill)', async () => {
+      // This simulates the flow: zombie detected → killed → port freed → rebind succeeds
+      const { server: zombie, port } = await listenOnPort();
+
+      // Verify port is occupied
+      const error = await new Promise<NodeJS.ErrnoException>((resolve) => {
+        const s = net.createServer();
+        s.on('error', (e: NodeJS.ErrnoException) => resolve(e));
+        s.listen(port, '127.0.0.1');
+      });
+      expect(error.code).toBe('EADDRINUSE');
+
+      // Kill the zombie (simulates killStaleProcess success)
+      await closeServer(zombie);
+      await new Promise(r => setTimeout(r, 100)); // brief pause
+
+      // Now rebind should succeed (simulates attemptBind retry)
+      const { server: newServer } = await listenOnPort(port);
+      expect((newServer.address() as net.AddressInfo).port).toBe(port);
+      await closeServer(newServer);
+    });
+  });
+
+  // ── PromotionManager state machine ────────────────────────────────────
+
+  describe('PromotionManager', () => {
+    it('PromotionManager class is importable and constructable', async () => {
+      const { PromotionManager } = await import('../../src/web/console/PromotionManager.js');
+      expect(typeof PromotionManager).toBe('function');
+
+      const mockOptions = {
+        sessionId: 'test-session',
+        portfolioDir: tempDir,
+        memorySink: { write: () => {}, close: async () => {} } as any,
+        registerLogSink: () => {},
+        wireSSEBroadcasts: () => {},
+      };
+
+      const mgr = new PromotionManager(
+        mockOptions,
+        41715,
+        async () => {}, // startAsLeader
+        async () => {}, // startAsFollower
+      );
+      expect(mgr).toBeDefined();
+    });
+
+    it('promote() calls startAsLeader when claim succeeds', async () => {
+      const { PromotionManager } = await import('../../src/web/console/PromotionManager.js');
+      const LeaderElection = await import('../../src/web/console/LeaderElection.js');
+
+      let leaderStarted = false;
+      const mockOptions = {
+        sessionId: 'promote-test',
+        portfolioDir: tempDir,
+        memorySink: { write: () => {}, close: async () => {} } as any,
+        registerLogSink: () => {},
+        wireSSEBroadcasts: () => {},
+      };
+
+      const mgr = new PromotionManager(
+        mockOptions,
+        41715,
+        async () => { leaderStarted = true; },
+        async () => {},
+      );
+
+      // Clean any existing lock so claim succeeds
+      await LeaderElection.deleteLeaderLock();
+
+      const mockSink = { close: async () => {} } as any;
+      const mockHeartbeat = { stop: async () => {} } as any;
+
+      await mgr.promote(mockSink, mockHeartbeat);
+
+      expect(leaderStarted).toBe(true);
+
+      // Clean up the lock file we created
+      await LeaderElection.deleteLeaderLock();
+    });
+
+    it('promote() respects MAX_PROMOTION_ATTEMPTS', async () => {
+      const { PromotionManager } = await import('../../src/web/console/PromotionManager.js');
+
+      let attempts = 0;
+      const mockOptions = {
+        sessionId: 'max-attempts-test',
+        portfolioDir: tempDir,
+        memorySink: { write: () => {}, close: async () => {} } as any,
+        registerLogSink: () => {},
+        wireSSEBroadcasts: () => {},
+      };
+
+      const mgr = new PromotionManager(
+        mockOptions,
+        41715,
+        async () => { attempts++; throw new Error('simulated bind failure'); },
+        async () => {},
+      );
+
+      const mockSink = { close: async () => {} } as any;
+      const mockHeartbeat = { stop: async () => {} } as any;
+
+      // Attempt promotion multiple times — should stop after MAX_PROMOTION_ATTEMPTS (3)
+      for (let i = 0; i < 5; i++) {
+        await mgr.promote(mockSink, mockHeartbeat);
+      }
+
+      // Should have tried at most 3 times (MAX_PROMOTION_ATTEMPTS)
+      expect(attempts).toBeLessThanOrEqual(3);
+    });
+  });
+
+  // ── findPidOnPort fallback ────────────────────────────────────────────
+
+  describe('findPidOnPort with fallback commands', () => {
+    it('finds a PID using available system commands', async () => {
+      const Recovery = await import('../../src/web/console/StaleProcessRecovery.js');
+      const { server, port } = await listenOnPort();
+
+      try {
+        const pid = await Recovery.findPidOnPort(port);
+        // Our own PID is filtered, so may be null, but shouldn't throw
+        expect(pid === null || pid > 0).toBe(true);
+      } finally {
+        await closeServer(server);
+      }
+    });
+  });
 });

--- a/tests/unit/config/consolePort.test.ts
+++ b/tests/unit/config/consolePort.test.ts
@@ -274,9 +274,12 @@ describe('Console port configuration (#1840)', () => {
       expect(source).toContain('another process holds this port');
     });
 
-    it('never kills processes on the configured port', async () => {
+    it('only kills verified DollhouseMCP processes on port conflict', async () => {
       const source = await readFile(join(SRC, 'src/web/server.ts'), 'utf8');
-      expect(source).not.toContain('process.kill');
+      // killStaleProcess verifies the process is DollhouseMCP before sending signals
+      expect(source).toContain('dollhousemcp');
+      expect(source).toContain('mcp-server');
+      expect(source).toContain('SIGTERM');
     });
 
     it('resolves promise on conflict (does not throw)', async () => {

--- a/tests/unit/config/consolePort.test.ts
+++ b/tests/unit/config/consolePort.test.ts
@@ -275,7 +275,7 @@ describe('Console port configuration (#1840)', () => {
     });
 
     it('only kills verified DollhouseMCP processes on port conflict', async () => {
-      const source = await readFile(join(SRC, 'src/web/server.ts'), 'utf8');
+      const source = await readFile(join(SRC, 'src/web/console/StaleProcessRecovery.ts'), 'utf8');
       // killStaleProcess verifies the process is DollhouseMCP before sending signals
       expect(source).toContain('dollhousemcp');
       expect(source).toContain('mcp-server');

--- a/tests/unit/execution-detection.test.ts
+++ b/tests/unit/execution-detection.test.ts
@@ -3,7 +3,7 @@
  * Verifies that the server correctly identifies different execution methods
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
 
 /**
@@ -137,7 +137,7 @@ describe('Execution Detection Logic', () => {
 
     test('should detect dollhousemcp bin entry on Windows', () => {
       if (path.sep !== '\\') return; // path.basename only splits on native separator
-      const { isCliExecution } = detectExecution('C:\\Users\\user\\AppData\\Roaming\\npm\\dollhousemcp', {});
+      const { isCliExecution } = detectExecution(String.raw`C:\Users\user\AppData\Roaming\npm\dollhousemcp`, {});
       expect(isCliExecution).toBe(true);
     });
 
@@ -148,7 +148,7 @@ describe('Execution Detection Logic', () => {
 
     test('should detect mcp-server bin entry on Windows', () => {
       if (path.sep !== '\\') return; // path.basename only splits on native separator
-      const { isCliExecution } = detectExecution('C:\\Users\\user\\AppData\\Roaming\\npm\\mcp-server', {});
+      const { isCliExecution } = detectExecution(String.raw`C:\Users\user\AppData\Roaming\npm\mcp-server`, {});
       expect(isCliExecution).toBe(true);
     });
 

--- a/tests/unit/execution-detection.test.ts
+++ b/tests/unit/execution-detection.test.ts
@@ -3,21 +3,44 @@
  * Verifies that the server correctly identifies different execution methods
  */
 
+import * as path from 'path';
 import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+
+/**
+ * Helper: reproduce the detection logic from index.ts so tests stay in sync.
+ * When the detection logic changes in index.ts, update this helper to match.
+ */
+function detectExecution(argv1: string, env: Record<string, string | undefined>) {
+  const rawScriptPath = argv1 ?? '';
+  // In tests we skip realpathSync — symlink resolution is tested separately
+  const scriptPath = rawScriptPath ? path.normalize(rawScriptPath) : '';
+  const isDirectExecution =
+    scriptPath.endsWith(`${path.sep}dist${path.sep}index.js`) ||
+    scriptPath.endsWith(`${path.sep}src${path.sep}index.ts`);
+  const isNpxExecution =
+    (env.npm_execpath?.includes('npx') ?? false) ||
+    env.npm_command === 'exec';
+  const binName = path.basename(rawScriptPath);
+  const isCliExecution = binName === 'dollhousemcp' || binName === 'mcp-server';
+  const isTest = env.JEST_WORKER_ID;
+  return { isDirectExecution, isNpxExecution, isCliExecution, isTest };
+}
 
 describe('Execution Detection Logic', () => {
   // Save original values
   const originalArgv1 = process.argv[1];
   const originalNpmExecPath = process.env.npm_execpath;
+  const originalNpmCommand = process.env.npm_command;
   const originalJestWorkerId = process.env.JEST_WORKER_ID;
-  
+
   beforeEach(() => {
     // Reset to clean state
     process.argv[1] = '/path/to/dist/index.js';
     delete process.env.npm_execpath;
+    delete process.env.npm_command;
     delete process.env.JEST_WORKER_ID;
   });
-  
+
   afterEach(() => {
     // Restore original values
     process.argv[1] = originalArgv1;
@@ -26,191 +49,209 @@ describe('Execution Detection Logic', () => {
     } else {
       delete process.env.npm_execpath;
     }
+    if (originalNpmCommand) {
+      process.env.npm_command = originalNpmCommand;
+    } else {
+      delete process.env.npm_command;
+    }
     if (originalJestWorkerId) {
       process.env.JEST_WORKER_ID = originalJestWorkerId;
     }
   });
 
   describe('Direct Execution Detection', () => {
-    test('should detect direct node execution', () => {
-      // Simulate direct execution
-      process.argv[1] = '/path/to/dist/index.js';
-      delete process.env.npm_execpath;
-      
-      const isDirectExecution = !process.env.npm_execpath;
+    test('should detect dist/index.js execution', () => {
+      const { isDirectExecution } = detectExecution('/path/to/dist/index.js', {});
       expect(isDirectExecution).toBe(true);
     });
-    
-    test('should not detect direct execution when npm_execpath is set', () => {
-      process.env.npm_execpath = '/usr/local/bin/npm';
-      
-      const isDirectExecution = !process.env.npm_execpath;
+
+    test('should detect src/index.ts execution', () => {
+      const { isDirectExecution } = detectExecution('/path/to/src/index.ts', {});
+      expect(isDirectExecution).toBe(true);
+    });
+
+    test('should not match arbitrary paths', () => {
+      const { isDirectExecution } = detectExecution('/path/to/node_modules/.bin/mcp-server', {});
       expect(isDirectExecution).toBe(false);
     });
   });
 
   describe('NPX Execution Detection', () => {
-    test('should detect npx execution', () => {
-      process.env.npm_execpath = '/usr/local/bin/npx';
-      
-      const isNpxExecution = (process.env.npm_execpath as any)?.includes('npx') || false;
+    test('should detect legacy npx (npm_execpath contains npx)', () => {
+      const { isNpxExecution } = detectExecution('/path/to/dist/index.js', {
+        npm_execpath: '/usr/local/bin/npx',
+      });
       expect(isNpxExecution).toBe(true);
     });
-    
-    test('should detect npx in various paths', () => {
+
+    test('should detect npx in various legacy paths', () => {
       const npxPaths = [
         '/usr/local/bin/npx',
         '/opt/homebrew/bin/npx',
         'C:\\Program Files\\nodejs\\npx.cmd',
-        '/home/user/.npm/bin/npx'
+        '/home/user/.npm/bin/npx',
+        '/usr/local/lib/node_modules/npm/bin/npx-cli.js',
       ];
-      
-      npxPaths.forEach(path => {
-        process.env.npm_execpath = path;
-        const isNpxExecution = (process.env.npm_execpath as any)?.includes('npx') || false;
+
+      npxPaths.forEach(p => {
+        const { isNpxExecution } = detectExecution('/any', { npm_execpath: p });
         expect(isNpxExecution).toBe(true);
       });
     });
-    
+
+    test('should detect modern npx (npm v7+ uses npm_command=exec)', () => {
+      const { isNpxExecution } = detectExecution('/any', {
+        npm_execpath: '/usr/local/lib/node_modules/npm/bin/npm-cli.js',
+        npm_command: 'exec',
+      });
+      expect(isNpxExecution).toBe(true);
+    });
+
+    test('should detect modern npx even without npm_execpath', () => {
+      const { isNpxExecution } = detectExecution('/any', {
+        npm_command: 'exec',
+      });
+      expect(isNpxExecution).toBe(true);
+    });
+
     test('should not detect npx when using npm directly', () => {
-      process.env.npm_execpath = '/usr/local/bin/npm';
-      
-      const isNpxExecution = (process.env.npm_execpath as any)?.includes('npx') || false;
+      const { isNpxExecution } = detectExecution('/any', {
+        npm_execpath: '/usr/local/lib/node_modules/npm/bin/npm-cli.js',
+      });
+      expect(isNpxExecution).toBe(false);
+    });
+
+    test('should not detect npx with unrelated npm_command', () => {
+      const { isNpxExecution } = detectExecution('/any', {
+        npm_command: 'install',
+      });
       expect(isNpxExecution).toBe(false);
     });
   });
 
   describe('CLI Execution Detection', () => {
-    test('should detect CLI execution on Unix-like systems', () => {
-      process.argv[1] = '/usr/local/bin/dollhousemcp';
-      
-      const isCliExecution = process.argv[1]?.endsWith('/dollhousemcp') || process.argv[1]?.endsWith('\\dollhousemcp') || false;
+    test('should detect dollhousemcp bin entry on Unix', () => {
+      const { isCliExecution } = detectExecution('/usr/local/bin/dollhousemcp', {});
       expect(isCliExecution).toBe(true);
     });
-    
-    test('should detect CLI execution on Windows', () => {
-      process.argv[1] = 'C:\\Users\\user\\AppData\\Roaming\\npm\\dollhousemcp';
-      
-      const isCliExecution = process.argv[1]?.endsWith('/dollhousemcp') || process.argv[1]?.endsWith('\\dollhousemcp') || false;
+
+    test('should detect dollhousemcp bin entry on Windows', () => {
+      if (path.sep !== '\\') return; // path.basename only splits on native separator
+      const { isCliExecution } = detectExecution('C:\\Users\\user\\AppData\\Roaming\\npm\\dollhousemcp', {});
       expect(isCliExecution).toBe(true);
     });
-    
-    test('should detect CLI in various installation paths', () => {
+
+    test('should detect mcp-server bin entry on Unix', () => {
+      const { isCliExecution } = detectExecution('/usr/local/bin/mcp-server', {});
+      expect(isCliExecution).toBe(true);
+    });
+
+    test('should detect mcp-server bin entry on Windows', () => {
+      if (path.sep !== '\\') return; // path.basename only splits on native separator
+      const { isCliExecution } = detectExecution('C:\\Users\\user\\AppData\\Roaming\\npm\\mcp-server', {});
+      expect(isCliExecution).toBe(true);
+    });
+
+    test('should detect mcp-server in npx .bin directory', () => {
+      const { isCliExecution } = detectExecution('/home/user/.npm/_npx/abc123/node_modules/.bin/mcp-server', {});
+      expect(isCliExecution).toBe(true);
+    });
+
+    test('should detect dollhousemcp in npx .bin directory', () => {
+      const { isCliExecution } = detectExecution('/home/user/.npm/_npx/abc123/node_modules/.bin/dollhousemcp', {});
+      expect(isCliExecution).toBe(true);
+    });
+
+    test('should detect CLI in various Unix installation paths', () => {
       const cliPaths = [
         '/usr/local/bin/dollhousemcp',
         '/opt/homebrew/bin/dollhousemcp',
-        'C:\\Program Files\\nodejs\\dollhousemcp',
         '/home/user/.npm/bin/dollhousemcp',
-        'C:\\Users\\user\\AppData\\Roaming\\npm\\dollhousemcp'
+        '/usr/local/bin/mcp-server',
+        '/opt/homebrew/bin/mcp-server',
+        '/home/user/.npm/bin/mcp-server',
       ];
-      
-      cliPaths.forEach(path => {
-        process.argv[1] = path;
-        const isCliExecution = process.argv[1]?.endsWith('/dollhousemcp') || process.argv[1]?.endsWith('\\dollhousemcp') || false;
+
+      cliPaths.forEach(p => {
+        const { isCliExecution } = detectExecution(p, {});
         expect(isCliExecution).toBe(true);
       });
     });
-    
-    test('should not detect CLI when running index.js directly', () => {
-      process.argv[1] = '/path/to/dist/index.js';
-      
-      const isCliExecution = process.argv[1]?.endsWith('/dollhousemcp') || process.argv[1]?.endsWith('\\dollhousemcp') || false;
+
+    test('should not detect CLI when running dist/index.js directly', () => {
+      const { isCliExecution } = detectExecution('/path/to/dist/index.js', {});
       expect(isCliExecution).toBe(false);
     });
   });
 
   describe('Test Environment Detection', () => {
     test('should detect test environment', () => {
-      process.env.JEST_WORKER_ID = '1';
-      
-      const isTest = process.env.JEST_WORKER_ID;
+      const { isTest } = detectExecution('/any', { JEST_WORKER_ID: '1' });
       expect(isTest).toBeTruthy();
     });
-    
+
     test('should not detect test environment in production', () => {
-      delete process.env.JEST_WORKER_ID;
-      
-      const isTest = process.env.JEST_WORKER_ID;
+      const { isTest } = detectExecution('/any', {});
       expect(isTest).toBeFalsy();
     });
   });
 
-  describe('Execution Environment Object', () => {
-    test('should correctly populate execution environment', () => {
-      process.env.npm_execpath = '/usr/local/bin/npx';
-      process.argv[1] = '/usr/local/bin/dollhousemcp';
-      
-      const EXECUTION_ENV = {
-        isNpx: process.env.npm_execpath?.includes('npx') || false,
-        isCli: process.argv[1]?.endsWith('/dollhousemcp') || false,
-        isDirect: !process.env.npm_execpath,
-        cwd: process.cwd(),
-        scriptPath: process.argv[1],
-      };
-      
-      expect(EXECUTION_ENV.isNpx).toBe(true);
-      expect(EXECUTION_ENV.isCli).toBe(true);
-      expect(EXECUTION_ENV.isDirect).toBe(false);
-      expect(EXECUTION_ENV.cwd).toBe(process.cwd());
-      expect(EXECUTION_ENV.scriptPath).toBe('/usr/local/bin/dollhousemcp');
+  describe('Server Startup Decision (integration scenarios)', () => {
+    test('npx @dollhousemcp/mcp-server — .bin/mcp-server symlink (the original bug)', () => {
+      // This is the exact scenario that was broken: npx runs .bin/mcp-server,
+      // Node keeps the symlink path in argv[1], and none of the old checks matched.
+      const { isDirectExecution, isNpxExecution, isCliExecution } = detectExecution(
+        '/home/user/.npm/_npx/abc123/node_modules/.bin/mcp-server',
+        {},
+      );
+      // isDirectExecution is false (no symlink resolution in test helper),
+      // but isCliExecution catches the mcp-server bin name
+      const shouldStart = isDirectExecution || isNpxExecution || isCliExecution;
+      expect(shouldStart).toBe(true);
+      expect(isCliExecution).toBe(true);
+    });
+
+    test('npx @dollhousemcp/mcp-server with modern npm (npm_command=exec)', () => {
+      const { isNpxExecution } = detectExecution(
+        '/home/user/.npm/_npx/abc123/node_modules/.bin/mcp-server',
+        { npm_command: 'exec' },
+      );
+      expect(isNpxExecution).toBe(true);
+    });
+
+    test('direct node dist/index.js execution', () => {
+      const { isDirectExecution } = detectExecution('/path/to/dist/index.js', {});
+      expect(isDirectExecution).toBe(true);
+    });
+
+    test('global install running dollhousemcp', () => {
+      const { isCliExecution } = detectExecution('/usr/local/bin/dollhousemcp', {});
+      expect(isCliExecution).toBe(true);
+    });
+
+    test('should not start server in test environment', () => {
+      const { isDirectExecution, isNpxExecution, isCliExecution, isTest } = detectExecution(
+        '/path/to/dist/index.js',
+        { JEST_WORKER_ID: '1' },
+      );
+      const shouldStart = (isDirectExecution || isNpxExecution || isCliExecution) && !isTest;
+      expect(shouldStart).toBe(false);
     });
   });
 
   describe('Progressive Retry Delays', () => {
     test('should use progressive delays for retries', () => {
       const STARTUP_DELAYS = [10, 50, 100, 200];
-      
+
       expect(STARTUP_DELAYS).toHaveLength(4);
-      expect(STARTUP_DELAYS[0]).toBe(10);  // Fast initial retry
-      expect(STARTUP_DELAYS[1]).toBe(50);  // Original delay
-      expect(STARTUP_DELAYS[2]).toBe(100); // Slower for slow machines
-      expect(STARTUP_DELAYS[3]).toBe(200); // Final attempt
-      
-      // Verify delays are progressive
+      expect(STARTUP_DELAYS[0]).toBe(10);
+      expect(STARTUP_DELAYS[1]).toBe(50);
+      expect(STARTUP_DELAYS[2]).toBe(100);
+      expect(STARTUP_DELAYS[3]).toBe(200);
+
       for (let i = 1; i < STARTUP_DELAYS.length; i++) {
         expect(STARTUP_DELAYS[i]).toBeGreaterThan(STARTUP_DELAYS[i - 1]);
       }
-    });
-  });
-
-  describe('Server Startup Decision', () => {
-    test('should start server for direct execution when not in test', () => {
-      delete process.env.npm_execpath;
-      delete process.env.JEST_WORKER_ID;
-      process.argv[1] = '/path/to/dist/index.js';
-      
-      const isDirectExecution = !process.env.npm_execpath;
-      const isNpxExecution = (process.env.npm_execpath as any)?.includes('npx') || false;
-      const isCliExecution = process.argv[1]?.endsWith('/dollhousemcp') || false;
-      const isTest = process.env.JEST_WORKER_ID;
-      
-      const shouldStart = (isDirectExecution || isNpxExecution || isCliExecution) && !isTest;
-      expect(shouldStart).toBe(true);
-    });
-    
-    test('should start server for npx execution when not in test', () => {
-      process.env.npm_execpath = '/usr/local/bin/npx';
-      delete process.env.JEST_WORKER_ID;
-      
-      const isDirectExecution = !process.env.npm_execpath;
-      const isNpxExecution = (process.env.npm_execpath as any)?.includes('npx') || false;
-      const isCliExecution = process.argv[1]?.endsWith('/dollhousemcp') || false;
-      const isTest = process.env.JEST_WORKER_ID;
-      
-      const shouldStart = (isDirectExecution || isNpxExecution || isCliExecution) && !isTest;
-      expect(shouldStart).toBe(true);
-    });
-    
-    test('should not start server in test environment', () => {
-      process.env.JEST_WORKER_ID = '1';
-      
-      const isDirectExecution = !process.env.npm_execpath;
-      const isNpxExecution = (process.env.npm_execpath as any)?.includes('npx') || false;
-      const isCliExecution = process.argv[1]?.endsWith('/dollhousemcp') || false;
-      const isTest = process.env.JEST_WORKER_ID;
-      
-      const shouldStart = (isDirectExecution || isNpxExecution || isCliExecution) && !isTest;
-      expect(shouldStart).toBe(false);
     });
   });
 });

--- a/tests/unit/web/console/stale-process-recovery.test.ts
+++ b/tests/unit/web/console/stale-process-recovery.test.ts
@@ -44,9 +44,11 @@ describe('Stale Process Recovery (#1850)', () => {
     const port2 = await getFreePort();
     expect(await recoverStalePort(port2)).toBe(false);
 
-    // --- platform: ps supports user= and command= ---
-    const { stdout } = await execAsync('ps', ['-p', String(process.pid), '-o', 'user=,command='], { timeout: 1000 });
-    expect(stdout.trim().length).toBeGreaterThan(0);
-    expect(stdout).toContain(userInfo().username);
+    // --- platform: ps supports user= and command= (Unix only) ---
+    if (process.platform !== 'win32') {
+      const { stdout } = await execAsync('ps', ['-p', String(process.pid), '-o', 'user=,command='], { timeout: 1000 });
+      expect(stdout.trim().length).toBeGreaterThan(0);
+      expect(stdout).toContain(userInfo().username);
+    }
   }, 15000);
 });

--- a/tests/unit/web/console/stale-process-recovery.test.ts
+++ b/tests/unit/web/console/stale-process-recovery.test.ts
@@ -1,14 +1,30 @@
 /**
  * Tests for stale process detection and recovery (#1850).
+ *
+ * Covers the actual failure modes from the diagnostic:
+ * - Stale process squatting on the console port
+ * - Lock file PID mismatch detection
+ * - Safety guards against killing non-DollhouseMCP processes
+ * - Platform compatibility for lsof/ps
+ * - Port recovery with real net.Server instances
  */
 
 import { describe, it, expect } from '@jest/globals';
 import * as net from 'node:net';
+import { mkdtemp, writeFile, rm, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { userInfo } from 'node:os';
 
 const execAsync = promisify(execFile);
+
+// Single import — Jest CJS fallback deadlocks on repeated dynamic imports of the same ESM module.
+let Recovery: typeof import('../../../../src/web/console/StaleProcessRecovery.js');
+
+beforeAll(async () => {
+  Recovery = await import('../../../../src/web/console/StaleProcessRecovery.js');
+});
 
 function getFreePort(): Promise<number> {
   return new Promise((resolve) => {
@@ -20,35 +36,274 @@ function getFreePort(): Promise<number> {
   });
 }
 
+function listenOnPort(): Promise<{ server: net.Server; port: number }> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.listen(0, '127.0.0.1', () => {
+      resolve({ server, port: (server.address() as net.AddressInfo).port });
+    });
+  });
+}
+
+function closeServer(server: net.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
 describe('Stale Process Recovery (#1850)', () => {
-  it('validates all safety guards and platform compatibility', async () => {
-    const { findPidOnPort, killStaleProcess, recoverStalePort } =
-      await import('../../../../src/web/console/StaleProcessRecovery.js');
 
-    // --- exports ---
-    expect(typeof findPidOnPort).toBe('function');
-    expect(typeof killStaleProcess).toBe('function');
-    expect(typeof recoverStalePort).toBe('function');
+  // ── findPidOnPort ─────────────────────────────────────────────────────
 
-    // --- findPidOnPort: free port returns null ---
-    const port1 = await getFreePort();
-    expect(await findPidOnPort(port1)).toBeNull();
+  describe('findPidOnPort', () => {
+    it('returns null for a port with no listener', async () => {
+      const port = await getFreePort();
+      expect(await Recovery.findPidOnPort(port)).toBeNull();
+    }, 10000);
 
-    // --- killStaleProcess: non-existent PID returns false ---
-    expect(await killStaleProcess(99999999, 41715)).toBe(false);
+    it('finds a PID on an active port', async () => {
+      const { server, port } = await listenOnPort();
+      try {
+        const pid = await Recovery.findPidOnPort(port);
+        // Our own PID is filtered out by findPidOnPort, so this may be null
+        // on systems where we're the only listener. Either way, not an error.
+        expect(pid === null || pid > 0).toBe(true);
+      } finally {
+        await closeServer(server);
+      }
+    }, 10000);
+  });
 
-    // --- killStaleProcess: current process rejected (not a .bin/mcp-server binary) ---
-    expect(await killStaleProcess(process.pid, 41715)).toBe(false);
+  // ── killStaleProcess safety guards ────────────────────────────────────
 
-    // --- recoverStalePort: free port returns false ---
-    const port2 = await getFreePort();
-    expect(await recoverStalePort(port2)).toBe(false);
+  describe('killStaleProcess', () => {
+    it('returns false for a non-existent PID', async () => {
+      expect(await Recovery.killStaleProcess(99999999, 41715)).toBe(false);
+    }, 10000);
 
-    // --- platform: ps supports user= and command= (Unix only) ---
+    it('returns false for current process (not a DollhouseMCP binary)', async () => {
+      // The Jest worker's command line is 'node jest...' not '.bin/mcp-server'
+      expect(await Recovery.killStaleProcess(process.pid, 41715)).toBe(false);
+    }, 10000);
+
     if (process.platform !== 'win32') {
-      const { stdout } = await execAsync('ps', ['-p', String(process.pid), '-o', 'user=,command='], { timeout: 1000 });
-      expect(stdout.trim().length).toBeGreaterThan(0);
-      expect(stdout).toContain(userInfo().username);
+      it('refuses to kill a plain node process (command line check)', async () => {
+        const { spawn } = await import('node:child_process');
+        const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 30000)'], {
+          detached: true,
+          stdio: 'ignore',
+        });
+        child.unref();
+
+        try {
+          // Should refuse — command is 'node -e setTimeout...' not mcp-server
+          expect(await Recovery.killStaleProcess(child.pid!, 41715)).toBe(false);
+          // Verify child is still alive
+          expect(() => process.kill(child.pid!, 0)).not.toThrow();
+        } finally {
+          try { process.kill(child.pid!, 'SIGKILL'); } catch { /* dead */ }
+        }
+      }, 10000);
     }
-  }, 15000);
+  });
+
+  // ── recoverStalePort ──────────────────────────────────────────────────
+
+  describe('recoverStalePort', () => {
+    it('returns false when no process is on the port', async () => {
+      const port = await getFreePort();
+      expect(await Recovery.recoverStalePort(port)).toBe(false);
+    }, 10000);
+
+    it('does not kill a non-DollhouseMCP server on the port', async () => {
+      const { server, port } = await listenOnPort();
+      try {
+        expect(await Recovery.recoverStalePort(port)).toBe(false);
+        // Server must still be alive
+        expect(server.address()).not.toBeNull();
+      } finally {
+        await closeServer(server);
+      }
+    }, 10000);
+  });
+
+  // ── Lock file mismatch scenarios ──────────────────────────────────────
+
+  describe('lock file mismatch detection', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'dollhouse-lock-test-'));
+      await mkdir(join(tempDir, 'run'), { recursive: true });
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it('creates a valid lock file structure', async () => {
+      const lockPath = join(tempDir, 'run', 'console-leader.auth.lock');
+      const lockData = {
+        version: 1,
+        pid: process.pid,
+        port: 41715,
+        sessionId: 'test-session',
+        startedAt: new Date().toISOString(),
+        heartbeat: new Date().toISOString(),
+      };
+      await writeFile(lockPath, JSON.stringify(lockData, null, 2));
+
+      // Read it back and verify structure
+      const { readFile } = await import('node:fs/promises');
+      const raw = await readFile(lockPath, 'utf8');
+      const parsed = JSON.parse(raw);
+      expect(parsed.version).toBe(1);
+      expect(parsed.pid).toBe(process.pid);
+      expect(parsed.port).toBe(41715);
+      expect(parsed.sessionId).toBe('test-session');
+    });
+
+    it('detects PID mismatch between lock file and port holder', async () => {
+      // Write a lock file claiming PID 12345 is the leader
+      const lockPath = join(tempDir, 'run', 'console-leader.auth.lock');
+      const lockData = {
+        version: 1,
+        pid: 12345,
+        port: 41715,
+        sessionId: 'old-leader',
+        startedAt: new Date().toISOString(),
+        heartbeat: new Date().toISOString(),
+      };
+      await writeFile(lockPath, JSON.stringify(lockData, null, 2));
+
+      // If a different PID (say 99999) is on the port, that's a squatter
+      // We can't easily test the full recoverStalePort with a custom lock path,
+      // but we can verify the lock file structure is correct for the comparison
+      const raw = JSON.parse(
+        await (await import('node:fs/promises')).readFile(lockPath, 'utf8'),
+      );
+      expect(raw.pid).toBe(12345);
+      // A process with PID != 12345 on port 41715 would be a squatter
+      expect(raw.pid).not.toBe(process.pid);
+    });
+  });
+
+  // ── Platform compatibility ────────────────────────────────────────────
+
+  describe('platform compatibility', () => {
+    if (process.platform !== 'win32') {
+      it('lsof is available and works', async () => {
+        try {
+          await execAsync('which', ['lsof'], { timeout: 1000 });
+        } catch {
+          // Not fatal — just means recovery is degraded
+          console.log('lsof not available on this system');
+        }
+        expect(true).toBe(true);
+      });
+
+      it('ps supports user= and command= output format', async () => {
+        const { stdout } = await execAsync(
+          'ps', ['-p', String(process.pid), '-o', 'user=,command='],
+          { timeout: 1000 },
+        );
+        expect(stdout.trim().length).toBeGreaterThan(0);
+        const { userInfo } = await import('node:os');
+        expect(stdout).toContain(userInfo().username);
+      });
+
+      it('lsof -ti returns PIDs for a listening port', async () => {
+        const { server, port } = await listenOnPort();
+        try {
+          const { stdout } = await execAsync('lsof', ['-ti', `:${port}`], { timeout: 1000 });
+          const pids = stdout.trim().split('\n').map(Number).filter(n => n > 0);
+          expect(pids.length).toBeGreaterThan(0);
+          expect(pids).toContain(process.pid);
+        } finally {
+          await closeServer(server);
+        }
+      });
+    }
+  });
+
+  // ── EADDRINUSE scenario ───────────────────────────────────────────────
+
+  describe('EADDRINUSE real scenario', () => {
+    it('net.Server produces EADDRINUSE when port is occupied', async () => {
+      const { server, port } = await listenOnPort();
+      try {
+        // Try to bind a second server on the same port
+        const error = await new Promise<NodeJS.ErrnoException>((resolve) => {
+          const server2 = net.createServer();
+          server2.on('error', (err: NodeJS.ErrnoException) => resolve(err));
+          server2.listen(port, '127.0.0.1');
+        });
+        expect(error.code).toBe('EADDRINUSE');
+      } finally {
+        await closeServer(server);
+      }
+    });
+
+    it('port becomes available after server closes', async () => {
+      const { server, port } = await listenOnPort();
+      await closeServer(server);
+
+      // Should be able to bind now
+      const server2 = net.createServer();
+      await new Promise<void>((resolve) => {
+        server2.listen(port, '127.0.0.1', () => resolve());
+      });
+      expect((server2.address() as net.AddressInfo).port).toBe(port);
+      await closeServer(server2);
+    });
+  });
+
+  // ── Safety: binary path detection ─────────────────────────────────────
+
+  describe('binary path detection safety', () => {
+    // Helper matching the same logic as StaleProcessRecovery.ts
+    function isDollhouseProcess(cmdLine: string): boolean {
+      const isDollhouseBin = /(?:^|\/)dollhousemcp(?:\s|$)/.test(cmdLine) ||
+        cmdLine.includes('.bin/dollhousemcp');
+      const isMcpServerBin = cmdLine.includes('.bin/mcp-server') ||
+        cmdLine.includes('dist/index.js');
+      return isDollhouseBin || isMcpServerBin;
+    }
+
+    it('rejects paths that only contain mcp-server as a directory', () => {
+      expect(isDollhouseProcess('/Users/mick/Developer/mcp-server/node_modules/.bin/jest')).toBe(false);
+    });
+
+    it('accepts .bin/mcp-server and .bin/dollhousemcp paths', () => {
+      expect(isDollhouseProcess('node /Users/mick/.npm/_npx/abc/node_modules/.bin/mcp-server')).toBe(true);
+      expect(isDollhouseProcess('node /Users/mick/.npm/_npx/abc/node_modules/.bin/dollhousemcp')).toBe(true);
+    });
+
+    it('accepts globally installed dollhousemcp', () => {
+      expect(isDollhouseProcess('/usr/local/bin/dollhousemcp')).toBe(true);
+      expect(isDollhouseProcess('/opt/homebrew/bin/dollhousemcp')).toBe(true);
+    });
+
+    it('accepts dist/index.js (direct node execution)', () => {
+      expect(isDollhouseProcess('node /path/to/@dollhousemcp/mcp-server/dist/index.js --web')).toBe(true);
+    });
+
+    it('rejects Jest workers running from the mcp-server project', () => {
+      expect(isDollhouseProcess('node /Users/mick/Developer/mcp-server/node_modules/.bin/jest')).toBe(false);
+      expect(isDollhouseProcess('node --experimental-vm-modules /Users/mick/mcp-server/node_modules/jest/bin/jest.js')).toBe(false);
+    });
+
+    it('rejects generic node processes', () => {
+      expect(isDollhouseProcess('node -e setTimeout(() => {}, 30000)')).toBe(false);
+      expect(isDollhouseProcess('/usr/local/bin/node server.js')).toBe(false);
+    });
+  });
+
+  // ── Exports ───────────────────────────────────────────────────────────
+
+  describe('module exports', () => {
+    it('all recovery functions are exported and callable', () => {
+      expect(typeof Recovery.findPidOnPort).toBe('function');
+      expect(typeof Recovery.killStaleProcess).toBe('function');
+      expect(typeof Recovery.recoverStalePort).toBe('function');
+    });
+  });
 });

--- a/tests/unit/web/console/stale-process-recovery.test.ts
+++ b/tests/unit/web/console/stale-process-recovery.test.ts
@@ -49,6 +49,15 @@ function closeServer(server: net.Server): Promise<void> {
   return new Promise((resolve) => server.close(() => resolve()));
 }
 
+/** Helper matching the same logic as StaleProcessRecovery.ts binary detection. */
+function isDollhouseProcess(cmdLine: string): boolean {
+  const isDollhouseBin = /(?:^|\/)dollhousemcp(?:\s|$)/.test(cmdLine) ||
+    cmdLine.includes('.bin/dollhousemcp');
+  const isMcpServerBin = cmdLine.includes('.bin/mcp-server') ||
+    cmdLine.includes('dist/index.js');
+  return isDollhouseBin || isMcpServerBin;
+}
+
 describe('Stale Process Recovery (#1850)', () => {
 
   // ── findPidOnPort ─────────────────────────────────────────────────────
@@ -93,13 +102,17 @@ describe('Stale Process Recovery (#1850)', () => {
         });
         child.unref();
 
+        const childPid = child.pid;
+        expect(childPid).toBeDefined();
+        if (!childPid) return;
+
         try {
           // Should refuse — command is 'node -e setTimeout...' not mcp-server
-          expect(await Recovery.killStaleProcess(child.pid!, 41715)).toBe(false);
+          expect(await Recovery.killStaleProcess(childPid, 41715)).toBe(false);
           // Verify child is still alive
-          expect(() => process.kill(child.pid!, 0)).not.toThrow();
+          expect(() => process.kill(childPid, 0)).not.toThrow();
         } finally {
-          try { process.kill(child.pid!, 'SIGKILL'); } catch { /* dead */ }
+          try { process.kill(childPid, 'SIGKILL'); } catch { /* dead */ }
         }
       }, 10000);
     }
@@ -259,15 +272,6 @@ describe('Stale Process Recovery (#1850)', () => {
   // ── Safety: binary path detection ─────────────────────────────────────
 
   describe('binary path detection safety', () => {
-    // Helper matching the same logic as StaleProcessRecovery.ts
-    function isDollhouseProcess(cmdLine: string): boolean {
-      const isDollhouseBin = /(?:^|\/)dollhousemcp(?:\s|$)/.test(cmdLine) ||
-        cmdLine.includes('.bin/dollhousemcp');
-      const isMcpServerBin = cmdLine.includes('.bin/mcp-server') ||
-        cmdLine.includes('dist/index.js');
-      return isDollhouseBin || isMcpServerBin;
-    }
-
     it('rejects paths that only contain mcp-server as a directory', () => {
       expect(isDollhouseProcess('/Users/mick/Developer/mcp-server/node_modules/.bin/jest')).toBe(false);
     });

--- a/tests/unit/web/console/stale-process-recovery.test.ts
+++ b/tests/unit/web/console/stale-process-recovery.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for stale process detection and recovery (#1850).
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import * as net from 'node:net';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { userInfo } from 'node:os';
+
+const execAsync = promisify(execFile);
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const p = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(p));
+    });
+  });
+}
+
+describe('Stale Process Recovery (#1850)', () => {
+  it('validates all safety guards and platform compatibility', async () => {
+    const { findPidOnPort, killStaleProcess, recoverStalePort } =
+      await import('../../../../src/web/console/StaleProcessRecovery.js');
+
+    // --- exports ---
+    expect(typeof findPidOnPort).toBe('function');
+    expect(typeof killStaleProcess).toBe('function');
+    expect(typeof recoverStalePort).toBe('function');
+
+    // --- findPidOnPort: free port returns null ---
+    const port1 = await getFreePort();
+    expect(await findPidOnPort(port1)).toBeNull();
+
+    // --- killStaleProcess: non-existent PID returns false ---
+    expect(await killStaleProcess(99999999, 41715)).toBe(false);
+
+    // --- killStaleProcess: current process rejected (not a .bin/mcp-server binary) ---
+    expect(await killStaleProcess(process.pid, 41715)).toBe(false);
+
+    // --- recoverStalePort: free port returns false ---
+    const port2 = await getFreePort();
+    expect(await recoverStalePort(port2)).toBe(false);
+
+    // --- platform: ps supports user= and command= ---
+    const { stdout } = await execAsync('ps', ['-p', String(process.pid), '-o', 'user=,command='], { timeout: 1000 });
+    expect(stdout.trim().length).toBeGreaterThan(0);
+    expect(stdout).toContain(userInfo().username);
+  }, 15000);
+});


### PR DESCRIPTION
## Summary

The root cause of empty console tabs: stale DollhouseMCP processes from prior sessions hold the port indefinitely. New processes mount all routes in memory but can't bind — the browser connects to the old bare server with no sinks.

Previous fix attempts added retry loops, but retries are useless when the zombie is a healthy Node process that never dies.

## Fix

`bindAndListen` now detects and kills the squatter on EADDRINUSE:

1. `findPidOnPort()` — uses `lsof -ti :PORT` to find who holds the socket
2. Compares against the leader lock file PID — if they differ, it's a squatter
3. `killStaleProcess()` — verifies the process is DollhouseMCP AND owned by the current OS user before sending SIGTERM
4. Waits up to 3s, SIGKILL if needed, then retries the bind

### Safety guards
- Only kills processes whose `ps` command line contains `dollhousemcp` or `mcp-server`
- Only kills processes owned by the current OS user (won't affect other users)
- Never kills a process that matches the lock file's elected leader
- Falls back to "existing instance" if anything fails

### Simplification
Removed the external retry loop from `startAsLeader` and the `retryBind` export — `bindAndListen` handles everything internally now.

## Test plan
- [x] Build passes
- [x] 161 console/port tests pass
- [ ] On Ziggy: kill old zombies, run `npx @dollhousemcp/mcp-server@rc --web`, verify all tabs work
- [ ] Start two sessions, verify leader/follower election still works (follower doesn't get killed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)