### PR TITLE
fix: --web mode bypasses leader election, bump to rc.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.12-rc.3",
+  "version": "2.0.12-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.12-rc.3",
+      "version": "2.0.12-rc.4",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.12-rc.3",
+  "version": "2.0.12-rc.4",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.12-rc.3",
+  "version": "2.0.12-rc.4",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.12-rc.3",
+      "version": "2.0.12-rc.4",
       "transport": {
         "type": "stdio"
       }

--- a/src/di/Container.ts
+++ b/src/di/Container.ts
@@ -864,6 +864,14 @@ export class DollhouseContainer {
     await this.deferredPolicyExport();
     await this.deferredLogHooks(timer);
     await this.deferredMetricsCollectors(timer);
+
+    // Sweep stale port files from prior sessions before any port operations (#1856).
+    // Runs unconditionally — stale files accumulate regardless of DOLLHOUSE_WEB_CONSOLE.
+    try {
+      const { sweepStalePortFiles } = await import('../web/portDiscovery.js');
+      await sweepStalePortFiles();
+    } catch { /* sweep failure is non-fatal */ }
+
     await this.deferredWebConsole(timer);
     await this.deferredPermissionServer(timer);
     await this.deferredDangerZoneInit(timer);
@@ -984,10 +992,6 @@ export class DollhouseContainer {
     timer.startPhase('web_console', false);
     try {
       if (!env.DOLLHOUSE_WEB_CONSOLE) return;
-
-      // Sweep stale port files from prior sessions before starting (#1856)
-      const { sweepStalePortFiles } = await import('../web/portDiscovery.js');
-      await sweepStalePortFiles();
 
       const activationStore = this.resolve<ActivationStore>('ActivationStore');
       const sessionId = activationStore.getSessionId();

--- a/src/di/Container.ts
+++ b/src/di/Container.ts
@@ -985,6 +985,10 @@ export class DollhouseContainer {
     try {
       if (!env.DOLLHOUSE_WEB_CONSOLE) return;
 
+      // Sweep stale port files from prior sessions before starting (#1856)
+      const { sweepStalePortFiles } = await import('../web/portDiscovery.js');
+      await sweepStalePortFiles();
+
       const activationStore = this.resolve<ActivationStore>('ActivationStore');
       const sessionId = activationStore.getSessionId();
       const portfolioManager = this.resolve<PortfolioManager>('PortfolioManager');
@@ -1647,6 +1651,12 @@ export class DollhouseContainer {
   }
 
   public async dispose(): Promise<void> {
+    // Close the HTTP server first so the port is freed immediately (#1856)
+    try {
+      const { shutdownWebServer } = await import('../web/server.js');
+      shutdownWebServer();
+    } catch { /* web server not started */ }
+
     // Close MetricsManager before general disposal (flush final snapshot)
     try {
       const metricsManager = this.resolve<MetricsManager>('MetricsManager');

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.12-rc.3';
-export const BUILD_TIMESTAMP = '2026-04-09T02:30:29.357Z';
+export const PACKAGE_VERSION = '2.0.12-rc.4';
+export const BUILD_TIMESTAMP = '2026-04-09T02:55:57.451Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';

--- a/src/index.ts
+++ b/src/index.ts
@@ -855,7 +855,16 @@ if ((isDirectExecution || isNpxExecution || isCliExecution) && (!isTest || isTes
         const container = new DollhouseContainer();
         await container.preparePortfolio();
         const bundle = await container.bootstrapHandlers();
-        await container.completeDeferredSetup();
+        // Do NOT call completeDeferredSetup() in --web mode (#1850).
+        // It runs UnifiedConsole leader election which starts a competing
+        // web server, sets serverRunning=true, and causes the actual
+        // startWebServer call below to early-return without binding.
+        // Standalone --web mode IS the server — no leader/follower needed.
+        // Run the port file sweep directly instead.
+        try {
+          const { sweepStalePortFiles } = await import('./web/portDiscovery.js');
+          await sweepStalePortFiles();
+        } catch { /* non-fatal */ }
         mcpAqlHandler = bundle.mcpAqlHandler;
         // Extract sinks from container — deferred setup may have already wired them
         try { memorySink = container.resolve<import('./logging/sinks/MemoryLogSink.js').MemoryLogSink>('MemoryLogSink'); } catch { /* not registered */ }

--- a/src/web/console/LeaderElection.ts
+++ b/src/web/console/LeaderElection.ts
@@ -358,4 +358,5 @@ export function registerLeaderCleanup(): void {
   process.once('exit', cleanup);
   process.once('SIGTERM', cleanup);
   process.once('SIGINT', cleanup);
+  process.once('SIGHUP', cleanup);
 }

--- a/src/web/console/LeaderElection.ts
+++ b/src/web/console/LeaderElection.ts
@@ -93,8 +93,9 @@ export function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
-    return false;
+  } catch (err: any) {
+    // EPERM = process exists but owned by another user — still alive
+    return err?.code === 'EPERM';
   }
 }
 

--- a/src/web/console/StaleProcessRecovery.ts
+++ b/src/web/console/StaleProcessRecovery.ts
@@ -133,15 +133,25 @@ export async function recoverStalePort(port: number): Promise<boolean> {
   const stalePid = await findPidOnPort(port);
   if (!stalePid) return false;
 
-  try {
-    const { readLeaderLock } = await import('./LeaderElection.js');
-    const lock = await readLeaderLock();
-    if (lock?.pid === stalePid && lock?.port === port && lock.pid !== process.pid) {
-      logger.warn(`[WebUI] Port ${port} held by legitimate leader (pid ${stalePid}) — not killing`);
-      return false;
+  // Check the lock file to see if this PID is a legitimate leader.
+  // TOCTOU mitigation: a new process may have JUST bound the port but not yet
+  // written its lock file. We read the lock, pause 500ms, then re-read. If the
+  // second read now matches the port holder, it's a fresh leader — don't kill.
+  const { readLeaderLock } = await import('./LeaderElection.js');
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const lock = await readLeaderLock();
+      if (lock?.pid === stalePid && lock?.port === port && lock.pid !== process.pid) {
+        await logger.warn(`[WebUI] Port ${port} held by legitimate leader (pid ${stalePid}) — not killing`);
+        return false;
+      }
+    } catch {
+      // Can't read lock file — continue to next attempt or kill
     }
-  } catch {
-    // Can't read lock file — treat port holder as squatter
+    if (attempt === 0) {
+      // Brief pause to let a freshly-started process write its lock file
+      await new Promise(r => setTimeout(r, 500));
+    }
   }
 
   const killed = await killStaleProcess(stalePid, port);

--- a/src/web/console/StaleProcessRecovery.ts
+++ b/src/web/console/StaleProcessRecovery.ts
@@ -98,11 +98,14 @@ export async function killStaleProcess(pid: number, port: number): Promise<boole
       return false;
     }
     await logger.debug(`[WebUI] Verified stale process ${pid} is DollhouseMCP`, { cmdLine });
-  } catch (err) {
-    // Check 3: If we can't verify, don't kill — safe default
-    await logger.debug(`[WebUI] Cannot verify process ${pid} — skipping kill`, {
-      error: err instanceof Error ? err.message : String(err),
-    });
+  } catch (err: any) {
+    // Check 3: If we can't verify, don't kill — safe default.
+    // Differentiate: ENOENT = ps not found, ESRCH = process died between find and verify.
+    const code = err?.code || err?.status;
+    const reason = code === 'ENOENT' ? 'ps command not found'
+      : code === 'ESRCH' ? 'process died during verification'
+      : err instanceof Error ? err.message : String(err);
+    await logger.debug(`[WebUI] Cannot verify process ${pid} — skipping kill (${reason})`);
     return false;
   }
 

--- a/src/web/console/StaleProcessRecovery.ts
+++ b/src/web/console/StaleProcessRecovery.ts
@@ -58,22 +58,14 @@ export async function findPidOnPort(port: number): Promise<number | null> {
 }
 
 /**
- * Kill a stale process holding a port. Sends SIGTERM, waits briefly,
- * then SIGKILL if still alive. Only kills DollhouseMCP processes
- * (verified by checking the command line and user ownership).
- *
- * Timeout: 1s for ps verification. Kill wait: 300ms × 10 polls = 3s
- * before escalating to SIGKILL. Total worst case: ~4s.
+ * Verify that a process is a DollhouseMCP binary owned by the current user.
+ * Returns true if safe to kill, false if we should leave it alone.
  */
-export async function killStaleProcess(pid: number, port: number): Promise<boolean> {
+async function verifyDollhouseProcess(pid: number, port: number): Promise<boolean> {
   const { execFile: execFileCb } = await import('node:child_process');
   const { promisify } = await import('node:util');
   const execFileAsync = promisify(execFileCb);
 
-  // Security verification flow — three checks must pass before we kill:
-  // 1. Process must be owned by the current OS user (prevents cross-user kills)
-  // 2. Command line must match a DollhouseMCP binary path (prevents killing other services)
-  // 3. If both fail or ps can't run, we refuse — safe default is to not kill
   try {
     const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'user=,command='], { timeout: 1000 });
 
@@ -84,10 +76,8 @@ export async function killStaleProcess(pid: number, port: number): Promise<boole
       return false;
     }
 
-    // Check 2: Binary identity — must be .bin/mcp-server, .bin/dollhousemcp,
-    // /bin/dollhousemcp (global install), or dist/index.js (direct node execution).
-    // NOT just 'mcp-server' anywhere in the path — that would match Jest workers
-    // running from within the mcp-server project directory.
+    // Check 2: Binary identity — .bin/mcp-server, .bin/dollhousemcp,
+    // /bin/dollhousemcp (global), or dist/index.js (direct node).
     const cmdLine = stdout.trim();
     const isDollhouseBin = /(?:^|\/)dollhousemcp(?:\s|$)/.test(cmdLine) ||
       cmdLine.includes('.bin/dollhousemcp');
@@ -98,26 +88,38 @@ export async function killStaleProcess(pid: number, port: number): Promise<boole
       return false;
     }
     await logger.debug(`[WebUI] Verified stale process ${pid} is DollhouseMCP`, { cmdLine });
+    return true;
   } catch (err: any) {
-    // Check 3: If we can't verify, don't kill — safe default.
-    // Differentiate: ENOENT = ps not found, ESRCH = process died between find and verify.
     const code = err?.code || err?.status;
-    const reason = code === 'ENOENT' ? 'ps command not found'
-      : code === 'ESRCH' ? 'process died during verification'
-      : err instanceof Error ? err.message : String(err);
+    let reason: string;
+    if (code === 'ENOENT') reason = 'ps command not found';
+    else if (code === 'ESRCH') reason = 'process died during verification';
+    else reason = err instanceof Error ? err.message : String(err);
     await logger.debug(`[WebUI] Cannot verify process ${pid} — skipping kill (${reason})`);
     return false;
   }
+}
+
+/**
+ * Kill a stale process holding a port. Sends SIGTERM, waits briefly,
+ * then SIGKILL if still alive. Only kills DollhouseMCP processes
+ * (verified via verifyDollhouseProcess).
+ *
+ * Timeout: 1s for ps verification. Kill wait: 300ms × 10 polls = 3s
+ * before escalating to SIGKILL. Total worst case: ~4s.
+ */
+export async function killStaleProcess(pid: number, port: number): Promise<boolean> {
+  if (!await verifyDollhouseProcess(pid, port)) return false;
 
   try {
     process.kill(pid, 'SIGTERM');
-    logger.warn(`[WebUI] Sent SIGTERM to stale process ${pid} on port ${port}`);
+    await logger.warn(`[WebUI] Sent SIGTERM to stale process ${pid} on port ${port}`);
     for (let i = 0; i < 10; i++) {
       await new Promise(r => setTimeout(r, 300));
       try { process.kill(pid, 0); } catch { return true; }
     }
     process.kill(pid, 'SIGKILL');
-    logger.warn(`[WebUI] Sent SIGKILL to stale process ${pid} on port ${port}`);
+    await logger.warn(`[WebUI] Sent SIGKILL to stale process ${pid} on port ${port}`);
     await new Promise(r => setTimeout(r, 500));
     return true;
   } catch {

--- a/src/web/portDiscovery.ts
+++ b/src/web/portDiscovery.ts
@@ -142,17 +142,22 @@ export function registerPortCleanup(): void {
  * is no longer alive. This prevents unbounded accumulation of port files
  * from crashed or abandoned sessions.
  *
+ * Note: This only removes metadata files, not processes or ports. The port
+ * binding itself (in bindAndListen) is atomic via listen(). There is no race
+ * between sweeping files and binding — they operate on independent resources.
+ *
  * Safe to call on every startup — only removes files for dead processes.
  */
-export async function sweepStalePortFiles(): Promise<number> {
+export async function sweepStalePortFiles(customDir?: string): Promise<number> {
   try {
-    await mkdir(RUN_DIR, { recursive: true });
-    const files = await readdir(RUN_DIR);
-    const portFiles = files.filter(f => /^permission-server-\d+\.port$/.test(f));
+    const dir = customDir || RUN_DIR;
+    await mkdir(dir, { recursive: true });
+    const files = await readdir(dir);
+    const PORT_FILE_RE = /^permission-server-(\d+)\.port$/;
     let removed = 0;
 
-    for (const file of portFiles) {
-      const match = file.match(/^permission-server-(\d+)\.port$/);
+    for (const file of files) {
+      const match = PORT_FILE_RE.exec(file);
       if (!match) continue;
       const pid = Number(match[1]);
 
@@ -162,14 +167,14 @@ export async function sweepStalePortFiles(): Promise<number> {
 
       if (!alive) {
         try {
-          await unlink(join(RUN_DIR, file));
+          await unlink(join(dir, file));
           removed++;
         } catch { /* already gone */ }
       }
     }
 
     if (removed > 0) {
-      logger.info(`[PortDiscovery] Swept ${removed} stale port files from ${RUN_DIR}`);
+      logger.info(`[PortDiscovery] Swept ${removed} stale port files from ${dir}`);
     }
     return removed;
   } catch (err) {

--- a/src/web/portDiscovery.ts
+++ b/src/web/portDiscovery.ts
@@ -148,7 +148,7 @@ export function registerPortCleanup(): void {
  *
  * Safe to call on every startup — only removes files for dead processes.
  */
-export async function sweepStalePortFiles(customDir?: string): Promise<number> {
+export async function sweepStalePortFiles(/** Absolute path to scan. Defaults to ~/.dollhouse/run/ */ customDir?: string): Promise<number> {
   try {
     const dir = customDir || RUN_DIR;
     await mkdir(dir, { recursive: true });

--- a/src/web/portDiscovery.ts
+++ b/src/web/portDiscovery.ts
@@ -18,7 +18,7 @@
 import { createServer, type Server } from 'node:net';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { mkdir, writeFile, unlink } from 'node:fs/promises';
+import { mkdir, writeFile, unlink, readdir } from 'node:fs/promises';
 import { env } from '../config/env.js';
 import { logger } from '../utils/logger.js';
 
@@ -132,6 +132,52 @@ export function registerPortCleanup(): void {
   process.once('exit', exitCleanup);
   process.once('SIGTERM', exitCleanup);
   process.once('SIGINT', exitCleanup);
+  process.once('SIGHUP', exitCleanup);
+}
+
+/**
+ * Sweep stale port files from ~/.dollhouse/run/ on startup (#1856).
+ *
+ * Scans for permission-server-{pid}.port files and removes any whose PID
+ * is no longer alive. This prevents unbounded accumulation of port files
+ * from crashed or abandoned sessions.
+ *
+ * Safe to call on every startup — only removes files for dead processes.
+ */
+export async function sweepStalePortFiles(): Promise<number> {
+  try {
+    await mkdir(RUN_DIR, { recursive: true });
+    const files = await readdir(RUN_DIR);
+    const portFiles = files.filter(f => /^permission-server-\d+\.port$/.test(f));
+    let removed = 0;
+
+    for (const file of portFiles) {
+      const match = file.match(/^permission-server-(\d+)\.port$/);
+      if (!match) continue;
+      const pid = Number(match[1]);
+
+      // Check if process is alive via signal-0
+      let alive = false;
+      try { process.kill(pid, 0); alive = true; } catch { /* dead */ }
+
+      if (!alive) {
+        try {
+          await unlink(join(RUN_DIR, file));
+          removed++;
+        } catch { /* already gone */ }
+      }
+    }
+
+    if (removed > 0) {
+      logger.info(`[PortDiscovery] Swept ${removed} stale port files from ${RUN_DIR}`);
+    }
+    return removed;
+  } catch (err) {
+    logger.debug('[PortDiscovery] Stale port file sweep failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return 0;
+  }
 }
 
 /**

--- a/src/web/portDiscovery.ts
+++ b/src/web/portDiscovery.ts
@@ -161,9 +161,16 @@ export async function sweepStalePortFiles(customDir?: string): Promise<number> {
       if (!match) continue;
       const pid = Number(match[1]);
 
-      // Check if process is alive via signal-0
+      // Check if process is alive via signal-0.
+      // ESRCH = process doesn't exist (dead). EPERM = process exists but
+      // owned by another user (alive — don't touch their port file).
       let alive = false;
-      try { process.kill(pid, 0); alive = true; } catch { /* dead */ }
+      try {
+        process.kill(pid, 0);
+        alive = true;
+      } catch (err: any) {
+        alive = err?.code === 'EPERM'; // EPERM = alive but different user
+      }
 
       if (!alive) {
         try {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -92,6 +92,20 @@ export function _resetServerState(): void {
 }
 
 /**
+ * Gracefully shut down the HTTP server (#1856).
+ * Closes the active server and resets module state so the port is freed
+ * immediately rather than lingering until process exit.
+ */
+export function shutdownWebServer(): void {
+  if (activeHttpServer) {
+    activeHttpServer.close();
+    activeHttpServer = null;
+    serverRunning = false;
+    logger.info(`[WebUI] HTTP server closed on port ${serverPort}`);
+  }
+}
+
+/**
  * Options for starting the web server.
  */
 export interface WebServerOptions {

--- a/tests/integration/console-lifecycle.test.ts
+++ b/tests/integration/console-lifecycle.test.ts
@@ -245,7 +245,7 @@ describe('Console Lifecycle Integration (#1850)', () => {
       expect(portFiles.length).toBe(6);
     });
 
-    it('stale port files are swept by manual sweep logic', async () => {
+    it('sweepStalePortFiles removes dead PID files and preserves alive', async () => {
       // Write files for dead PIDs and one for our own (alive) PID
       for (let i = 0; i < 5; i++) {
         await writeFile(join(runDir, `permission-server-${99999990 + i}.port`), '41715');
@@ -253,30 +253,15 @@ describe('Console Lifecycle Integration (#1850)', () => {
       await writeFile(join(runDir, `permission-server-${process.pid}.port`), '41715');
       await writeFile(join(runDir, 'permission-server.port'), '41715'); // latest file — not PID-keyed
 
-      // Sweep: same logic as sweepStalePortFiles
-      const { readdir: readDir, unlink: unlinkFile } = await import('node:fs/promises');
-      const files = await readDir(runDir);
-      const pidFiles = files.filter(f => /^permission-server-\d+\.port$/.test(f));
-      let removed = 0;
-
-      for (const file of pidFiles) {
-        const match = file.match(/^permission-server-(\d+)\.port$/);
-        if (!match) continue;
-        const pid = Number(match[1]);
-        let alive = false;
-        try { process.kill(pid, 0); alive = true; } catch { /* dead */ }
-        if (!alive) {
-          await unlinkFile(join(runDir, file));
-          removed++;
-        }
-      }
+      const { sweepStalePortFiles } = await import('../../src/web/portDiscovery.js');
+      const removed = await sweepStalePortFiles(runDir);
 
       expect(removed).toBe(5); // 5 dead PIDs swept
+      const { readdir: readDir } = await import('node:fs/promises');
       const remaining = await readDir(runDir);
       const remainingPid = remaining.filter(f => /^permission-server-\d+\.port$/.test(f));
       expect(remainingPid.length).toBe(1); // Only our PID survives
-      // The non-PID-keyed 'permission-server.port' should also survive
-      expect(remaining).toContain('permission-server.port');
+      expect(remaining).toContain('permission-server.port'); // Non-PID file preserved
     });
   });
 

--- a/tests/integration/console-lifecycle.test.ts
+++ b/tests/integration/console-lifecycle.test.ts
@@ -239,10 +239,44 @@ describe('Console Lifecycle Integration (#1850)', () => {
       await writeFile(join(runDir, 'permission-server.port'), '41715');
 
       // All 6 files exist — this is the accumulation problem
-      const { readdir } = await import('node:fs/promises');
-      const files = await readdir(runDir);
+      const { readdir: readDir } = await import('node:fs/promises');
+      const files = await readDir(runDir);
       const portFiles = files.filter(f => f.includes('permission-server'));
       expect(portFiles.length).toBe(6);
+    });
+
+    it('stale port files are swept by manual sweep logic', async () => {
+      // Write files for dead PIDs and one for our own (alive) PID
+      for (let i = 0; i < 5; i++) {
+        await writeFile(join(runDir, `permission-server-${99999990 + i}.port`), '41715');
+      }
+      await writeFile(join(runDir, `permission-server-${process.pid}.port`), '41715');
+      await writeFile(join(runDir, 'permission-server.port'), '41715'); // latest file — not PID-keyed
+
+      // Sweep: same logic as sweepStalePortFiles
+      const { readdir: readDir, unlink: unlinkFile } = await import('node:fs/promises');
+      const files = await readDir(runDir);
+      const pidFiles = files.filter(f => /^permission-server-\d+\.port$/.test(f));
+      let removed = 0;
+
+      for (const file of pidFiles) {
+        const match = file.match(/^permission-server-(\d+)\.port$/);
+        if (!match) continue;
+        const pid = Number(match[1]);
+        let alive = false;
+        try { process.kill(pid, 0); alive = true; } catch { /* dead */ }
+        if (!alive) {
+          await unlinkFile(join(runDir, file));
+          removed++;
+        }
+      }
+
+      expect(removed).toBe(5); // 5 dead PIDs swept
+      const remaining = await readDir(runDir);
+      const remainingPid = remaining.filter(f => /^permission-server-\d+\.port$/.test(f));
+      expect(remainingPid.length).toBe(1); // Only our PID survives
+      // The non-PID-keyed 'permission-server.port' should also survive
+      expect(remaining).toContain('permission-server.port');
     });
   });
 

--- a/tests/unit/web/console/lifecycle-cleanup.test.ts
+++ b/tests/unit/web/console/lifecycle-cleanup.test.ts
@@ -50,8 +50,9 @@ describe('Process Lifecycle Cleanup (#1856)', () => {
     });
 
     it('PID extraction from port filename works', () => {
+      const PORT_FILE_RE = /^permission-server-(\d+)\.port$/;
       const extract = (filename: string): number | null => {
-        const match = filename.match(/^permission-server-(\d+)\.port$/);
+        const match = PORT_FILE_RE.exec(filename);
         return match ? Number(match[1]) : null;
       };
 
@@ -69,29 +70,14 @@ describe('Process Lifecycle Cleanup (#1856)', () => {
       expect(() => process.kill(99999999, 0)).toThrow();
     });
 
-    it('simulated sweep removes dead PID files from temp dir', async () => {
+    it('sweepStalePortFiles removes dead PID files from custom dir', async () => {
       // Write files for dead and alive PIDs
       await writeFile(join(runDir, 'permission-server-99999991.port'), '41715');
       await writeFile(join(runDir, 'permission-server-99999992.port'), '41715');
       await writeFile(join(runDir, `permission-server-${process.pid}.port`), '41715');
 
-      // Manual sweep — same logic as sweepStalePortFiles but on temp dir
-      const files = await readdir(runDir);
-      const portFiles = files.filter(f => /^permission-server-\d+\.port$/.test(f));
-      let removed = 0;
-
-      for (const file of portFiles) {
-        const match = file.match(/^permission-server-(\d+)\.port$/);
-        if (!match) continue;
-        const pid = Number(match[1]);
-        let alive = false;
-        try { process.kill(pid, 0); alive = true; } catch { /* dead */ }
-        if (!alive) {
-          const { unlink } = await import('node:fs/promises');
-          await unlink(join(runDir, file));
-          removed++;
-        }
-      }
+      const { sweepStalePortFiles } = await import('../../../../src/web/portDiscovery.js');
+      const removed = await sweepStalePortFiles(runDir);
 
       expect(removed).toBe(2); // Two dead PIDs
       const remaining = await readdir(runDir);

--- a/tests/unit/web/console/lifecycle-cleanup.test.ts
+++ b/tests/unit/web/console/lifecycle-cleanup.test.ts
@@ -66,8 +66,16 @@ describe('Process Lifecycle Cleanup (#1856)', () => {
       // Current process is alive
       expect(() => process.kill(process.pid, 0)).not.toThrow();
 
-      // Non-existent PID throws
+      // Non-existent PID throws ESRCH
       expect(() => process.kill(99999999, 0)).toThrow();
+    });
+
+    it('EPERM is treated as alive (different user process)', async () => {
+      const LeaderElection = await import('../../../../src/web/console/LeaderElection.js');
+      // PID 1 (init/launchd) is always alive but owned by root — EPERM on signal-0
+      if (process.getuid && process.getuid() !== 0) {
+        expect(LeaderElection.isProcessAlive(1)).toBe(true);
+      }
     });
 
     it('sweepStalePortFiles removes dead PID files from custom dir', async () => {

--- a/tests/unit/web/console/lifecycle-cleanup.test.ts
+++ b/tests/unit/web/console/lifecycle-cleanup.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for process lifecycle cleanup (#1856).
+ *
+ * Verifies that stale port files are swept on startup and that
+ * shutdown cleanup functions are properly exported.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { mkdtemp, writeFile, readdir, rm, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+describe('Process Lifecycle Cleanup (#1856)', () => {
+  let tempDir: string;
+  let runDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'dollhouse-cleanup-test-'));
+    runDir = join(tempDir, 'run');
+    await mkdir(runDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('sweepStalePortFiles', () => {
+    it('removes port files for dead PIDs', async () => {
+      // Write port files for non-existent PIDs
+      await writeFile(join(runDir, 'permission-server-99999991.port'), '41715');
+      await writeFile(join(runDir, 'permission-server-99999992.port'), '41715');
+      await writeFile(join(runDir, 'permission-server-99999993.port'), '41715');
+
+      const { sweepStalePortFiles } = await import('../../../../src/web/portDiscovery.js');
+
+      // We can't easily redirect sweepStalePortFiles to our temp dir since
+      // it uses a module-level RUN_DIR constant. Instead, verify the function
+      // exists and is callable — integration tests cover the full sweep.
+      expect(typeof sweepStalePortFiles).toBe('function');
+    });
+
+    it('port file naming pattern matches expected format', async () => {
+      const pattern = /^permission-server-\d+\.port$/;
+
+      expect(pattern.test('permission-server-12345.port')).toBe(true);
+      expect(pattern.test('permission-server-99999.port')).toBe(true);
+      expect(pattern.test('permission-server.port')).toBe(false);
+      expect(pattern.test('console-leader.auth.lock')).toBe(false);
+      expect(pattern.test('console-token.auth.json')).toBe(false);
+    });
+
+    it('PID extraction from port filename works', () => {
+      const extract = (filename: string): number | null => {
+        const match = filename.match(/^permission-server-(\d+)\.port$/);
+        return match ? Number(match[1]) : null;
+      };
+
+      expect(extract('permission-server-12345.port')).toBe(12345);
+      expect(extract('permission-server-99999.port')).toBe(99999);
+      expect(extract('permission-server.port')).toBeNull();
+      expect(extract('other-file.txt')).toBeNull();
+    });
+
+    it('dead PID detection works correctly', () => {
+      // Current process is alive
+      expect(() => process.kill(process.pid, 0)).not.toThrow();
+
+      // Non-existent PID throws
+      expect(() => process.kill(99999999, 0)).toThrow();
+    });
+
+    it('simulated sweep removes dead PID files from temp dir', async () => {
+      // Write files for dead and alive PIDs
+      await writeFile(join(runDir, 'permission-server-99999991.port'), '41715');
+      await writeFile(join(runDir, 'permission-server-99999992.port'), '41715');
+      await writeFile(join(runDir, `permission-server-${process.pid}.port`), '41715');
+
+      // Manual sweep — same logic as sweepStalePortFiles but on temp dir
+      const files = await readdir(runDir);
+      const portFiles = files.filter(f => /^permission-server-\d+\.port$/.test(f));
+      let removed = 0;
+
+      for (const file of portFiles) {
+        const match = file.match(/^permission-server-(\d+)\.port$/);
+        if (!match) continue;
+        const pid = Number(match[1]);
+        let alive = false;
+        try { process.kill(pid, 0); alive = true; } catch { /* dead */ }
+        if (!alive) {
+          const { unlink } = await import('node:fs/promises');
+          await unlink(join(runDir, file));
+          removed++;
+        }
+      }
+
+      expect(removed).toBe(2); // Two dead PIDs
+      const remaining = await readdir(runDir);
+      const remainingPorts = remaining.filter(f => /^permission-server-\d+\.port$/.test(f));
+      expect(remainingPorts.length).toBe(1); // Only current PID's file
+      expect(remainingPorts[0]).toBe(`permission-server-${process.pid}.port`);
+    });
+  });
+
+  describe('Shutdown functions exported', () => {
+    it('shutdownWebServer is exported from server.ts', async () => {
+      const { shutdownWebServer } = await import('../../../../src/web/server.js');
+      expect(typeof shutdownWebServer).toBe('function');
+    });
+
+    it('registerPortCleanup is exported from portDiscovery.ts', async () => {
+      const { registerPortCleanup } = await import('../../../../src/web/portDiscovery.js');
+      expect(typeof registerPortCleanup).toBe('function');
+    });
+
+    it('registerLeaderCleanup is exported from LeaderElection.ts', async () => {
+      const { registerLeaderCleanup } = await import('../../../../src/web/console/LeaderElection.js');
+      expect(typeof registerLeaderCleanup).toBe('function');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

**Root cause of rc.3 failure on Ziggy**: `completeDeferredSetup()` in the `--web` standalone path runs UnifiedConsole leader election, which calls `startWebServer()` internally. This sets `serverRunning=true`. When the `--web` path's own `startWebServer` call runs afterward, it early-returns without binding. The process prints the banner but never listens on the port.

**Fix**: Skip `completeDeferredSetup()` entirely in `--web` mode. Standalone `--web` IS the server — leader/follower election is for Claude Desktop multi-session. Run the port file sweep directly instead.

Also includes #1857 lifecycle cleanup (startup sweep, shutdown cleanup, SIGHUP, EPERM fix) which was missing from rc.3.

## Test plan
- [ ] On Ziggy: `npx @dollhousemcp/mcp-server@rc --web` — verify all tabs populated
- [ ] `curl http://127.0.0.1:41715/api/console/token/info` returns data, not 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)