### PR TITLE
chore: update RC to 2.0.12-rc.6 with develop changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.12-rc.5",
+  "version": "2.0.12-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.12-rc.5",
+      "version": "2.0.12-rc.6",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.12-rc.5",
+  "version": "2.0.12-rc.6",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.12-rc.5",
+  "version": "2.0.12-rc.6",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.12-rc.5",
+      "version": "2.0.12-rc.6",
       "transport": {
         "type": "stdio"
       }

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.12-rc.5';
-export const BUILD_TIMESTAMP = '2026-04-09T03:22:18.527Z';
+export const PACKAGE_VERSION = '2.0.12-rc.6';
+export const BUILD_TIMESTAMP = '2026-04-09T03:56:19.643Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';

--- a/src/index.ts
+++ b/src/index.ts
@@ -848,6 +848,18 @@ if ((isDirectExecution || isNpxExecution || isCliExecution) && (!isTest || isTes
       const cliPort = portArg ? Number.parseInt(portArg.split('=')[1], 10) : undefined;
       const noBrowser = process.argv.includes('--no-open');
 
+      // Pre-flight: kill any stale DollhouseMCP process squatting on our port
+      // BEFORE any container/server setup. This is the definitive fix for #1850 —
+      // clear the port first, then start cleanly.
+      try {
+        const targetPort = cliPort || env.DOLLHOUSE_WEB_CONSOLE_PORT;
+        const { recoverStalePort } = await import('./web/console/StaleProcessRecovery.js');
+        const recovered = await recoverStalePort(targetPort);
+        if (recovered) {
+          console.error(`  Cleared stale process from port ${targetPort}\n`);
+        }
+      } catch { /* recovery failure is non-fatal — bindAndListen will handle EADDRINUSE */ }
+
       let mcpAqlHandler;
       let memorySink: import('./logging/sinks/MemoryLogSink.js').MemoryLogSink | undefined;
       let metricsSink: import('./metrics/sinks/MemoryMetricsSink.js').MemoryMetricsSink | undefined;
@@ -855,7 +867,16 @@ if ((isDirectExecution || isNpxExecution || isCliExecution) && (!isTest || isTes
         const container = new DollhouseContainer();
         await container.preparePortfolio();
         const bundle = await container.bootstrapHandlers();
-        await container.completeDeferredSetup();
+        // Do NOT call completeDeferredSetup() in --web mode (#1850).
+        // It runs UnifiedConsole leader election which starts a competing
+        // web server, sets serverRunning=true, and causes the actual
+        // startWebServer call below to early-return without binding.
+        // Standalone --web mode IS the server — no leader/follower needed.
+        // Run the port file sweep directly instead.
+        try {
+          const { sweepStalePortFiles } = await import('./web/portDiscovery.js');
+          await sweepStalePortFiles();
+        } catch { /* non-fatal */ }
         mcpAqlHandler = bundle.mcpAqlHandler;
         // Extract sinks from container — deferred setup may have already wired them
         try { memorySink = container.resolve<import('./logging/sinks/MemoryLogSink.js').MemoryLogSink>('MemoryLogSink'); } catch { /* not registered */ }

--- a/src/index.ts
+++ b/src/index.ts
@@ -851,14 +851,21 @@ if ((isDirectExecution || isNpxExecution || isCliExecution) && (!isTest || isTes
       // Pre-flight: kill any stale DollhouseMCP process squatting on our port
       // BEFORE any container/server setup. This is the definitive fix for #1850 —
       // clear the port first, then start cleanly.
+      // Race condition note: a new process could grab the port between kill and
+      // our bind, but recoverStalePort's TOCTOU mitigation (500ms lock file
+      // re-read) and bindAndListen's own recovery handle that edge case.
+      const targetPort = cliPort || env.DOLLHOUSE_WEB_CONSOLE_PORT;
       try {
-        const targetPort = cliPort || env.DOLLHOUSE_WEB_CONSOLE_PORT;
         const { recoverStalePort } = await import('./web/console/StaleProcessRecovery.js');
         const recovered = await recoverStalePort(targetPort);
         if (recovered) {
           console.error(`  Cleared stale process from port ${targetPort}\n`);
         }
-      } catch { /* recovery failure is non-fatal — bindAndListen will handle EADDRINUSE */ }
+      } catch (err) {
+        // Non-fatal — bindAndListen will handle EADDRINUSE as a fallback.
+        // Log so operators can diagnose recovery failures.
+        console.error(`[DollhouseMCP] Pre-flight port recovery failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
 
       let mcpAqlHandler;
       let memorySink: import('./logging/sinks/MemoryLogSink.js').MemoryLogSink | undefined;

--- a/src/web/console/StaleProcessRecovery.ts
+++ b/src/web/console/StaleProcessRecovery.ts
@@ -11,6 +11,17 @@
 
 // Use lazy import for logger to avoid pulling in the full env.ts/config chain
 // at module load time. This keeps the module independently testable.
+/** Timeout for lsof/fuser/ps system calls (ms) */
+const COMMAND_TIMEOUT_MS = 1000;
+/** Polling interval when waiting for SIGTERM to take effect (ms) */
+const SIGTERM_POLL_MS = 300;
+/** Number of polls before escalating to SIGKILL */
+const KILL_POLL_COUNT = 10;
+/** Wait after SIGKILL before returning (ms) */
+const SIGKILL_WAIT_MS = 500;
+/** Wait between lock file reads for TOCTOU mitigation (ms) */
+const LOCK_RECHECK_DELAY_MS = 500;
+
 let _logger: typeof import('../../utils/logger.js').logger | null = null;
 async function getLogger() {
   if (!_logger) {
@@ -44,7 +55,7 @@ export async function findPidOnPort(port: number): Promise<number | null> {
     { bin: 'fuser', args: [`${port}/tcp`] },
   ]) {
     try {
-      const { stdout, stderr } = await execFileAsync(cmd.bin, cmd.args, { timeout: 1000 });
+      const { stdout, stderr } = await execFileAsync(cmd.bin, cmd.args, { timeout: COMMAND_TIMEOUT_MS });
       // fuser outputs to stderr on some systems
       const output = (stdout || stderr || '').trim();
       const pids = output.split(/\s+/).map(Number).filter(n => !Number.isNaN(n) && n > 0);
@@ -75,7 +86,7 @@ export async function killStaleProcess(pid: number, port: number): Promise<boole
   // 2. Command line must match a DollhouseMCP binary path (prevents killing other services)
   // 3. If both fail or ps can't run, we refuse — safe default is to not kill
   try {
-    const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'user=,command='], { timeout: 1000 });
+    const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'user=,command='], { timeout: COMMAND_TIMEOUT_MS });
 
     // Check 1: User ownership — only kill our own processes
     const currentUser = (await import('node:os')).userInfo().username;
@@ -109,13 +120,13 @@ export async function killStaleProcess(pid: number, port: number): Promise<boole
   try {
     process.kill(pid, 'SIGTERM');
     logger.warn(`[WebUI] Sent SIGTERM to stale process ${pid} on port ${port}`);
-    for (let i = 0; i < 10; i++) {
-      await new Promise(r => setTimeout(r, 300));
+    for (let i = 0; i < KILL_POLL_COUNT; i++) {
+      await new Promise(r => setTimeout(r, SIGTERM_POLL_MS));
       try { process.kill(pid, 0); } catch { return true; }
     }
     process.kill(pid, 'SIGKILL');
     logger.warn(`[WebUI] Sent SIGKILL to stale process ${pid} on port ${port}`);
-    await new Promise(r => setTimeout(r, 500));
+    await new Promise(r => setTimeout(r, SIGKILL_WAIT_MS));
     return true;
   } catch {
     return true; // process already dead
@@ -133,21 +144,29 @@ export async function recoverStalePort(port: number): Promise<boolean> {
   const stalePid = await findPidOnPort(port);
   if (!stalePid) return false;
 
-  try {
-    const { readLeaderLock } = await import('./LeaderElection.js');
-    const lock = await readLeaderLock();
-    if (lock?.pid === stalePid && lock?.port === port && lock.pid !== process.pid) {
-      logger.warn(`[WebUI] Port ${port} held by legitimate leader (pid ${stalePid}) — not killing`);
-      return false;
+  // TOCTOU mitigation: a new process may have just bound the port but not yet
+  // written its lock file. Read the lock, pause, re-read. If the second read
+  // now matches the port holder, it's a fresh leader — don't kill.
+  const { readLeaderLock } = await import('./LeaderElection.js');
+  for (let check = 0; check < 2; check++) {
+    try {
+      const lock = await readLeaderLock();
+      if (lock?.pid === stalePid && lock?.port === port && lock.pid !== process.pid) {
+        await logger.warn(`[WebUI] Port ${port} held by legitimate leader (pid ${stalePid}) — not killing`);
+        return false;
+      }
+    } catch {
+      // Can't read lock file — continue to next check or kill
     }
-  } catch {
-    // Can't read lock file — treat port holder as squatter
+    if (check === 0) {
+      await new Promise(r => setTimeout(r, LOCK_RECHECK_DELAY_MS));
+    }
   }
 
   const killed = await killStaleProcess(stalePid, port);
   if (killed) {
     logger.info(`[WebUI] Stale process ${stalePid} removed from port ${port}`);
-    await new Promise(r => setTimeout(r, 500));
+    await new Promise(r => setTimeout(r, SIGKILL_WAIT_MS)); // brief pause for port release
   }
   return killed;
 }

--- a/tests/integration/web-standalone-mode.test.ts
+++ b/tests/integration/web-standalone-mode.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Integration tests for standalone --web mode (#1850).
+ *
+ * Verifies the --web startup path has the correct structure:
+ * 1. Pre-flight zombie kill runs BEFORE container setup
+ * 2. completeDeferredSetup() is NOT called (prevents leader election conflict)
+ * 3. Port file sweep runs independently
+ * 4. startWebServer is called with full sinks
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { readFile } from 'node:fs/promises';
+import * as path from 'node:path';
+
+const PROJECT_ROOT = path.resolve(__dirname, '../../');
+
+describe('Standalone --web mode (#1850)', () => {
+  let webModeSource: string;
+
+  beforeAll(async () => {
+    webModeSource = await readFile(path.join(PROJECT_ROOT, 'src/index.ts'), 'utf8');
+  });
+
+  describe('Pre-flight zombie kill', () => {
+    it('calls recoverStalePort before container bootstrap', () => {
+      // Search within the --web block only
+      const webStart = webModeSource.indexOf('if (isWebMode)');
+      const webBlock = webModeSource.slice(webStart);
+      const recoverIdx = webBlock.indexOf('recoverStalePort(targetPort)');
+      const containerIdx = webBlock.indexOf('new DollhouseContainer()');
+      expect(recoverIdx).toBeGreaterThan(-1);
+      expect(containerIdx).toBeGreaterThan(-1);
+      // Pre-flight must come BEFORE container creation
+      expect(recoverIdx).toBeLessThan(containerIdx);
+    });
+
+    it('logs recovery failures instead of swallowing them', () => {
+      // The catch block must log, not be empty
+      const preflightSection = webModeSource.slice(
+        webModeSource.indexOf('Pre-flight: kill any stale'),
+        webModeSource.indexOf('let mcpAqlHandler'),
+      );
+      expect(preflightSection).toContain('console.error');
+      expect(preflightSection).toContain('Pre-flight port recovery failed');
+      expect(preflightSection).not.toContain('catch { /*');
+    });
+
+    it('uses the CLI port flag when provided', () => {
+      expect(webModeSource).toContain('cliPort || env.DOLLHOUSE_WEB_CONSOLE_PORT');
+    });
+  });
+
+  describe('completeDeferredSetup skipped', () => {
+    // Extract the --web IIFE: from "if (isWebMode)" to the ".catch(err =>" that ends it
+    function getWebModeBlock(): string {
+      const start = webModeSource.indexOf('if (isWebMode)');
+      const end = webModeSource.indexOf('[DollhouseMCP] Web UI failed to start:', start);
+      return webModeSource.slice(start, end);
+    }
+
+    it('does NOT call completeDeferredSetup in the --web path', () => {
+      const block = getWebModeBlock();
+      // Check for the actual method call, not comments about it
+      expect(block).not.toContain('container.completeDeferredSetup()');
+      // The comment explaining WHY it's skipped should be present
+      expect(block).toContain('Do NOT call completeDeferredSetup');
+    });
+
+    it('runs sweepStalePortFiles directly instead', () => {
+      expect(getWebModeBlock()).toContain('sweepStalePortFiles');
+    });
+
+    it('still bootstraps handlers for MCP-AQL gateway', () => {
+      const block = getWebModeBlock();
+      expect(block).toContain('bootstrapHandlers');
+      expect(block).toContain('mcpAqlHandler');
+    });
+  });
+
+  describe('Server startup with full sinks', () => {
+    function getWebModeBlock(): string {
+      const start = webModeSource.indexOf('if (isWebMode)');
+      const end = webModeSource.indexOf('[DollhouseMCP] Web UI failed to start:', start);
+      return webModeSource.slice(start, end);
+    }
+
+    it('passes all required options to startWebServer', () => {
+      const block = getWebModeBlock();
+      expect(block).toContain('memorySink');
+      expect(block).toContain('metricsSink');
+      expect(block).toContain('tokenStore');
+      expect(block).toContain('additionalRouters');
+    });
+
+    it('creates fallback sinks when container does not provide them', () => {
+      const block = getWebModeBlock();
+      expect(block).toContain('MemoryLogSink');
+      expect(block).toContain('MemoryMetricsSink');
+    });
+  });
+
+  describe('Race condition documentation', () => {
+    it('documents the TOCTOU mitigation in the pre-flight comment', () => {
+      const preflightSection = webModeSource.slice(
+        webModeSource.indexOf('Pre-flight: kill any stale'),
+        webModeSource.indexOf('const targetPort'),
+      );
+      expect(preflightSection).toContain('TOCTOU');
+    });
+  });
+
+  describe('StaleProcessRecovery module', () => {
+    it('recoverStalePort is importable and callable', async () => {
+      const { recoverStalePort } = await import('../../src/web/console/StaleProcessRecovery.js');
+      expect(typeof recoverStalePort).toBe('function');
+
+      // Should return false for a port with nothing on it
+      const result = await recoverStalePort(59997);
+      expect(result).toBe(false);
+    });
+
+    it('verifyDollhouseProcess is not exported (internal)', async () => {
+      const mod = await import('../../src/web/console/StaleProcessRecovery.js');
+      expect((mod as any).verifyDollhouseProcess).toBeUndefined();
+    });
+  });
+});

--- a/tests/integration/web-standalone-mode.test.ts
+++ b/tests/integration/web-standalone-mode.test.ts
@@ -11,8 +11,27 @@
 import { describe, it, expect } from '@jest/globals';
 import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
+import * as net from 'node:net';
 
 const PROJECT_ROOT = path.resolve(__dirname, '../../');
+
+/** Extract the --web IIFE from index.ts source. */
+function getWebModeBlock(source: string): string {
+  const start = source.indexOf('if (isWebMode)');
+  const end = source.indexOf('[DollhouseMCP] Web UI failed to start:', start);
+  return source.slice(start, end);
+}
+
+/** Get a dynamically assigned free port from the OS. */
+function getFreePort(): Promise<number> {
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const p = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(p));
+    });
+  });
+}
 
 describe('Standalone --web mode (#1850)', () => {
   let webModeSource: string;
@@ -23,19 +42,15 @@ describe('Standalone --web mode (#1850)', () => {
 
   describe('Pre-flight zombie kill', () => {
     it('calls recoverStalePort before container bootstrap', () => {
-      // Search within the --web block only
-      const webStart = webModeSource.indexOf('if (isWebMode)');
-      const webBlock = webModeSource.slice(webStart);
+      const webBlock = getWebModeBlock(webModeSource);
       const recoverIdx = webBlock.indexOf('recoverStalePort(targetPort)');
       const containerIdx = webBlock.indexOf('new DollhouseContainer()');
       expect(recoverIdx).toBeGreaterThan(-1);
       expect(containerIdx).toBeGreaterThan(-1);
-      // Pre-flight must come BEFORE container creation
       expect(recoverIdx).toBeLessThan(containerIdx);
     });
 
     it('logs recovery failures instead of swallowing them', () => {
-      // The catch block must log, not be empty
       const preflightSection = webModeSource.slice(
         webModeSource.indexOf('Pre-flight: kill any stale'),
         webModeSource.indexOf('let mcpAqlHandler'),
@@ -51,41 +66,26 @@ describe('Standalone --web mode (#1850)', () => {
   });
 
   describe('completeDeferredSetup skipped', () => {
-    // Extract the --web IIFE: from "if (isWebMode)" to the ".catch(err =>" that ends it
-    function getWebModeBlock(): string {
-      const start = webModeSource.indexOf('if (isWebMode)');
-      const end = webModeSource.indexOf('[DollhouseMCP] Web UI failed to start:', start);
-      return webModeSource.slice(start, end);
-    }
-
     it('does NOT call completeDeferredSetup in the --web path', () => {
-      const block = getWebModeBlock();
-      // Check for the actual method call, not comments about it
+      const block = getWebModeBlock(webModeSource);
       expect(block).not.toContain('container.completeDeferredSetup()');
-      // The comment explaining WHY it's skipped should be present
       expect(block).toContain('Do NOT call completeDeferredSetup');
     });
 
     it('runs sweepStalePortFiles directly instead', () => {
-      expect(getWebModeBlock()).toContain('sweepStalePortFiles');
+      expect(getWebModeBlock(webModeSource)).toContain('sweepStalePortFiles');
     });
 
     it('still bootstraps handlers for MCP-AQL gateway', () => {
-      const block = getWebModeBlock();
+      const block = getWebModeBlock(webModeSource);
       expect(block).toContain('bootstrapHandlers');
       expect(block).toContain('mcpAqlHandler');
     });
   });
 
   describe('Server startup with full sinks', () => {
-    function getWebModeBlock(): string {
-      const start = webModeSource.indexOf('if (isWebMode)');
-      const end = webModeSource.indexOf('[DollhouseMCP] Web UI failed to start:', start);
-      return webModeSource.slice(start, end);
-    }
-
     it('passes all required options to startWebServer', () => {
-      const block = getWebModeBlock();
+      const block = getWebModeBlock(webModeSource);
       expect(block).toContain('memorySink');
       expect(block).toContain('metricsSink');
       expect(block).toContain('tokenStore');
@@ -93,7 +93,7 @@ describe('Standalone --web mode (#1850)', () => {
     });
 
     it('creates fallback sinks when container does not provide them', () => {
-      const block = getWebModeBlock();
+      const block = getWebModeBlock(webModeSource);
       expect(block).toContain('MemoryLogSink');
       expect(block).toContain('MemoryMetricsSink');
     });
@@ -114,8 +114,9 @@ describe('Standalone --web mode (#1850)', () => {
       const { recoverStalePort } = await import('../../src/web/console/StaleProcessRecovery.js');
       expect(typeof recoverStalePort).toBe('function');
 
-      // Should return false for a port with nothing on it
-      const result = await recoverStalePort(59997);
+      // Use a dynamically assigned free port — no hardcoded port numbers
+      const freePort = await getFreePort();
+      const result = await recoverStalePort(freePort);
       expect(result).toBe(false);
     });
 


### PR DESCRIPTION
## Summary

Merges develop into the RC branch and bumps to rc.6.

### New since rc.5
- Magic numbers extracted to named constants (COMMAND_TIMEOUT_MS, SIGTERM_POLL_MS, etc.)
- TOCTOU mitigation (double lock file read with 500ms gap)
- SonarCloud fixes (S7721, S4144 — deduplicated test helpers)
- Dynamic test port selection (no hardcoded ports)
- 11 integration tests for --web standalone mode

### Version
2.0.12-rc.5 → 2.0.12-rc.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)