### PR TITLE
[codex] fix agent storage index after create

### DIFF
--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -348,6 +348,7 @@ export class AgentManager extends BaseElementManager<Agent> {
 
       // Cache the element after successful creation
       this.cacheElement(agent, filename);
+      await this.storageLayer.notifySaved(filename, absolutePath);
       // Note: No reload() here — cacheElement() stores the element correctly.
       // See Issue #491 for why PersonaManager's reload-after-create was removed.
 

--- a/tests/integration/mcp-aql/create.test.ts
+++ b/tests/integration/mcp-aql/create.test.ts
@@ -292,6 +292,57 @@ describe('MCP-AQL CREATE Endpoint Integration', () => {
       const names = (data.items || []).map((i: any) => i.name || i.element_name);
       expect(names).toContain('listable-persona');
     });
+
+    it('should list and activate a newly created agent immediately after creation (Issue #1873)', async () => {
+      const createResult = await mcpAqlHandler.handleCreate({
+        operation: 'create_element',
+        params: {
+          element_name: 'cache-coherence-agent',
+          element_type: 'agents',
+          description: 'Tests that agent index-backed reads work immediately after creation',
+          instructions: 'Execute integration test tasks methodically and report completion.',
+          content: '# Cache Coherence Agent\n\nMust be listable and activatable right away.',
+        },
+      });
+
+      expect(createResult.success).toBe(true);
+
+      await waitForCacheSettle();
+
+      const listResult = await mcpAqlHandler.handleRead({
+        operation: 'list_elements',
+        elementType: 'agent',
+        params: {},
+      });
+
+      expect(listResult.success).toBe(true);
+      const listData = listResult.data as { items?: Array<{ name: string }> };
+      const names = (listData.items || []).map((i: any) => i.name || i.element_name);
+      expect(names).toContain('cache-coherence-agent');
+
+      const activateResult = await mcpAqlHandler.handleRead({
+        operation: 'activate_element',
+        params: {
+          element_name: 'cache-coherence-agent',
+          element_type: 'agents',
+        },
+      });
+
+      expect(activateResult.success).toBe(true);
+      const activateText = activateResult.data?.content?.[0]?.text ?? '';
+      expect(activateText.toLowerCase()).toContain('activated');
+
+      const activeResult = await mcpAqlHandler.handleRead({
+        operation: 'get_active_elements',
+        params: {
+          element_type: 'agents',
+        },
+      });
+
+      expect(activeResult.success).toBe(true);
+      const activeText = activeResult.data?.content?.[0]?.text ?? '';
+      expect(activeText).toContain('cache-coherence-agent');
+    });
   });
 
   describe('import_element operation', () => {

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -137,6 +137,22 @@ describe('AgentManager', () => {
       );
     });
 
+    it('should notify the storage layer after creating a new agent', async () => {
+      const notifySavedSpy = jest.spyOn((agentManager as any).storageLayer, 'notifySaved');
+
+      const result = await agentManager.create(
+        'indexed-agent',
+        'A test agent',
+        'Agent instructions here'
+      );
+
+      expect(result.success).toBe(true);
+      expect(notifySavedSpy).toHaveBeenCalledWith(
+        'indexed-agent.md',
+        expect.stringContaining(path.join('agents', 'indexed-agent.md'))
+      );
+    });
+
     it('should reject invalid agent names', async () => {
       const result = await agentManager.create(
         'invalid name!',


### PR DESCRIPTION
## Summary

Fix agent creation so newly created agents are immediately discoverable through index-backed lookups.

## Root Cause

`AgentManager.create()` wrote the new agent file and cached the element, but it did not notify the storage layer about the new file. Other element managers go through `BaseElementManager.save()`, which updates both the cache and the storage-layer index.

That gap meant agent creation could succeed while later index-driven paths like `findByName()` missed the new agent until a later scan refreshed the index.

## What Changed

- call `storageLayer.notifySaved()` after successful agent file creation in `AgentManager.create()`
- add a unit regression test that verifies agent creation updates the storage layer

## Impact

This should make newly created agents visible immediately to follow-up operations that depend on indexed lookups after create.

## Validation

- `npm test -- tests/unit/elements/agents/AgentManager.test.ts`

## Related

- Closes #1873