### PR TITLE
[codex] fix ensemble member deactivation

### DIFF
--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -849,7 +849,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
    * @param identifier - Ensemble name or identifier
    * @returns Deactivation result with success status and message
    */
-  async deactivateEnsemble(identifier: string): Promise<{ success: boolean; message: string }> {
+  async deactivateEnsemble(identifier: string): Promise<{ success: boolean; message: string; ensemble?: Ensemble }> {
     // PERFORMANCE FIX: Use findByName() instead of list()
     const ensemble = await this.findByName(identifier);
 
@@ -876,7 +876,8 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
     return {
       success: true,
       // CONSISTENCY FIX: Use standardized success message format
-      message: ElementMessages.deactivated(ElementType.ENSEMBLE, ensemble.metadata.name)
+      message: ElementMessages.deactivated(ElementType.ENSEMBLE, ensemble.metadata.name),
+      ensemble
     };
   }
 

--- a/src/handlers/strategies/EnsembleActivationStrategy.ts
+++ b/src/handlers/strategies/EnsembleActivationStrategy.ts
@@ -14,6 +14,8 @@ import { PersonaManager } from '../../persona/PersonaManager.js';
 import { PortfolioManager } from '../../portfolio/PortfolioManager.js';
 import { BaseActivationStrategy } from './BaseActivationStrategy.js';
 import { ElementActivationStrategy, MCPResponse } from './ElementActivationStrategy.js';
+import type { Ensemble } from '../../elements/ensembles/Ensemble.js';
+import type { ElementManagers, EnsembleElement } from '../../elements/ensembles/types.js';
 
 export class EnsembleActivationStrategy extends BaseActivationStrategy implements ElementActivationStrategy {
   constructor(
@@ -44,14 +46,7 @@ export class EnsembleActivationStrategy extends BaseActivationStrategy implement
 
     // Activate the ensemble with all managers (orchestration)
     try {
-      const result = await ensemble.activateEnsemble(this.portfolioManager, {
-        skillManager: this.skillManager,
-        templateManager: this.templateManager,
-        agentManager: this.agentManager,
-        memoryManager: this.memoryManager,
-        personaManager: this.personaManager,
-        ensembleManager: this.ensembleManager
-      });
+      const result = await ensemble.activateEnsemble(this.portfolioManager, this.getManagers());
 
       const statusEmoji = result.success ? '✅' : '⚠️';
       const details = [
@@ -116,7 +111,60 @@ export class EnsembleActivationStrategy extends BaseActivationStrategy implement
       this.throwNotFoundError(name, 'Ensemble');
     }
 
+    if (deactivationResult.ensemble) {
+      await this.deactivateMembers(deactivationResult.ensemble);
+    }
+
     return this.createSuccessResponse(`✅ Ensemble '${name}' deactivated`);
+  }
+
+  private getManagers(): ElementManagers {
+    return {
+      skillManager: this.skillManager,
+      templateManager: this.templateManager,
+      agentManager: this.agentManager,
+      memoryManager: this.memoryManager,
+      personaManager: this.personaManager,
+      ensembleManager: this.ensembleManager
+    };
+  }
+
+  private async deactivateMembers(ensemble: Ensemble): Promise<void> {
+    const deactivationPromises = (ensemble.metadata.elements || []).map((element) =>
+      this.deactivateMember(element)
+    );
+    await Promise.all(deactivationPromises);
+  }
+
+  private async deactivateMember(element: EnsembleElement): Promise<void> {
+    const normalizedType = element.element_type.toLowerCase();
+
+    switch (normalizedType) {
+      case 'skill':
+      case 'skills':
+        await this.skillManager.deactivateSkill(element.element_name);
+        return;
+      case 'persona':
+      case 'personas':
+        await Promise.resolve(this.personaManager.deactivatePersona(element.element_name));
+        return;
+      case 'agent':
+      case 'agents':
+        await this.agentManager.deactivateAgent(element.element_name);
+        return;
+      case 'memory':
+      case 'memories':
+        await this.memoryManager.deactivateMemory(element.element_name);
+        return;
+      case 'ensemble':
+      case 'ensembles':
+        await this.ensembleManager.deactivateEnsemble(element.element_name);
+        return;
+      case 'template':
+      case 'templates':
+      default:
+        return;
+    }
   }
 
   /**

--- a/tests/integration/mcp-aql/ensemble-activation-registration.test.ts
+++ b/tests/integration/mcp-aql/ensemble-activation-registration.test.ts
@@ -128,4 +128,65 @@ describe('Ensemble Activation Registration (Issue #1769)', () => {
     const activeText = JSON.stringify(activePersonas);
     expect(activeText).toContain('ensemble-test-persona');
   });
+
+  it('should remove ensemble-activated members from get_active_elements after deactivation', async () => {
+    await mcpAqlHandler.handleCreate({
+      operation: 'create_element',
+      element_type: 'persona',
+      params: {
+        element_name: 'ensemble-deactivate-persona',
+        description: 'Persona for ensemble deactivation test',
+        instructions: 'You are a test persona.',
+      },
+    });
+
+    await mcpAqlHandler.handleCreate({
+      operation: 'create_element',
+      element_type: 'skill',
+      params: {
+        element_name: 'ensemble-deactivate-skill',
+        description: 'Skill for ensemble deactivation test',
+        content: 'Test skill content.',
+      },
+    });
+
+    await mcpAqlHandler.handleCreate({
+      operation: 'create_element',
+      element_type: 'ensemble',
+      params: {
+        element_name: 'deactivation-ensemble',
+        description: 'Ensemble for deactivation registration',
+        metadata: {
+          elements: [
+            { element_name: 'ensemble-deactivate-persona', element_type: 'persona', role: 'primary' },
+            { element_name: 'ensemble-deactivate-skill', element_type: 'skill', role: 'support' },
+          ],
+        },
+      },
+    });
+
+    await mcpAqlHandler.handleRead({
+      operation: 'activate_element',
+      element_type: 'ensemble',
+      params: { element_name: 'deactivation-ensemble', element_type: 'ensemble' },
+    });
+
+    await mcpAqlHandler.handleRead({
+      operation: 'deactivate_element',
+      element_type: 'ensemble',
+      params: { element_name: 'deactivation-ensemble', element_type: 'ensemble' },
+    });
+
+    const activePersonas = await mcpAqlHandler.handleRead({
+      operation: 'get_active_elements',
+      params: { element_type: 'persona' },
+    });
+    expect(JSON.stringify(activePersonas)).not.toContain('ensemble-deactivate-persona');
+
+    const activeSkills = await mcpAqlHandler.handleRead({
+      operation: 'get_active_elements',
+      params: { element_type: 'skill' },
+    });
+    expect(JSON.stringify(activeSkills)).not.toContain('ensemble-deactivate-skill');
+  });
 });

--- a/tests/unit/handlers/strategies/EnsembleActivationStrategy.test.ts
+++ b/tests/unit/handlers/strategies/EnsembleActivationStrategy.test.ts
@@ -27,11 +27,19 @@ describe('EnsembleActivationStrategy', () => {
     } as unknown as jest.Mocked<EnsembleManager>;
 
     mockPortfolioManager = {} as jest.Mocked<PortfolioManager>;
-    mockSkillManager = {} as jest.Mocked<SkillManager>;
+    mockSkillManager = {
+      deactivateSkill: jest.fn(),
+    } as unknown as jest.Mocked<SkillManager>;
     mockTemplateManager = {} as jest.Mocked<TemplateManager>;
-    mockAgentManager = {} as jest.Mocked<AgentManager>;
-    mockMemoryManager = {} as jest.Mocked<MemoryManager>;
-    mockPersonaManager = {} as jest.Mocked<PersonaManager>;
+    mockAgentManager = {
+      deactivateAgent: jest.fn(),
+    } as unknown as jest.Mocked<AgentManager>;
+    mockMemoryManager = {
+      deactivateMemory: jest.fn(),
+    } as unknown as jest.Mocked<MemoryManager>;
+    mockPersonaManager = {
+      deactivatePersona: jest.fn(),
+    } as unknown as jest.Mocked<PersonaManager>;
 
     strategy = new EnsembleActivationStrategy(
       mockEnsembleManager,
@@ -249,13 +257,47 @@ describe('EnsembleActivationStrategy', () => {
     it('should deactivate ensemble with deactivate method', async () => {
       mockEnsembleManager.deactivateEnsemble.mockResolvedValue({
         success: true,
-        message: '✅ Ensemble active-ensemble deactivated'
+        message: '✅ Ensemble active-ensemble deactivated',
+        ensemble: {
+          metadata: {
+            name: 'active-ensemble',
+            elements: [],
+          },
+        } as any
       });
 
       const result = await strategy.deactivate('active-ensemble');
 
       expect(result.content[0].text).toContain('active-ensemble');
       expect(result.content[0].text).toContain('deactivated');
+    });
+
+    it('should deactivate ensemble members via their type managers', async () => {
+      mockEnsembleManager.deactivateEnsemble.mockResolvedValue({
+        success: true,
+        message: '✅ Ensemble active-ensemble deactivated',
+        ensemble: {
+          metadata: {
+            name: 'active-ensemble',
+            elements: [
+              { element_name: 'persona-member', element_type: 'persona' },
+              { element_name: 'skill-member', element_type: 'skill' },
+              { element_name: 'agent-member', element_type: 'agent' },
+              { element_name: 'memory-member', element_type: 'memory' },
+              { element_name: 'nested-ensemble', element_type: 'ensemble' },
+              { element_name: 'template-member', element_type: 'template' },
+            ],
+          },
+        } as any
+      });
+
+      await strategy.deactivate('active-ensemble');
+
+      expect(mockPersonaManager.deactivatePersona).toHaveBeenCalledWith('persona-member');
+      expect(mockSkillManager.deactivateSkill).toHaveBeenCalledWith('skill-member');
+      expect(mockAgentManager.deactivateAgent).toHaveBeenCalledWith('agent-member');
+      expect(mockMemoryManager.deactivateMemory).toHaveBeenCalledWith('memory-member');
+      expect(mockEnsembleManager.deactivateEnsemble).toHaveBeenCalledWith('nested-ensemble');
     });
 
     // Issue #275: Now throws error instead of returning error content


### PR DESCRIPTION
## Summary

Fix ensemble deactivation so member elements are removed from their type managers' active sets when the ensemble is deactivated.

## Root Cause

Ensemble activation already routed member activation through the individual type managers, which registered members in manager-level active sets used by `get_active_elements`.

Deactivation did not mirror that flow. The ensemble itself was marked inactive, but member cleanup never went back through the type managers, so personas/skills/memories/agents activated by the ensemble could remain visible as active.

## What Changed

- return the ensemble object from `EnsembleManager.deactivateEnsemble()`
- have `EnsembleActivationStrategy.deactivate()` walk ensemble members and call the matching type-manager deactivation methods
- add a unit regression for manager-driven member cleanup
- add an integration regression that verifies `get_active_elements` no longer shows ensemble members after deactivation

## Impact

This restores activation/deactivation symmetry for ensemble-managed elements and makes `get_active_elements` reflect the real state after ensemble shutdown.

## Validation

- `npm test -- tests/unit/handlers/strategies/EnsembleActivationStrategy.test.ts`
- `npm run test:integration -- tests/integration/mcp-aql/ensemble-activation-registration.test.ts`

## Related

- Closes #1876