### PR TITLE
[codex] fix template variable routing

### DIFF
--- a/src/handlers/element-crud/createElement.ts
+++ b/src/handlers/element-crud/createElement.ts
@@ -285,11 +285,11 @@ export async function createElement(context: ElementCrudContext, args: CreateEle
         // FIX: Issue #20 - Catch duplicate errors from TemplateManager
         try {
           const template = await context.templateManager.create({
-            ...sanitized,
             name: validatedName,
             description: validatedDescription,
             instructions: instructions,
             content: content || '',
+            metadata: sanitized,
           });
           const successMsg = `${warningText}✅ Created template '${template.metadata.name}' successfully`;
           return { content: [{ type: "text", text: `${context.getPersonaIndicator()}${successMsg}` }] };

--- a/src/handlers/mcp-aql/SchemaDispatcher.ts
+++ b/src/handlers/mcp-aql/SchemaDispatcher.ts
@@ -596,9 +596,9 @@ function buildArgs(
       }
 
       const isTemplate = resolvedType === ElementType.TEMPLATE || resolvedType === 'template';
-      if (isTemplate && params.variables !== undefined) {
+      if (isTemplate && Array.isArray(params.variables)) {
         const currentMetadata = result.metadata as Record<string, unknown> | undefined;
-        if (!currentMetadata || currentMetadata.variables === undefined) {
+        if (currentMetadata?.variables === undefined) {
           result.metadata = { ...currentMetadata, variables: params.variables };
         }
       }

--- a/src/handlers/mcp-aql/SchemaDispatcher.ts
+++ b/src/handlers/mcp-aql/SchemaDispatcher.ts
@@ -595,6 +595,14 @@ function buildArgs(
         }
       }
 
+      const isTemplate = resolvedType === ElementType.TEMPLATE || resolvedType === 'template';
+      if (isTemplate && params.variables !== undefined) {
+        const currentMetadata = result.metadata as Record<string, unknown> | undefined;
+        if (!currentMetadata || currentMetadata.variables === undefined) {
+          result.metadata = { ...currentMetadata, variables: params.variables };
+        }
+      }
+
       // Agent V2 fields: goal, activates, tools, systemPrompt, autonomy, resilience
       const isAgent = resolvedType === ElementType.AGENT || resolvedType === 'agent';
       if (isAgent) {

--- a/tests/integration/mcp-aql/read.test.ts
+++ b/tests/integration/mcp-aql/read.test.ts
@@ -853,6 +853,44 @@ describe('MCP-AQL READ Endpoint Integration', () => {
   });
 
   describe('render operation', () => {
+    it('should render a template created with top-level variable declarations', async () => {
+      const createResult = await mcpAqlHandler.handleCreate({
+        operation: 'create_element',
+        element_type: 'template',
+        params: {
+          element_name: 'top-level-variable-template',
+          description: 'Template with top-level variable declarations',
+          content: '# Rendered\n\n{{summary}}\n\n{{details}}',
+          variables: [
+            { name: 'summary', type: 'string', required: true },
+            { name: 'details', type: 'string', required: true },
+          ],
+        },
+      });
+
+      expect(createResult.success).toBe(true);
+      await waitForCacheSettle();
+
+      const renderResult = await mcpAqlHandler.handleRead({
+        operation: 'render',
+        params: {
+          element_name: 'top-level-variable-template',
+          variables: {
+            summary: 'Smoke test summary content',
+            details: 'Smoke test details content',
+          },
+        },
+      });
+
+      expect(renderResult.success).toBe(true);
+      if (renderResult.success) {
+        const data = renderResult.data as { success?: boolean; content?: string };
+        expect(data.success).toBe(true);
+        expect(data.content).toContain('Smoke test summary content');
+        expect(data.content).toContain('Smoke test details content');
+      }
+    });
+
     it('should render a template with variables', async () => {
       const result = await mcpAqlHandler.handleRead({
         operation: 'render',

--- a/tests/unit/handlers/element-crud/createElement.helper.test.ts
+++ b/tests/unit/handlers/element-crud/createElement.helper.test.ts
@@ -239,20 +239,26 @@ describe('createElement helper', () => {
   });
 
   describe('template creation', () => {
-    it('should create template with content', async () => {
+    it('should create template with metadata routed through the metadata field', async () => {
       const result = await createElement(mockContext, {
         name: 'email-template',
         type: ElementType.TEMPLATE,
         description: 'Email template',
         content: 'Dear {{name}}, ...',
-        metadata: { variables: ['name'] },
+        metadata: {
+          category: 'email',
+          variables: [{ name: 'name', type: 'string', required: true }],
+        },
       });
 
       expect(mockContext.templateManager.create).toHaveBeenCalledWith(
         expect.objectContaining({
           content: 'Dear {{name}}, ...',
-          variables: ['name'],
-        })
+          metadata: {
+            category: 'email',
+            variables: [{ name: 'name', type: 'string', required: true }],
+          },
+        }),
       );
       expect(result.content[0].text).toContain('✅');
     });

--- a/tests/unit/handlers/mcp-aql/SchemaDispatcher.test.ts
+++ b/tests/unit/handlers/mcp-aql/SchemaDispatcher.test.ts
@@ -424,6 +424,30 @@ describe('SchemaDispatcher', () => {
       );
     });
 
+    it('should merge top-level template variables into metadata on create_element', async () => {
+      await SchemaDispatcher.dispatch(
+        'create_element',
+        {
+          element_name: 'RenderTemplate',
+          description: 'A renderable template',
+          content: 'Hello {{name}}',
+          variables: [{ name: 'name', type: 'string', required: true }],
+        },
+        registryWithElementCRUD,
+        { operation: 'create_element', elementType: 'template', params: {} }
+      );
+
+      expect(mockElementCRUD.createElement).toHaveBeenCalledWith(
+        expect.objectContaining({
+          elementName: 'RenderTemplate',
+          elementType: 'template',
+          metadata: {
+            variables: [{ name: 'name', type: 'string', required: true }],
+          },
+        })
+      );
+    });
+
     it('should throw if type cannot be resolved from any source', async () => {
       await expect(
         SchemaDispatcher.dispatch(

--- a/tests/unit/handlers/mcp-aql/SchemaDispatcher.test.ts
+++ b/tests/unit/handlers/mcp-aql/SchemaDispatcher.test.ts
@@ -448,6 +448,34 @@ describe('SchemaDispatcher', () => {
       );
     });
 
+    it('should ignore non-array top-level template variables on create_element', async () => {
+      await SchemaDispatcher.dispatch(
+        'create_element',
+        {
+          element_name: 'RenderTemplate',
+          description: 'A renderable template',
+          content: 'Hello {{name}}',
+          variables: 'name',
+        },
+        registryWithElementCRUD,
+        { operation: 'create_element', elementType: 'template', params: {} }
+      );
+
+      expect(mockElementCRUD.createElement).toHaveBeenCalledWith(
+        expect.objectContaining({
+          elementName: 'RenderTemplate',
+          elementType: 'template',
+        })
+      );
+      expect(mockElementCRUD.createElement).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            variables: 'name',
+          }),
+        })
+      );
+    });
+
     it('should throw if type cannot be resolved from any source', async () => {
       await expect(
         SchemaDispatcher.dispatch(


### PR DESCRIPTION
## Summary
- merge top-level template variable declarations into metadata during schema dispatch
- pass template metadata through the TemplateManager create contract so declared variables are persisted
- add unit and integration regression coverage for create-plus-render behavior

## Testing
- npm test -- tests/unit/handlers/mcp-aql/SchemaDispatcher.test.ts
- npm test -- tests/unit/handlers/element-crud/createElement.helper.test.ts
- npx jest --config tests/jest.integration.config.cjs tests/integration/mcp-aql/read.test.ts -t "should render a template created with top-level variable declarations" --runInBand --forceExit

Closes #1875