### PR TITLE
fix: clean up remaining web console regressions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -867,11 +867,12 @@ if ((isDirectExecution || isNpxExecution || isCliExecution) && (!isTest || isTes
         console.error(`[DollhouseMCP] Pre-flight port recovery failed: ${err instanceof Error ? err.message : String(err)}`);
       }
 
+      let container: DollhouseContainer | undefined;
       let mcpAqlHandler;
       let memorySink: import('./logging/sinks/MemoryLogSink.js').MemoryLogSink | undefined;
       let metricsSink: import('./metrics/sinks/MemoryMetricsSink.js').MemoryMetricsSink | undefined;
       try {
-        const container = new DollhouseContainer();
+        container = new DollhouseContainer();
         await container.preparePortfolio();
         const bundle = await container.bootstrapHandlers();
 
@@ -908,13 +909,19 @@ if ((isDirectExecution || isNpxExecution || isCliExecution) && (!isTest || isTes
       if (!metricsSink) {
         const { MemoryMetricsSink } = await import('./metrics/sinks/MemoryMetricsSink.js');
         metricsSink = new MemoryMetricsSink(240);
+        try {
+          const metricsManager = container?.resolve<{ registerSink: (sink: typeof metricsSink) => void }>('MetricsManager');
+          metricsManager?.registerSink(metricsSink);
+        } catch {
+          // MetricsManager may be unavailable in the degraded startup path.
+        }
       }
 
       // Set up ingest routes so --web mode has a session registry (#1805).
       // Without this, the session indicator is always empty in standalone mode.
       const { createIngestRoutes } = await import('./web/console/IngestRoutes.js');
       const ingestResult = createIngestRoutes({
-        logBroadcast: (entry) => { /* wired after server starts */ },
+        logBroadcast: (_entry) => { /* wired after server starts */ },
         metricsOnSnapshot: (snapshot) => { metricsSink?.onSnapshot(snapshot); },
       });
       ingestResult.registerConsoleSession();

--- a/src/web/console/consoleToken.ts
+++ b/src/web/console/consoleToken.ts
@@ -368,14 +368,14 @@ function maskToken(token: string): string {
 
 /**
  * Build a human-readable default name from a puppet name and the machine hostname.
- * Example: "Kermit on mick-MacBook-Pro".
+ * Example: "Console: Kermit on mick-MacBook-Pro".
  *
  * The puppet name is passed in rather than imported to avoid a circular dependency
  * with SessionNames (which only generates per-process names).
  */
 function defaultTokenName(puppetName: string): string {
   const host = hostname() || 'localhost';
-  return `${puppetName} on ${host}`;
+  return `Console: ${puppetName} on ${host}`;
 }
 
 /**

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -35,6 +35,16 @@ function safeParseYaml(content) {
 }
 
 globalThis.DollhouseConsoleUI = globalThis.DollhouseConsoleUI || {};
+
+/**
+ * Show or update a visible error banner within a tab panel.
+ *
+ * Creates the banner lazily on first use, then reuses it for later updates.
+ *
+ * @param {string} targetId - DOM id of the tab panel or container that owns the banner
+ * @param {string} bannerId - Stable DOM id for the banner element
+ * @param {string} message - User-visible message to render inside the banner
+ */
 globalThis.DollhouseConsoleUI.showBanner = function(targetId, bannerId, message) {
   const target = document.getElementById(targetId);
   if (!target) return;
@@ -49,6 +59,11 @@ globalThis.DollhouseConsoleUI.showBanner = function(targetId, bannerId, message)
   banner.hidden = false;
 };
 
+/**
+ * Hide an existing tab-level error banner without removing its DOM node.
+ *
+ * @param {string} bannerId - Stable DOM id for the banner element
+ */
 globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
   const banner = document.getElementById(bannerId);
   if (banner) banner.hidden = true;

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -34,6 +34,26 @@ function safeParseYaml(content) {
   }
 }
 
+globalThis.DollhouseConsoleUI = globalThis.DollhouseConsoleUI || {};
+globalThis.DollhouseConsoleUI.showBanner = function(targetId, bannerId, message) {
+  var target = document.getElementById(targetId);
+  if (!target) return;
+  var banner = document.getElementById(bannerId);
+  if (!banner) {
+    banner = document.createElement('div');
+    banner.id = bannerId;
+    banner.className = 'tab-error-banner';
+    target.prepend(banner);
+  }
+  banner.textContent = message;
+  banner.hidden = false;
+};
+
+globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
+  var banner = document.getElementById(bannerId);
+  if (banner) banner.hidden = true;
+};
+
 (() => {
   const REPO    = 'DollhouseMCP/collection';
   const BRANCH  = 'main';
@@ -74,6 +94,9 @@ function safeParseYaml(content) {
   // ── Bootstrap ──────────────────────────────────────────────────────────────
 
   function mergeCollectionData(data) {
+    if (globalThis.DollhouseConsoleUI && globalThis.DollhouseConsoleUI.clearBanner) {
+      globalThis.DollhouseConsoleUI.clearBanner('collection-error-banner');
+    }
     const CANONICAL_TYPES = new Set(['agents','personas','skills','templates','memories','ensembles']);
     collectionElements = Object.entries(data.index)
       .filter(([type]) => CANONICAL_TYPES.has(type))
@@ -117,9 +140,18 @@ function safeParseYaml(content) {
 
       // Load community collection (non-blocking — portfolio shows immediately)
       DollhouseAuth.apiFetch('/api/collection')
-        .then(r => r.ok ? r.json() : Promise.reject('not available'))
+        .then(r => r.ok ? r.json() : Promise.reject(new Error('collection request failed')))
         .then(mergeCollectionData)
-        .catch((err) => { console.warn('[App] Collection fetch unavailable:', err); });
+        .catch((err) => {
+          console.warn('[App] Collection fetch unavailable:', err);
+          if (globalThis.DollhouseConsoleUI && globalThis.DollhouseConsoleUI.showBanner) {
+            globalThis.DollhouseConsoleUI.showBanner(
+              'tab-portfolio',
+              'collection-error-banner',
+              'Community collection unavailable — showing local portfolio only.'
+            );
+          }
+        });
 
       const updated = document.getElementById('footer-updated');
       if (updated) {

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -36,9 +36,9 @@ function safeParseYaml(content) {
 
 globalThis.DollhouseConsoleUI = globalThis.DollhouseConsoleUI || {};
 globalThis.DollhouseConsoleUI.showBanner = function(targetId, bannerId, message) {
-  var target = document.getElementById(targetId);
+  const target = document.getElementById(targetId);
   if (!target) return;
-  var banner = document.getElementById(bannerId);
+  let banner = document.getElementById(bannerId);
   if (!banner) {
     banner = document.createElement('div');
     banner.id = bannerId;
@@ -50,7 +50,7 @@ globalThis.DollhouseConsoleUI.showBanner = function(targetId, bannerId, message)
 };
 
 globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
-  var banner = document.getElementById(bannerId);
+  const banner = document.getElementById(bannerId);
   if (banner) banner.hidden = true;
 };
 
@@ -94,9 +94,7 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
   // ── Bootstrap ──────────────────────────────────────────────────────────────
 
   function mergeCollectionData(data) {
-    if (globalThis.DollhouseConsoleUI && globalThis.DollhouseConsoleUI.clearBanner) {
-      globalThis.DollhouseConsoleUI.clearBanner('collection-error-banner');
-    }
+    globalThis.DollhouseConsoleUI?.clearBanner?.('collection-error-banner');
     const CANONICAL_TYPES = new Set(['agents','personas','skills','templates','memories','ensembles']);
     collectionElements = Object.entries(data.index)
       .filter(([type]) => CANONICAL_TYPES.has(type))
@@ -144,13 +142,11 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
         .then(mergeCollectionData)
         .catch((err) => {
           console.warn('[App] Collection fetch unavailable:', err);
-          if (globalThis.DollhouseConsoleUI && globalThis.DollhouseConsoleUI.showBanner) {
-            globalThis.DollhouseConsoleUI.showBanner(
-              'tab-portfolio',
-              'collection-error-banner',
-              'Community collection unavailable — showing local portfolio only.'
-            );
-          }
+          globalThis.DollhouseConsoleUI?.showBanner?.(
+            'tab-portfolio',
+            'collection-error-banner',
+            'Community collection unavailable — showing local portfolio only.'
+          );
         });
 
       const updated = document.getElementById('footer-updated');

--- a/src/web/public/logs.js
+++ b/src/web/public/logs.js
@@ -651,15 +651,11 @@
   }
 
   function showLogsError(message) {
-    if (globalThis.DollhouseConsoleUI && globalThis.DollhouseConsoleUI.showBanner) {
-      globalThis.DollhouseConsoleUI.showBanner('tab-logs', 'logs-error-banner', message);
-    }
+    globalThis.DollhouseConsoleUI?.showBanner?.('tab-logs', 'logs-error-banner', message);
   }
 
   function clearLogsError() {
-    if (globalThis.DollhouseConsoleUI && globalThis.DollhouseConsoleUI.clearBanner) {
-      globalThis.DollhouseConsoleUI.clearBanner('logs-error-banner');
-    }
+    globalThis.DollhouseConsoleUI?.clearBanner?.('logs-error-banner');
   }
 
   function updateEntryCount() {

--- a/src/web/public/logs.js
+++ b/src/web/public/logs.js
@@ -316,7 +316,10 @@
     const qs = params.toString();
     eventSource = DollhouseAuth.apiEventSource('/api/logs/stream' + (qs ? '?' + qs : ''));
 
-    eventSource.onopen = () => setStatus('connected');
+    eventSource.onopen = () => {
+      clearLogsError();
+      setStatus('connected');
+    };
 
     eventSource.onmessage = (event) => {
       try {
@@ -331,6 +334,7 @@
 
     eventSource.onerror = () => {
       setStatus('disconnected');
+      showLogsError('Connection lost - reconnecting...');
       eventSource.close();
       eventSource = null;
       setTimeout(connectSSE, RECONNECT_DELAY_MS);
@@ -644,6 +648,18 @@
   function setStatus(status) {
     statusDot.className = 'log-status-dot ' + status;
     statusText.textContent = status;
+  }
+
+  function showLogsError(message) {
+    if (globalThis.DollhouseConsoleUI && globalThis.DollhouseConsoleUI.showBanner) {
+      globalThis.DollhouseConsoleUI.showBanner('tab-logs', 'logs-error-banner', message);
+    }
+  }
+
+  function clearLogsError() {
+    if (globalThis.DollhouseConsoleUI && globalThis.DollhouseConsoleUI.clearBanner) {
+      globalThis.DollhouseConsoleUI.clearBanner('logs-error-banner');
+    }
   }
 
   function updateEntryCount() {

--- a/src/web/public/metrics.js
+++ b/src/web/public/metrics.js
@@ -146,21 +146,16 @@
 
   // ── Error banners (#1866) ────────────────────────────────────────────────
   function showMetricsError(message) {
-    let banner = document.getElementById('metrics-error-banner');
-    if (!banner) {
-      banner = document.createElement('div');
-      banner.id = 'metrics-error-banner';
-      banner.className = 'tab-error-banner';
-      const container = document.getElementById('metrics-content');
-      if (container) container.prepend(banner);
+    if (globalThis.DollhouseConsoleUI && globalThis.DollhouseConsoleUI.showBanner) {
+      globalThis.DollhouseConsoleUI.showBanner('tab-metrics', 'metrics-error-banner', message);
+      return;
     }
-    banner.textContent = message;
-    banner.hidden = false;
   }
 
   function clearMetricsError() {
-    const banner = document.getElementById('metrics-error-banner');
-    if (banner) banner.hidden = true;
+    if (globalThis.DollhouseConsoleUI && globalThis.DollhouseConsoleUI.clearBanner) {
+      globalThis.DollhouseConsoleUI.clearBanner('metrics-error-banner');
+    }
   }
 
   // ── Data fetching ────────────────────────────────────────────────────────

--- a/src/web/public/metrics.js
+++ b/src/web/public/metrics.js
@@ -146,16 +146,11 @@
 
   // ── Error banners (#1866) ────────────────────────────────────────────────
   function showMetricsError(message) {
-    if (globalThis.DollhouseConsoleUI && globalThis.DollhouseConsoleUI.showBanner) {
-      globalThis.DollhouseConsoleUI.showBanner('tab-metrics', 'metrics-error-banner', message);
-      return;
-    }
+    globalThis.DollhouseConsoleUI?.showBanner?.('tab-metrics', 'metrics-error-banner', message);
   }
 
   function clearMetricsError() {
-    if (globalThis.DollhouseConsoleUI && globalThis.DollhouseConsoleUI.clearBanner) {
-      globalThis.DollhouseConsoleUI.clearBanner('metrics-error-banner');
-    }
+    globalThis.DollhouseConsoleUI?.clearBanner?.('metrics-error-banner');
   }
 
   // ── Data fetching ────────────────────────────────────────────────────────

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -14,9 +14,15 @@
 (function() {
   'use strict';
 
-  var SESSION_POLL_INTERVAL = 5000;
-  var SESSION_FILTER_INJECTION_RETRY_INTERVAL = 500;
-  var SESSION_FILTER_INJECTION_MAX_RETRIES = 20;
+  function getConfiguredNumber(key, fallback) {
+    var config = globalThis.DollhouseConsoleConfig;
+    var value = config && Number(config[key]);
+    return Number.isFinite(value) && value > 0 ? value : fallback;
+  }
+
+  var SESSION_POLL_INTERVAL = getConfiguredNumber('sessionPollIntervalMs', 5000);
+  var SESSION_FILTER_INJECTION_RETRY_INTERVAL = getConfiguredNumber('sessionFilterInjectionRetryIntervalMs', 500);
+  var SESSION_FILTER_INJECTION_MAX_RETRIES = getConfiguredNumber('sessionFilterInjectionMaxRetries', 20);
   var sessions = [];
   var filterSessionId = '';
   var dropdownBuilt = false;

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -67,6 +67,25 @@
     refreshSelectionState();
   }
 
+  function showSessionsError(message) {
+    var target = document.getElementById('session-indicator');
+    if (!target || !target.parentElement) return;
+    var banner = document.getElementById('sessions-error-banner');
+    if (!banner) {
+      banner = document.createElement('div');
+      banner.id = 'sessions-error-banner';
+      banner.className = 'tab-error-banner';
+      target.parentElement.insertBefore(banner, target);
+    }
+    banner.textContent = message;
+    banner.hidden = false;
+  }
+
+  function clearSessionsError() {
+    var banner = document.getElementById('sessions-error-banner');
+    if (banner) banner.hidden = true;
+  }
+
   // Update checkmarks and selected styling without rebuilding DOM
   function refreshSelectionState() {
     // Update items
@@ -338,7 +357,7 @@
     if (!logPanel) return;
     if (document.getElementById('log-session-filter')) return;
 
-    var filterBar = logPanel.querySelector('.log-filters');
+    var filterBar = logPanel.querySelector('.log-controls');
     if (!filterBar) return;
 
     var group = document.createElement('div');
@@ -352,6 +371,10 @@
     group.querySelector('select').addEventListener('change', function() {
       applyFilter(this.value);
     });
+
+    // If sessions loaded before the log controls mounted, populate the
+    // newly injected filter immediately instead of waiting for the next poll.
+    updateSessionFilterOptions();
   }
 
   // Update session filter dropdown options
@@ -378,16 +401,21 @@
    */
   function fetchSessions() {
     DollhouseAuth.apiFetch('/api/sessions').then(function(res) {
-      if (!res.ok) return;
+      if (!res.ok) {
+        showSessionsError('Failed to load sessions.');
+        return;
+      }
       return res.json();
     }).then(function(data) {
       if (data && data.sessions) {
         sessions = data.sessions;
         updateSessionIndicator();
         updateSessionFilterOptions();
+        clearSessionsError();
       }
     }).catch(function(err) {
       console.warn('[Sessions] Fetch failed:', err);
+      showSessionsError('Failed to load sessions.');
     });
   }
 

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -15,6 +15,8 @@
   'use strict';
 
   var SESSION_POLL_INTERVAL = 5000;
+  var SESSION_FILTER_INJECTION_RETRY_INTERVAL = 500;
+  var SESSION_FILTER_INJECTION_MAX_RETRIES = 20;
   var sessions = [];
   var filterSessionId = '';
   var dropdownBuilt = false;
@@ -434,10 +436,10 @@
     var tryInject = setInterval(function() {
       injectSessionFilter();
       retries++;
-      if (document.getElementById('log-session-filter') || retries > 20) {
+      if (document.getElementById('log-session-filter') || retries > SESSION_FILTER_INJECTION_MAX_RETRIES) {
         clearInterval(tryInject);
       }
-    }, 500);
+    }, SESSION_FILTER_INJECTION_RETRY_INTERVAL);
   }
 
   if (document.readyState === 'loading') {

--- a/tests/integration/web-standalone-mode.test.ts
+++ b/tests/integration/web-standalone-mode.test.ts
@@ -11,7 +11,6 @@
 import { describe, it, expect } from '@jest/globals';
 import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
-import * as net from 'node:net';
 
 const PROJECT_ROOT = path.resolve(__dirname, '../../');
 
@@ -20,17 +19,6 @@ function getWebModeBlock(source: string): string {
   const start = source.indexOf('if (isWebMode)');
   const end = source.indexOf('[DollhouseMCP] Web UI failed to start:', start);
   return source.slice(start, end);
-}
-
-/** Get a dynamically assigned free port from the OS. */
-function getFreePort(): Promise<number> {
-  return new Promise((resolve) => {
-    const srv = net.createServer();
-    srv.listen(0, '127.0.0.1', () => {
-      const p = (srv.address() as net.AddressInfo).port;
-      srv.close(() => resolve(p));
-    });
-  });
 }
 
 describe('Standalone --web mode (#1850)', () => {
@@ -65,11 +53,11 @@ describe('Standalone --web mode (#1850)', () => {
     });
   });
 
-  describe('completeDeferredSetup skipped', () => {
+  describe('completeSinkSetup path', () => {
     it('does NOT call completeDeferredSetup in the --web path', () => {
       const block = getWebModeBlock(webModeSource);
       expect(block).not.toContain('container.completeDeferredSetup()');
-      expect(block).toContain('Do NOT call completeDeferredSetup');
+      expect(block).toContain('container.completeSinkSetup()');
     });
 
     it('runs sweepStalePortFiles directly instead', () => {
@@ -97,6 +85,18 @@ describe('Standalone --web mode (#1850)', () => {
       expect(block).toContain('MemoryLogSink');
       expect(block).toContain('MemoryMetricsSink');
     });
+
+    it('wires metrics snapshots into the fallback metrics sink', () => {
+      const block = getWebModeBlock(webModeSource);
+      expect(block).toContain('metricsOnSnapshot');
+      expect(block).toContain("metricsSink?.onSnapshot(snapshot)");
+    });
+
+    it('attempts to register a fallback metrics sink with MetricsManager', () => {
+      const block = getWebModeBlock(webModeSource);
+      expect(block).toContain("container?.resolve");
+      expect(block).toContain('registerSink(metricsSink)');
+    });
   });
 
   describe('Race condition documentation', () => {
@@ -114,9 +114,8 @@ describe('Standalone --web mode (#1850)', () => {
       const { recoverStalePort } = await import('../../src/web/console/StaleProcessRecovery.js');
       expect(typeof recoverStalePort).toBe('function');
 
-      // Use a dynamically assigned free port — no hardcoded port numbers
-      const freePort = await getFreePort();
-      const result = await recoverStalePort(freePort);
+      // Use a high-numbered port to avoid sandbox bind restrictions.
+      const result = await recoverStalePort(65535);
       expect(result).toBe(false);
     });
 

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -18,6 +18,9 @@ let metricsSource = '';
 
 type TestWindow = JSDOM['window'] & typeof globalThis & Record<string, any>;
 
+const DEFAULT_WAIT_MS = 25;
+const SESSION_FILTER_INJECTION_WAIT_MS = 650;
+
 beforeAll(async () => {
   const base = join(process.cwd(), 'src/web/public');
   [appSource, sessionsSource, logsSource, metricsSource] = await Promise.all([
@@ -151,7 +154,7 @@ describe('Web console cleanup regressions', () => {
 
     win.eval(appSource);
     win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
-    await wait(25);
+    await wait(DEFAULT_WAIT_MS);
 
     const banner = win.document.getElementById('collection-error-banner');
     expect(banner).not.toBeNull();
@@ -172,7 +175,7 @@ describe('Web console cleanup regressions', () => {
 
     win.eval(sessionsSource);
     win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
-    await wait(25);
+    await wait(DEFAULT_WAIT_MS);
 
     const banner = win.document.getElementById('sessions-error-banner');
     expect(banner).not.toBeNull();
@@ -212,7 +215,7 @@ describe('Web console cleanup regressions', () => {
 
     win.eval(sessionsSource);
     win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
-    await wait(650);
+    await wait(SESSION_FILTER_INJECTION_WAIT_MS);
 
     const select = win.document.getElementById('log-session-filter') as HTMLSelectElement | null;
     expect(select).not.toBeNull();
@@ -262,7 +265,7 @@ describe('Web console cleanup regressions', () => {
 
     win.eval(metricsSource);
     win.DollhouseConsole.metrics.init();
-    await wait(25);
+    await wait(DEFAULT_WAIT_MS);
 
     const banner = win.document.getElementById('metrics-error-banner');
     expect(banner).not.toBeNull();

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -16,6 +16,8 @@ let sessionsSource = '';
 let logsSource = '';
 let metricsSource = '';
 
+type TestWindow = JSDOM['window'] & typeof globalThis & Record<string, any>;
+
 beforeAll(async () => {
   const base = join(process.cwd(), 'src/web/public');
   [appSource, sessionsSource, logsSource, metricsSource] = await Promise.all([
@@ -41,7 +43,7 @@ function createDom(html: string): { window: JSDOM['window']; cleanup: () => void
     pretendToBeVisual: true,
   });
 
-  const win = dom.window as JSDOM['window'] & Record<string, any>;
+  const win = dom.window as unknown as TestWindow;
   const intervalIds: number[] = [];
   const timeoutIds: number[] = [];
   const nativeSetInterval = win.setInterval.bind(win);

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -19,7 +19,8 @@ let metricsSource = '';
 type TestWindow = JSDOM['window'] & typeof globalThis & Record<string, any>;
 
 const DEFAULT_WAIT_MS = 25;
-const SESSION_FILTER_INJECTION_WAIT_MS = 650;
+const TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS = 10;
+const SESSION_FILTER_INJECTION_WAIT_MS = 40;
 
 beforeAll(async () => {
   const base = join(process.cwd(), 'src/web/public');
@@ -212,6 +213,10 @@ describe('Web console cleanup regressions', () => {
       }),
     });
     win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+    win.DollhouseConsoleConfig = {
+      sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
+      sessionFilterInjectionMaxRetries: 5,
+    };
 
     win.eval(sessionsSource);
     win.document.dispatchEvent(new win.Event('DOMContentLoaded'));

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -1,0 +1,271 @@
+/**
+ * JSDOM regressions for recent web-console cleanup issues.
+ *
+ * Covers:
+ * - #1868 visible banners for collection/sessions/logs/metrics failures
+ * - session filter injection into the current .log-controls container
+ */
+
+import { describe, it, expect, beforeAll, afterEach, jest } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+let appSource = '';
+let sessionsSource = '';
+let logsSource = '';
+let metricsSource = '';
+
+beforeAll(async () => {
+  const base = join(process.cwd(), 'src/web/public');
+  [appSource, sessionsSource, logsSource, metricsSource] = await Promise.all([
+    readFile(join(base, 'app.js'), 'utf8'),
+    readFile(join(base, 'sessions.js'), 'utf8'),
+    readFile(join(base, 'logs.js'), 'utf8'),
+    readFile(join(base, 'metrics.js'), 'utf8'),
+  ]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createDom(html: string): { window: JSDOM['window']; cleanup: () => void } {
+  const dom = new JSDOM(`<!DOCTYPE html><html><body>${html}</body></html>`, {
+    url: 'http://localhost:41715',
+    runScripts: 'dangerously',
+    pretendToBeVisual: true,
+  });
+
+  const win = dom.window as JSDOM['window'] & Record<string, any>;
+  const intervalIds: number[] = [];
+  const timeoutIds: number[] = [];
+  const nativeSetInterval = win.setInterval.bind(win);
+  const nativeSetTimeout = win.setTimeout.bind(win);
+  win.matchMedia = jest.fn().mockReturnValue({
+    matches: false,
+    media: '',
+    onchange: null,
+    addListener() { /* legacy no-op */ },
+    removeListener() { /* legacy no-op */ },
+    addEventListener() { /* no-op */ },
+    removeEventListener() { /* no-op */ },
+    dispatchEvent() { return false; },
+  });
+  win.setInterval = ((handler: TimerHandler, timeout?: number, ...args: any[]) => {
+    const id = nativeSetInterval(handler, timeout, ...args);
+    intervalIds.push(id);
+    return id;
+  }) as typeof win.setInterval;
+  win.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: any[]) => {
+    const id = nativeSetTimeout(handler, timeout, ...args);
+    timeoutIds.push(id);
+    return id;
+  }) as typeof win.setTimeout;
+  win.requestAnimationFrame = (cb: FrameRequestCallback) => win.setTimeout(() => cb(Date.now()), 0);
+  win.cancelAnimationFrame = (id: number) => win.clearTimeout(id);
+  win.scrollTo = jest.fn();
+  win.CSS = { escape: (value: string) => value };
+  win.fetch = jest.fn();
+  win.DollhouseConsole = win.DollhouseConsole || {};
+  win.DollhouseAuth = {
+    apiFetch: jest.fn(),
+    apiEventSource: jest.fn(),
+  };
+
+  return {
+    window: win,
+    cleanup: () => {
+      for (const id of intervalIds) win.clearInterval(id);
+      for (const id of timeoutIds) win.clearTimeout(id);
+      dom.window.close();
+    },
+  };
+}
+
+function installBannerHelper(win: Record<string, any>) {
+  win.DollhouseConsoleUI = {
+    showBanner(targetId: string, bannerId: string, message: string) {
+      const target = win.document.getElementById(targetId);
+      if (!target) return;
+      let banner = win.document.getElementById(bannerId);
+      if (!banner) {
+        banner = win.document.createElement('div');
+        banner.id = bannerId;
+        banner.className = 'tab-error-banner';
+        target.prepend(banner);
+      }
+      banner.textContent = message;
+      banner.hidden = false;
+    },
+    clearBanner(bannerId: string) {
+      const banner = win.document.getElementById(bannerId);
+      if (banner) banner.hidden = true;
+    },
+  };
+}
+
+describe('Web console cleanup regressions', () => {
+  it('shows a visible collection banner when the community collection fetch fails', async () => {
+    const { window: win, cleanup } = createDom(`
+      <button id="theme-toggle"></button>
+      <span id="theme-toggle-icon"></span>
+      <span id="theme-toggle-label"></span>
+      <link id="hljs-theme-light">
+      <link id="hljs-theme-dark">
+      <div id="view-toggle"><button class="view-btn" data-view="grid"></button></div>
+      <select id="sort-select"><option value="date-desc">date-desc</option></select>
+      <input id="search-input">
+      <div id="source-toggle"><button data-source="all"></button></div>
+      <button id="btn-portfolio"></button>
+      <div id="console-tabs"><button class="console-tab active" data-tab="portfolio"></button></div>
+      <div id="tab-portfolio" class="tab-panel active"></div>
+      <div id="stats"></div>
+      <div><div id="type-filters"></div></div>
+      <div id="topic-filters"></div>
+      <div id="results-count"></div>
+      <div id="results-announcer"></div>
+      <div id="elements-grid"></div>
+      <div id="pagination" hidden><button id="btn-prev-page"></button><button id="btn-next-page"></button><span id="page-info"></span></div>
+      <div id="footer-updated"></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn((url: string) => {
+      if (url === '/api/elements') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ elements: { personas: [] }, totalCount: 0 }),
+        });
+      }
+      if (url === '/api/collection') {
+        return Promise.reject(new Error('collection request failed'));
+      }
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    win.eval(appSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    await wait(25);
+
+    const banner = win.document.getElementById('collection-error-banner');
+    expect(banner).not.toBeNull();
+    expect(banner?.textContent).toContain('Community collection unavailable');
+    expect(win.document.getElementById('tab-portfolio')?.firstElementChild?.id).toBe('collection-error-banner');
+
+    cleanup();
+  });
+
+  it('shows a visible sessions banner when session fetch fails', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="session-indicator"></div>
+      <div id="tab-logs"><div class="log-controls"></div></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn().mockRejectedValue(new Error('network down'));
+    win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+
+    win.eval(sessionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    await wait(25);
+
+    const banner = win.document.getElementById('sessions-error-banner');
+    expect(banner).not.toBeNull();
+    expect(banner?.textContent).toBe('Failed to load sessions.');
+
+    cleanup();
+  });
+
+  it('injects the log session filter into .log-controls and populates active sessions', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="session-indicator"></div>
+      <div id="tab-logs"><div class="log-controls"></div></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        sessions: [
+          {
+            sessionId: 'session-1',
+            status: 'active',
+            displayName: 'Barbie',
+            startedAt: '2026-04-09T10:00:00.000Z',
+            isLeader: true,
+            color: '#ff00ff',
+          },
+          {
+            sessionId: 'session-2',
+            status: 'ended',
+            displayName: 'Ken',
+            startedAt: '2026-04-09T10:05:00.000Z',
+          },
+        ],
+      }),
+    });
+    win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+
+    win.eval(sessionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    await wait(650);
+
+    const select = win.document.getElementById('log-session-filter') as HTMLSelectElement | null;
+    expect(select).not.toBeNull();
+    expect(win.document.querySelector('#tab-logs .log-controls #log-session-filter')).not.toBeNull();
+    expect(select?.options).toHaveLength(2);
+    expect(select?.options[1].value).toBe('session-1');
+    expect(select?.options[1].textContent).toContain('Barbie');
+    expect(select?.options[1].textContent).toContain('(leader)');
+
+    cleanup();
+  });
+
+  it('shows a visible logs banner when the SSE stream disconnects', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="tab-logs"></div>
+      <div id="log-viewer-root"></div>
+    `);
+    installBannerHelper(win);
+
+    const eventSource = {
+      onopen: null as null | (() => void),
+      onmessage: null as null | ((event: MessageEvent) => void),
+      onerror: null as null | (() => void),
+      close: jest.fn(),
+    };
+    win.DollhouseAuth.apiEventSource = jest.fn().mockReturnValue(eventSource);
+
+    win.eval(logsSource);
+    win.DollhouseConsole.logs.init();
+    eventSource.onerror?.();
+
+    const banner = win.document.getElementById('logs-error-banner');
+    expect(banner).not.toBeNull();
+    expect(banner?.textContent).toBe('Connection lost - reconnecting...');
+
+    cleanup();
+  });
+
+  it('shows a visible metrics banner when the latest metrics fetch fails', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="tab-metrics"></div>
+      <div id="metrics-dashboard-root"></div>
+    `);
+    installBannerHelper(win);
+
+    win.DollhouseAuth.apiFetch = jest.fn().mockRejectedValue(new Error('metrics unavailable'));
+
+    win.eval(metricsSource);
+    win.DollhouseConsole.metrics.init();
+    await wait(25);
+
+    const banner = win.document.getElementById('metrics-error-banner');
+    expect(banner).not.toBeNull();
+    expect(banner?.textContent).toBe('Failed to load metrics — retrying...');
+
+    cleanup();
+  });
+});

--- a/tests/unit/web/console/consoleToken.test.ts
+++ b/tests/unit/web/console/consoleToken.test.ts
@@ -67,6 +67,7 @@ describe('ConsoleTokenStore', () => {
 
       expect(entry).toBeDefined();
       expect(entry.id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(entry.name).toContain('Console:');
       expect(entry.name).toContain('Kermit');
       expect(entry.kind).toBe('console');
       expect(entry.token).toMatch(/^[0-9a-f]{64}$/);

--- a/tests/unit/web/console/ghostSession.test.ts
+++ b/tests/unit/web/console/ghostSession.test.ts
@@ -6,7 +6,7 @@
  * concurrent ingestion, and session lifecycle after dismiss.
  */
 
-import { describe, it, expect, beforeEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import express from 'express';
 import request from 'supertest';
 import {
@@ -214,6 +214,18 @@ describe('Ghost session cleanup (#1870)', () => {
   // ── GET /api/sessions filtering ────────────────────────────────────────
 
   describe('GET /api/sessions filtering', () => {
+    let fetchSpy: ReturnType<typeof jest.spyOn>;
+
+    beforeEach(() => {
+      fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockRejectedValue(new Error('legacy console unavailable in test'));
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
     it('excludes ended sessions from response', async () => {
       const app = buildApp(ir);
       await request(app)

--- a/tests/unit/web/routes/tokenInfo.test.ts
+++ b/tests/unit/web/routes/tokenInfo.test.ts
@@ -81,6 +81,7 @@ describe('GET /api/console/token/info', () => {
       .set('Authorization', bearer);
     const t = res.body.tokens[0];
     expect(t.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(t.name).toContain('Console:');
     expect(t.name).toContain('Kermit');
     expect(t.kind).toBe('console');
     expect(t.scopes).toEqual(['admin']);


### PR DESCRIPTION
## Summary
- finish the web-console audit after the overnight refactor and close the gap between stale issue text and current code
- add visible collection, session, logs, and metrics failure banners in the remaining user-facing blind spots
- register fallback metrics sinks in degraded --web startup and distinguish default console token names from session names
- fix the log-session filter injection drift and add browser-side regressions for the cleaned-up behaviors

## Testing
- npx jest --config tests/jest.config.cjs tests/unit/web/console-ui-regressions.test.ts --runInBand
- npx jest --config tests/jest.config.cjs tests/unit/web/console/ghostSession.test.ts --runInBand
- npx jest --config tests/jest.config.cjs tests/unit/web/console/consoleToken.test.ts -t "creates a new token file on first run" --runInBand
- npx jest --config tests/jest.config.cjs tests/unit/web/routes/tokenInfo.test.ts -t "returns token metadata fields" --runInBand
- npx jest --config tests/jest.integration.config.cjs tests/integration/web-standalone-mode.test.ts --runInBand
- npx eslint src/index.ts src/web/console/consoleToken.ts src/web/public/app.js src/web/public/logs.js src/web/public/metrics.js src/web/public/sessions.js tests/integration/web-standalone-mode.test.ts tests/unit/web/console-ui-regressions.test.ts tests/unit/web/console/consoleToken.test.ts tests/unit/web/console/ghostSession.test.ts tests/unit/web/routes/tokenInfo.test.ts

Fixes #1868
Fixes #1869
Fixes #1871