### PR TITLE
feat: session identity foundation for multi-user HTTP support

### DIFF
--- a/src/context/ContextPolicy.ts
+++ b/src/context/ContextPolicy.ts
@@ -1,0 +1,97 @@
+/**
+ * Context Policy Helpers for DollhouseMCP
+ *
+ * Provides safe access patterns for SessionContext throughout the codebase.
+ * Consumers should prefer getSessionOrSystem() for non-critical paths and
+ * requireSessionContext() (via ContextTracker) for paths that must have a
+ * real session.
+ *
+ * STRICT MODE: When NODE_ENV !== 'production' OR DOLLHOUSE_STRICT_CONTEXT
+ * is 'true', getSessionOrSystem() emits a warning when it falls back to
+ * SYSTEM_CONTEXT. This helps detect missing session wiring during development
+ * without breaking production behaviour.
+ *
+ * @module context/ContextPolicy
+ */
+
+import type { SessionContext } from './SessionContext.js';
+import type { ContextTracker } from '../security/encryption/ContextTracker.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Sentinel SessionContext used when no real session is active.
+ *
+ * Represents an internal system operation with no user identity.
+ * Returned by getSessionOrSystem() when called outside a session context.
+ */
+export const SYSTEM_CONTEXT: Readonly<SessionContext> = Object.freeze({
+  userId: 'system',
+  sessionId: 'system',
+  tenantId: null,
+  transport: 'stdio' as const,
+  createdAt: 0,
+});
+
+/**
+ * Thrown by ContextTracker.requireSessionContext() when called outside
+ * an active session context.
+ */
+export class SessionContextRequiredError extends Error {
+  /** Caller name provided at construction, if any. */
+  public readonly caller: string | undefined;
+
+  /**
+   * @param caller - Optional caller identifier for debugging (e.g. 'PersonaManager.activate')
+   */
+  constructor(caller?: string) {
+    const detail = caller ? ` (called from: ${caller})` : '';
+    super(`SessionContext required but no session is active${detail}`);
+    this.name = 'SessionContextRequiredError';
+    this.caller = caller;
+  }
+}
+
+/**
+ * Determines whether strict context checking is active.
+ *
+ * Strict mode is enabled in all non-production environments and
+ * in production when DOLLHOUSE_STRICT_CONTEXT=true is explicitly set.
+ *
+ * @returns true when strict mode warnings should be emitted
+ */
+export function isStrictMode(): boolean {
+  return (
+    process.env['NODE_ENV'] !== 'production' ||
+    process.env['DOLLHOUSE_STRICT_CONTEXT'] === 'true'
+  );
+}
+
+/**
+ * Returns the current SessionContext from the tracker, or SYSTEM_CONTEXT
+ * if no session is active.
+ *
+ * In strict mode, emits a warning when falling back to SYSTEM_CONTEXT so
+ * that missing session wiring is visible during development.
+ *
+ * @param tracker - The ContextTracker instance to query
+ * @param caller - Optional caller name for warning messages
+ * @returns The active SessionContext, or SYSTEM_CONTEXT as fallback
+ */
+export function getSessionOrSystem(
+  tracker: ContextTracker,
+  caller?: string
+): SessionContext {
+  const session = tracker.getSessionContext();
+  if (session !== undefined) {
+    return session;
+  }
+
+  if (isStrictMode()) {
+    const callerInfo = caller ? ` [${caller}]` : '';
+    logger.warn(
+      `[ContextPolicy]${callerInfo} No SessionContext active — falling back to SYSTEM_CONTEXT`
+    );
+  }
+
+  return SYSTEM_CONTEXT;
+}

--- a/src/context/SessionContext.ts
+++ b/src/context/SessionContext.ts
@@ -42,3 +42,14 @@ export interface SessionContext {
   /** Email address, if available from auth provider. */
   readonly email?: string;
 }
+
+/**
+ * Resolves a SessionContext for an incoming MCP request.
+ *
+ * For stdio transport: a constant function returning the single stdio session.
+ * For HTTP transport (future): extracts session from authenticated connection metadata.
+ *
+ * The parameter type uses `unknown` rather than a concrete MCP SDK type to keep
+ * the context module free of MCP SDK dependencies.
+ */
+export type SessionResolver = (request: unknown) => SessionContext;

--- a/src/context/SessionContext.ts
+++ b/src/context/SessionContext.ts
@@ -1,0 +1,44 @@
+/**
+ * Session Context for DollhouseMCP
+ *
+ * Provides identity and transport information for the current MCP session.
+ * Used by ContextTracker to associate execution contexts with authenticated
+ * sessions, enabling per-user audit trails and future multi-tenant support.
+ *
+ * All fields are readonly. Instances are Object.freeze()'d at creation time
+ * by ContextTracker.createSessionContext() and StdioSession.createStdioSession().
+ *
+ * @module context/SessionContext
+ */
+
+/**
+ * Immutable identity and transport metadata for an MCP session.
+ *
+ * Created once at session initialization and propagated via AsyncLocalStorage
+ * through ContextTracker.
+ */
+export interface SessionContext {
+  /** Stable user identifier. 'local-user' for stdio, JWT sub for HTTP. */
+  readonly userId: string;
+
+  /** Per-session correlation ID. 'default' for stdio, UUID for HTTP. */
+  readonly sessionId: string;
+
+  /**
+   * Tenant identifier for multi-tenant HTTP deployments.
+   * Always null for stdio transport and single-tenant deployments.
+   */
+  readonly tenantId: string | null;
+
+  /** Transport layer this session is running over. */
+  readonly transport: 'stdio' | 'http';
+
+  /** Unix timestamp (ms) when the session was created. */
+  readonly createdAt: number;
+
+  /** Human-readable display name, if available. */
+  readonly displayName?: string;
+
+  /** Email address, if available from auth provider. */
+  readonly email?: string;
+}

--- a/src/context/StdioSession.ts
+++ b/src/context/StdioSession.ts
@@ -1,0 +1,40 @@
+/**
+ * Stdio Session Factory for DollhouseMCP
+ *
+ * Creates a SessionContext for stdio transport (the default MCP transport
+ * used by Claude Desktop, Claude Code CLI, and local development).
+ *
+ * Environment variable sources:
+ * - DOLLHOUSE_USER: userId (default: 'local-user')
+ * - DOLLHOUSE_SESSION_ID: sessionId (default: 'default')
+ *
+ * The sessionId default 'default' matches existing ActivationStore behavior,
+ * preserving the activations-default.json persistence file across restarts.
+ *
+ * @module context/StdioSession
+ */
+
+import type { SessionContext } from './SessionContext.js';
+
+/**
+ * Creates a frozen SessionContext for the current stdio session.
+ *
+ * Reads DOLLHOUSE_USER and DOLLHOUSE_SESSION_ID from the environment.
+ * Falls back to 'local-user' and 'default' respectively when unset.
+ *
+ * @returns Frozen SessionContext for stdio transport
+ */
+export function createStdioSession(): Readonly<SessionContext> {
+  const userId =
+    process.env['DOLLHOUSE_USER']?.trim() || 'local-user';
+  const sessionId =
+    process.env['DOLLHOUSE_SESSION_ID']?.trim() || 'default';
+
+  return Object.freeze<SessionContext>({
+    userId,
+    sessionId,
+    tenantId: null,
+    transport: 'stdio',
+    createdAt: Date.now(),
+  });
+}

--- a/src/context/StdioSession.ts
+++ b/src/context/StdioSession.ts
@@ -17,16 +17,24 @@
 import type { SessionContext } from './SessionContext.js';
 
 /**
+ * Default userId when DOLLHOUSE_USER is not set.
+ * Used by identity migration (Step 1.5) to distinguish default stdio sessions
+ * from sessions with explicitly-set identity. Temporary — removed in Phase 3
+ * when SessionContext becomes the sole identity authority.
+ */
+export const STDIO_DEFAULT_USER_ID = 'local-user';
+
+/**
  * Creates a frozen SessionContext for the current stdio session.
  *
  * Reads DOLLHOUSE_USER and DOLLHOUSE_SESSION_ID from the environment.
- * Falls back to 'local-user' and 'default' respectively when unset.
+ * Falls back to STDIO_DEFAULT_USER_ID and 'default' respectively when unset.
  *
  * @returns Frozen SessionContext for stdio transport
  */
 export function createStdioSession(): Readonly<SessionContext> {
   const userId =
-    process.env['DOLLHOUSE_USER']?.trim() || 'local-user';
+    process.env['DOLLHOUSE_USER']?.trim() || STDIO_DEFAULT_USER_ID;
   const sessionId =
     process.env['DOLLHOUSE_SESSION_ID']?.trim() || 'default';
 

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Context Module for DollhouseMCP
+ *
+ * Exports session context types, policy helpers, and transport-specific
+ * session factories.
+ *
+ * @module context
+ */
+
+// Types
+export type { SessionContext } from './SessionContext.js';
+
+// Policy: sentinel, error class, helpers
+export {
+  SYSTEM_CONTEXT,
+  SessionContextRequiredError,
+  isStrictMode,
+  getSessionOrSystem,
+} from './ContextPolicy.js';
+
+// Transport factories
+export { createStdioSession } from './StdioSession.js';

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -8,7 +8,7 @@
  */
 
 // Types
-export type { SessionContext } from './SessionContext.js';
+export type { SessionContext, SessionResolver } from './SessionContext.js';
 
 // Policy: sentinel, error class, helpers
 export {

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -18,5 +18,5 @@ export {
   getSessionOrSystem,
 } from './ContextPolicy.js';
 
-// Transport factories
-export { createStdioSession } from './StdioSession.js';
+// Transport factories and constants
+export { createStdioSession, STDIO_DEFAULT_USER_ID } from './StdioSession.js';

--- a/src/di/Container.ts
+++ b/src/di/Container.ts
@@ -576,10 +576,17 @@ export class DollhouseContainer {
     this.register('DangerZoneEnforcer', () => new DangerZoneEnforcer(
       this.resolve('FileOperationsService')
     ));
+    // Shared stdio session — single source of truth for session identity
+    this.register('StdioSession', () => createStdioSession());
     // Issue #598: ActivationStore for per-session activation persistence
-    this.register('ActivationStore', () => new ActivationStore(
-      this.resolve('FileOperationsService')
-    ));
+    this.register('ActivationStore', () => {
+      const session = this.resolve<ReturnType<typeof createStdioSession>>('StdioSession');
+      return new ActivationStore(
+        this.resolve('FileOperationsService'),
+        undefined,
+        session.sessionId
+      );
+    });
     // Issue #142: VerificationStore for danger zone challenge codes (server-side)
     this.register('VerificationStore', () => new VerificationStore());
     // Issue #522: Non-blocking OS dialog notifier for verification codes
@@ -716,7 +723,7 @@ export class DollhouseContainer {
 
     // SERVER
     this.register('ServerSetup', () => {
-      const stdioSession = createStdioSession();
+      const stdioSession = this.resolve<ReturnType<typeof createStdioSession>>('StdioSession');
       const sessionResolver: SessionResolver = () => stdioSession;
       return new ServerSetup(
         this.resolve<ContextTracker>('ContextTracker'),

--- a/src/di/Container.ts
+++ b/src/di/Container.ts
@@ -339,6 +339,7 @@ export class DollhouseContainer {
       this.resolve('MetadataService'),
       this.resolve('PersonaImporter'),
       this.resolve('StateChangeNotifier'),
+      this.resolve('ContextTracker'),
       {
         eventDispatcher: this.resolve('ElementEventDispatcher'),
         enableFileWatcher: true,
@@ -1358,7 +1359,8 @@ export class DollhouseContainer {
     const identityHandler = new IdentityHandler(
       personaManager,
       initService,
-      indicatorService
+      indicatorService,
+      this.resolve('ContextTracker')
     );
 
     const configHandler = new ConfigHandler(

--- a/src/di/Container.ts
+++ b/src/di/Container.ts
@@ -86,6 +86,8 @@ import { VerificationNotifier } from "../services/VerificationNotifier.js";
 import { PatternEncryptor } from "../security/encryption/PatternEncryptor.js";
 import { PatternDecryptor } from "../security/encryption/PatternDecryptor.js";
 import { ContextTracker } from "../security/encryption/ContextTracker.js";
+import { createStdioSession } from "../context/StdioSession.js";
+import type { SessionResolver } from "../context/SessionContext.js";
 import { PatternExtractor } from "../security/validation/PatternExtractor.js";
 import { BackgroundValidator } from "../security/validation/BackgroundValidator.js";
 import { SecurityTelemetry } from "../security/telemetry/SecurityTelemetry.js";
@@ -705,9 +707,14 @@ export class DollhouseContainer {
     }));
 
     // SERVER
-    this.register('ServerSetup', () => new ServerSetup(
-      this.resolve<ContextTracker>('ContextTracker')
-    ));
+    this.register('ServerSetup', () => {
+      const stdioSession = createStdioSession();
+      const sessionResolver: SessionResolver = () => stdioSession;
+      return new ServerSetup(
+        this.resolve<ContextTracker>('ContextTracker'),
+        sessionResolver,
+      );
+    });
     this.register('ServerStartup', () => new ServerStartup(
       this.resolve('PortfolioManager'),
       this.resolve('FileLockManager'),

--- a/src/di/Container.ts
+++ b/src/di/Container.ts
@@ -287,7 +287,9 @@ export class DollhouseContainer {
     this.register('GitHubRateLimiter', () => new GitHubRateLimiter(
       this.resolve('TokenManager')
     ));
-    this.register('ElementEventDispatcher', () => ElementEventDispatcher.getSharedDispatcher());
+    this.register('ElementEventDispatcher', () => new ElementEventDispatcher(
+      this.resolve('ContextTracker')
+    ));
     this.register('MCPLogger', () => logger);
 
     this.register('PersonaImporter', () => {
@@ -491,7 +493,8 @@ export class DollhouseContainer {
       this.resolve('MetadataService'),
       this.resolve('FileWatchService'),
       this.resolve('CacheMemoryBudget'),
-      this.resolve('BackupService')
+      this.resolve('BackupService'),
+      this.resolve('ElementEventDispatcher')
     ));
     this.register('TemplateManager', () => new TemplateManager(
       this.resolve('PortfolioManager'),
@@ -502,7 +505,8 @@ export class DollhouseContainer {
       this.resolve('MetadataService'),
       this.resolve('FileWatchService'),
       this.resolve('CacheMemoryBudget'),
-      this.resolve('BackupService')
+      this.resolve('BackupService'),
+      this.resolve('ElementEventDispatcher')
     ));
     this.register('TemplateRenderer', () => new TemplateRenderer(this.resolve('TemplateManager')));
     this.register('AgentManager', () => new AgentManager(
@@ -515,7 +519,8 @@ export class DollhouseContainer {
       this.resolve('MetadataService'),
       this.resolve('FileWatchService'),
       this.resolve('CacheMemoryBudget'),
-      this.resolve('BackupService')
+      this.resolve('BackupService'),
+      this.resolve('ElementEventDispatcher')
     ));
     this.register('MemoryManager', () => new MemoryManager(
       this.resolve('PortfolioManager'),
@@ -526,7 +531,8 @@ export class DollhouseContainer {
       this.resolve('MetadataService'),
       this.resolve('FileWatchService'),
       this.resolve('CacheMemoryBudget'),
-      this.resolve('BackupService')
+      this.resolve('BackupService'),
+      this.resolve('ElementEventDispatcher')
     ));
     this.register('EnsembleManager', () => new EnsembleManager(
       this.resolve('PortfolioManager'),
@@ -537,7 +543,8 @@ export class DollhouseContainer {
       this.resolve('MetadataService'),
       this.resolve('FileWatchService'),
       this.resolve('CacheMemoryBudget'),
-      this.resolve('BackupService')
+      this.resolve('BackupService'),
+      this.resolve('ElementEventDispatcher')
     ));
     Memory.configureMemoryManagerResolver(() => this.resolve('MemoryManager'));
     // Issue #51: Configure retention policy resolver for Memory class

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -45,6 +45,7 @@ import {
   createExecutionContext,
 } from './safetyTierService.js';
 import { BaseElementManager } from '../base/BaseElementManager.js';
+import type { ElementEventDispatcher } from '../../events/ElementEventDispatcher.js';
 import { ElementType } from '../../portfolio/types.js';
 import { toSingularLabel } from '../../utils/elementTypeNormalization.js';
 import { sanitizeInput, validatePath } from '../../security/InputValidator.js';
@@ -117,10 +118,11 @@ export class AgentManager extends BaseElementManager<Agent> {
     metadataService: MetadataService,
     fileWatchService?: FileWatchService,
     memoryBudget?: import('../../cache/CacheMemoryBudget.js').CacheMemoryBudget,
-    backupService?: import('../../services/BackupService.js').BackupService
+    backupService?: import('../../services/BackupService.js').BackupService,
+    eventDispatcher?: ElementEventDispatcher
   ) {
     const elementDirOverride = path.join(baseDir, ElementType.AGENT);
-    super(ElementType.AGENT, portfolioManager, fileLockManager, { elementDirOverride, fileWatchService, memoryBudget, backupService }, fileOperationsService, validationRegistry);
+    super(ElementType.AGENT, portfolioManager, fileLockManager, { elementDirOverride, fileWatchService, memoryBudget, backupService, eventDispatcher }, fileOperationsService, validationRegistry);
     this.stateDir = path.join(this.elementDir, STATE_DIRECTORY);
     this.triggerValidationService = validationRegistry.getTriggerValidationService();
     this.validationService = validationRegistry.getValidationService();

--- a/src/elements/base/BaseElementManager.ts
+++ b/src/elements/base/BaseElementManager.ts
@@ -260,7 +260,7 @@ export abstract class BaseElementManager<T extends IElement> implements IElement
       );
     }
 
-    this.eventDispatcher = options.eventDispatcher ?? ElementEventDispatcher.getSharedDispatcher();
+    this.eventDispatcher = options.eventDispatcher ?? new ElementEventDispatcher();
     this.autoReloadOnExternalChange =
       options.autoReloadOnExternalChange ?? process.env.AUTO_RELOAD_ON_EXTERNAL_CHANGE === 'true';
 

--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -22,6 +22,7 @@ import { ElementValidationResult } from '../../types/elements/IElement.js';
 import { ElementType } from '../../portfolio/types.js';
 import { toSingularLabel } from '../../utils/elementTypeNormalization.js';
 import { BaseElementManager } from '../base/BaseElementManager.js';
+import type { ElementEventDispatcher } from '../../events/ElementEventDispatcher.js';
 import { FileLockManager } from '../../security/fileLockManager.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
 import { logger } from '../../utils/logger.js';
@@ -81,9 +82,10 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
     private metadataService: MetadataService,
     fileWatchService?: FileWatchService,
     memoryBudget?: import('../../cache/CacheMemoryBudget.js').CacheMemoryBudget,
-    backupService?: import('../../services/BackupService.js').BackupService
+    backupService?: import('../../services/BackupService.js').BackupService,
+    eventDispatcher?: ElementEventDispatcher
   ) {
-    super(ElementType.ENSEMBLE, portfolioManager, fileLockManager, { fileWatchService, memoryBudget, backupService }, fileOperationsService, validationRegistry);
+    super(ElementType.ENSEMBLE, portfolioManager, fileLockManager, { fileWatchService, memoryBudget, backupService, eventDispatcher }, fileOperationsService, validationRegistry);
     this.ensemblesDir = this.elementDir;
     this.validationService = validationRegistry.getValidationService();
     this.serializationService = serializationService;

--- a/src/elements/memories/MemoryManager.ts
+++ b/src/elements/memories/MemoryManager.ts
@@ -15,6 +15,7 @@ import { ElementValidationResult } from '../../types/elements/IElement.js';
 import { ElementType } from '../../portfolio/types.js';
 import { toSingularLabel } from '../../utils/elementTypeNormalization.js';
 import { BaseElementManager } from '../base/BaseElementManager.js';
+import type { ElementEventDispatcher } from '../../events/ElementEventDispatcher.js';
 import {
   getValidatedScanCooldown,
   getValidatedIndexDebounce,
@@ -133,9 +134,10 @@ export class MemoryManager extends BaseElementManager<Memory> {
     private metadataService: MetadataService,
     fileWatchService?: FileWatchService,
     memoryBudget?: import('../../cache/CacheMemoryBudget.js').CacheMemoryBudget,
-    backupService?: import('../../services/BackupService.js').BackupService
+    backupService?: import('../../services/BackupService.js').BackupService,
+    eventDispatcher?: ElementEventDispatcher
   ) {
-    super(ElementType.MEMORY, portfolioManager, fileLockManager, { fileWatchService, memoryBudget, backupService }, fileOperationsService, validationRegistry);
+    super(ElementType.MEMORY, portfolioManager, fileLockManager, { fileWatchService, memoryBudget, backupService, eventDispatcher }, fileOperationsService, validationRegistry);
     this.memoriesDir = this.elementDir;
     this.triggerValidationService = validationRegistry.getTriggerValidationService();
     this.validationService = validationRegistry.getValidationService();

--- a/src/elements/skills/SkillManager.ts
+++ b/src/elements/skills/SkillManager.ts
@@ -5,6 +5,7 @@
  */
 
 import { BaseElementManager } from '../base/BaseElementManager.js';
+import type { ElementEventDispatcher } from '../../events/ElementEventDispatcher.js';
 import { Skill, SkillMetadata } from './Skill.js';
 import { ElementType } from '../../portfolio/types.js';
 import { toSingularLabel } from '../../utils/elementTypeNormalization.js';
@@ -48,9 +49,10 @@ export class SkillManager extends BaseElementManager<Skill> {
     private metadataService: MetadataService,
     fileWatchService?: FileWatchService,
     memoryBudget?: import('../../cache/CacheMemoryBudget.js').CacheMemoryBudget,
-    backupService?: import('../../services/BackupService.js').BackupService
+    backupService?: import('../../services/BackupService.js').BackupService,
+    eventDispatcher?: ElementEventDispatcher
   ) {
-    super(ElementType.SKILL, portfolioManager, fileLockManager, { fileWatchService, memoryBudget, backupService }, fileOperationsService, validationRegistry);
+    super(ElementType.SKILL, portfolioManager, fileLockManager, { fileWatchService, memoryBudget, backupService, eventDispatcher }, fileOperationsService, validationRegistry);
     this.triggerValidationService = validationRegistry.getTriggerValidationService();
     this.validationService = validationRegistry.getValidationService();
     this.serializationService = serializationService;

--- a/src/elements/templates/TemplateManager.ts
+++ b/src/elements/templates/TemplateManager.ts
@@ -13,6 +13,7 @@ import { UnicodeValidator } from '../../security/validators/unicodeValidator.js'
 import { FileLockManager } from '../../security/fileLockManager.js';
 import { logger } from '../../utils/logger.js';
 import { BaseElementManager } from '../base/BaseElementManager.js';
+import type { ElementEventDispatcher } from '../../events/ElementEventDispatcher.js';
 import { Template, TemplateMetadata } from './Template.js';
 import { PortfolioManager } from '../../portfolio/PortfolioManager.js';
 import { ValidationRegistry } from '../../services/validation/ValidationRegistry.js';
@@ -39,9 +40,10 @@ export class TemplateManager extends BaseElementManager<Template> {
     private metadataService: MetadataService,
     fileWatchService?: FileWatchService,
     memoryBudget?: import('../../cache/CacheMemoryBudget.js').CacheMemoryBudget,
-    backupService?: import('../../services/BackupService.js').BackupService
+    backupService?: import('../../services/BackupService.js').BackupService,
+    eventDispatcher?: ElementEventDispatcher
   ) {
-    super(ElementType.TEMPLATE, portfolioManager, fileLockManager, { fileWatchService, memoryBudget, backupService }, fileOperationsService, validationRegistry);
+    super(ElementType.TEMPLATE, portfolioManager, fileLockManager, { fileWatchService, memoryBudget, backupService, eventDispatcher }, fileOperationsService, validationRegistry);
     this.triggerValidationService = validationRegistry.getTriggerValidationService();
     this.validationService = validationRegistry.getValidationService();
     this.serializationService = serializationService;

--- a/src/events/ElementEventDispatcher.ts
+++ b/src/events/ElementEventDispatcher.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events';
 import { ElementType } from '../portfolio/types.js';
 import { IElement, IElementMetadata } from '../types/elements/IElement.js';
+import type { ContextTracker } from '../security/encryption/ContextTracker.js';
 
 export type ElementLifecycleEvent =
   | 'element:load:start'
@@ -28,6 +29,10 @@ export interface ElementEventPayload {
   generation?: number;
   error?: unknown;
   extra?: Record<string, unknown>;
+  /** Session user identity, auto-populated from SessionContext when available. */
+  userId?: string;
+  /** Session identifier, auto-populated from SessionContext when available. */
+  sessionId?: string;
 }
 
 export type ElementEventHandler = (payload: ElementEventPayload) => void | Promise<void>;
@@ -35,10 +40,16 @@ export type ElementEventHandler = (payload: ElementEventPayload) => void | Promi
 /**
  * Lightweight dispatcher for element lifecycle events.
  * Provides minimal EventEmitter wrapper with immutable payload semantics.
+ *
+ * DI-MANAGED: Instantiated by the DI container with ContextTracker injected.
+ * Session attribution (userId/sessionId) is auto-populated from SessionContext
+ * at emit time. For emitAsync, session is captured before the setImmediate
+ * boundary to prevent AsyncLocalStorage context loss.
  */
 export class ElementEventDispatcher {
   private readonly emitter = new EventEmitter();
-  private static shared: ElementEventDispatcher | null = null;
+
+  constructor(private readonly contextTracker?: ContextTracker) {}
 
   /**
    * Subscribe to an event. Returns an unsubscribe function.
@@ -62,16 +73,27 @@ export class ElementEventDispatcher {
 
   /**
    * Emit synchronously (used for start/veto events).
+   * Session attribution is read from AsyncLocalStorage via ContextTracker.
    */
   emit(event: ElementLifecycleEvent, payload: ElementEventPayload): void {
-    this.emitter.emit(event, { ...payload });
+    const session = this.contextTracker?.getSessionContext();
+    this.emitter.emit(event, {
+      ...payload,
+      ...(session ? { userId: session.userId, sessionId: session.sessionId } : {}),
+    });
   }
 
   /**
    * Emit asynchronously to decouple observers.
+   * Session is captured BEFORE setImmediate — AsyncLocalStorage context
+   * is lost across the boundary.
    */
   emitAsync(event: ElementLifecycleEvent, payload: ElementEventPayload): void {
-    const cloned = { ...payload };
+    const session = this.contextTracker?.getSessionContext();
+    const cloned: ElementEventPayload = {
+      ...payload,
+      ...(session ? { userId: session.userId, sessionId: session.sessionId } : {}),
+    };
     setImmediate(() => {
       this.emitter.emit(event, cloned);
     });
@@ -93,15 +115,5 @@ export class ElementEventDispatcher {
       snapshot.category = (element.metadata as any).category;
     }
     return snapshot;
-  }
-
-  /**
-   * Shared singleton dispatcher used when managers don't inject their own.
-   */
-  static getSharedDispatcher(): ElementEventDispatcher {
-    if (!this.shared) {
-      this.shared = new ElementEventDispatcher();
-    }
-    return this.shared;
   }
 }

--- a/src/handlers/IdentityHandler.ts
+++ b/src/handlers/IdentityHandler.ts
@@ -17,12 +17,14 @@ import { PersonaManager } from '../persona/PersonaManager.js';
 import { InitializationService } from '../services/InitializationService.js';
 import { PersonaIndicatorService } from '../services/PersonaIndicatorService.js';
 import { SecurityMonitor } from '../security/securityMonitor.js';
+import type { ContextTracker } from '../security/encryption/ContextTracker.js';
 
 export class IdentityHandler {
   constructor(
     private readonly personaManager: PersonaManager,
     private readonly initService: InitializationService,
-    private readonly indicatorService: PersonaIndicatorService
+    private readonly indicatorService: PersonaIndicatorService,
+    private readonly contextTracker?: ContextTracker
   ) {}
 
   private async ensureInitialized(): Promise<void> {

--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -221,6 +221,12 @@ function validateLogQueryParams(params: Record<string, unknown>): LogQueryOption
   if (typeof params.correlationId === 'string') {
     options.correlationId = params.correlationId;
   }
+  if (typeof params.userId === 'string') {
+    options.userId = params.userId;
+  }
+  if (typeof params.sessionId === 'string') {
+    options.sessionId = params.sessionId;
+  }
 
   return options;
 }

--- a/src/logging/LogHooks.ts
+++ b/src/logging/LogHooks.ts
@@ -44,6 +44,20 @@ type RequestContextProvider = {
   getSessionContext(): SessionContext | undefined;
 };
 
+/** Capture correlationId, userId, and sessionId from the current request context. */
+function getRequestAttribution(tracker: RequestContextProvider | null): {
+  correlationId?: string;
+  userId?: string;
+  sessionId?: string;
+} {
+  const session = tracker?.getSessionContext();
+  return {
+    correlationId: tracker?.getCorrelationId(),
+    userId: session?.userId,
+    sessionId: session?.sessionId,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Exported factory for TriggerMetricsTracker (created outside DI container)
 // ---------------------------------------------------------------------------
@@ -61,9 +75,7 @@ export function getTriggerMetricsLogListener(
       source: 'TriggerMetricsTracker',
       message,
       data,
-      correlationId: contextTracker?.getCorrelationId(),
-      userId: contextTracker?.getSessionContext()?.userId,
-      sessionId: contextTracker?.getSessionContext()?.sessionId,
+      ...getRequestAttribution(contextTracker ?? null),
     };
     logManager.log(entry);
   };
@@ -86,9 +98,7 @@ export function getSecurityAuditorLogListener(
       source: 'SecurityAuditor',
       message,
       data,
-      correlationId: contextTracker?.getCorrelationId(),
-      userId: contextTracker?.getSessionContext()?.userId,
-      sessionId: contextTracker?.getSessionContext()?.sessionId,
+      ...getRequestAttribution(contextTracker ?? null),
     };
     logManager.log(entry);
   };
@@ -131,9 +141,7 @@ export function wireLogHooks(
         source: 'MCPLogger',
         message: logEntry.message,
         data: logEntry.data != null ? logEntry.data : undefined,
-        correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext()?.userId,
-        sessionId: contextTracker?.getSessionContext()?.sessionId,
+        ...getRequestAttribution(contextTracker),
       };
       logManager.log(entry);
     });
@@ -156,9 +164,7 @@ export function wireLogHooks(
           severity: logEntry.severity,
           sourceComponent: logEntry.source,
         },
-        correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext()?.userId,
-        sessionId: contextTracker?.getSessionContext()?.sessionId,
+        ...getRequestAttribution(contextTracker),
       };
       logManager.log(entry);
     });
@@ -182,9 +188,7 @@ export function wireLogHooks(
         source: 'SecurityTelemetry',
         message: `Blocked ${telEntry.attackType}: ${telEntry.pattern}`,
         data: telEntry.metadata,
-        correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext()?.userId,
-        sessionId: contextTracker?.getSessionContext()?.sessionId,
+        ...getRequestAttribution(contextTracker),
       };
       logManager.log(entry);
     });
@@ -205,9 +209,7 @@ export function wireLogHooks(
         source: 'PerformanceMonitor',
         message,
         data,
-        correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext()?.userId,
-        sessionId: contextTracker?.getSessionContext()?.sessionId,
+        ...getRequestAttribution(contextTracker),
       };
       logManager.log(entry);
     });
@@ -240,7 +242,7 @@ export function wireLogHooks(
     for (const eventName of loggedEvents) {
       const unsub = dispatcher.on(eventName, (payload: any) => {
         const level = eventLevelMap[eventName] ?? 'debug';
-        const requestCorrelationId = contextTracker?.getCorrelationId();
+        const attribution = getRequestAttribution(contextTracker);
         // Use elementId if available, fall back to filename from filePath
         const elementName = payload.elementId
           || (payload.filePath ? payload.filePath.replace(/\.[^.]+$/, '') : '');
@@ -256,9 +258,8 @@ export function wireLogHooks(
             ...(payload.correlationId ? { operationId: payload.correlationId } : {}),
             ...(payload.filePath ? { filePath: payload.filePath } : {}),
           },
-          correlationId: requestCorrelationId ?? payload.correlationId,
-          userId: contextTracker?.getSessionContext()?.userId,
-          sessionId: contextTracker?.getSessionContext()?.sessionId,
+          ...attribution,
+          correlationId: attribution.correlationId ?? payload.correlationId,
         };
         logManager.log(entry);
       });
@@ -280,9 +281,7 @@ export function wireLogHooks(
         source: 'OperationalTelemetry',
         message,
         data,
-        correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext()?.userId,
-        sessionId: contextTracker?.getSessionContext()?.sessionId,
+        ...getRequestAttribution(contextTracker),
       };
       logManager.log(entry);
     });
@@ -303,9 +302,7 @@ export function wireLogHooks(
         source: 'FileLockManager',
         message,
         data,
-        correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext()?.userId,
-        sessionId: contextTracker?.getSessionContext()?.sessionId,
+        ...getRequestAttribution(contextTracker),
       };
       logManager.log(entry);
     });
@@ -323,9 +320,7 @@ export function wireLogHooks(
         source: 'DefaultElementProvider',
         message,
         data,
-        correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext()?.userId,
-        sessionId: contextTracker?.getSessionContext()?.sessionId,
+        ...getRequestAttribution(contextTracker),
       };
       logManager.log(entry);
     });
@@ -343,9 +338,7 @@ export function wireLogHooks(
         source: 'LRUCache',
         message,
         data,
-        correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext()?.userId,
-        sessionId: contextTracker?.getSessionContext()?.sessionId,
+        ...getRequestAttribution(contextTracker),
       };
       logManager.log(entry);
     });
@@ -367,9 +360,7 @@ export function wireLogHooks(
         source: 'StateChangeNotifier',
         message: `State change: ${event.type}`,
         data: { previousValue: event.previousValue, newValue: event.newValue },
-        correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext()?.userId,
-        sessionId: contextTracker?.getSessionContext()?.sessionId,
+        ...getRequestAttribution(contextTracker),
       };
       logManager.log(entry);
     };

--- a/src/logging/LogHooks.ts
+++ b/src/logging/LogHooks.ts
@@ -38,7 +38,10 @@ const SEVERITY_TO_LEVEL: Record<string, LogLevel> = {
 // CorrelationId provider interface (subset of ContextTracker)
 // ---------------------------------------------------------------------------
 
-type CorrelationIdProvider = { getCorrelationId(): string | undefined };
+type CorrelationIdProvider = {
+  getCorrelationId(): string | undefined;
+  getSessionContext?(): { userId: string; sessionId: string } | undefined;
+};
 
 // ---------------------------------------------------------------------------
 // Exported factory for TriggerMetricsTracker (created outside DI container)
@@ -58,6 +61,8 @@ export function getTriggerMetricsLogListener(
       message,
       data,
       correlationId: contextTracker?.getCorrelationId(),
+      userId: contextTracker?.getSessionContext?.()?.userId,
+      sessionId: contextTracker?.getSessionContext?.()?.sessionId,
     };
     logManager.log(entry);
   };
@@ -81,6 +86,8 @@ export function getSecurityAuditorLogListener(
       message,
       data,
       correlationId: contextTracker?.getCorrelationId(),
+      userId: contextTracker?.getSessionContext?.()?.userId,
+      sessionId: contextTracker?.getSessionContext?.()?.sessionId,
     };
     logManager.log(entry);
   };
@@ -124,6 +131,8 @@ export function wireLogHooks(
         message: logEntry.message,
         data: logEntry.data != null ? logEntry.data : undefined,
         correlationId: contextTracker?.getCorrelationId(),
+        userId: contextTracker?.getSessionContext?.()?.userId,
+        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
       };
       logManager.log(entry);
     });
@@ -147,6 +156,8 @@ export function wireLogHooks(
           sourceComponent: logEntry.source,
         },
         correlationId: contextTracker?.getCorrelationId(),
+        userId: contextTracker?.getSessionContext?.()?.userId,
+        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
       };
       logManager.log(entry);
     });
@@ -171,6 +182,8 @@ export function wireLogHooks(
         message: `Blocked ${telEntry.attackType}: ${telEntry.pattern}`,
         data: telEntry.metadata,
         correlationId: contextTracker?.getCorrelationId(),
+        userId: contextTracker?.getSessionContext?.()?.userId,
+        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
       };
       logManager.log(entry);
     });
@@ -192,6 +205,8 @@ export function wireLogHooks(
         message,
         data,
         correlationId: contextTracker?.getCorrelationId(),
+        userId: contextTracker?.getSessionContext?.()?.userId,
+        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
       };
       logManager.log(entry);
     });
@@ -241,6 +256,8 @@ export function wireLogHooks(
             ...(payload.filePath ? { filePath: payload.filePath } : {}),
           },
           correlationId: requestCorrelationId ?? payload.correlationId,
+          userId: contextTracker?.getSessionContext?.()?.userId,
+          sessionId: contextTracker?.getSessionContext?.()?.sessionId,
         };
         logManager.log(entry);
       });
@@ -263,6 +280,8 @@ export function wireLogHooks(
         message,
         data,
         correlationId: contextTracker?.getCorrelationId(),
+        userId: contextTracker?.getSessionContext?.()?.userId,
+        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
       };
       logManager.log(entry);
     });
@@ -284,6 +303,8 @@ export function wireLogHooks(
         message,
         data,
         correlationId: contextTracker?.getCorrelationId(),
+        userId: contextTracker?.getSessionContext?.()?.userId,
+        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
       };
       logManager.log(entry);
     });
@@ -302,6 +323,8 @@ export function wireLogHooks(
         message,
         data,
         correlationId: contextTracker?.getCorrelationId(),
+        userId: contextTracker?.getSessionContext?.()?.userId,
+        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
       };
       logManager.log(entry);
     });
@@ -320,6 +343,8 @@ export function wireLogHooks(
         message,
         data,
         correlationId: contextTracker?.getCorrelationId(),
+        userId: contextTracker?.getSessionContext?.()?.userId,
+        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
       };
       logManager.log(entry);
     });
@@ -342,6 +367,8 @@ export function wireLogHooks(
         message: `State change: ${event.type}`,
         data: { previousValue: event.previousValue, newValue: event.newValue },
         correlationId: contextTracker?.getCorrelationId(),
+        userId: contextTracker?.getSessionContext?.()?.userId,
+        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
       };
       logManager.log(entry);
     };

--- a/src/logging/LogHooks.ts
+++ b/src/logging/LogHooks.ts
@@ -14,6 +14,7 @@
 
 import type { LogManager } from './LogManager.js';
 import type { LogLevel, UnifiedLogEntry } from './types.js';
+import type { SessionContext } from '../context/SessionContext.js';
 import { SecurityMonitor } from '../security/securityMonitor.js';
 import { DefaultElementProvider } from '../portfolio/DefaultElementProvider.js';
 import { LRUCache } from '../cache/LRUCache.js';
@@ -35,12 +36,12 @@ const SEVERITY_TO_LEVEL: Record<string, LogLevel> = {
 };
 
 // ---------------------------------------------------------------------------
-// CorrelationId provider interface (subset of ContextTracker)
+// Request context provider interface (subset of ContextTracker)
 // ---------------------------------------------------------------------------
 
-type CorrelationIdProvider = {
+type RequestContextProvider = {
   getCorrelationId(): string | undefined;
-  getSessionContext?(): { userId: string; sessionId: string } | undefined;
+  getSessionContext(): SessionContext | undefined;
 };
 
 // ---------------------------------------------------------------------------
@@ -49,7 +50,7 @@ type CorrelationIdProvider = {
 
 export function getTriggerMetricsLogListener(
   logManager: LogManager,
-  contextTracker?: CorrelationIdProvider,
+  contextTracker?: RequestContextProvider,
 ): (level: 'debug' | 'info' | 'warn' | 'error', message: string, data?: Record<string, unknown>) => void {
   return (level, message, data) => {
     const entry: UnifiedLogEntry = {
@@ -61,8 +62,8 @@ export function getTriggerMetricsLogListener(
       message,
       data,
       correlationId: contextTracker?.getCorrelationId(),
-      userId: contextTracker?.getSessionContext?.()?.userId,
-      sessionId: contextTracker?.getSessionContext?.()?.sessionId,
+      userId: contextTracker?.getSessionContext()?.userId,
+      sessionId: contextTracker?.getSessionContext()?.sessionId,
     };
     logManager.log(entry);
   };
@@ -74,7 +75,7 @@ export function getTriggerMetricsLogListener(
 
 export function getSecurityAuditorLogListener(
   logManager: LogManager,
-  contextTracker?: CorrelationIdProvider,
+  contextTracker?: RequestContextProvider,
 ): (level: 'debug' | 'info' | 'warn' | 'error', message: string, data?: Record<string, unknown>) => void {
   return (level, message, data) => {
     const entry: UnifiedLogEntry = {
@@ -86,8 +87,8 @@ export function getSecurityAuditorLogListener(
       message,
       data,
       correlationId: contextTracker?.getCorrelationId(),
-      userId: contextTracker?.getSessionContext?.()?.userId,
-      sessionId: contextTracker?.getSessionContext?.()?.sessionId,
+      userId: contextTracker?.getSessionContext()?.userId,
+      sessionId: contextTracker?.getSessionContext()?.sessionId,
     };
     logManager.log(entry);
   };
@@ -111,9 +112,9 @@ export function wireLogHooks(
   const cleanups: (() => void)[] = [];
 
   // Resolve ContextTracker for correlationId injection
-  let contextTracker: CorrelationIdProvider | null = null;
+  let contextTracker: RequestContextProvider | null = null;
   try {
-    contextTracker = container.resolve<CorrelationIdProvider>('ContextTracker');
+    contextTracker = container.resolve<RequestContextProvider>('ContextTracker');
   } catch { /* ContextTracker not registered */ }
 
   // --- MCPLogger (application) -------------------------------------------
@@ -131,8 +132,8 @@ export function wireLogHooks(
         message: logEntry.message,
         data: logEntry.data != null ? logEntry.data : undefined,
         correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext?.()?.userId,
-        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
+        userId: contextTracker?.getSessionContext()?.userId,
+        sessionId: contextTracker?.getSessionContext()?.sessionId,
       };
       logManager.log(entry);
     });
@@ -156,8 +157,8 @@ export function wireLogHooks(
           sourceComponent: logEntry.source,
         },
         correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext?.()?.userId,
-        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
+        userId: contextTracker?.getSessionContext()?.userId,
+        sessionId: contextTracker?.getSessionContext()?.sessionId,
       };
       logManager.log(entry);
     });
@@ -182,8 +183,8 @@ export function wireLogHooks(
         message: `Blocked ${telEntry.attackType}: ${telEntry.pattern}`,
         data: telEntry.metadata,
         correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext?.()?.userId,
-        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
+        userId: contextTracker?.getSessionContext()?.userId,
+        sessionId: contextTracker?.getSessionContext()?.sessionId,
       };
       logManager.log(entry);
     });
@@ -205,8 +206,8 @@ export function wireLogHooks(
         message,
         data,
         correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext?.()?.userId,
-        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
+        userId: contextTracker?.getSessionContext()?.userId,
+        sessionId: contextTracker?.getSessionContext()?.sessionId,
       };
       logManager.log(entry);
     });
@@ -256,8 +257,8 @@ export function wireLogHooks(
             ...(payload.filePath ? { filePath: payload.filePath } : {}),
           },
           correlationId: requestCorrelationId ?? payload.correlationId,
-          userId: contextTracker?.getSessionContext?.()?.userId,
-          sessionId: contextTracker?.getSessionContext?.()?.sessionId,
+          userId: contextTracker?.getSessionContext()?.userId,
+          sessionId: contextTracker?.getSessionContext()?.sessionId,
         };
         logManager.log(entry);
       });
@@ -280,8 +281,8 @@ export function wireLogHooks(
         message,
         data,
         correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext?.()?.userId,
-        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
+        userId: contextTracker?.getSessionContext()?.userId,
+        sessionId: contextTracker?.getSessionContext()?.sessionId,
       };
       logManager.log(entry);
     });
@@ -303,8 +304,8 @@ export function wireLogHooks(
         message,
         data,
         correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext?.()?.userId,
-        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
+        userId: contextTracker?.getSessionContext()?.userId,
+        sessionId: contextTracker?.getSessionContext()?.sessionId,
       };
       logManager.log(entry);
     });
@@ -323,8 +324,8 @@ export function wireLogHooks(
         message,
         data,
         correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext?.()?.userId,
-        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
+        userId: contextTracker?.getSessionContext()?.userId,
+        sessionId: contextTracker?.getSessionContext()?.sessionId,
       };
       logManager.log(entry);
     });
@@ -343,8 +344,8 @@ export function wireLogHooks(
         message,
         data,
         correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext?.()?.userId,
-        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
+        userId: contextTracker?.getSessionContext()?.userId,
+        sessionId: contextTracker?.getSessionContext()?.sessionId,
       };
       logManager.log(entry);
     });
@@ -367,8 +368,8 @@ export function wireLogHooks(
         message: `State change: ${event.type}`,
         data: { previousValue: event.previousValue, newValue: event.newValue },
         correlationId: contextTracker?.getCorrelationId(),
-        userId: contextTracker?.getSessionContext?.()?.userId,
-        sessionId: contextTracker?.getSessionContext?.()?.sessionId,
+        userId: contextTracker?.getSessionContext()?.userId,
+        sessionId: contextTracker?.getSessionContext()?.sessionId,
       };
       logManager.log(entry);
     };

--- a/src/logging/formatters/JsonlFormatter.ts
+++ b/src/logging/formatters/JsonlFormatter.ts
@@ -22,6 +22,12 @@ export class JsonlFormatter implements ILogFormatter {
     if (entry.correlationId !== undefined) {
       obj.correlationId = entry.correlationId;
     }
+    if (entry.userId !== undefined) {
+      obj.userId = entry.userId;
+    }
+    if (entry.sessionId !== undefined) {
+      obj.sessionId = entry.sessionId;
+    }
 
     return JSON.stringify(obj) + '\n';
   }

--- a/src/logging/formatters/PlainTextFormatter.ts
+++ b/src/logging/formatters/PlainTextFormatter.ts
@@ -7,7 +7,8 @@ export class PlainTextFormatter implements ILogFormatter {
     const ts = entry.timestamp.replace('T', ' ').replace('Z', '');
     const level = entry.level.toUpperCase();
     const corrId = entry.correlationId ? ` [${entry.correlationId}]` : '';
-    let output = `[${ts}] [${level}] [${entry.source}]${corrId} ${entry.message}\n`;
+    const sessId = entry.sessionId ? ` [${entry.sessionId}]` : '';
+    let output = `[${ts}] [${level}] [${entry.source}]${corrId}${sessId} ${entry.message}\n`;
 
     if (entry.error) {
       output += `  ${entry.error.name}: ${entry.error.message}\n`;

--- a/src/logging/sinks/MemoryLogSink.ts
+++ b/src/logging/sinks/MemoryLogSink.ts
@@ -107,6 +107,14 @@ export class MemoryLogSink implements ILogSink {
       const corrId = options.correlationId;
       entries = entries.filter(e => e.correlationId === corrId);
     }
+    if (options?.userId) {
+      const uid = options.userId;
+      entries = entries.filter(e => e.userId === uid);
+    }
+    if (options?.sessionId) {
+      const sid = options.sessionId;
+      entries = entries.filter(e => e.sessionId === sid);
+    }
 
     // 4. Count total before pagination
     const total = entries.length;

--- a/src/logging/types.ts
+++ b/src/logging/types.ts
@@ -45,6 +45,10 @@ export interface UnifiedLogEntry {
     stack?: string;
   };
   correlationId?: string;
+  /** Session user identity, auto-populated from SessionContext when available. */
+  userId?: string;
+  /** Session identifier, auto-populated from SessionContext when available. */
+  sessionId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -86,6 +90,8 @@ export interface LogQueryOptions {
   limit?: number;
   offset?: number;
   correlationId?: string;
+  userId?: string;
+  sessionId?: string;
 }
 
 export interface LogQueryResult {

--- a/src/persona/PersonaManager.ts
+++ b/src/persona/PersonaManager.ts
@@ -1430,11 +1430,13 @@ export class PersonaManager extends BaseElementManager<PersonaElement> {
       return;
     }
 
+    const session = this.contextTracker?.getSessionContext();
     this.notifier.notifyPersonaChange({
       type,
       previousValue,
       newValue,
-      timestamp: new Date()
+      timestamp: new Date(),
+      ...(session ? { userId: session.userId, sessionId: session.sessionId } : {}),
     });
   }
 

--- a/src/persona/PersonaManager.ts
+++ b/src/persona/PersonaManager.ts
@@ -32,6 +32,9 @@ import { MetadataService } from '../services/MetadataService.js';
 import { SerializationService } from '../services/SerializationService.js';
 import { FileOperationsService } from '../services/FileOperationsService.js';
 import { getActiveElementLimitConfig, getMaxActiveLimit } from '../config/active-element-limits.js';
+import type { ContextTracker } from '../security/encryption/ContextTracker.js';
+import { STDIO_DEFAULT_USER_ID } from '../context/StdioSession.js';
+import { SYSTEM_CONTEXT } from '../context/ContextPolicy.js';
 
 /**
  * Validated and sanitized persona input data
@@ -58,7 +61,9 @@ export class PersonaManager extends BaseElementManager<PersonaElement> {
    * Issue #281: Changed from single active persona to Set for multiple active
    */
   private activePersonas: Set<string> = new Set();
+  /** @deprecated Read identity from SessionContext via ContextTracker. Remove in Phase 3. */
   private currentUser: string | null = null;
+  private contextTracker?: ContextTracker;
   private indicatorConfig: IndicatorConfig;
   protected override portfolioManager: PortfolioManager;
   protected override fileLockManager: FileLockManager;
@@ -80,6 +85,7 @@ export class PersonaManager extends BaseElementManager<PersonaElement> {
     metadataService: MetadataService,
     personaImporter?: PersonaImporter,
     notifier?: StateChangeNotifier,
+    contextTracker?: ContextTracker,
     baseOptions: PersonaManagerOptions = {}
   ) {
     super(ElementType.PERSONA, portfolioManager, fileLockManager, baseOptions, fileOperationsService, validationRegistry);
@@ -92,6 +98,7 @@ export class PersonaManager extends BaseElementManager<PersonaElement> {
     this.personasDir = this.portfolioManager.getElementDir(ElementType.PERSONA);
     this.triggerValidationService = validationRegistry.getTriggerValidationService();
     this.validationService = validationRegistry.getValidationService();
+    this.contextTracker = contextTracker;
     this.metadataService = metadataService;
     this.serializationService = new SerializationService();
     this.initializePathValidator();
@@ -1248,9 +1255,28 @@ export class PersonaManager extends BaseElementManager<PersonaElement> {
    * Get current user identity
    */
   getUserIdentity(): { username: string | null; email: string | null } {
+    // Explicitly-set identity takes precedence over frozen session
+    if (this.currentUser) {
+      return {
+        username: this.currentUser,
+        email: process.env.DOLLHOUSE_EMAIL || null,
+      };
+    }
+
+    // Session-level identity (HTTP auth, DOLLHOUSE_USER at startup).
+    // Temporary check — Phase 3 removes the STDIO_DEFAULT_USER_ID guard.
+    const session = this.contextTracker?.getSessionContext();
+    if (session && session.userId !== STDIO_DEFAULT_USER_ID && session.userId !== SYSTEM_CONTEXT.userId) {
+      return {
+        username: session.displayName || session.userId,
+        email: session.email || process.env.DOLLHOUSE_EMAIL || null,
+      };
+    }
+
+    // Fall back to process.env (existing behavior)
     return {
       username: process.env.DOLLHOUSE_USER || null,
-      email: process.env.DOLLHOUSE_EMAIL || null
+      email: process.env.DOLLHOUSE_EMAIL || null,
     };
   }
   
@@ -1280,11 +1306,22 @@ export class PersonaManager extends BaseElementManager<PersonaElement> {
    * REFACTORED: Now delegates to MetadataService for consistent user attribution
    */
   public getCurrentUserForAttribution(): string {
-    // Only sync if PersonaManager has an explicitly-set user;
-    // otherwise let MetadataService resolve via its own fallback chain.
+    // Explicitly-set identity (via set_user_identity tool) takes precedence
+    // over frozen session identity, because it's more recent.
     if (this.currentUser) {
       this.metadataService.setCurrentUser(this.currentUser);
+      return this.metadataService.getCurrentUser();
     }
+
+    // Session-level identity (HTTP auth, DOLLHOUSE_USER at startup).
+    // Temporary check — Phase 3 removes the STDIO_DEFAULT_USER_ID guard
+    // and makes SessionContext the sole identity authority.
+    const session = this.contextTracker?.getSessionContext();
+    if (session && session.userId !== STDIO_DEFAULT_USER_ID && session.userId !== SYSTEM_CONTEXT.userId) {
+      return session.displayName || session.userId;
+    }
+
+    // MetadataService fallback chain (OS username → anonymous ID)
     return this.metadataService.getCurrentUser();
   }
   

--- a/src/persona/PersonaManager.ts
+++ b/src/persona/PersonaManager.ts
@@ -61,9 +61,9 @@ export class PersonaManager extends BaseElementManager<PersonaElement> {
    * Issue #281: Changed from single active persona to Set for multiple active
    */
   private activePersonas: Set<string> = new Set();
-  /** @deprecated Read identity from SessionContext via ContextTracker. Remove in Phase 3. */
+  // Phase 3: Replace with SessionContext as sole identity authority. Remove this field.
   private currentUser: string | null = null;
-  private contextTracker?: ContextTracker;
+  private readonly contextTracker?: ContextTracker;
   private indicatorConfig: IndicatorConfig;
   protected override portfolioManager: PortfolioManager;
   protected override fileLockManager: FileLockManager;

--- a/src/security/encryption/ContextTracker.ts
+++ b/src/security/encryption/ContextTracker.ts
@@ -23,6 +23,8 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { randomBytes } from 'node:crypto';
 import { logger } from '../../utils/logger.js';
+import type { SessionContext } from '../../context/SessionContext.js';
+import { SessionContextRequiredError } from '../../context/ContextPolicy.js';
 
 /**
  * Execution context information
@@ -39,6 +41,13 @@ export interface ExecutionContext {
 
   /** Additional context metadata */
   metadata?: Record<string, unknown>;
+
+  /**
+   * Session context associated with this execution.
+   * Optional for backward compatibility — callers not yet using sessions
+   * may omit this field without any behavioural change.
+   */
+  session?: SessionContext;
 }
 
 /**
@@ -147,6 +156,61 @@ export class ContextTracker {
   clearContext(): void {
     // AsyncLocalStorage doesn't have a direct clear method
     // Context is automatically cleared when execution exits
+  }
+
+  /**
+   * Get the SessionContext from the current execution context, if any.
+   *
+   * @returns The SessionContext if one is stored in the current context,
+   *          or undefined if no context is active or no session was set.
+   */
+  getSessionContext(): SessionContext | undefined {
+    return this.getContext()?.session;
+  }
+
+  /**
+   * Get the SessionContext from the current execution context, throwing if
+   * no session is present.
+   *
+   * Use this when a real user identity is required (e.g., audit logging,
+   * per-user rate limits). Use getSessionOrSystem() from ContextPolicy for
+   * paths that can safely fall back to a system identity.
+   *
+   * @param caller - Optional caller identifier for error messages
+   * @throws {SessionContextRequiredError} When no session context is active
+   * @returns The active SessionContext
+   */
+  requireSessionContext(caller?: string): SessionContext {
+    const session = this.getSessionContext();
+    if (session === undefined) {
+      throw new SessionContextRequiredError(caller);
+    }
+    return session;
+  }
+
+  /**
+   * Create an ExecutionContext with an associated SessionContext.
+   *
+   * The SessionContext is shallow-copied and Object.freeze()'d before storage
+   * to prevent downstream mutation of session identity.
+   *
+   * @param type - Context type (same values as createContext)
+   * @param session - The SessionContext to associate with this execution
+   * @param metadata - Optional additional metadata
+   * @returns New ExecutionContext with frozen session attached
+   */
+  createSessionContext(
+    type: ExecutionContext['type'],
+    session: SessionContext,
+    metadata?: Record<string, unknown>
+  ): ExecutionContext {
+    return {
+      type,
+      requestId: this.generateRequestId(),
+      timestamp: Date.now(),
+      metadata,
+      session: Object.freeze({ ...session }),
+    };
   }
 
   /**

--- a/src/server/ServerSetup.ts
+++ b/src/server/ServerSetup.ts
@@ -25,7 +25,7 @@ export class ServerSetup {
   private static readonly DEFERRED_SETUP_TIMEOUT_MS = 10_000;
   private toolCache: LRUCache<Tool[]>;
   private contextTracker: ContextTracker;
-  private sessionResolver?: SessionResolver;
+  private readonly sessionResolver?: SessionResolver;
   private elementCrudHandler: ElementCRUDHandler | null = null;
   /** Issue #706 Phase 4: Promise that resolves when deferred setup completes. */
   private deferredSetupPromise: Promise<void> | null = null;

--- a/src/server/ServerSetup.ts
+++ b/src/server/ServerSetup.ts
@@ -16,6 +16,7 @@ import { generatePrescriptiveDigest } from './PrescriptiveDigest.js';
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { ContextTracker } from '../security/encryption/ContextTracker.js';
 import type { ElementCRUDHandler } from '../handlers/ElementCRUDHandler.js';
+import type { SessionResolver } from '../context/SessionContext.js';
 // ConfigWizardCheck import removed - auto-trigger disabled for v1.8.0
 
 export class ServerSetup {
@@ -24,12 +25,14 @@ export class ServerSetup {
   private static readonly DEFERRED_SETUP_TIMEOUT_MS = 10_000;
   private toolCache: LRUCache<Tool[]>;
   private contextTracker: ContextTracker;
+  private sessionResolver?: SessionResolver;
   private elementCrudHandler: ElementCRUDHandler | null = null;
   /** Issue #706 Phase 4: Promise that resolves when deferred setup completes. */
   private deferredSetupPromise: Promise<void> | null = null;
 
-  constructor(contextTracker: ContextTracker) {
+  constructor(contextTracker: ContextTracker, sessionResolver?: SessionResolver) {
     this.contextTracker = contextTracker;
+    this.sessionResolver = sessionResolver;
     this.toolCache = new LRUCache<Tool[]>({
       name: 'tool-discovery',
       maxSize: 1,
@@ -78,35 +81,42 @@ export class ServerSetup {
    * Setup the ListToolsRequest handler with caching
    */
   private setupListToolsHandler(server: Server, toolRegistry: ToolRegistry): void {
-    server.setRequestHandler(ListToolsRequestSchema, async () => {
-      const startTime = Date.now();
-      
-      // Try to get cached tools first
-      let tools = this.toolCache.get(ServerSetup.TOOL_CACHE_KEY);
+    server.setRequestHandler(ListToolsRequestSchema, async (request) => {
+      const session = this.sessionResolver?.(request);
+      const context = session
+        ? this.contextTracker.createSessionContext('llm-request', session, { toolName: 'list_tools' })
+        : this.contextTracker.createContext('llm-request', { toolName: 'list_tools' });
 
-      if (!tools) {
-        // Cache miss - fetch tools from registry
-        tools = toolRegistry.getAllTools();
+      return this.contextTracker.runAsync(context, async () => {
+        const startTime = Date.now();
 
-        // Cache the results for future requests
-        this.toolCache.set(ServerSetup.TOOL_CACHE_KEY, tools);
+        // Try to get cached tools first
+        let tools = this.toolCache.get(ServerSetup.TOOL_CACHE_KEY);
 
-        const duration = Date.now() - startTime;
-        logger.info('ToolDiscoveryCache: Cache miss - fetched and cached tools', {
-          toolCount: tools.length,
-          duration: `${duration}ms`,
-          source: 'registry'
-        });
-      } else {
-        const duration = Date.now() - startTime;
-        logger.debug('ToolDiscoveryCache: Cache hit - returned cached tools', {
-          toolCount: tools.length,
-          duration: `${duration}ms`,
-          source: 'cache'
-        });
-      }
-      
-      return { tools };
+        if (!tools) {
+          // Cache miss - fetch tools from registry
+          tools = toolRegistry.getAllTools();
+
+          // Cache the results for future requests
+          this.toolCache.set(ServerSetup.TOOL_CACHE_KEY, tools);
+
+          const duration = Date.now() - startTime;
+          logger.info('ToolDiscoveryCache: Cache miss - fetched and cached tools', {
+            toolCount: tools.length,
+            duration: `${duration}ms`,
+            source: 'registry'
+          });
+        } else {
+          const duration = Date.now() - startTime;
+          logger.debug('ToolDiscoveryCache: Cache hit - returned cached tools', {
+            toolCount: tools.length,
+            duration: `${duration}ms`,
+            source: 'cache'
+          });
+        }
+
+        return { tools };
+      });
     });
   }
   
@@ -118,9 +128,10 @@ export class ServerSetup {
       // Issue #706 Phase 4: Hold first request(s) until deferred setup completes
       await this.awaitDeferredSetup();
 
-      const context = this.contextTracker.createContext('llm-request', {
-        toolName: request.params.name,
-      });
+      const session = this.sessionResolver?.(request);
+      const context = session
+        ? this.contextTracker.createSessionContext('llm-request', session, { toolName: request.params.name })
+        : this.contextTracker.createContext('llm-request', { toolName: request.params.name });
       return this.contextTracker.runAsync(context, async () => {
         const { name, arguments: args } = request.params;
 

--- a/src/services/ActivationStore.ts
+++ b/src/services/ActivationStore.ts
@@ -176,9 +176,9 @@ export class ActivationStore {
 
   constructor(fileOps: FileOperationsService, stateDir?: string, sessionId?: string) {
     this.fileOps = fileOps;
-    this.sessionId = sessionId !== undefined
-      ? validateExternalSessionId(sessionId)
-      : resolveSessionId();
+    this.sessionId = sessionId === undefined
+      ? resolveSessionId()
+      : validateExternalSessionId(sessionId);
     this.enabled = isPersistenceEnabled();
     this.stateDir = stateDir ?? path.join(os.homedir(), '.dollhouse', 'state');
     this.persistPath = path.join(this.stateDir, `activations-${this.sessionId}.json`);

--- a/src/services/ActivationStore.ts
+++ b/src/services/ActivationStore.ts
@@ -107,6 +107,25 @@ function resolveSessionId(): string {
 }
 
 /**
+ * Validates a sessionId provided externally (e.g., from SessionContext via DI).
+ * Uses the same SESSION_ID_PATTERN as resolveSessionId() to ensure path safety.
+ */
+function validateExternalSessionId(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    logger.warn('[ActivationStore] Empty sessionId provided — falling back to resolveSessionId()');
+    return resolveSessionId();
+  }
+  if (!SESSION_ID_PATTERN.test(trimmed)) {
+    logger.warn(
+      `[ActivationStore] Invalid external sessionId '${trimmed}' — falling back to 'default'`
+    );
+    return 'default';
+  }
+  return trimmed;
+}
+
+/**
  * Checks whether activation persistence is enabled.
  */
 function isPersistenceEnabled(): boolean {
@@ -155,9 +174,11 @@ export class ActivationStore {
 
   private state: PersistedActivationState;
 
-  constructor(fileOps: FileOperationsService, stateDir?: string) {
+  constructor(fileOps: FileOperationsService, stateDir?: string, sessionId?: string) {
     this.fileOps = fileOps;
-    this.sessionId = resolveSessionId();
+    this.sessionId = sessionId !== undefined
+      ? validateExternalSessionId(sessionId)
+      : resolveSessionId();
     this.enabled = isPersistenceEnabled();
     this.stateDir = stateDir ?? path.join(os.homedir(), '.dollhouse', 'state');
     this.persistPath = path.join(this.stateDir, `activations-${this.sessionId}.json`);

--- a/src/services/StateChangeNotifier.ts
+++ b/src/services/StateChangeNotifier.ts
@@ -10,6 +10,10 @@ export interface PersonaStateChangeEvent {
   previousValue: string | null;
   newValue: string | null;
   timestamp: Date;
+  /** Session user identity, populated by the caller from SessionContext. */
+  userId?: string;
+  /** Session identifier, populated by the caller from SessionContext. */
+  sessionId?: string;
 }
 
 /**

--- a/tests/helpers/di-mocks.ts
+++ b/tests/helpers/di-mocks.ts
@@ -730,6 +730,7 @@ export function createRealPersonaManager(
     metadataService,
     overrides?.personaImporter,
     overrides?.notifier,
+    undefined, // contextTracker — injected by DI container in production
     { fileWatchService } // baseOptions
   );
 }

--- a/tests/integration/ensembles/EnsembleActivation.integration.test.ts
+++ b/tests/integration/ensembles/EnsembleActivation.integration.test.ts
@@ -106,6 +106,7 @@ describe('Ensemble Activation Integration Tests', () => {
       metadataService,
       undefined, // personaImporter
       undefined, // notifier
+      undefined, // contextTracker
       { fileWatchService } // baseOptions
     );
 

--- a/tests/unit/context/ContextPolicy.test.ts
+++ b/tests/unit/context/ContextPolicy.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for ContextPolicy helpers
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  SYSTEM_CONTEXT,
+  SessionContextRequiredError,
+  isStrictMode,
+  getSessionOrSystem,
+} from '../../../src/context/ContextPolicy.js';
+import { ContextTracker } from '../../../src/security/encryption/ContextTracker.js';
+import type { SessionContext } from '../../../src/context/SessionContext.js';
+
+const TEST_SESSION: SessionContext = Object.freeze({
+  userId: 'test-user',
+  sessionId: 'test-session',
+  tenantId: null,
+  transport: 'stdio' as const,
+  createdAt: 1000000,
+});
+
+describe('SessionContextRequiredError', () => {
+  it('should have name SessionContextRequiredError', () => {
+    const err = new SessionContextRequiredError();
+    expect(err.name).toBe('SessionContextRequiredError');
+  });
+
+  it('should include caller in message when provided', () => {
+    const err = new SessionContextRequiredError('PersonaManager.activate');
+    expect(err.message).toContain('PersonaManager.activate');
+    expect(err.caller).toBe('PersonaManager.activate');
+  });
+
+  it('should be instanceof Error', () => {
+    const err = new SessionContextRequiredError();
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('should have undefined caller when not provided', () => {
+    const err = new SessionContextRequiredError();
+    expect(err.caller).toBeUndefined();
+  });
+});
+
+describe('isStrictMode', () => {
+  const originalNodeEnv = process.env['NODE_ENV'];
+  const originalStrict = process.env['DOLLHOUSE_STRICT_CONTEXT'];
+
+  afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env['NODE_ENV'];
+    } else {
+      process.env['NODE_ENV'] = originalNodeEnv;
+    }
+    if (originalStrict === undefined) {
+      delete process.env['DOLLHOUSE_STRICT_CONTEXT'];
+    } else {
+      process.env['DOLLHOUSE_STRICT_CONTEXT'] = originalStrict;
+    }
+  });
+
+  it('should return true in development', () => {
+    process.env['NODE_ENV'] = 'development';
+    expect(isStrictMode()).toBe(true);
+  });
+
+  it('should return true in test', () => {
+    process.env['NODE_ENV'] = 'test';
+    expect(isStrictMode()).toBe(true);
+  });
+
+  it('should return false in production without override', () => {
+    process.env['NODE_ENV'] = 'production';
+    delete process.env['DOLLHOUSE_STRICT_CONTEXT'];
+    expect(isStrictMode()).toBe(false);
+  });
+
+  it('should return true in production with DOLLHOUSE_STRICT_CONTEXT=true', () => {
+    process.env['NODE_ENV'] = 'production';
+    process.env['DOLLHOUSE_STRICT_CONTEXT'] = 'true';
+    expect(isStrictMode()).toBe(true);
+  });
+});
+
+describe('getSessionOrSystem', () => {
+  let tracker: ContextTracker;
+
+  beforeEach(() => {
+    tracker = new ContextTracker();
+  });
+
+  it('should return SYSTEM_CONTEXT when no session is active', () => {
+    const result = getSessionOrSystem(tracker);
+    expect(result).toBe(SYSTEM_CONTEXT);
+  });
+
+  it('should return the active session when one exists', async () => {
+    const context = tracker.createSessionContext('background-task', TEST_SESSION);
+    let result: SessionContext | undefined;
+
+    await tracker.runAsync(context, async () => {
+      result = getSessionOrSystem(tracker);
+    });
+
+    expect(result?.userId).toBe('test-user');
+    expect(result?.sessionId).toBe('test-session');
+  });
+
+  it('should not return SYSTEM_CONTEXT when a session is active', async () => {
+    const context = tracker.createSessionContext('llm-request', TEST_SESSION);
+    let result: SessionContext | undefined;
+
+    await tracker.runAsync(context, async () => {
+      result = getSessionOrSystem(tracker);
+    });
+
+    expect(result).not.toBe(SYSTEM_CONTEXT);
+  });
+});

--- a/tests/unit/context/SessionContext.test.ts
+++ b/tests/unit/context/SessionContext.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests for SessionContext interface and SYSTEM_CONTEXT sentinel
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import type { SessionContext } from '../../../src/context/SessionContext.js';
+import { SYSTEM_CONTEXT } from '../../../src/context/ContextPolicy.js';
+
+describe('SYSTEM_CONTEXT', () => {
+  it('should be frozen', () => {
+    expect(Object.isFrozen(SYSTEM_CONTEXT)).toBe(true);
+  });
+
+  it('should have userId "system"', () => {
+    expect(SYSTEM_CONTEXT.userId).toBe('system');
+  });
+
+  it('should have sessionId "system"', () => {
+    expect(SYSTEM_CONTEXT.sessionId).toBe('system');
+  });
+
+  it('should have null tenantId', () => {
+    expect(SYSTEM_CONTEXT.tenantId).toBeNull();
+  });
+
+  it('should have transport "stdio"', () => {
+    expect(SYSTEM_CONTEXT.transport).toBe('stdio');
+  });
+
+  it('should have createdAt of 0', () => {
+    expect(SYSTEM_CONTEXT.createdAt).toBe(0);
+  });
+
+  it('should not allow mutation', () => {
+    expect(() => {
+      (SYSTEM_CONTEXT as any).userId = 'hacked';
+    }).toThrow();
+  });
+
+  it('should satisfy SessionContext interface shape', () => {
+    const session: SessionContext = SYSTEM_CONTEXT;
+    expect(session).toBeDefined();
+    expect(session.userId).toBe('system');
+  });
+});

--- a/tests/unit/context/StdioSession.test.ts
+++ b/tests/unit/context/StdioSession.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for StdioSession factory
+ */
+
+import { describe, it, expect, afterEach } from '@jest/globals';
+import { createStdioSession } from '../../../src/context/StdioSession.js';
+
+describe('createStdioSession', () => {
+  const originalUser = process.env['DOLLHOUSE_USER'];
+  const originalSession = process.env['DOLLHOUSE_SESSION_ID'];
+
+  afterEach(() => {
+    if (originalUser === undefined) {
+      delete process.env['DOLLHOUSE_USER'];
+    } else {
+      process.env['DOLLHOUSE_USER'] = originalUser;
+    }
+    if (originalSession === undefined) {
+      delete process.env['DOLLHOUSE_SESSION_ID'];
+    } else {
+      process.env['DOLLHOUSE_SESSION_ID'] = originalSession;
+    }
+  });
+
+  it('should default userId to "local-user" when DOLLHOUSE_USER is unset', () => {
+    delete process.env['DOLLHOUSE_USER'];
+    const session = createStdioSession();
+    expect(session.userId).toBe('local-user');
+  });
+
+  it('should use DOLLHOUSE_USER when set', () => {
+    process.env['DOLLHOUSE_USER'] = 'alice';
+    const session = createStdioSession();
+    expect(session.userId).toBe('alice');
+  });
+
+  it('should default sessionId to "default" when DOLLHOUSE_SESSION_ID is unset', () => {
+    delete process.env['DOLLHOUSE_SESSION_ID'];
+    const session = createStdioSession();
+    expect(session.sessionId).toBe('default');
+  });
+
+  it('should use DOLLHOUSE_SESSION_ID when set', () => {
+    process.env['DOLLHOUSE_SESSION_ID'] = 'claude-code';
+    const session = createStdioSession();
+    expect(session.sessionId).toBe('claude-code');
+  });
+
+  it('should always have transport "stdio"', () => {
+    const session = createStdioSession();
+    expect(session.transport).toBe('stdio');
+  });
+
+  it('should always have tenantId null', () => {
+    const session = createStdioSession();
+    expect(session.tenantId).toBeNull();
+  });
+
+  it('should set createdAt to a recent timestamp', () => {
+    const before = Date.now();
+    const session = createStdioSession();
+    const after = Date.now();
+    expect(session.createdAt).toBeGreaterThanOrEqual(before);
+    expect(session.createdAt).toBeLessThanOrEqual(after);
+  });
+
+  it('should return a frozen object', () => {
+    const session = createStdioSession();
+    expect(Object.isFrozen(session)).toBe(true);
+  });
+
+  it('should trim whitespace from DOLLHOUSE_USER', () => {
+    process.env['DOLLHOUSE_USER'] = '  bob  ';
+    const session = createStdioSession();
+    expect(session.userId).toBe('bob');
+  });
+
+  it('should trim whitespace from DOLLHOUSE_SESSION_ID', () => {
+    process.env['DOLLHOUSE_SESSION_ID'] = '  my-session  ';
+    const session = createStdioSession();
+    expect(session.sessionId).toBe('my-session');
+  });
+});

--- a/tests/unit/events/ElementEventDispatcher.test.ts
+++ b/tests/unit/events/ElementEventDispatcher.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
-import { ElementEventDispatcher, type ElementLifecycleEvent } from '../../../src/events/ElementEventDispatcher.js';
+import { ElementEventDispatcher, type ElementLifecycleEvent, type ElementEventPayload } from '../../../src/events/ElementEventDispatcher.js';
 import { ElementType } from '../../../src/portfolio/types.js';
+import { ContextTracker } from '../../../src/security/encryption/ContextTracker.js';
+import type { SessionContext } from '../../../src/context/SessionContext.js';
 
 function createPayload() {
   return {
@@ -49,5 +51,84 @@ describe('ElementEventDispatcher', () => {
     dispatcher.emit('element:cache:refresh', createPayload());
 
     expect(events).toEqual(['element:cache:refresh']);
+  });
+});
+
+const TEST_SESSION: SessionContext = Object.freeze({
+  userId: 'http-user-alice',
+  sessionId: 'session-456',
+  tenantId: null,
+  transport: 'http' as const,
+  createdAt: Date.now(),
+});
+
+describe('ElementEventDispatcher — session attribution', () => {
+  it('emit() adds userId and sessionId when session is active', async () => {
+    const tracker = new ContextTracker();
+    const dispatcher = new ElementEventDispatcher(tracker);
+    const ctx = tracker.createSessionContext('llm-request', TEST_SESSION);
+
+    let received: ElementEventPayload | undefined;
+    dispatcher.on('element:save:success', (payload) => {
+      received = payload;
+    });
+
+    await tracker.runAsync(ctx, async () => {
+      dispatcher.emit('element:save:success', createPayload());
+    });
+
+    expect(received?.userId).toBe('http-user-alice');
+    expect(received?.sessionId).toBe('session-456');
+  });
+
+  it('emitAsync() captures session before setImmediate boundary', async () => {
+    const tracker = new ContextTracker();
+    const dispatcher = new ElementEventDispatcher(tracker);
+    const ctx = tracker.createSessionContext('llm-request', TEST_SESSION);
+
+    let received: ElementEventPayload | undefined;
+    dispatcher.on('element:load:success', (payload) => {
+      received = payload;
+    });
+
+    await tracker.runAsync(ctx, async () => {
+      dispatcher.emitAsync('element:load:success', createPayload());
+    });
+
+    // Wait for setImmediate to fire
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(received?.userId).toBe('http-user-alice');
+    expect(received?.sessionId).toBe('session-456');
+  });
+
+  it('emit() does not add session fields when no ContextTracker', () => {
+    const dispatcher = new ElementEventDispatcher(); // no tracker
+
+    let received: ElementEventPayload | undefined;
+    dispatcher.on('element:delete:success', (payload) => {
+      received = payload;
+    });
+
+    dispatcher.emit('element:delete:success', createPayload());
+
+    expect(received?.userId).toBeUndefined();
+    expect(received?.sessionId).toBeUndefined();
+  });
+
+  it('emit() does not add session fields when no session active', () => {
+    const tracker = new ContextTracker();
+    const dispatcher = new ElementEventDispatcher(tracker);
+
+    let received: ElementEventPayload | undefined;
+    dispatcher.on('element:activate', (payload) => {
+      received = payload;
+    });
+
+    // No runAsync — no session in AsyncLocalStorage
+    dispatcher.emit('element:activate', createPayload());
+
+    expect(received?.userId).toBeUndefined();
+    expect(received?.sessionId).toBeUndefined();
   });
 });

--- a/tests/unit/logging/LogHooks.test.ts
+++ b/tests/unit/logging/LogHooks.test.ts
@@ -1154,4 +1154,97 @@ describe('LogHooks', () => {
       });
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Session attribution (userId/sessionId) via ContextTracker
+  // -------------------------------------------------------------------------
+
+  describe('session attribution injection', () => {
+    it('should include userId and sessionId when ContextTracker has active session', () => {
+      const mockListener = jest.fn();
+      const mcpLogger = {
+        addLogListener: jest.fn((fn) => {
+          mockListener.mockImplementation(fn);
+          return jest.fn();
+        }),
+      };
+      const mockContextTracker = {
+        getCorrelationId: jest.fn(() => 'REQ-1'),
+        getSessionContext: jest.fn(() => ({ userId: 'alice', sessionId: 'sess-1' })),
+      };
+      const container = makeMockContainer({
+        MCPLogger: mcpLogger,
+        ContextTracker: mockContextTracker,
+      });
+
+      wireLogHooks(mockLogManager, container);
+
+      mockListener({
+        timestamp: new Date(),
+        level: 'info',
+        message: 'Test with session',
+      });
+
+      expect(mockLogManager.logCalls).toHaveLength(1);
+      const entry = mockLogManager.logCalls[0];
+      expect(entry.userId).toBe('alice');
+      expect(entry.sessionId).toBe('sess-1');
+      expect(entry.correlationId).toBe('REQ-1');
+    });
+
+    it('should omit userId and sessionId when no session active', () => {
+      const mockListener = jest.fn();
+      const mcpLogger = {
+        addLogListener: jest.fn((fn) => {
+          mockListener.mockImplementation(fn);
+          return jest.fn();
+        }),
+      };
+      const mockContextTracker = {
+        getCorrelationId: jest.fn(() => undefined),
+        getSessionContext: jest.fn(() => undefined),
+      };
+      const container = makeMockContainer({
+        MCPLogger: mcpLogger,
+        ContextTracker: mockContextTracker,
+      });
+
+      wireLogHooks(mockLogManager, container);
+
+      mockListener({
+        timestamp: new Date(),
+        level: 'info',
+        message: 'Test without session',
+      });
+
+      expect(mockLogManager.logCalls).toHaveLength(1);
+      const entry = mockLogManager.logCalls[0];
+      expect(entry.userId).toBeUndefined();
+      expect(entry.sessionId).toBeUndefined();
+    });
+
+    it('should omit userId and sessionId when no ContextTracker registered', () => {
+      const mockListener = jest.fn();
+      const mcpLogger = {
+        addLogListener: jest.fn((fn) => {
+          mockListener.mockImplementation(fn);
+          return jest.fn();
+        }),
+      };
+      const container = makeMockContainer({ MCPLogger: mcpLogger });
+
+      wireLogHooks(mockLogManager, container);
+
+      mockListener({
+        timestamp: new Date(),
+        level: 'info',
+        message: 'Test no tracker',
+      });
+
+      expect(mockLogManager.logCalls).toHaveLength(1);
+      const entry = mockLogManager.logCalls[0];
+      expect(entry.userId).toBeUndefined();
+      expect(entry.sessionId).toBeUndefined();
+    });
+  });
 });

--- a/tests/unit/logging/LogHooks.test.ts
+++ b/tests/unit/logging/LogHooks.test.ts
@@ -894,6 +894,7 @@ describe('LogHooks', () => {
       };
       const mockContextTracker = {
         getCorrelationId: jest.fn(() => 'REQ-12345'),
+        getSessionContext: jest.fn(() => undefined),
       };
       const container = makeMockContainer({
         MCPLogger: mcpLogger,
@@ -922,6 +923,7 @@ describe('LogHooks', () => {
       };
       const mockContextTracker = {
         getCorrelationId: jest.fn(() => undefined),
+        getSessionContext: jest.fn(() => undefined),
       };
       const container = makeMockContainer({
         MCPLogger: mcpLogger,
@@ -975,6 +977,7 @@ describe('LogHooks', () => {
       };
       const mockContextTracker = {
         getCorrelationId: jest.fn(() => 'REQ-LEVEL-ID'),
+        getSessionContext: jest.fn(() => undefined),
       };
       const container = makeMockContainer({
         ElementEventDispatcher: dispatcher,
@@ -1011,6 +1014,7 @@ describe('LogHooks', () => {
       };
       const mockContextTracker = {
         getCorrelationId: jest.fn(() => undefined),
+        getSessionContext: jest.fn(() => undefined),
       };
       const container = makeMockContainer({
         ElementEventDispatcher: dispatcher,
@@ -1040,7 +1044,7 @@ describe('LogHooks', () => {
 
   describe('getTriggerMetricsLogListener with contextTracker', () => {
     it('should include correlationId when contextTracker is provided', () => {
-      const mockContextTracker = { getCorrelationId: jest.fn(() => 'TRIGGER-REQ-1') };
+      const mockContextTracker = { getCorrelationId: jest.fn(() => 'TRIGGER-REQ-1'), getSessionContext: jest.fn(() => undefined) };
       const listener = getTriggerMetricsLogListener(mockLogManager, mockContextTracker);
 
       listener('info', 'Trigger fired', { triggerId: 'T-1' });
@@ -1064,7 +1068,7 @@ describe('LogHooks', () => {
 
   describe('getSecurityAuditorLogListener with contextTracker', () => {
     it('should include correlationId when contextTracker is provided', () => {
-      const mockContextTracker = { getCorrelationId: jest.fn(() => 'AUDIT-REQ-1') };
+      const mockContextTracker = { getCorrelationId: jest.fn(() => 'AUDIT-REQ-1'), getSessionContext: jest.fn(() => undefined) };
       const listener = getSecurityAuditorLogListener(mockLogManager, mockContextTracker);
 
       listener('warn', 'Violation', { rule: 'TEST' });
@@ -1202,6 +1206,7 @@ describe('LogHooks', () => {
       };
       const mockContextTracker = {
         getCorrelationId: jest.fn(() => undefined),
+        getSessionContext: jest.fn(() => undefined),
         getSessionContext: jest.fn(() => undefined),
       };
       const container = makeMockContainer({

--- a/tests/unit/logging/LogHooks.test.ts
+++ b/tests/unit/logging/LogHooks.test.ts
@@ -1207,7 +1207,6 @@ describe('LogHooks', () => {
       const mockContextTracker = {
         getCorrelationId: jest.fn(() => undefined),
         getSessionContext: jest.fn(() => undefined),
-        getSessionContext: jest.fn(() => undefined),
       };
       const container = makeMockContainer({
         MCPLogger: mcpLogger,

--- a/tests/unit/persona/PersonaManager.identity.test.ts
+++ b/tests/unit/persona/PersonaManager.identity.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Unit tests for PersonaManager session-aware identity reads (Step 1.5)
+ *
+ * Tests that getCurrentUserForAttribution() and getUserIdentity() prefer
+ * SessionContext when an explicit identity is present, falling back to
+ * MetadataService/process.env for default stdio sessions.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+
+jest.mock('../../../src/utils/logger.js', () => ({
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/security/securityMonitor.js', () => ({
+  SecurityMonitor: { logSecurityEvent: jest.fn() },
+}));
+
+import { ContextTracker } from '../../../src/security/encryption/ContextTracker.js';
+import { STDIO_DEFAULT_USER_ID } from '../../../src/context/StdioSession.js';
+import { SYSTEM_CONTEXT } from '../../../src/context/ContextPolicy.js';
+import type { SessionContext } from '../../../src/context/SessionContext.js';
+import {
+  createMockPortfolioManager,
+  createMockValidationRegistry,
+} from '../../helpers/di-mocks.js';
+
+// MetadataService mock — controls what the fallback chain returns
+const mockGetCurrentUser = jest.fn<() => string>().mockReturnValue('os-fallback-user');
+const mockSetCurrentUser = jest.fn();
+const mockMetadataService = {
+  getCurrentUser: mockGetCurrentUser,
+  setCurrentUser: mockSetCurrentUser,
+};
+
+const mockFileLockManager = { withLock: jest.fn() };
+const mockFileOps = {};
+const mockIndicatorConfig = {};
+
+// Dynamic import to avoid hoisting issues with mocks
+let PersonaManager: any;
+
+beforeAll(async () => {
+  const mod = await import('../../../src/persona/PersonaManager.js');
+  PersonaManager = mod.PersonaManager;
+});
+
+function createPersonaManager(contextTracker?: ContextTracker) {
+  return new PersonaManager(
+    createMockPortfolioManager(),
+    mockIndicatorConfig,
+    mockFileLockManager,
+    mockFileOps,
+    createMockValidationRegistry(),
+    mockMetadataService,
+    undefined, // personaImporter
+    undefined, // notifier
+    contextTracker,
+    {}, // baseOptions
+  );
+}
+
+function makeSession(overrides: Partial<SessionContext> = {}): SessionContext {
+  return Object.freeze({
+    userId: 'http-user-alice',
+    sessionId: 'session-123',
+    tenantId: null,
+    transport: 'http' as const,
+    createdAt: Date.now(),
+    ...overrides,
+  });
+}
+
+describe('PersonaManager — session-aware identity (Step 1.5)', () => {
+  let tracker: ContextTracker;
+
+  beforeEach(() => {
+    tracker = new ContextTracker();
+    mockGetCurrentUser.mockReturnValue('os-fallback-user');
+    mockSetCurrentUser.mockClear();
+    delete process.env.DOLLHOUSE_USER;
+    delete process.env.DOLLHOUSE_EMAIL;
+  });
+
+  const originalUser = process.env.DOLLHOUSE_USER;
+  const originalEmail = process.env.DOLLHOUSE_EMAIL;
+
+  afterEach(() => {
+    if (originalUser === undefined) delete process.env.DOLLHOUSE_USER;
+    else process.env.DOLLHOUSE_USER = originalUser;
+    if (originalEmail === undefined) delete process.env.DOLLHOUSE_EMAIL;
+    else process.env.DOLLHOUSE_EMAIL = originalEmail;
+  });
+
+  describe('getCurrentUserForAttribution', () => {
+    it('returns session userId when it is an explicit identity', async () => {
+      const pm = createPersonaManager(tracker);
+      const session = makeSession({ userId: 'http-user-alice' });
+      const ctx = tracker.createSessionContext('llm-request', session);
+
+      let result: string | undefined;
+      await tracker.runAsync(ctx, async () => {
+        result = pm.getCurrentUserForAttribution();
+      });
+
+      expect(result).toBe('http-user-alice');
+    });
+
+    it('returns session displayName over userId when both present', async () => {
+      const pm = createPersonaManager(tracker);
+      const session = makeSession({ userId: 'uid-123', displayName: 'Alice Smith' });
+      const ctx = tracker.createSessionContext('llm-request', session);
+
+      let result: string | undefined;
+      await tracker.runAsync(ctx, async () => {
+        result = pm.getCurrentUserForAttribution();
+      });
+
+      expect(result).toBe('Alice Smith');
+    });
+
+    it('falls back to MetadataService when session userId is default stdio', async () => {
+      const pm = createPersonaManager(tracker);
+      const session = makeSession({ userId: STDIO_DEFAULT_USER_ID });
+      const ctx = tracker.createSessionContext('llm-request', session);
+
+      let result: string | undefined;
+      await tracker.runAsync(ctx, async () => {
+        result = pm.getCurrentUserForAttribution();
+      });
+
+      expect(result).toBe('os-fallback-user');
+    });
+
+    it('falls back to MetadataService when session userId is system', async () => {
+      const pm = createPersonaManager(tracker);
+      const session = makeSession({ userId: SYSTEM_CONTEXT.userId });
+      const ctx = tracker.createSessionContext('llm-request', session);
+
+      let result: string | undefined;
+      await tracker.runAsync(ctx, async () => {
+        result = pm.getCurrentUserForAttribution();
+      });
+
+      expect(result).toBe('os-fallback-user');
+    });
+
+    it('falls back to MetadataService when no session is active', () => {
+      const pm = createPersonaManager(tracker);
+      const result = pm.getCurrentUserForAttribution();
+      expect(result).toBe('os-fallback-user');
+    });
+
+    it('falls back when no contextTracker injected (backward compat)', () => {
+      const pm = createPersonaManager(); // no tracker
+      const result = pm.getCurrentUserForAttribution();
+      expect(result).toBe('os-fallback-user');
+    });
+  });
+
+  describe('getUserIdentity', () => {
+    it('returns session identity for explicit session', async () => {
+      const pm = createPersonaManager(tracker);
+      const session = makeSession({
+        userId: 'http-user-bob',
+        email: 'bob@example.com',
+      });
+      const ctx = tracker.createSessionContext('llm-request', session);
+
+      let result: { username: string | null; email: string | null } | undefined;
+      await tracker.runAsync(ctx, async () => {
+        result = pm.getUserIdentity();
+      });
+
+      expect(result?.username).toBe('http-user-bob');
+      expect(result?.email).toBe('bob@example.com');
+    });
+
+    it('falls back to process.env for default stdio session', async () => {
+      process.env.DOLLHOUSE_USER = 'env-user';
+      process.env.DOLLHOUSE_EMAIL = 'env@example.com';
+
+      const pm = createPersonaManager(tracker);
+      const session = makeSession({ userId: STDIO_DEFAULT_USER_ID });
+      const ctx = tracker.createSessionContext('llm-request', session);
+
+      let result: { username: string | null; email: string | null } | undefined;
+      await tracker.runAsync(ctx, async () => {
+        result = pm.getUserIdentity();
+      });
+
+      expect(result?.username).toBe('env-user');
+      expect(result?.email).toBe('env@example.com');
+    });
+
+    it('falls back to process.env when no session active', () => {
+      process.env.DOLLHOUSE_USER = 'env-user';
+      const pm = createPersonaManager(tracker);
+      const result = pm.getUserIdentity();
+      expect(result.username).toBe('env-user');
+    });
+
+    it('returns null username when no session and no env var', () => {
+      const pm = createPersonaManager(tracker);
+      const result = pm.getUserIdentity();
+      expect(result.username).toBeNull();
+      expect(result.email).toBeNull();
+    });
+  });
+});

--- a/tests/unit/security/encryption/ContextTracker.session.test.ts
+++ b/tests/unit/security/encryption/ContextTracker.session.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for ContextTracker session-context methods
+ *
+ * Tests the three new methods added in Phase 1 Step 1.1:
+ * - getSessionContext()
+ * - requireSessionContext()
+ * - createSessionContext()
+ *
+ * The existing ContextTracker.test.ts remains unmodified.
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { ContextTracker } from '../../../../src/security/encryption/ContextTracker.js';
+import { SessionContextRequiredError } from '../../../../src/context/ContextPolicy.js';
+import type { SessionContext } from '../../../../src/context/SessionContext.js';
+
+const TEST_SESSION: SessionContext = Object.freeze({
+  userId: 'tracker-test-user',
+  sessionId: 'tracker-test-session',
+  tenantId: null,
+  transport: 'stdio' as const,
+  createdAt: 2000000,
+});
+
+describe('ContextTracker — session methods', () => {
+  let tracker: ContextTracker;
+
+  beforeEach(() => {
+    tracker = new ContextTracker();
+    tracker.clearContext();
+  });
+
+  describe('createSessionContext', () => {
+    it('should create context with session attached', () => {
+      const ctx = tracker.createSessionContext('llm-request', TEST_SESSION);
+
+      expect(ctx.type).toBe('llm-request');
+      expect(ctx.session).toBeDefined();
+      expect(ctx.session?.userId).toBe('tracker-test-user');
+    });
+
+    it('should freeze the session object', () => {
+      const ctx = tracker.createSessionContext('background-task', TEST_SESSION);
+      expect(Object.isFrozen(ctx.session)).toBe(true);
+    });
+
+    it('should generate requestId and timestamp', () => {
+      const ctx = tracker.createSessionContext('test', TEST_SESSION);
+      expect(ctx.requestId).toBeDefined();
+      expect(ctx.timestamp).toBeGreaterThan(0);
+    });
+
+    it('should accept optional metadata', () => {
+      const ctx = tracker.createSessionContext('test', TEST_SESSION, {
+        tool: 'test-tool',
+      });
+      expect(ctx.metadata?.tool).toBe('test-tool');
+    });
+
+    it('should shallow-copy session before freezing', () => {
+      const mutableSession: SessionContext = {
+        userId: 'mutable',
+        sessionId: 'mutable-session',
+        tenantId: null,
+        transport: 'stdio',
+        createdAt: 3000000,
+      };
+      const ctx = tracker.createSessionContext('test', mutableSession);
+
+      // The stored session should be a separate frozen copy
+      expect(ctx.session?.userId).toBe('mutable');
+      expect(Object.isFrozen(ctx.session)).toBe(true);
+    });
+  });
+
+  describe('getSessionContext', () => {
+    it('should return undefined when no context is active', () => {
+      expect(tracker.getSessionContext()).toBeUndefined();
+    });
+
+    it('should return undefined when context has no session', () => {
+      const ctx = tracker.createContext('llm-request');
+      tracker.run(ctx, () => {
+        expect(tracker.getSessionContext()).toBeUndefined();
+      });
+    });
+
+    it('should return session when context has one', async () => {
+      const ctx = tracker.createSessionContext('background-task', TEST_SESSION);
+      let result: SessionContext | undefined;
+
+      await tracker.runAsync(ctx, async () => {
+        result = tracker.getSessionContext();
+      });
+
+      expect(result?.userId).toBe('tracker-test-user');
+      expect(result?.sessionId).toBe('tracker-test-session');
+    });
+
+    it('should return undefined after context exits', async () => {
+      const ctx = tracker.createSessionContext('test', TEST_SESSION);
+      await tracker.runAsync(ctx, async () => {
+        expect(tracker.getSessionContext()).toBeDefined();
+      });
+      expect(tracker.getSessionContext()).toBeUndefined();
+    });
+
+    it('should propagate through nested async calls', async () => {
+      const ctx = tracker.createSessionContext('llm-request', TEST_SESSION);
+
+      const innerCheck = async (): Promise<SessionContext | undefined> => {
+        return tracker.getSessionContext();
+      };
+
+      let result: SessionContext | undefined;
+      await tracker.runAsync(ctx, async () => {
+        result = await innerCheck();
+      });
+
+      expect(result?.userId).toBe('tracker-test-user');
+    });
+  });
+
+  describe('requireSessionContext', () => {
+    it('should throw when no context is active', () => {
+      expect(() => tracker.requireSessionContext()).toThrow(
+        SessionContextRequiredError
+      );
+    });
+
+    it('should throw when context has no session', () => {
+      const ctx = tracker.createContext('llm-request');
+      tracker.run(ctx, () => {
+        expect(() => tracker.requireSessionContext()).toThrow(
+          SessionContextRequiredError
+        );
+      });
+    });
+
+    it('should include caller in error when provided', () => {
+      try {
+        tracker.requireSessionContext('TestCaller.method');
+        expect(true).toBe(false); // should not reach
+      } catch (err) {
+        expect((err as SessionContextRequiredError).message).toContain(
+          'TestCaller.method'
+        );
+      }
+    });
+
+    it('should return session when one is active', async () => {
+      const ctx = tracker.createSessionContext('test', TEST_SESSION);
+      let result: SessionContext | undefined;
+
+      await tracker.runAsync(ctx, async () => {
+        result = tracker.requireSessionContext();
+      });
+
+      expect(result?.userId).toBe('tracker-test-user');
+    });
+  });
+
+  describe('backward compatibility', () => {
+    it('createContext should still work without session', () => {
+      const ctx = tracker.createContext('llm-request', { tool: 'foo' });
+      expect(ctx.session).toBeUndefined();
+      expect(ctx.type).toBe('llm-request');
+      expect(ctx.metadata?.tool).toBe('foo');
+    });
+
+    it('existing run() works with session-less context', () => {
+      const ctx = tracker.createContext('background-task');
+      let captured;
+      tracker.run(ctx, () => {
+        captured = tracker.getContext();
+      });
+      expect(captured).toEqual(ctx);
+    });
+
+    it('isLLMContext still works with session context', async () => {
+      const ctx = tracker.createSessionContext('llm-request', TEST_SESSION);
+      let isLLM = false;
+
+      await tracker.runAsync(ctx, async () => {
+        isLLM = tracker.isLLMContext();
+      });
+
+      expect(isLLM).toBe(true);
+    });
+
+    it('getCorrelationId works with session context', async () => {
+      const ctx = tracker.createSessionContext('llm-request', TEST_SESSION);
+      let correlationId: string | undefined;
+
+      await tracker.runAsync(ctx, async () => {
+        correlationId = tracker.getCorrelationId();
+      });
+
+      expect(correlationId).toBeDefined();
+      expect(correlationId).toBe(ctx.requestId);
+    });
+  });
+});

--- a/tests/unit/server/ServerSetup.test.ts
+++ b/tests/unit/server/ServerSetup.test.ts
@@ -28,6 +28,8 @@ jest.mock('../../../src/utils/logger.js', () => ({
 
 import { ServerSetup } from '../../../src/server/ServerSetup.js';
 import { ContextTracker } from '../../../src/security/encryption/ContextTracker.js';
+import type { SessionContext } from '../../../src/context/SessionContext.js';
+import { createStdioSession } from '../../../src/context/StdioSession.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -332,6 +334,121 @@ describe('ServerSetup', () => {
       await callHandler({ params: { name: 'test_tool', arguments: {} } });
 
       expect(mockTools.test_tool).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('session context propagation', () => {
+    it('should return undefined getSessionContext when no resolver is provided', async () => {
+      let capturedSession: SessionContext | undefined;
+      const mockTools = {
+        test_tool: jest.fn(async () => {
+          capturedSession = contextTracker.getSessionContext();
+          return { content: [{ type: 'text', text: 'ok' }] };
+        }),
+      };
+
+      const server = createMockServer();
+      const registry = createMockToolRegistry(mockTools);
+      serverSetup.setupServer(server as any, registry as any);
+
+      const callHandler = server.getCallToolHandler();
+      await callHandler({ params: { name: 'test_tool', arguments: {} } });
+
+      expect(capturedSession).toBeUndefined();
+    });
+
+    it('should provide SessionContext inside handler when resolver is given', async () => {
+      const stdioSession = createStdioSession();
+      const setupWithSession = new ServerSetup(contextTracker, () => stdioSession);
+
+      let capturedSession: SessionContext | undefined;
+      const mockTools = {
+        test_tool: jest.fn(async () => {
+          capturedSession = contextTracker.getSessionContext();
+          return { content: [{ type: 'text', text: 'ok' }] };
+        }),
+      };
+
+      const server = createMockServer();
+      const registry = createMockToolRegistry(mockTools);
+      setupWithSession.setupServer(server as any, registry as any);
+
+      const callHandler = server.getCallToolHandler();
+      await callHandler({ params: { name: 'test_tool', arguments: {} } });
+
+      expect(capturedSession).toBeDefined();
+      expect(capturedSession!.transport).toBe('stdio');
+      expect(capturedSession!.tenantId).toBeNull();
+      expect(Object.isFrozen(capturedSession)).toBe(true);
+    });
+
+    it('should clear session context after handler completes', async () => {
+      const stdioSession = createStdioSession();
+      const setupWithSession = new ServerSetup(contextTracker, () => stdioSession);
+
+      const mockTools = {
+        test_tool: jest.fn(async () => {
+          return { content: [{ type: 'text', text: 'ok' }] };
+        }),
+      };
+
+      const server = createMockServer();
+      const registry = createMockToolRegistry(mockTools);
+      setupWithSession.setupServer(server as any, registry as any);
+
+      const callHandler = server.getCallToolHandler();
+      await callHandler({ params: { name: 'test_tool', arguments: {} } });
+
+      expect(contextTracker.getSessionContext()).toBeUndefined();
+    });
+
+    it('should preserve llm-request type and toolName metadata with session', async () => {
+      const stdioSession = createStdioSession();
+      const setupWithSession = new ServerSetup(contextTracker, () => stdioSession);
+
+      let capturedContext: any;
+      const mockTools = {
+        my_tool: jest.fn(async () => {
+          capturedContext = contextTracker.getContext();
+          return { content: [{ type: 'text', text: 'ok' }] };
+        }),
+      };
+
+      const server = createMockServer();
+      const registry = createMockToolRegistry(mockTools);
+      setupWithSession.setupServer(server as any, registry as any);
+
+      const callHandler = server.getCallToolHandler();
+      await callHandler({ params: { name: 'my_tool', arguments: {} } });
+
+      expect(capturedContext.type).toBe('llm-request');
+      expect(capturedContext.metadata).toEqual({ toolName: 'my_tool' });
+      expect(capturedContext.session).toBeDefined();
+    });
+
+    it('should return the same session across multiple calls', async () => {
+      const stdioSession = createStdioSession();
+      const setupWithSession = new ServerSetup(contextTracker, () => stdioSession);
+
+      const sessions: (SessionContext | undefined)[] = [];
+      const mockTools = {
+        test_tool: jest.fn(async () => {
+          sessions.push(contextTracker.getSessionContext());
+          return { content: [{ type: 'text', text: 'ok' }] };
+        }),
+      };
+
+      const server = createMockServer();
+      const registry = createMockToolRegistry(mockTools);
+      setupWithSession.setupServer(server as any, registry as any);
+
+      const callHandler = server.getCallToolHandler();
+      await callHandler({ params: { name: 'test_tool', arguments: {} } });
+      await callHandler({ params: { name: 'test_tool', arguments: {} } });
+
+      expect(sessions).toHaveLength(2);
+      expect(sessions[0]!.userId).toBe(sessions[1]!.userId);
+      expect(sessions[0]!.sessionId).toBe(sessions[1]!.sessionId);
     });
   });
 });

--- a/tests/unit/services/ActivationStore.test.ts
+++ b/tests/unit/services/ActivationStore.test.ts
@@ -119,41 +119,43 @@ describe('ActivationStore', () => {
     });
 
     describe('with explicit sessionId parameter', () => {
+      const testStateDir = path.join('fake-home', '.dollhouse', 'test-state');
+
       it('should use provided sessionId when valid', () => {
-        const s = new ActivationStore(mockFileOps, '/tmp/test', 'explicit-session');
+        const s = new ActivationStore(mockFileOps, testStateDir, 'explicit-session');
         expect(s.getSessionId()).toBe('explicit-session');
       });
 
       it('should fall back to default when provided sessionId has path traversal', () => {
-        const s = new ActivationStore(mockFileOps, '/tmp/test', '../evil-path');
+        const s = new ActivationStore(mockFileOps, testStateDir, '../evil-path');
         expect(s.getSessionId()).toBe('default');
       });
 
       it('should fall back to default when provided sessionId starts with number', () => {
-        const s = new ActivationStore(mockFileOps, '/tmp/test', '123-bad');
+        const s = new ActivationStore(mockFileOps, testStateDir, '123-bad');
         expect(s.getSessionId()).toBe('default');
       });
 
       it('should fall back to resolveSessionId when provided sessionId is empty string', () => {
-        const s = new ActivationStore(mockFileOps, '/tmp/test', '');
+        const s = new ActivationStore(mockFileOps, testStateDir, '');
         // Empty string triggers resolveSessionId() fallback which generates random ID
         expect(s.getSessionId()).toMatch(/^session-[a-z0-9]+-[a-f0-9]+$/);
       });
 
       it('should trim whitespace from provided sessionId', () => {
-        const s = new ActivationStore(mockFileOps, '/tmp/test', '  valid-session  ');
+        const s = new ActivationStore(mockFileOps, testStateDir, '  valid-session  ');
         expect(s.getSessionId()).toBe('valid-session');
       });
 
       it('should still use resolveSessionId when sessionId param is undefined', () => {
         process.env.DOLLHOUSE_SESSION_ID = 'from-env';
-        const s = new ActivationStore(mockFileOps, '/tmp/test', undefined);
+        const s = new ActivationStore(mockFileOps, testStateDir, undefined);
         expect(s.getSessionId()).toBe('from-env');
       });
 
       it('should prefer explicit sessionId over env var', () => {
         process.env.DOLLHOUSE_SESSION_ID = 'from-env';
-        const s = new ActivationStore(mockFileOps, '/tmp/test', 'from-param');
+        const s = new ActivationStore(mockFileOps, testStateDir, 'from-param');
         expect(s.getSessionId()).toBe('from-param');
       });
     });

--- a/tests/unit/services/ActivationStore.test.ts
+++ b/tests/unit/services/ActivationStore.test.ts
@@ -118,6 +118,46 @@ describe('ActivationStore', () => {
       expect(s.getSessionId()).toBe('default');
     });
 
+    describe('with explicit sessionId parameter', () => {
+      it('should use provided sessionId when valid', () => {
+        const s = new ActivationStore(mockFileOps, '/tmp/test', 'explicit-session');
+        expect(s.getSessionId()).toBe('explicit-session');
+      });
+
+      it('should fall back to default when provided sessionId has path traversal', () => {
+        const s = new ActivationStore(mockFileOps, '/tmp/test', '../evil-path');
+        expect(s.getSessionId()).toBe('default');
+      });
+
+      it('should fall back to default when provided sessionId starts with number', () => {
+        const s = new ActivationStore(mockFileOps, '/tmp/test', '123-bad');
+        expect(s.getSessionId()).toBe('default');
+      });
+
+      it('should fall back to resolveSessionId when provided sessionId is empty string', () => {
+        const s = new ActivationStore(mockFileOps, '/tmp/test', '');
+        // Empty string triggers resolveSessionId() fallback which generates random ID
+        expect(s.getSessionId()).toMatch(/^session-[a-z0-9]+-[a-f0-9]+$/);
+      });
+
+      it('should trim whitespace from provided sessionId', () => {
+        const s = new ActivationStore(mockFileOps, '/tmp/test', '  valid-session  ');
+        expect(s.getSessionId()).toBe('valid-session');
+      });
+
+      it('should still use resolveSessionId when sessionId param is undefined', () => {
+        process.env.DOLLHOUSE_SESSION_ID = 'from-env';
+        const s = new ActivationStore(mockFileOps, '/tmp/test', undefined);
+        expect(s.getSessionId()).toBe('from-env');
+      });
+
+      it('should prefer explicit sessionId over env var', () => {
+        process.env.DOLLHOUSE_SESSION_ID = 'from-env';
+        const s = new ActivationStore(mockFileOps, '/tmp/test', 'from-param');
+        expect(s.getSessionId()).toBe('from-param');
+      });
+    });
+
     it('should be enabled by default', () => {
       expect(store.isEnabled()).toBe(true);
     });


### PR DESCRIPTION
## Summary

Adds per-request session identity tracking to the MCP server, laying the groundwork for hosted HTTP and multi-user support. Today, user identity and session state are stored in process-global variables (`process.env`, singleton fields). This PR threads a `SessionContext` through the entire request lifecycle via `AsyncLocalStorage`, so every handler, event, and log entry knows which session made the request.

**For stdio (current transport), behavior is unchanged.** The stdio session gets a synthetic identity that preserves all existing defaults. For a future HTTP transport, a different `SessionResolver` can be plugged in to provide authenticated per-connection identity.

## What changed

- **SessionContext types and ContextTracker extension** — New `src/context/` module with `SessionContext` interface, context-loss policy helpers, and stdio session factory. `ContextTracker` extended with `getSessionContext()`, `requireSessionContext()`, and `createSessionContext()`

- **ServerSetup session wiring** — `ServerSetup` accepts an optional `SessionResolver`. Both `setupCallToolHandler` and `setupListToolsHandler` now wrap requests in session-aware execution context. The DI container creates a shared stdio session and passes it to both `ServerSetup` and `ActivationStore`

- **ElementEventDispatcher: static singleton removed** — Migrated from `getSharedDispatcher()` static to a DI-managed instance with `ContextTracker` injected. `emit()` and `emitAsync()` auto-populate `userId`/`sessionId` on event payloads. All 6 element managers now receive the dispatcher via explicit constructor injection

- **Identity reads are session-aware** — `PersonaManager.getCurrentUserForAttribution()` and `getUserIdentity()` check `SessionContext` first, falling back to the existing `MetadataService` chain. `ContextTracker` injected into both `PersonaManager` and `IdentityHandler`

- **ActivationStore wired from SessionContext** — Constructor accepts explicit `sessionId` instead of reading `process.env` independently. Fixes a latent bug where `SessionContext` and `ActivationStore` could disagree on the default session ID

- **Log entry attribution** — `UnifiedLogEntry` now carries `userId`/`sessionId`, populated at all 12 `LogHooks` injection sites. Formatters, query filtering, and `validateLogQueryParams` updated accordingly

## What this does NOT change

- No changes to the MCP protocol or tool signatures
- No changes to stdio transport behavior
- No database or storage schema changes
- `setUserIdentity()` still writes to process-global state (session-scoped writes come in a later PR with scoped DI)
- Per-session log sinks deferred (shared queue is fine for single-session stdio)

## Test plan

- [ ] 9,900+ existing unit tests pass
- [ ] Integration tests pass
- [ ] MCP protocol smoke tests pass (133/135, 2 pre-existing failures already fixed on develop)
- [ ] New test coverage for: SessionContext types, context policy helpers, stdio session factory, ContextTracker session methods, ServerSetup session propagation, PersonaManager identity fallback, ElementEventDispatcher session attribution, ActivationStore explicit sessionId, LogHooks session attribution
- [ ] ESLint clean (zero issues in changed files)
- [ ] TypeScript strict mode clean
- [ ] Semantic analyzer clean