### PR TITLE
feat: show Setup tab once per version, not just first-ever visit

### DIFF
--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -2118,15 +2118,15 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
     if (!applyHashTab()) {
       // Version check takes priority over saved tab — upgraders must see Setup
       // regardless of whether they have a saved tab from their previous session.
-      if (localStorage.getItem(SETUP_SEEN_KEY) !== currentServerVersion) {
-        localStorage.setItem(SETUP_SEEN_KEY, currentServerVersion);
-        switchToTab('setup');
-      } else {
+      if (localStorage.getItem(SETUP_SEEN_KEY) === currentServerVersion) {
         const savedTab = localStorage.getItem(TAB_KEY);
         if (savedTab) {
           switchToTab(savedTab);
           lazyInitTab(savedTab, tabInits);
         }
+      } else {
+        localStorage.setItem(SETUP_SEEN_KEY, currentServerVersion);
+        switchToTab('setup');
       }
     }
 

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -2116,13 +2116,17 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
     }
 
     if (!applyHashTab()) {
-      const savedTab = localStorage.getItem(TAB_KEY);
-      if (savedTab) {
-        switchToTab(savedTab);
-        lazyInitTab(savedTab, tabInits);
-      } else if (localStorage.getItem(SETUP_SEEN_KEY) !== currentServerVersion) {
+      // Version check takes priority over saved tab — upgraders must see Setup
+      // regardless of whether they have a saved tab from their previous session.
+      if (localStorage.getItem(SETUP_SEEN_KEY) !== currentServerVersion) {
         localStorage.setItem(SETUP_SEEN_KEY, currentServerVersion);
         switchToTab('setup');
+      } else {
+        const savedTab = localStorage.getItem(TAB_KEY);
+        if (savedTab) {
+          switchToTab(savedTab);
+          lazyInitTab(savedTab, tabInits);
+        }
       }
     }
 

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -1978,11 +1978,15 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
 
     const TAB_KEY = 'dollhousemcp-active-tab';
     const SETUP_SEEN_KEY = 'dollhousemcp-setup-seen';
+    // Server version injected at request time — used to show Setup tab once per version
+    // so upgraders automatically see it on each new release (not just first-ever visit).
+    const currentServerVersion = document.querySelector('meta[name="dollhouse-server-version"]')?.content || 'unknown';
 
     // Determine which tab to show on load:
-    // 1. Saved tab from last visit (localStorage)
-    // 2. Setup tab on first-ever visit
-    // 3. Portfolio (HTML default)
+    // 1. URL hash (deep link)
+    // 2. Saved tab from last visit (localStorage)
+    // 3. Setup tab if not seen on this version yet
+    // 4. Portfolio (HTML default)
     const switchToTab = (tabName) => {
       if (!consoleTabs) return;
       const btn = consoleTabs.querySelector(`[data-tab="${tabName}"]`);
@@ -2113,8 +2117,8 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
       if (savedTab) {
         switchToTab(savedTab);
         lazyInitTab(savedTab, tabInits);
-      } else if (!localStorage.getItem(SETUP_SEEN_KEY)) {
-        localStorage.setItem(SETUP_SEEN_KEY, '1');
+      } else if (localStorage.getItem(SETUP_SEEN_KEY) !== currentServerVersion) {
+        localStorage.setItem(SETUP_SEEN_KEY, currentServerVersion);
         switchToTab('setup');
       }
     }

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -1980,7 +1980,10 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
     const SETUP_SEEN_KEY = 'dollhousemcp-setup-seen';
     // Server version injected at request time — used to show Setup tab once per version
     // so upgraders automatically see it on each new release (not just first-ever visit).
-    const currentServerVersion = document.querySelector('meta[name="dollhouse-server-version"]')?.content || 'unknown';
+    // Validate format (semver-like) before trusting the value; malformed falls back to
+    // 'unknown' which safely triggers setup on every load rather than silently skipping.
+    const _rawVersion = document.querySelector('meta[name="dollhouse-server-version"]')?.content || '';
+    const currentServerVersion = /^\d+\.\d+\.\d+/.test(_rawVersion) ? _rawVersion : 'unknown';
 
     // Determine which tab to show on load:
     // 1. URL hash (deep link)

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -12,6 +12,8 @@
        as an Authorization: Bearer header on fetch calls, or as a ?token= query
        param on EventSource connections. An empty value means auth is off. -->
   <meta name="dollhouse-console-token" content="{{CONSOLE_TOKEN}}">
+  <!-- Server version — injected at request time for version-aware UI behaviour (e.g. setup-seen per version). -->
+  <meta name="dollhouse-server-version" content="{{DOLLHOUSE_VERSION}}">
   <link rel="stylesheet" href="fonts.css">
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="logs.css">

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -31,6 +31,7 @@ import type { MemoryLogSink } from '../logging/sinks/MemoryLogSink.js';
 import type { MemoryMetricsSink } from '../metrics/sinks/MemoryMetricsSink.js';
 import type { ConsoleTokenStore } from './console/consoleToken.js';
 import { createAuthMiddleware } from './middleware/authMiddleware.js';
+import { PACKAGE_VERSION } from '../generated/version.js';
 
 /**
  * Public path prefixes that never require authentication (#1780).
@@ -48,6 +49,8 @@ const PUBLIC_PATH_PREFIXES = [
 
 /** Placeholder in index.html that is replaced with the current console token. */
 const TOKEN_META_PLACEHOLDER = '{{CONSOLE_TOKEN}}';
+/** Placeholder in index.html that is replaced with the running server version. */
+const VERSION_META_PLACEHOLDER = '{{DOLLHOUSE_VERSION}}';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 /**
@@ -399,7 +402,9 @@ export async function startWebServer(options: WebServerOptions): Promise<WebServ
       .replaceAll("'", '&#39;')
       .replaceAll('<', '&lt;')
       .replaceAll('>', '&gt;');
-    cachedIndexHtml = template.replaceAll(TOKEN_META_PLACEHOLDER, escapedToken);
+    cachedIndexHtml = template
+      .replaceAll(TOKEN_META_PLACEHOLDER, escapedToken)
+      .replaceAll(VERSION_META_PLACEHOLDER, PACKAGE_VERSION);
     cachedTokenValue = tokenValue;
     return cachedIndexHtml;
   };

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -916,9 +916,19 @@ describe('Setup Tab — Regressions', () => {
     it('validates version format before using it (rejects malformed values)', () => {
       const appJs = readFileSync(join(PUBLIC_DIR, 'app.js'), 'utf-8');
       // Semver-like validation guard present
-      expect(appJs).toContain('/^\\d+\\.\\d+\\.\\d+/.test(');
+      expect(appJs).toContain(String.raw`/^\d+\.\d+\.\d+/.test(`);
       // Falls back to 'unknown' for invalid versions
       expect(appJs).toContain("'unknown'");
+    });
+
+    it('version check takes priority over saved-tab restoration', () => {
+      const appJs = readFileSync(join(PUBLIC_DIR, 'app.js'), 'utf-8');
+      // The version check block must appear before the savedTab block in source
+      const versionCheckIdx = appJs.indexOf("localStorage.getItem(SETUP_SEEN_KEY) !== currentServerVersion");
+      const savedTabIdx = appJs.indexOf("localStorage.getItem(TAB_KEY)");
+      expect(versionCheckIdx).toBeGreaterThan(0);
+      expect(savedTabIdx).toBeGreaterThan(0);
+      expect(versionCheckIdx).toBeLessThan(savedTabIdx);
     });
 
     it('index.html has the dollhouse-server-version meta tag placeholder', () => {

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -896,8 +896,8 @@ describe('Setup Tab — Regressions', () => {
 
     it('shows setup tab when stored version does not match current version', () => {
       const appJs = readFileSync(join(PUBLIC_DIR, 'app.js'), 'utf-8');
-      // Version comparison — not a simple truthy check
-      expect(appJs).toContain("localStorage.getItem(SETUP_SEEN_KEY) !== currentServerVersion");
+      // Version comparison — positive branch restores tab, else branch shows setup
+      expect(appJs).toContain("localStorage.getItem(SETUP_SEEN_KEY) === currentServerVersion");
       expect(appJs).toContain("switchToTab('setup')");
     });
 
@@ -924,7 +924,7 @@ describe('Setup Tab — Regressions', () => {
     it('version check takes priority over saved-tab restoration', () => {
       const appJs = readFileSync(join(PUBLIC_DIR, 'app.js'), 'utf-8');
       // The version check block must appear before the savedTab block in source
-      const versionCheckIdx = appJs.indexOf("localStorage.getItem(SETUP_SEEN_KEY) !== currentServerVersion");
+      const versionCheckIdx = appJs.indexOf("localStorage.getItem(SETUP_SEEN_KEY) === currentServerVersion");
       const savedTabIdx = appJs.indexOf("localStorage.getItem(TAB_KEY)");
       expect(versionCheckIdx).toBeGreaterThan(0);
       expect(savedTabIdx).toBeGreaterThan(0);

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -894,10 +894,36 @@ describe('Setup Tab — Regressions', () => {
       expect(appJs).toContain("localStorage.getItem(TAB_KEY)");
     });
 
-    it('first visit defaults to setup tab', () => {
+    it('shows setup tab when stored version does not match current version', () => {
       const appJs = readFileSync(join(PUBLIC_DIR, 'app.js'), 'utf-8');
+      // Version comparison — not a simple truthy check
+      expect(appJs).toContain("localStorage.getItem(SETUP_SEEN_KEY) !== currentServerVersion");
       expect(appJs).toContain("switchToTab('setup')");
-      expect(appJs).toContain('dollhousemcp-setup-seen');
+    });
+
+    it('stores the version string (not "1") in the setup-seen flag', () => {
+      const appJs = readFileSync(join(PUBLIC_DIR, 'app.js'), 'utf-8');
+      expect(appJs).toContain('localStorage.setItem(SETUP_SEEN_KEY, currentServerVersion)');
+      // Must NOT store the old hard-coded sentinel value
+      expect(appJs).not.toContain("localStorage.setItem(SETUP_SEEN_KEY, '1')");
+    });
+
+    it('reads server version from the dollhouse-server-version meta tag', () => {
+      const appJs = readFileSync(join(PUBLIC_DIR, 'app.js'), 'utf-8');
+      expect(appJs).toContain('meta[name="dollhouse-server-version"]');
+    });
+
+    it('validates version format before using it (rejects malformed values)', () => {
+      const appJs = readFileSync(join(PUBLIC_DIR, 'app.js'), 'utf-8');
+      // Semver-like validation guard present
+      expect(appJs).toContain('/^\\d+\\.\\d+\\.\\d+/.test(');
+      // Falls back to 'unknown' for invalid versions
+      expect(appJs).toContain("'unknown'");
+    });
+
+    it('index.html has the dollhouse-server-version meta tag placeholder', () => {
+      expect(html).toContain('name="dollhouse-server-version"');
+      expect(html).toContain('{{DOLLHOUSE_VERSION}}');
     });
   });
 


### PR DESCRIPTION
## Summary
- Users upgrading (e.g. 2.0.3 → 2.0.11) had `dollhousemcp-setup-seen` already set from their previous version and never saw the Setup tab auto-open on upgrade
- Server now injects `{{DOLLHOUSE_VERSION}}` into a meta tag at request time alongside the existing `{{CONSOLE_TOKEN}}` substitution
- `app.js` compares the stored flag value against the current version — a mismatch opens Setup and records the new version string
- Existing users with `'1'` stored will see Setup once on first load after upgrade (version mismatch), then not again until the next release

## Changes
- `src/web/server.ts` — add `VERSION_META_PLACEHOLDER` constant and inject `PACKAGE_VERSION` during HTML template render
- `src/web/public/index.html` — add `dollhouse-server-version` meta tag with `{{DOLLHOUSE_VERSION}}` placeholder
- `src/web/public/app.js` — read version from meta tag, compare to stored flag, store version string instead of `'1'`

## Test plan
- [ ] Fresh browser (no localStorage): Setup tab opens, `dollhousemcp-setup-seen` set to current version
- [ ] Same version revisit: last active tab restored, Setup does not re-open
- [ ] Simulate upgrade: manually set `dollhousemcp-setup-seen` to an old version in devtools → Setup tab opens on reload, flag updated to new version

Closes #1753

🤖 Generated with [Claude Code](https://claude.com/claude-code)