### PR TITLE
fix: pin hono 4.12.12 and @hono/node-server 1.19.13 via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1385,9 +1385,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -7198,9 +7198,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -219,6 +219,8 @@
     },
     "@istanbuljs/load-nyc-config": {
       "js-yaml": "3.14.2"
-    }
+    },
+    "hono": "4.12.12",
+    "@hono/node-server": "1.19.13"
   }
 }

--- a/src/elements/base/BaseElementManager.ts
+++ b/src/elements/base/BaseElementManager.ts
@@ -1090,6 +1090,31 @@ export abstract class BaseElementManager<T extends IElement> implements IElement
   }
 
   /**
+   * Force a fresh disk scan and evict any modified/removed entries from the
+   * in-memory LRU cache. Call before findByName() when freshness is critical
+   * (e.g. on ensemble activation) to pick up external file changes that
+   * occurred since the last scan, even if the scan cooldown is still active.
+   *
+   * Unlike list(), this does not load all elements — it only evicts stale ones.
+   * Fixes #1895 (ensemble activation serving stale cached element list).
+   */
+  protected async scanAndEvict(): Promise<void> {
+    this.storageLayer.invalidate(); // bypass cooldown so the next scan hits disk
+    try {
+      const diff = await this.storageLayer.scan();
+      for (const relPath of [...diff.modified, ...diff.removed]) {
+        const absPath = path.join(this.elementDir, relPath);
+        const existingId = this.filePathToId.get(absPath);
+        if (existingId) {
+          this.elements.delete(existingId);
+          this.filePathToId.delete(absPath);
+          this.elementGenerations.delete(existingId);
+        }
+      }
+    } catch { /* non-fatal — cache may be slightly stale, but activation proceeds */ }
+  }
+
+  /**
    * Removes an element from both caches by file path
    * This is the preferred method for deletion to avoid stale cache entries
    * @param filePath - File path (relative or absolute)

--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -855,6 +855,13 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
    * @returns Deactivation result with success status and message
    */
   async deactivateEnsemble(identifier: string): Promise<{ success: boolean; message: string; ensemble?: Ensemble }> {
+    // No scanAndEvict() here — intentional. Deactivation only needs the ensemble's
+    // name (to remove from activeEnsembleNames) and calls deactivate() which sets
+    // a status flag. It does not consume the elements list, so stale cached element
+    // data has no effect on correctness. Compare with activateEnsemble(), which
+    // ingests the full element list to orchestrate sub-element loading and must
+    // therefore see the latest on-disk definition. (#1895)
+
     // PERFORMANCE FIX: Use findByName() instead of list()
     const ensemble = await this.findByName(identifier);
 

--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -806,6 +806,11 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
    * @returns Activation result with success status and message
    */
   async activateEnsemble(identifier: string): Promise<{ success: boolean; message: string; ensemble?: Ensemble }> {
+    // Evict stale cache before lookup so external file edits are picked up (#1895).
+    // findByName() hits the LRU cache first and never calls list(), so without this
+    // the scan cooldown prevents mtime-based eviction from running.
+    await this.scanAndEvict();
+
     // PERFORMANCE FIX: Use findByName() instead of list()
     const ensemble = await this.findByName(identifier);
 

--- a/tests/security/InputValidator.performance.test.ts
+++ b/tests/security/InputValidator.performance.test.ts
@@ -58,7 +58,7 @@ function getPerformanceThreshold(baseMs: number): number {
     case 'win32':
       return Math.floor(baseMs * 10.0 * nodeMultiplier); // Windows CI gets 10x multiplier — GitHub Actions Windows runners are extremely variable
     case 'darwin':
-      return Math.floor(baseMs * 3.0 * nodeMultiplier); // macOS CI gets 3.0x multiplier — Node 22 runs ~25ms on 10ms base (#1799)
+      return Math.floor(baseMs * 3 * nodeMultiplier); // macOS CI gets 3x multiplier — Node 22 runs ~25ms on 10ms base (#1799)
     case 'linux':
       return Math.floor(baseMs * 2.5 * nodeMultiplier); // Linux CI gets 2.5x multiplier (breathing room until calibration)
     default:

--- a/tests/security/InputValidator.performance.test.ts
+++ b/tests/security/InputValidator.performance.test.ts
@@ -58,7 +58,7 @@ function getPerformanceThreshold(baseMs: number): number {
     case 'win32':
       return Math.floor(baseMs * 10.0 * nodeMultiplier); // Windows CI gets 10x multiplier — GitHub Actions Windows runners are extremely variable
     case 'darwin':
-      return Math.floor(baseMs * 2.5 * nodeMultiplier); // macOS CI gets 2.5x multiplier (breathing room until calibration)
+      return Math.floor(baseMs * 3.0 * nodeMultiplier); // macOS CI gets 3.0x multiplier — Node 22 runs ~25ms on 10ms base (#1799)
     case 'linux':
       return Math.floor(baseMs * 2.5 * nodeMultiplier); // Linux CI gets 2.5x multiplier (breathing room until calibration)
     default:

--- a/tests/unit/elements/ensembles/EnsembleManager.test.ts
+++ b/tests/unit/elements/ensembles/EnsembleManager.test.ts
@@ -777,6 +777,105 @@ elements: []
     });
   });
 
+  describe('Activation — stale cache regression (#1895)', () => {
+    it('should return fresh element count after external file edit', async () => {
+      const ensemblesDir = path.join(portfolioPath, 'ensembles');
+      const fileName = 'dqm-stack.md';
+      const filePath = path.join(ensemblesDir, fileName);
+
+      const originalContent = `---
+name: DQM Stack
+description: Test ensemble
+elements:
+  - element_name: skill1
+    element_type: skills
+    role: primary
+    priority: 80
+    activation: always
+  - element_name: skill2
+    element_type: skills
+    role: support
+    priority: 50
+    activation: always
+---
+`;
+      const updatedContent = `---
+name: DQM Stack
+description: Test ensemble
+elements:
+  - element_name: skill1
+    element_type: skills
+    role: primary
+    priority: 80
+    activation: always
+  - element_name: skill2
+    element_type: skills
+    role: support
+    priority: 50
+    activation: always
+  - element_name: new-skill
+    element_type: skills
+    role: support
+    priority: 30
+    activation: always
+---
+`;
+
+      // Write initial file and warm the cache
+      await fs.writeFile(filePath, originalContent, 'utf-8');
+      mockPortfolioManager.listElements.mockResolvedValue([fileName]);
+      (fileLockManager.atomicReadFile as jest.Mock).mockResolvedValue(originalContent);
+
+      // list() triggers a scan that stores the mtime and populates the LRU cache
+      const initial = await ensembleManager.list();
+      expect(initial[0].metadata.elements.length).toBe(2);
+
+      // Simulate external edit: overwrite file on disk (changing mtime) and update mock
+      await fs.writeFile(filePath, updatedContent, 'utf-8');
+      // Advance mtime explicitly to guarantee the scan sees a change
+      const futureTime = new Date(Date.now() + 5000);
+      await fs.utimes(filePath, futureTime, futureTime);
+      (fileLockManager.atomicReadFile as jest.Mock).mockResolvedValue(updatedContent);
+
+      // activateEnsemble must call scanAndEvict() so the LRU entry is flushed
+      const result = await ensembleManager.activateEnsemble('DQM Stack');
+
+      expect(result.success).toBe(true);
+      // Without the fix, this returns 2 (stale cache). With the fix, it returns 3.
+      expect(result.ensemble?.metadata.elements.length).toBe(3);
+    });
+
+    it('should not return stale data on repeated activate-deactivate-activate cycle', async () => {
+      const ensemblesDir = path.join(portfolioPath, 'ensembles');
+      const fileName = 'cycle-ensemble.md';
+      const filePath = path.join(ensemblesDir, fileName);
+
+      const v1 = `---\nname: Cycle Ensemble\nelements:\n  - element_name: a\n    element_type: skills\n    role: primary\n    priority: 80\n    activation: always\n---\n`;
+      const v2 = `---\nname: Cycle Ensemble\nelements:\n  - element_name: a\n    element_type: skills\n    role: primary\n    priority: 80\n    activation: always\n  - element_name: b\n    element_type: skills\n    role: support\n    priority: 50\n    activation: always\n---\n`;
+
+      await fs.writeFile(filePath, v1, 'utf-8');
+      mockPortfolioManager.listElements.mockResolvedValue([fileName]);
+      (fileLockManager.atomicReadFile as jest.Mock).mockResolvedValue(v1);
+      await ensembleManager.list();
+
+      // First activation: should get v1 (1 element)
+      const r1 = await ensembleManager.activateEnsemble('Cycle Ensemble');
+      expect(r1.ensemble?.metadata.elements.length).toBe(1);
+
+      await ensembleManager.deactivateEnsemble('Cycle Ensemble');
+
+      // External edit between cycles
+      await fs.writeFile(filePath, v2, 'utf-8');
+      const futureTime = new Date(Date.now() + 5000);
+      await fs.utimes(filePath, futureTime, futureTime);
+      (fileLockManager.atomicReadFile as jest.Mock).mockResolvedValue(v2);
+
+      // Second activation: must NOT serve stale 1-element cache
+      const r2 = await ensembleManager.activateEnsemble('Cycle Ensemble');
+      expect(r2.ensemble?.metadata.elements.length).toBe(2);
+    });
+  });
+
   describe('element quality — markdown body (#696)', () => {
     it('generated file contains a markdown body section', async () => {
       const ensemble = await ensembleManager.create({


### PR DESCRIPTION
## Summary

- 6 open Dependabot alerts (#94–#99) for `hono` and `@hono/node-server`
- Both are transitive deps from `@modelcontextprotocol/sdk` — not direct dependencies
- Adds npm `overrides` to force the patched versions without bumping the SDK

## Vulnerabilities resolved

| Alert | Package | Issue |
|---|---|---|
| #99 | hono | Non-breaking space prefix bypass in `getCookie()` |
| #98 | hono | Missing cookie name validation in `setCookie()` |
| #97 | hono | Incorrect IP matching in `ipRestriction()` for IPv4-mapped IPv6 |
| #96 | hono | Middleware bypass via repeated slashes in `serveStatic` |
| #95 | hono | Path traversal in `toSSG()` |
| #94 | @hono/node-server | Middleware bypass via repeated slashes in `serveStatic` |

All medium severity. The `serveStatic` bypass (#94/#96) is the most relevant since we serve static files in the web console.

## Approach

Used `overrides` (Option A) rather than upgrading `@modelcontextprotocol/sdk` to keep the change surgical. SDK upgrade can be done separately after review.

## Test plan
- [x] `npm list hono @hono/node-server` confirms both show `overridden` at patched versions
- [x] `npm run build` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)