### PR TITLE
fix: pin hono 4.12.12 and @hono/node-server 1.19.13 via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1385,9 +1385,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -7198,9 +7198,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -219,6 +219,8 @@
     },
     "@istanbuljs/load-nyc-config": {
       "js-yaml": "3.14.2"
-    }
+    },
+    "hono": "4.12.12",
+    "@hono/node-server": "1.19.13"
   }
 }


### PR DESCRIPTION
## Summary

Closes 6 open Dependabot alerts (#94–#99) by adding `overrides` to `package.json`.

Both `hono` and `@hono/node-server` are transitive deps from `@modelcontextprotocol/sdk` — not direct dependencies — so they can't be updated via a normal `npm update`.

**Only `package.json` and `package-lock.json` are changed.**

## Vulnerabilities resolved

| Alert | Package | Issue |
|---|---|---|
| #99 | hono | Non-breaking space prefix bypass in `getCookie()` |
| #98 | hono | Missing cookie name validation in `setCookie()` |
| #97 | hono | Incorrect IP matching in `ipRestriction()` for IPv4-mapped IPv6 |
| #96 | hono | Middleware bypass via repeated slashes in `serveStatic` |
| #95 | hono | Path traversal in `toSSG()` |
| #94 | @hono/node-server | Middleware bypass via repeated slashes in `serveStatic` |

All medium severity. The `serveStatic` bypass (#94/#96) is the most relevant since we serve static files in the web console.

## Approach

Used `overrides` rather than bumping `@modelcontextprotocol/sdk` to keep the change surgical. SDK upgrade can be done deliberately as a separate step.

## Test plan
- [x] `npm list hono @hono/node-server` confirms both show `overridden` at patched versions
- [x] `npm run build` compiles cleanly
- [x] Only `package.json` + `package-lock.json` in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)