### PR TITLE
fix: separate console token names from session puppet-name pool (#1871)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -930,10 +930,10 @@ if ((isDirectExecution || isNpxExecution || isCliExecution) && (!isTest || isTes
       // Mirrors UnifiedConsole.ts:startAsLeader() — without this,
       // /api/console/totp and /api/console/token return 404.
       const { ConsoleTokenStore } = await import('./web/console/consoleToken.js');
-      const { pickRandomPuppetName } = await import('./web/console/SessionNames.js');
+      const { pickRandomTokenName } = await import('./web/console/SessionNames.js');
       const tokenStore = new ConsoleTokenStore(env.DOLLHOUSE_CONSOLE_TOKEN_FILE);
       try {
-        await tokenStore.ensureInitialized(pickRandomPuppetName());
+        await tokenStore.ensureInitialized(pickRandomTokenName());
       } catch (err) {
         console.error('[DollhouseMCP] Failed to initialize console token store — Auth tab will be non-functional', err);
       }

--- a/src/web/console/SessionNames.ts
+++ b/src/web/console/SessionNames.ts
@@ -16,7 +16,7 @@ import { logger } from '../../utils/logger.js';
  * Famous puppets, marionettes, and puppet characters from around the world.
  * Order doesn't matter — the pool is shuffled on startup.
  */
-const ALL_PUPPET_NAMES: readonly string[] = [
+export const ALL_PUPPET_NAMES: readonly string[] = [
   // Classic & traditional
   'Punch',
   'Judy',
@@ -124,7 +124,7 @@ const PUPPET_NAMES: string[] = shuffleArray([...ALL_PUPPET_NAMES]);
  * Names evoke costume pieces — a token is something you wear or carry,
  * not a person.
  */
-const ALL_TOKEN_NAMES: readonly string[] = [
+export const ALL_TOKEN_NAMES: readonly string[] = [
   // Victorian & theatrical
   'Top Hat',
   'Monocle',

--- a/src/web/console/SessionNames.ts
+++ b/src/web/console/SessionNames.ts
@@ -117,13 +117,75 @@ function shuffleArray<T>(arr: T[]): T[] {
 const PUPPET_NAMES: string[] = shuffleArray([...ALL_PUPPET_NAMES]);
 
 /**
- * Pick a random puppet name from the pool, independent of the session
- * name assignment. Used by the console token module (#1780) to generate
- * a friendly default name for newly created tokens. Does not reserve the
- * name — multiple callers can receive the same value.
+ * Iconic attire and accessories drawn from famous dolls, puppets, and
+ * theatrical characters throughout history. Used to name console tokens
+ * so they never collide with the session puppet-name pool (#1871).
+ *
+ * Names evoke costume pieces — a token is something you wear or carry,
+ * not a person.
  */
-export function pickRandomPuppetName(): string {
-  return ALL_PUPPET_NAMES[randomInt(ALL_PUPPET_NAMES.length)];
+const ALL_TOKEN_NAMES: readonly string[] = [
+  // Victorian & theatrical
+  'Top Hat',
+  'Monocle',
+  'Trench Coat',
+  'Opera Cape',
+  'Opera Gloves',
+  'Velvet Cloak',
+  'Lace Collar',
+  'Silk Cravat',
+  'Waistcoat',
+  'Gilt Button',
+
+  // Phantom, masks, mystery
+  'Half Mask',
+  'Domino Mask',
+  'Feathered Mask',
+
+  // Punch & Judy / Harlequin
+  'Jester Bells',
+  'Diamond Suit',
+  'Bell Cap',
+  'Slapstick',
+  'Red Nose',
+
+  // Puppet traditions
+  'Marionette Strings',
+  'Cracked Porcelain',
+  'Papier-Mâché',
+
+  // Classic dolls & characters
+  'Pink Corvette',
+  'Red Yarn Hair',
+  'Sailor Suit',
+  'Yellow Hat',
+  'Ruby Slippers',
+  'Glass Slipper',
+  'Blue Ribbon',
+  'Striped Stockings',
+
+  // Wizard / witch / fantasy
+  'Pointed Hat',
+  'Broomstick',
+  'Silver Wand',
+  'Tin Crown',
+  'Straw Hat',
+
+  // Adventure & mystery
+  'Deerstalker',
+  'Magnifying Glass',
+  'Feathered Cap',
+  'Silver Buckle',
+  'Wicker Basket',
+];
+
+/**
+ * Pick a random token name from the attire pool.
+ * Used by the console token module to name newly created tokens (#1871).
+ * Drawn from a separate pool to avoid collision with session puppet names.
+ */
+export function pickRandomTokenName(): string {
+  return ALL_TOKEN_NAMES[randomInt(ALL_TOKEN_NAMES.length)];
 }
 
 /**

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -177,7 +177,7 @@ async function startAsLeader(
   consolePort: number = DEFAULT_CONSOLE_PORT,
 ): Promise<UnifiedConsoleResult> {
   const { startWebServer } = await import('../server.js');
-  const { pickRandomPuppetName } = await import('./SessionNames.js');
+  const { pickRandomTokenName } = await import('./SessionNames.js');
 
   // Initialize the console token store (#1780). Creates the token file on
   // first run, reads the existing tokens on subsequent runs. The token is
@@ -185,7 +185,7 @@ async function startAsLeader(
   // Feature flag DOLLHOUSE_WEB_AUTH_ENABLED controls enforcement; the file
   // is generated regardless so consumers can attach tokens preemptively.
   const tokenStore = new ConsoleTokenStore(env.DOLLHOUSE_CONSOLE_TOKEN_FILE);
-  const primaryToken = await tokenStore.ensureInitialized(pickRandomPuppetName());
+  const primaryToken = await tokenStore.ensureInitialized(pickRandomTokenName());
   logger.info('[UnifiedConsole] Console token store initialized', {
     tokenId: primaryToken.id,
     tokenName: primaryToken.name,

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -619,9 +619,9 @@ async function startFallbackServer(options: OpenBrowserOptions, port: number): P
   // Reuse cached token store — two instances on the same file can race on writes.
   if (!cachedTokenStore) {
     const { ConsoleTokenStore: TokenStore } = await import('./console/consoleToken.js');
-    const { pickRandomPuppetName } = await import('./console/SessionNames.js');
+    const { pickRandomTokenName } = await import('./console/SessionNames.js');
     cachedTokenStore = new TokenStore(env.DOLLHOUSE_CONSOLE_TOKEN_FILE);
-    try { await cachedTokenStore.ensureInitialized(pickRandomPuppetName()); }
+    try { await cachedTokenStore.ensureInitialized(pickRandomTokenName()); }
     catch (err) { logger.warn('[WebUI] Failed to init token store for browser open', err); }
   }
 

--- a/tests/unit/web/console/SessionNames.test.ts
+++ b/tests/unit/web/console/SessionNames.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for SessionNames — pool separation (#1871).
+ *
+ * Verifies that:
+ *   - pickRandomTokenName() draws from the attire/accessories pool
+ *   - Token names and puppet session names never overlap
+ *   - SessionNamePool behaviour is unchanged by the token-pool split
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+import {
+  ALL_PUPPET_NAMES,
+  ALL_TOKEN_NAMES,
+  pickRandomTokenName,
+  SessionNamePool,
+} from '../../../../src/web/console/SessionNames.js';
+
+// ─── Pool contents ──────────────────────────────────────────────────────────
+
+describe('ALL_PUPPET_NAMES', () => {
+  it('contains at least 20 names', () => {
+    expect(ALL_PUPPET_NAMES.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it('contains known puppet/character names', () => {
+    expect(ALL_PUPPET_NAMES).toContain('Kermit');
+    expect(ALL_PUPPET_NAMES).toContain('Pinocchio');
+    expect(ALL_PUPPET_NAMES).toContain('Elmo');
+  });
+});
+
+describe('ALL_TOKEN_NAMES', () => {
+  it('contains at least 20 names', () => {
+    expect(ALL_TOKEN_NAMES.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it('contains known attire/accessory names', () => {
+    expect(ALL_TOKEN_NAMES).toContain('Top Hat');
+    expect(ALL_TOKEN_NAMES).toContain('Monocle');
+    expect(ALL_TOKEN_NAMES).toContain('Ruby Slippers');
+  });
+});
+
+// ─── Pool separation (#1871) ─────────────────────────────────────────────────
+
+describe('pool separation (#1871)', () => {
+  it('token pool and puppet pool have zero overlap', () => {
+    const puppetSet = new Set(ALL_PUPPET_NAMES);
+    const collisions = ALL_TOKEN_NAMES.filter(name => puppetSet.has(name));
+    expect(collisions).toHaveLength(0);
+  });
+});
+
+// ─── pickRandomTokenName() ───────────────────────────────────────────────────
+
+describe('pickRandomTokenName()', () => {
+  it('returns a non-empty string', () => {
+    const name = pickRandomTokenName();
+    expect(typeof name).toBe('string');
+    expect(name.length).toBeGreaterThan(0);
+  });
+
+  it('returns a value from ALL_TOKEN_NAMES', () => {
+    // Sample 50 calls — every result must be in the token pool
+    const tokenSet = new Set(ALL_TOKEN_NAMES);
+    for (let i = 0; i < 50; i++) {
+      expect(tokenSet.has(pickRandomTokenName())).toBe(true);
+    }
+  });
+
+  it('never returns a puppet session name', () => {
+    const puppetSet = new Set(ALL_PUPPET_NAMES);
+    for (let i = 0; i < 50; i++) {
+      expect(puppetSet.has(pickRandomTokenName())).toBe(false);
+    }
+  });
+});
+
+// ─── SessionNamePool ─────────────────────────────────────────────────────────
+
+describe('SessionNamePool', () => {
+  it('assigns a name from the puppet pool', () => {
+    const pool = new SessionNamePool();
+    const name = pool.assign('session-1');
+    expect(ALL_PUPPET_NAMES).toContain(name);
+  });
+
+  it('never assigns a token attire name to a session', () => {
+    const pool = new SessionNamePool();
+    const tokenSet = new Set(ALL_TOKEN_NAMES);
+    const name = pool.assign('session-1');
+    expect(tokenSet.has(name)).toBe(false);
+  });
+
+  it('is idempotent — same session always gets the same name', () => {
+    const pool = new SessionNamePool();
+    const first = pool.assign('session-abc');
+    const second = pool.assign('session-abc');
+    expect(second).toBe(first);
+  });
+
+  it('assigns different names to different sessions', () => {
+    const pool = new SessionNamePool();
+    const a = pool.assign('session-a');
+    const b = pool.assign('session-b');
+    expect(b).not.toBe(a);
+  });
+
+  it('does not assign Punch to a leader session', () => {
+    // Punch is in FOLLOWER_ONLY_NAMES — leaders must never receive it
+    const pool = new SessionNamePool();
+    const names = new Set<string>();
+    // Assign enough sessions to exercise most of the pool
+    for (let i = 0; i < 30; i++) {
+      names.add(pool.assign(`leader-${i}`, /* isLeader= */ true));
+    }
+    expect(names.has('Punch')).toBe(false);
+  });
+
+  it('non-leader sessions can receive Punch', () => {
+    // Exhaust the non-Punch names so Punch is the only one left, then
+    // confirm a follower session eventually gets it.  We do this by
+    // seeding many follower sessions until Punch appears (or we confirm
+    // it exists in the pool at all via ALL_PUPPET_NAMES).
+    expect(ALL_PUPPET_NAMES).toContain('Punch');
+    // Punch is in the pool — it is NOT in FOLLOWER_ONLY for non-leaders
+    const pool = new SessionNamePool();
+    const names = new Set<string>();
+    for (let i = 0; i < ALL_PUPPET_NAMES.length; i++) {
+      names.add(pool.assign(`follower-${i}`, /* isLeader= */ false));
+    }
+    expect(names.has('Punch')).toBe(true);
+  });
+
+  it('getName() returns the assigned name', () => {
+    const pool = new SessionNamePool();
+    pool.assign('session-x');
+    expect(pool.getName('session-x')).toBeTruthy();
+  });
+
+  it('getName() returns undefined for unknown session', () => {
+    const pool = new SessionNamePool();
+    expect(pool.getName('nonexistent')).toBeUndefined();
+  });
+
+  it('getColor() returns a hex color for a known puppet name', () => {
+    // Force Kermit by exhausting sessions until we see it — or just
+    // confirm getColor returns something hex-shaped for any assigned name.
+    const pool = new SessionNamePool();
+    pool.assign('session-color');
+    const color = pool.getColor('session-color');
+    // Color may be undefined if the name is a fallback; only assert if set
+    if (color !== undefined) {
+      expect(color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+
+  it('release() frees the name from the pool', () => {
+    const pool = new SessionNamePool();
+    pool.assign('session-rel');
+    pool.release('session-rel');
+    expect(pool.getName('session-rel')).toBeUndefined();
+  });
+
+  it('falls back to session-ID segment when pool is exhausted', () => {
+    const pool = new SessionNamePool();
+    // Assign all names in the puppet pool
+    for (let i = 0; i < ALL_PUPPET_NAMES.length; i++) {
+      pool.assign(`session-${i}`);
+    }
+    // With fake timers, cooldowns won't expire — next assign is a fallback
+    jest.useFakeTimers();
+    try {
+      const fallback = pool.assign('overflow-segment-here');
+      // Fallback is the second dash-segment, i.e. "segment"
+      expect(fallback).toBe('segment');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Console tokens and MCP session names were drawn from the same puppet-name pool, causing confusing collisions (e.g. a token named "Kermit" and an active session named "Kermit" appearing side-by-side in the Security tab)
- Tokens now get names from a separate **attire and accessories** pool — iconic costume pieces from famous dolls, puppets, and theatrical characters: `Top Hat`, `Monocle`, `Pink Corvette`, `Half Mask`, `Trench Coat`, `Ruby Slippers`, `Marionette Strings`, etc.
- Sessions keep the existing puppet character name pool unchanged

## Changes

- `SessionNames.ts` — add `ALL_TOKEN_NAMES` (40 attire/accessory names) and export `pickRandomTokenName()`
- `UnifiedConsole.ts`, `server.ts`, `index.ts` — swap `pickRandomPuppetName()` → `pickRandomTokenName()` at all three token initialization call sites

## Test plan

- [ ] Start the server fresh — console token file gets an attire name (e.g. `Top Hat`)
- [ ] Connect an MCP session — session gets a puppet name (e.g. `Kermit`)
- [ ] Verify the two names are never from the same pool
- [ ] Security tab shows token name and session name without collision

Closes #1871

🤖 Generated with [Claude Code](https://claude.com/claude-code)