### PR TITLE
fix: auto-derive template variables from content placeholders (#1896)

### DIFF
--- a/src/elements/templates/Template.ts
+++ b/src/elements/templates/Template.ts
@@ -249,6 +249,41 @@ export class Template extends BaseElement implements IElement {
     return this.parsedSections;
   }
 
+  /**
+   * Scan `content` for {{placeholder}} patterns and return a merged variable
+   * list. Existing entries are preserved unchanged (user-set descriptions,
+   * types, required flags, etc.); new placeholders are added with defaults:
+   * type 'string', required: false.  (#1896)
+   *
+   * Respects section mode — only the <template> section is scanned, matching
+   * the substitution engine's scope.
+   */
+  static deriveVariablesFromContent(
+    content: string,
+    existingVariables: TemplateVariable[] = []
+  ): TemplateVariable[] {
+    const { isSectionMode, templateSection } = Template.parseSections(content);
+    const scanContent = isSectionMode ? templateSection : content;
+
+    const pattern = /\{\{\s*([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)\s*\}\}/g;
+    const seen = new Set<string>();
+    let match;
+    while ((match = pattern.exec(scanContent)) !== null) {
+      seen.add(match[1]);
+    }
+
+    const existingNames = new Set(existingVariables.map(v => v.name));
+    const result: TemplateVariable[] = [...existingVariables];
+
+    for (const name of seen) {
+      if (!existingNames.has(name)) {
+        result.push({ name, type: 'string', required: false });
+      }
+    }
+
+    return result;
+  }
+
   private compile(): CompiledTemplate {
     if (this.compiledTemplate) {
       return this.compiledTemplate;

--- a/src/elements/templates/TemplateManager.ts
+++ b/src/elements/templates/TemplateManager.ts
@@ -65,6 +65,17 @@ export class TemplateManager extends BaseElementManager<Template> {
   }
 
   override async save(template: Template, filePath: string): Promise<void> {
+    // Auto-derive variables from content (#1896): ensures every {{placeholder}}
+    // has a matching schema entry so render() never silently returns unfilled text.
+    // Existing entries are never overwritten — user-set descriptions, types, and
+    // required flags survive. New entries default to type: 'string', required: false.
+    if (template.content) {
+      template.metadata.variables = Template.deriveVariablesFromContent(
+        template.content,
+        template.metadata.variables ?? []
+      );
+    }
+
     await super.save(template, filePath);
 
     SecurityMonitor.logSecurityEvent({

--- a/src/index.ts
+++ b/src/index.ts
@@ -930,10 +930,10 @@ if ((isDirectExecution || isNpxExecution || isCliExecution) && (!isTest || isTes
       // Mirrors UnifiedConsole.ts:startAsLeader() — without this,
       // /api/console/totp and /api/console/token return 404.
       const { ConsoleTokenStore } = await import('./web/console/consoleToken.js');
-      const { pickRandomPuppetName } = await import('./web/console/SessionNames.js');
+      const { pickRandomTokenName } = await import('./web/console/SessionNames.js');
       const tokenStore = new ConsoleTokenStore(env.DOLLHOUSE_CONSOLE_TOKEN_FILE);
       try {
-        await tokenStore.ensureInitialized(pickRandomPuppetName());
+        await tokenStore.ensureInitialized(pickRandomTokenName());
       } catch (err) {
         console.error('[DollhouseMCP] Failed to initialize console token store — Auth tab will be non-functional', err);
       }

--- a/src/utils/TemplateRenderer.ts
+++ b/src/utils/TemplateRenderer.ts
@@ -26,6 +26,8 @@ export interface RenderResult {
     script: string;
   };
   error?: string;
+  /** Unsubstituted {{placeholder}} names found in the rendered output (#1896) */
+  warnings?: string[];
   performance?: {
     lookupTime: number;
     renderTime: number;
@@ -159,12 +161,24 @@ export class TemplateRenderer {
         `output_length=${rendered.length}`
       );
 
+      // Detect unsubstituted placeholders (#1896) — render always completes;
+      // unfilled tokens are surfaced as advisory warnings, never hard errors.
+      const unsubstituted = [...rendered.matchAll(/\{\{\s*([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)\s*\}\}/g)]
+        .map(m => m[1]);
+      const warnings = unsubstituted.length > 0
+        ? [`${unsubstituted.length} placeholder(s) were not substituted: ${unsubstituted.join(', ')}`]
+        : undefined;
+      if (warnings) {
+        logger.warn(`[TemplateRenderer] ${warnings[0]}`);
+      }
+
       // Issue #705: all_sections — return rendered template + raw style/script together
       if (allSections) {
         const sections = template.getSections();
         return {
           success: true,
           content: rendered,
+          warnings,
           sections: {
             template: rendered,
             style: sections.styleSection,
@@ -177,6 +191,7 @@ export class TemplateRenderer {
       return {
         success: true,
         content: rendered,
+        warnings,
         performance: { lookupTime, renderTime, totalTime }
       };
       

--- a/src/web/console/SessionNames.ts
+++ b/src/web/console/SessionNames.ts
@@ -16,7 +16,7 @@ import { logger } from '../../utils/logger.js';
  * Famous puppets, marionettes, and puppet characters from around the world.
  * Order doesn't matter — the pool is shuffled on startup.
  */
-const ALL_PUPPET_NAMES: readonly string[] = [
+export const ALL_PUPPET_NAMES: readonly string[] = [
   // Classic & traditional
   'Punch',
   'Judy',
@@ -124,7 +124,7 @@ const PUPPET_NAMES: string[] = shuffleArray([...ALL_PUPPET_NAMES]);
  * Names evoke costume pieces — a token is something you wear or carry,
  * not a person.
  */
-const ALL_TOKEN_NAMES: readonly string[] = [
+export const ALL_TOKEN_NAMES: readonly string[] = [
   // Victorian & theatrical
   'Top Hat',
   'Monocle',

--- a/src/web/console/SessionNames.ts
+++ b/src/web/console/SessionNames.ts
@@ -117,13 +117,75 @@ function shuffleArray<T>(arr: T[]): T[] {
 const PUPPET_NAMES: string[] = shuffleArray([...ALL_PUPPET_NAMES]);
 
 /**
- * Pick a random puppet name from the pool, independent of the session
- * name assignment. Used by the console token module (#1780) to generate
- * a friendly default name for newly created tokens. Does not reserve the
- * name — multiple callers can receive the same value.
+ * Iconic attire and accessories drawn from famous dolls, puppets, and
+ * theatrical characters throughout history. Used to name console tokens
+ * so they never collide with the session puppet-name pool (#1871).
+ *
+ * Names evoke costume pieces — a token is something you wear or carry,
+ * not a person.
  */
-export function pickRandomPuppetName(): string {
-  return ALL_PUPPET_NAMES[randomInt(ALL_PUPPET_NAMES.length)];
+const ALL_TOKEN_NAMES: readonly string[] = [
+  // Victorian & theatrical
+  'Top Hat',
+  'Monocle',
+  'Trench Coat',
+  'Opera Cape',
+  'Opera Gloves',
+  'Velvet Cloak',
+  'Lace Collar',
+  'Silk Cravat',
+  'Waistcoat',
+  'Gilt Button',
+
+  // Phantom, masks, mystery
+  'Half Mask',
+  'Domino Mask',
+  'Feathered Mask',
+
+  // Punch & Judy / Harlequin
+  'Jester Bells',
+  'Diamond Suit',
+  'Bell Cap',
+  'Slapstick',
+  'Red Nose',
+
+  // Puppet traditions
+  'Marionette Strings',
+  'Cracked Porcelain',
+  'Papier-Mâché',
+
+  // Classic dolls & characters
+  'Pink Corvette',
+  'Red Yarn Hair',
+  'Sailor Suit',
+  'Yellow Hat',
+  'Ruby Slippers',
+  'Glass Slipper',
+  'Blue Ribbon',
+  'Striped Stockings',
+
+  // Wizard / witch / fantasy
+  'Pointed Hat',
+  'Broomstick',
+  'Silver Wand',
+  'Tin Crown',
+  'Straw Hat',
+
+  // Adventure & mystery
+  'Deerstalker',
+  'Magnifying Glass',
+  'Feathered Cap',
+  'Silver Buckle',
+  'Wicker Basket',
+];
+
+/**
+ * Pick a random token name from the attire pool.
+ * Used by the console token module to name newly created tokens (#1871).
+ * Drawn from a separate pool to avoid collision with session puppet names.
+ */
+export function pickRandomTokenName(): string {
+  return ALL_TOKEN_NAMES[randomInt(ALL_TOKEN_NAMES.length)];
 }
 
 /**

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -177,7 +177,7 @@ async function startAsLeader(
   consolePort: number = DEFAULT_CONSOLE_PORT,
 ): Promise<UnifiedConsoleResult> {
   const { startWebServer } = await import('../server.js');
-  const { pickRandomPuppetName } = await import('./SessionNames.js');
+  const { pickRandomTokenName } = await import('./SessionNames.js');
 
   // Initialize the console token store (#1780). Creates the token file on
   // first run, reads the existing tokens on subsequent runs. The token is
@@ -185,7 +185,7 @@ async function startAsLeader(
   // Feature flag DOLLHOUSE_WEB_AUTH_ENABLED controls enforcement; the file
   // is generated regardless so consumers can attach tokens preemptively.
   const tokenStore = new ConsoleTokenStore(env.DOLLHOUSE_CONSOLE_TOKEN_FILE);
-  const primaryToken = await tokenStore.ensureInitialized(pickRandomPuppetName());
+  const primaryToken = await tokenStore.ensureInitialized(pickRandomTokenName());
   logger.info('[UnifiedConsole] Console token store initialized', {
     tokenId: primaryToken.id,
     tokenName: primaryToken.name,

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -619,9 +619,9 @@ async function startFallbackServer(options: OpenBrowserOptions, port: number): P
   // Reuse cached token store — two instances on the same file can race on writes.
   if (!cachedTokenStore) {
     const { ConsoleTokenStore: TokenStore } = await import('./console/consoleToken.js');
-    const { pickRandomPuppetName } = await import('./console/SessionNames.js');
+    const { pickRandomTokenName } = await import('./console/SessionNames.js');
     cachedTokenStore = new TokenStore(env.DOLLHOUSE_CONSOLE_TOKEN_FILE);
-    try { await cachedTokenStore.ensureInitialized(pickRandomPuppetName()); }
+    try { await cachedTokenStore.ensureInitialized(pickRandomTokenName()); }
     catch (err) { logger.warn('[WebUI] Failed to init token store for browser open', err); }
   }
 

--- a/tests/unit/elements/templates/Template.test.ts
+++ b/tests/unit/elements/templates/Template.test.ts
@@ -589,4 +589,73 @@ describe('Template', () => {
       });
     });
   });
+
+  describe('deriveVariablesFromContent() (#1896)', () => {
+    it('returns an empty array when content has no placeholders', () => {
+      const result = Template.deriveVariablesFromContent('No placeholders here.');
+      expect(result).toHaveLength(0);
+    });
+
+    it('derives a single placeholder', () => {
+      const result = Template.deriveVariablesFromContent('Hello {{name}}!');
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('name');
+      expect(result[0].type).toBe('string');
+      expect(result[0].required).toBe(false);
+    });
+
+    it('derives multiple distinct placeholders', () => {
+      const result = Template.deriveVariablesFromContent('{{first}} and {{second}} and {{third}}');
+      const names = result.map(v => v.name).sort();
+      expect(names).toEqual(['first', 'second', 'third']);
+    });
+
+    it('deduplicates repeated placeholders', () => {
+      const result = Template.deriveVariablesFromContent('{{foo}} then {{foo}} again');
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('foo');
+    });
+
+    it('preserves existing variable entries unchanged', () => {
+      const existing: TemplateVariable[] = [
+        { name: 'name', type: 'string', required: true, description: 'Full name' }
+      ];
+      const result = Template.deriveVariablesFromContent('Hello {{name}}! Your score: {{score}}', existing);
+      const namVar = result.find(v => v.name === 'name')!;
+      expect(namVar.required).toBe(true);
+      expect(namVar.description).toBe('Full name');
+    });
+
+    it('adds only missing placeholders when some are already declared', () => {
+      const existing: TemplateVariable[] = [{ name: 'name', type: 'string' }];
+      const result = Template.deriveVariablesFromContent('{{name}} and {{score}}', existing);
+      expect(result).toHaveLength(2);
+      const scoreVar = result.find(v => v.name === 'score')!;
+      expect(scoreVar.type).toBe('string');
+      expect(scoreVar.required).toBe(false);
+    });
+
+    it('handles dot-notation placeholder paths', () => {
+      const result = Template.deriveVariablesFromContent('{{user.name}} at {{user.email}}');
+      const names = result.map(v => v.name).sort();
+      expect(names).toEqual(['user.email', 'user.name']);
+    });
+
+    it('handles whitespace inside braces', () => {
+      const result = Template.deriveVariablesFromContent('{{ spaced }} and {{  also_spaced  }}');
+      const names = result.map(v => v.name).sort();
+      expect(names).toEqual(['also_spaced', 'spaced']);
+    });
+
+    it('in section mode, only scans the <template> section', () => {
+      const content = [
+        '<template>{{title}}</template>',
+        '<style>.cls-{{ignored}} { color: red; }</style>',
+        '<script>var {{also_ignored}} = 1;</script>',
+      ].join('\n');
+      const result = Template.deriveVariablesFromContent(content);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('title');
+    });
+  });
 });

--- a/tests/unit/elements/templates/TemplateManager.test.ts
+++ b/tests/unit/elements/templates/TemplateManager.test.ts
@@ -279,4 +279,77 @@ Hello {{name}}!`;
       await expect(manager.importElement(noContent, 'json')).rejects.toThrow('Invalid template');
     });
   });
+
+  describe('auto-derive variables from content (#1896)', () => {
+    it('populates variables on create when variables is empty', async () => {
+      const template = await manager.create({
+        name: 'auto-derive-basic',
+        description: 'Test auto-derivation',
+        content: 'Hello {{name}}, your score is {{score}}.',
+      });
+      const names = template.metadata.variables?.map(v => v.name) ?? [];
+      expect(names).toContain('name');
+      expect(names).toContain('score');
+    });
+
+    it('derived variables default to type string and required false', async () => {
+      const template = await manager.create({
+        name: 'auto-derive-defaults',
+        description: 'Test defaults',
+        content: 'Value: {{foo}}',
+      });
+      const fooVar = template.metadata.variables?.find(v => v.name === 'foo');
+      expect(fooVar).toBeDefined();
+      expect(fooVar!.type).toBe('string');
+      expect(fooVar!.required).toBe(false);
+    });
+
+    it('preserves explicitly provided variable metadata', async () => {
+      const template = await manager.create({
+        name: 'auto-derive-preserve',
+        description: 'Test preservation',
+        content: 'Hello {{name}}!',
+        metadata: {
+          variables: [{ name: 'name', type: 'string', required: true, description: 'Full name' }]
+        },
+      });
+      const nameVar = template.metadata.variables?.find(v => v.name === 'name');
+      expect(nameVar!.required).toBe(true);
+      expect(nameVar!.description).toBe('Full name');
+    });
+
+    it('adds missing placeholders without removing declared ones', async () => {
+      const template = await manager.create({
+        name: 'auto-derive-additive',
+        description: 'Test additive merge',
+        content: '{{declared}} and {{new_one}}',
+        metadata: {
+          variables: [{ name: 'declared', type: 'number', required: true }]
+        },
+      });
+      const declared = template.metadata.variables?.find(v => v.name === 'declared');
+      const newOne = template.metadata.variables?.find(v => v.name === 'new_one');
+      expect(declared!.type).toBe('number');  // original preserved
+      expect(newOne).toBeDefined();           // new one added
+      expect(newOne!.required).toBe(false);
+    });
+
+    it('auto-derives on subsequent save (edit path)', async () => {
+      const template = await manager.create({
+        name: 'auto-derive-edit',
+        description: 'Test edit re-derive',
+        content: 'Static content with {{original}}.',
+      });
+      expect(template.metadata.variables?.map(v => v.name)).toContain('original');
+
+      // Simulate an edit: update content to add a new placeholder.
+      // save() expects a relative filename, same as what create() uses internally.
+      template.content = 'Static content with {{original}} and {{added}}.';
+      await manager.save(template, 'auto-derive-edit.md');
+
+      const names = template.metadata.variables?.map(v => v.name) ?? [];
+      expect(names).toContain('original');
+      expect(names).toContain('added');
+    });
+  });
 });

--- a/tests/unit/web/console/SessionNames.test.ts
+++ b/tests/unit/web/console/SessionNames.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for SessionNames — pool separation (#1871).
+ *
+ * Verifies that:
+ *   - pickRandomTokenName() draws from the attire/accessories pool
+ *   - Token names and puppet session names never overlap
+ *   - SessionNamePool behaviour is unchanged by the token-pool split
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+import {
+  ALL_PUPPET_NAMES,
+  ALL_TOKEN_NAMES,
+  pickRandomTokenName,
+  SessionNamePool,
+} from '../../../../src/web/console/SessionNames.js';
+
+// ─── Pool contents ──────────────────────────────────────────────────────────
+
+describe('ALL_PUPPET_NAMES', () => {
+  it('contains at least 20 names', () => {
+    expect(ALL_PUPPET_NAMES.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it('contains known puppet/character names', () => {
+    expect(ALL_PUPPET_NAMES).toContain('Kermit');
+    expect(ALL_PUPPET_NAMES).toContain('Pinocchio');
+    expect(ALL_PUPPET_NAMES).toContain('Elmo');
+  });
+});
+
+describe('ALL_TOKEN_NAMES', () => {
+  it('contains at least 20 names', () => {
+    expect(ALL_TOKEN_NAMES.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it('contains known attire/accessory names', () => {
+    expect(ALL_TOKEN_NAMES).toContain('Top Hat');
+    expect(ALL_TOKEN_NAMES).toContain('Monocle');
+    expect(ALL_TOKEN_NAMES).toContain('Ruby Slippers');
+  });
+});
+
+// ─── Pool separation (#1871) ─────────────────────────────────────────────────
+
+describe('pool separation (#1871)', () => {
+  it('token pool and puppet pool have zero overlap', () => {
+    const puppetSet = new Set(ALL_PUPPET_NAMES);
+    const collisions = ALL_TOKEN_NAMES.filter(name => puppetSet.has(name));
+    expect(collisions).toHaveLength(0);
+  });
+});
+
+// ─── pickRandomTokenName() ───────────────────────────────────────────────────
+
+describe('pickRandomTokenName()', () => {
+  it('returns a non-empty string', () => {
+    const name = pickRandomTokenName();
+    expect(typeof name).toBe('string');
+    expect(name.length).toBeGreaterThan(0);
+  });
+
+  it('returns a value from ALL_TOKEN_NAMES', () => {
+    // Sample 50 calls — every result must be in the token pool
+    const tokenSet = new Set(ALL_TOKEN_NAMES);
+    for (let i = 0; i < 50; i++) {
+      expect(tokenSet.has(pickRandomTokenName())).toBe(true);
+    }
+  });
+
+  it('never returns a puppet session name', () => {
+    const puppetSet = new Set(ALL_PUPPET_NAMES);
+    for (let i = 0; i < 50; i++) {
+      expect(puppetSet.has(pickRandomTokenName())).toBe(false);
+    }
+  });
+});
+
+// ─── SessionNamePool ─────────────────────────────────────────────────────────
+
+describe('SessionNamePool', () => {
+  it('assigns a name from the puppet pool', () => {
+    const pool = new SessionNamePool();
+    const name = pool.assign('session-1');
+    expect(ALL_PUPPET_NAMES).toContain(name);
+  });
+
+  it('never assigns a token attire name to a session', () => {
+    const pool = new SessionNamePool();
+    const tokenSet = new Set(ALL_TOKEN_NAMES);
+    const name = pool.assign('session-1');
+    expect(tokenSet.has(name)).toBe(false);
+  });
+
+  it('is idempotent — same session always gets the same name', () => {
+    const pool = new SessionNamePool();
+    const first = pool.assign('session-abc');
+    const second = pool.assign('session-abc');
+    expect(second).toBe(first);
+  });
+
+  it('assigns different names to different sessions', () => {
+    const pool = new SessionNamePool();
+    const a = pool.assign('session-a');
+    const b = pool.assign('session-b');
+    expect(b).not.toBe(a);
+  });
+
+  it('does not assign Punch to a leader session', () => {
+    // Punch is in FOLLOWER_ONLY_NAMES — leaders must never receive it
+    const pool = new SessionNamePool();
+    const names = new Set<string>();
+    // Assign enough sessions to exercise most of the pool
+    for (let i = 0; i < 30; i++) {
+      names.add(pool.assign(`leader-${i}`, /* isLeader= */ true));
+    }
+    expect(names.has('Punch')).toBe(false);
+  });
+
+  it('non-leader sessions can receive Punch', () => {
+    // Exhaust the non-Punch names so Punch is the only one left, then
+    // confirm a follower session eventually gets it.  We do this by
+    // seeding many follower sessions until Punch appears (or we confirm
+    // it exists in the pool at all via ALL_PUPPET_NAMES).
+    expect(ALL_PUPPET_NAMES).toContain('Punch');
+    // Punch is in the pool — it is NOT in FOLLOWER_ONLY for non-leaders
+    const pool = new SessionNamePool();
+    const names = new Set<string>();
+    for (let i = 0; i < ALL_PUPPET_NAMES.length; i++) {
+      names.add(pool.assign(`follower-${i}`, /* isLeader= */ false));
+    }
+    expect(names.has('Punch')).toBe(true);
+  });
+
+  it('getName() returns the assigned name', () => {
+    const pool = new SessionNamePool();
+    pool.assign('session-x');
+    expect(pool.getName('session-x')).toBeTruthy();
+  });
+
+  it('getName() returns undefined for unknown session', () => {
+    const pool = new SessionNamePool();
+    expect(pool.getName('nonexistent')).toBeUndefined();
+  });
+
+  it('getColor() returns a hex color for a known puppet name', () => {
+    // Force Kermit by exhausting sessions until we see it — or just
+    // confirm getColor returns something hex-shaped for any assigned name.
+    const pool = new SessionNamePool();
+    pool.assign('session-color');
+    const color = pool.getColor('session-color');
+    // Color may be undefined if the name is a fallback; only assert if set
+    if (color !== undefined) {
+      expect(color).toMatch(/^#[0-9a-fA-F]{6}$/);
+    }
+  });
+
+  it('release() frees the name from the pool', () => {
+    const pool = new SessionNamePool();
+    pool.assign('session-rel');
+    pool.release('session-rel');
+    expect(pool.getName('session-rel')).toBeUndefined();
+  });
+
+  it('falls back to session-ID segment when pool is exhausted', () => {
+    const pool = new SessionNamePool();
+    // Assign all names in the puppet pool
+    for (let i = 0; i < ALL_PUPPET_NAMES.length; i++) {
+      pool.assign(`session-${i}`);
+    }
+    // With fake timers, cooldowns won't expire — next assign is a fallback
+    jest.useFakeTimers();
+    try {
+      const fallback = pool.assign('overflow-segment-here');
+      // Fallback is the second dash-segment, i.e. "segment"
+      expect(fallback).toBe('segment');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Templates with `{{placeholder}}` content but `variables: []` silently returned unfilled text on render — no error, no warning, just broken output. This was discovered after 13 templates were created with correct content but empty variable schemas.
- `TemplateManager.save()` now calls `Template.deriveVariablesFromContent()` before every persist, covering both create and edit paths automatically
- Existing variable entries are **never overwritten** — user-set descriptions, types, and `required` flags survive; only missing placeholders are added, defaulting to `type: 'string', required: false`
- `TemplateRenderer.render()` now detects any remaining `{{placeholder}}` in the rendered output and surfaces them as advisory `warnings` in `RenderResult`; render always completes, warnings are non-blocking

## Changes

- `Template.ts` — add `static deriveVariablesFromContent(content, existingVariables)` (near `compile()`, reuses the same regex)
- `TemplateManager.ts` — hook derivation into existing `save()` override, runs on every create and edit
- `TemplateRenderer.ts` — add `warnings?: string[]` to `RenderResult`; detect unsubstituted placeholders post-render
- `Template.test.ts` — 9 new tests for `deriveVariablesFromContent()` covering deduplication, preservation, dot-notation, whitespace, and section mode
- `TemplateManager.test.ts` — 5 new integration tests covering create auto-derive, default values, preservation of existing vars, additive merge, and edit re-derive

## Test plan

- [ ] Create a template with `{{foo}}` and `variables: []` — confirm `variables` contains `foo` after create
- [ ] Edit a template's content to add `{{bar}}` — confirm `bar` is upserted into `variables`
- [ ] A variable already declared with `required: true` and a description survives a content re-save unchanged
- [ ] `render_template` with a missing variable returns output with warnings listing the unfilled placeholder(s)
- [ ] All existing templates with `variables: []` are unaffected until their content is next edited

Closes #1896

🤖 Generated with [Claude Code](https://claude.com/claude-code)