### PR TITLE
fix: auto-derive template variables from content placeholders (#1896)

### DIFF
--- a/src/elements/templates/Template.ts
+++ b/src/elements/templates/Template.ts
@@ -84,7 +84,7 @@ export class Template extends BaseElement implements IElement {
   // SECURITY FIX #4: Memory management constants
   // Prevents unbounded template size and variable count that could exhaust memory
   private readonly MAX_TEMPLATE_SIZE = 100 * 1024; // 100KB max template size
-  private readonly MAX_VARIABLE_COUNT = 100;       // Max variables per template
+  private static readonly MAX_VARIABLE_COUNT = 100; // Max variables per template
   private readonly MAX_INCLUDE_DEPTH = 5;          // Prevent infinite include loops
   private readonly MAX_STRING_LENGTH = 10000;      // Max length for string variables
 
@@ -136,8 +136,8 @@ export class Template extends BaseElement implements IElement {
 
     // SECURITY FIX #3 & #4: Validate variables
     if (this.metadata.variables) {
-      if (this.metadata.variables.length > this.MAX_VARIABLE_COUNT) {
-        throw ErrorHandler.createError(`Variable count ${this.metadata.variables.length} exceeds maximum ${this.MAX_VARIABLE_COUNT}`, ErrorCategory.VALIDATION_ERROR, ValidationErrorCodes.TOO_MANY_VARIABLES);
+      if (this.metadata.variables.length > Template.MAX_VARIABLE_COUNT) {
+        throw ErrorHandler.createError(`Variable count ${this.metadata.variables.length} exceeds maximum ${Template.MAX_VARIABLE_COUNT}`, ErrorCategory.VALIDATION_ERROR, ValidationErrorCodes.TOO_MANY_VARIABLES);
       }
       
       this.metadata.variables = this.metadata.variables.map(variable => ({
@@ -301,6 +301,21 @@ export class Template extends BaseElement implements IElement {
       if (!existingNames.has(name)) {
         result.push({ name, type: 'string', required: false });
       }
+    }
+
+    // Enforce the same MAX_VARIABLE_COUNT limit as the constructor.
+    // When auto-derive would exceed the cap, truncate and surface a structured
+    // error so the calling LLM knows to split the content across templates.
+    if (result.length > Template.MAX_VARIABLE_COUNT) {
+      const overflow = result.splice(Template.MAX_VARIABLE_COUNT);
+      const overflowNames = overflow.map(v => v.name).join(', ');
+      throw ErrorHandler.createError(
+        `Auto-derive reached the ${Template.MAX_VARIABLE_COUNT}-variable limit. ` +
+        `${overflow.length} placeholder(s) were not registered: ${overflowNames}. ` +
+        `Split this content across multiple templates and combine them in an ensemble.`,
+        ErrorCategory.VALIDATION_ERROR,
+        ValidationErrorCodes.TOO_MANY_VARIABLES
+      );
     }
 
     return result;
@@ -852,7 +867,7 @@ export class Template extends BaseElement implements IElement {
     // Check if all tokens have corresponding variable definitions
     const compiled = this.compile();
     const definedVars = new Set(this.metadata.variables?.map(v => v.name) || []);
-    const usedVars = new Set(compiled.tokens.map(t => t.variable.split('.')[0]));
+    const usedVars = new Set(compiled.tokens.map(t => t.variable));
 
     usedVars.forEach(varName => {
       if (!definedVars.has(varName)) {

--- a/src/elements/templates/Template.ts
+++ b/src/elements/templates/Template.ts
@@ -779,20 +779,20 @@ export class Template extends BaseElement implements IElement {
   public override validate(): ElementValidationResult {
     const result = super.validate();
 
-    // Initialize arrays if not present
-    // FIX: Use nullish coalescing assignment (SonarCloud S6606)
-    result.errors ??= [];
-    result.warnings ??= [];
-    
+    // Capture arrays as locals so TypeScript knows they're always defined
+    // and call sites never need ! or inline ??= expressions (S1121, S6606).
+    const errors = result.errors ??= [];
+    const warnings = result.warnings ??= [];
+
     // Content validation
     if (!this.content || this.content.trim().length === 0) {
-      result.errors.push({
+      errors.push({
         field: 'content',
         message: 'Template content cannot be empty',
         code: 'EMPTY_CONTENT'
       });
     }
-    
+
     // Check for unmatched tokens.
     // Issue #705: In section mode, only count tokens within the <template> section —
     // <style> and <script> sections are raw passthrough where }} is intentional.
@@ -802,31 +802,31 @@ export class Template extends BaseElement implements IElement {
     const openTokens = (tokenCheckContent.match(/\{\{/g) || []).length;
     const closeTokens = (tokenCheckContent.match(/\}\}/g) || []).length;
     if (openTokens !== closeTokens) {
-      result.errors.push({
+      errors.push({
         field: 'content',
         message: 'Template has unmatched variable tokens',
         code: 'UNMATCHED_TOKENS'
       });
     }
-    
+
     // Validate output format
     const validFormats = ['markdown', 'html', 'json', 'yaml', 'text', 'xml'];
     if (this.metadata.output_format && !validFormats.includes(this.metadata.output_format)) {
-      result.warnings.push({
+      warnings.push({
         field: 'output_format',
         message: `Unknown output format '${this.metadata.output_format}'. Common formats: ${validFormats.join(', ')}`,
         severity: 'low'
       });
     }
-    
+
     // Validate variables
     if (this.metadata.variables) {
       const variableNames = new Set<string>();
-      
+
       this.metadata.variables.forEach((variable, index) => {
         // Check for duplicate names
         if (variableNames.has(variable.name)) {
-          (result.errors ??= []).push({
+          errors.push({
             field: `variables[${index}].name`,
             message: `Duplicate variable name '${variable.name}'`,
             code: 'DUPLICATE_VARIABLE'
@@ -839,7 +839,7 @@ export class Template extends BaseElement implements IElement {
           try {
             new RegExp(variable.validation);
           } catch (e) {
-            (result.errors ??= []).push({
+            errors.push({
               field: `variables[${index}].validation`,
               message: `Invalid regex pattern: ${e}`,
               code: 'INVALID_REGEX'
@@ -848,15 +848,15 @@ export class Template extends BaseElement implements IElement {
         }
       });
     }
-    
+
     // Check if all tokens have corresponding variable definitions
     const compiled = this.compile();
     const definedVars = new Set(this.metadata.variables?.map(v => v.name) || []);
     const usedVars = new Set(compiled.tokens.map(t => t.variable.split('.')[0]));
-    
+
     usedVars.forEach(varName => {
       if (!definedVars.has(varName)) {
-        (result.warnings ??= []).push({
+        warnings.push({
           field: 'variables',
           message: `Template uses undefined variable '${varName}'`,
           severity: 'medium'

--- a/src/elements/templates/Template.ts
+++ b/src/elements/templates/Template.ts
@@ -826,20 +826,20 @@ export class Template extends BaseElement implements IElement {
       this.metadata.variables.forEach((variable, index) => {
         // Check for duplicate names
         if (variableNames.has(variable.name)) {
-          result.errors!.push({
+          (result.errors ??= []).push({
             field: `variables[${index}].name`,
             message: `Duplicate variable name '${variable.name}'`,
             code: 'DUPLICATE_VARIABLE'
           });
         }
         variableNames.add(variable.name);
-        
+
         // Validate regex patterns
         if (variable.validation) {
           try {
             new RegExp(variable.validation);
           } catch (e) {
-            result.errors!.push({
+            (result.errors ??= []).push({
               field: `variables[${index}].validation`,
               message: `Invalid regex pattern: ${e}`,
               code: 'INVALID_REGEX'
@@ -856,7 +856,7 @@ export class Template extends BaseElement implements IElement {
     
     usedVars.forEach(varName => {
       if (!definedVars.has(varName)) {
-        result.warnings!.push({
+        (result.warnings ??= []).push({
           field: 'variables',
           message: `Template uses undefined variable '${varName}'`,
           severity: 'medium'

--- a/src/elements/templates/Template.ts
+++ b/src/elements/templates/Template.ts
@@ -249,6 +249,41 @@ export class Template extends BaseElement implements IElement {
     return this.parsedSections;
   }
 
+  /**
+   * Scan `content` for {{placeholder}} patterns and return a merged variable
+   * list. Existing entries are preserved unchanged (user-set descriptions,
+   * types, required flags, etc.); new placeholders are added with defaults:
+   * type 'string', required: false.  (#1896)
+   *
+   * Respects section mode — only the <template> section is scanned, matching
+   * the substitution engine's scope.
+   */
+  static deriveVariablesFromContent(
+    content: string,
+    existingVariables: TemplateVariable[] = []
+  ): TemplateVariable[] {
+    const { isSectionMode, templateSection } = Template.parseSections(content);
+    const scanContent = isSectionMode ? templateSection : content;
+
+    const pattern = /\{\{\s*([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)\s*\}\}/g;
+    const seen = new Set<string>();
+    let match;
+    while ((match = pattern.exec(scanContent)) !== null) {
+      seen.add(match[1]);
+    }
+
+    const existingNames = new Set(existingVariables.map(v => v.name));
+    const result: TemplateVariable[] = [...existingVariables];
+
+    for (const name of seen) {
+      if (!existingNames.has(name)) {
+        result.push({ name, type: 'string', required: false });
+      }
+    }
+
+    return result;
+  }
+
   private compile(): CompiledTemplate {
     if (this.compiledTemplate) {
       return this.compiledTemplate;

--- a/src/elements/templates/Template.ts
+++ b/src/elements/templates/Template.ts
@@ -250,13 +250,35 @@ export class Template extends BaseElement implements IElement {
   }
 
   /**
-   * Scan `content` for {{placeholder}} patterns and return a merged variable
+   * Scan `content` for `{{placeholder}}` patterns and return a merged variable
    * list. Existing entries are preserved unchanged (user-set descriptions,
    * types, required flags, etc.); new placeholders are added with defaults:
-   * type 'string', required: false.  (#1896)
+   * `type: 'string'`, `required: false`. (#1896)
    *
-   * Respects section mode — only the <template> section is scanned, matching
-   * the substitution engine's scope.
+   * Respects section mode — only the `<template>` section is scanned,
+   * matching the substitution engine's scope.
+   *
+   * **Performance:** Single-pass regex scan — O(n) in content length.
+   * Called by `TemplateManager.save()` on every create/edit, so content
+   * is already validated and size-bounded (≤ 100 KB) before reaching here.
+   *
+   * @param content - Raw template content (may include section tags)
+   * @param existingVariables - Already-declared variables; never overwritten
+   * @returns Merged variable list: existing entries first, new entries appended
+   *
+   * @example
+   * // New template — empty schema gets fully populated
+   * deriveVariablesFromContent('Hello {{name}}, score: {{score}}')
+   * // → [{ name: 'name', type: 'string', required: false },
+   * //    { name: 'score', type: 'string', required: false }]
+   *
+   * @example
+   * // Existing entry preserved; only the missing placeholder is added
+   * deriveVariablesFromContent('{{name}} earns {{points}}', [
+   *   { name: 'name', type: 'string', required: true, description: 'Display name' }
+   * ])
+   * // → [{ name: 'name', type: 'string', required: true, description: 'Display name' },
+   * //    { name: 'points', type: 'string', required: false }]
    */
   static deriveVariablesFromContent(
     content: string,

--- a/src/elements/templates/TemplateManager.ts
+++ b/src/elements/templates/TemplateManager.ts
@@ -65,6 +65,17 @@ export class TemplateManager extends BaseElementManager<Template> {
   }
 
   override async save(template: Template, filePath: string): Promise<void> {
+    // Auto-derive variables from content (#1896): ensures every {{placeholder}}
+    // has a matching schema entry so render() never silently returns unfilled text.
+    // Existing entries are never overwritten — user-set descriptions, types, and
+    // required flags survive. New entries default to type: 'string', required: false.
+    if (template.content) {
+      template.metadata.variables = Template.deriveVariablesFromContent(
+        template.content,
+        template.metadata.variables ?? []
+      );
+    }
+
     await super.save(template, filePath);
 
     SecurityMonitor.logSecurityEvent({

--- a/src/utils/TemplateRenderer.ts
+++ b/src/utils/TemplateRenderer.ts
@@ -163,14 +163,7 @@ export class TemplateRenderer {
 
       // Detect unsubstituted placeholders (#1896) — render always completes;
       // unfilled tokens are surfaced as advisory warnings, never hard errors.
-      const unsubstituted = [...rendered.matchAll(/\{\{\s*([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)\s*\}\}/g)]
-        .map(m => m[1]);
-      const warnings = unsubstituted.length > 0
-        ? [`${unsubstituted.length} placeholder(s) were not substituted: ${unsubstituted.join(', ')}`]
-        : undefined;
-      if (warnings) {
-        logger.warn(`[TemplateRenderer] ${warnings[0]}`);
-      }
+      const warnings = this.detectUnsubstituted(normalizedName, rendered);
 
       // Issue #705: all_sections — return rendered template + raw style/script together
       if (allSections) {
@@ -213,6 +206,21 @@ export class TemplateRenderer {
         performance: { lookupTime: 0, renderTime: 0, totalTime }
       };
     }
+  }
+
+  /**
+   * Scan rendered output for any remaining {{placeholder}} patterns and
+   * return an advisory warnings array (or undefined if everything was filled).
+   * Extracted from render() to keep its cognitive complexity within limits.
+   * (#1896)
+   */
+  private detectUnsubstituted(templateName: string, rendered: string): string[] | undefined {
+    const unsubstituted = [...rendered.matchAll(/\{\{\s*([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)\s*\}\}/g)]
+      .map(m => m[1]);
+    if (unsubstituted.length === 0) return undefined;
+    const msg = `${unsubstituted.length} placeholder(s) were not substituted: ${unsubstituted.join(', ')}`;
+    logger.warn(`[TemplateRenderer] '${templateName}': ${msg}`);
+    return [msg];
   }
 
   /**

--- a/src/utils/TemplateRenderer.ts
+++ b/src/utils/TemplateRenderer.ts
@@ -26,6 +26,8 @@ export interface RenderResult {
     script: string;
   };
   error?: string;
+  /** Unsubstituted {{placeholder}} names found in the rendered output (#1896) */
+  warnings?: string[];
   performance?: {
     lookupTime: number;
     renderTime: number;
@@ -159,12 +161,24 @@ export class TemplateRenderer {
         `output_length=${rendered.length}`
       );
 
+      // Detect unsubstituted placeholders (#1896) — render always completes;
+      // unfilled tokens are surfaced as advisory warnings, never hard errors.
+      const unsubstituted = [...rendered.matchAll(/\{\{\s*([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)\s*\}\}/g)]
+        .map(m => m[1]);
+      const warnings = unsubstituted.length > 0
+        ? [`${unsubstituted.length} placeholder(s) were not substituted: ${unsubstituted.join(', ')}`]
+        : undefined;
+      if (warnings) {
+        logger.warn(`[TemplateRenderer] ${warnings[0]}`);
+      }
+
       // Issue #705: all_sections — return rendered template + raw style/script together
       if (allSections) {
         const sections = template.getSections();
         return {
           success: true,
           content: rendered,
+          warnings,
           sections: {
             template: rendered,
             style: sections.styleSection,
@@ -177,6 +191,7 @@ export class TemplateRenderer {
       return {
         success: true,
         content: rendered,
+        warnings,
         performance: { lookupTime, renderTime, totalTime }
       };
       

--- a/tests/unit/elements/templates/Template.test.ts
+++ b/tests/unit/elements/templates/Template.test.ts
@@ -589,4 +589,73 @@ describe('Template', () => {
       });
     });
   });
+
+  describe('deriveVariablesFromContent() (#1896)', () => {
+    it('returns an empty array when content has no placeholders', () => {
+      const result = Template.deriveVariablesFromContent('No placeholders here.');
+      expect(result).toHaveLength(0);
+    });
+
+    it('derives a single placeholder', () => {
+      const result = Template.deriveVariablesFromContent('Hello {{name}}!');
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('name');
+      expect(result[0].type).toBe('string');
+      expect(result[0].required).toBe(false);
+    });
+
+    it('derives multiple distinct placeholders', () => {
+      const result = Template.deriveVariablesFromContent('{{first}} and {{second}} and {{third}}');
+      const names = result.map(v => v.name).sort();
+      expect(names).toEqual(['first', 'second', 'third']);
+    });
+
+    it('deduplicates repeated placeholders', () => {
+      const result = Template.deriveVariablesFromContent('{{foo}} then {{foo}} again');
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('foo');
+    });
+
+    it('preserves existing variable entries unchanged', () => {
+      const existing: TemplateVariable[] = [
+        { name: 'name', type: 'string', required: true, description: 'Full name' }
+      ];
+      const result = Template.deriveVariablesFromContent('Hello {{name}}! Your score: {{score}}', existing);
+      const namVar = result.find(v => v.name === 'name')!;
+      expect(namVar.required).toBe(true);
+      expect(namVar.description).toBe('Full name');
+    });
+
+    it('adds only missing placeholders when some are already declared', () => {
+      const existing: TemplateVariable[] = [{ name: 'name', type: 'string' }];
+      const result = Template.deriveVariablesFromContent('{{name}} and {{score}}', existing);
+      expect(result).toHaveLength(2);
+      const scoreVar = result.find(v => v.name === 'score')!;
+      expect(scoreVar.type).toBe('string');
+      expect(scoreVar.required).toBe(false);
+    });
+
+    it('handles dot-notation placeholder paths', () => {
+      const result = Template.deriveVariablesFromContent('{{user.name}} at {{user.email}}');
+      const names = result.map(v => v.name).sort();
+      expect(names).toEqual(['user.email', 'user.name']);
+    });
+
+    it('handles whitespace inside braces', () => {
+      const result = Template.deriveVariablesFromContent('{{ spaced }} and {{  also_spaced  }}');
+      const names = result.map(v => v.name).sort();
+      expect(names).toEqual(['also_spaced', 'spaced']);
+    });
+
+    it('in section mode, only scans the <template> section', () => {
+      const content = [
+        '<template>{{title}}</template>',
+        '<style>.cls-{{ignored}} { color: red; }</style>',
+        '<script>var {{also_ignored}} = 1;</script>',
+      ].join('\n');
+      const result = Template.deriveVariablesFromContent(content);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('title');
+    });
+  });
 });

--- a/tests/unit/elements/templates/Template.test.ts
+++ b/tests/unit/elements/templates/Template.test.ts
@@ -339,7 +339,7 @@ describe('Template', () => {
         ]
       }, 'Hello {{defined}} and {{undefined}}!', metadataService);
       const result = template.validate();
-      
+
       expect(result.valid).toBe(true);
       expect(result.warnings).toContainEqual(
         expect.objectContaining({
@@ -348,6 +348,24 @@ describe('Template', () => {
           severity: 'medium'
         })
       );
+    });
+
+    it('should not warn for dot-notation variables registered with their full path', () => {
+      // deriveVariablesFromContent stores 'user.name' as the variable name;
+      // validate() must match against the full path, not just the root 'user'.
+      const template = new Template({
+        name: 'Dot Notation Vars',
+        variables: [
+          { name: 'user.name', type: 'string' },
+          { name: 'user.email', type: 'string' }
+        ]
+      }, 'Hello {{user.name}}, your email is {{user.email}}.', metadataService);
+      const result = template.validate();
+
+      const undefinedVarWarnings = (result.warnings ?? []).filter(
+        w => w.field === 'variables' && w.message.includes('undefined variable')
+      );
+      expect(undefinedVarWarnings).toHaveLength(0);
     });
 
     it('should suggest best practices', () => {
@@ -656,6 +674,20 @@ describe('Template', () => {
       const result = Template.deriveVariablesFromContent(content);
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('title');
+    });
+
+    it('throws with ensemble guidance when derived count would exceed 100', () => {
+      // Build content with 101 distinct placeholders
+      const placeholders = Array.from({ length: 101 }, (_, i) => `{{var_${i}}}`).join(' ');
+      expect(() => Template.deriveVariablesFromContent(placeholders)).toThrow(
+        /Split this content across multiple templates and combine them in an ensemble/
+      );
+    });
+
+    it('succeeds when derived count is exactly 100', () => {
+      const placeholders = Array.from({ length: 100 }, (_, i) => `{{var_${i}}}`).join(' ');
+      const result = Template.deriveVariablesFromContent(placeholders);
+      expect(result).toHaveLength(100);
     });
   });
 });

--- a/tests/unit/elements/templates/Template.test.ts
+++ b/tests/unit/elements/templates/Template.test.ts
@@ -606,7 +606,7 @@ describe('Template', () => {
 
     it('derives multiple distinct placeholders', () => {
       const result = Template.deriveVariablesFromContent('{{first}} and {{second}} and {{third}}');
-      const names = result.map(v => v.name).sort();
+      const names = result.map(v => v.name).sort((a, b) => a.localeCompare(b));
       expect(names).toEqual(['first', 'second', 'third']);
     });
 
@@ -637,13 +637,13 @@ describe('Template', () => {
 
     it('handles dot-notation placeholder paths', () => {
       const result = Template.deriveVariablesFromContent('{{user.name}} at {{user.email}}');
-      const names = result.map(v => v.name).sort();
+      const names = result.map(v => v.name).sort((a, b) => a.localeCompare(b));
       expect(names).toEqual(['user.email', 'user.name']);
     });
 
     it('handles whitespace inside braces', () => {
       const result = Template.deriveVariablesFromContent('{{ spaced }} and {{  also_spaced  }}');
-      const names = result.map(v => v.name).sort();
+      const names = result.map(v => v.name).sort((a, b) => a.localeCompare(b));
       expect(names).toEqual(['also_spaced', 'spaced']);
     });
 

--- a/tests/unit/elements/templates/TemplateManager.test.ts
+++ b/tests/unit/elements/templates/TemplateManager.test.ts
@@ -279,4 +279,77 @@ Hello {{name}}!`;
       await expect(manager.importElement(noContent, 'json')).rejects.toThrow('Invalid template');
     });
   });
+
+  describe('auto-derive variables from content (#1896)', () => {
+    it('populates variables on create when variables is empty', async () => {
+      const template = await manager.create({
+        name: 'auto-derive-basic',
+        description: 'Test auto-derivation',
+        content: 'Hello {{name}}, your score is {{score}}.',
+      });
+      const names = template.metadata.variables?.map(v => v.name) ?? [];
+      expect(names).toContain('name');
+      expect(names).toContain('score');
+    });
+
+    it('derived variables default to type string and required false', async () => {
+      const template = await manager.create({
+        name: 'auto-derive-defaults',
+        description: 'Test defaults',
+        content: 'Value: {{foo}}',
+      });
+      const fooVar = template.metadata.variables?.find(v => v.name === 'foo');
+      expect(fooVar).toBeDefined();
+      expect(fooVar!.type).toBe('string');
+      expect(fooVar!.required).toBe(false);
+    });
+
+    it('preserves explicitly provided variable metadata', async () => {
+      const template = await manager.create({
+        name: 'auto-derive-preserve',
+        description: 'Test preservation',
+        content: 'Hello {{name}}!',
+        metadata: {
+          variables: [{ name: 'name', type: 'string', required: true, description: 'Full name' }]
+        },
+      });
+      const nameVar = template.metadata.variables?.find(v => v.name === 'name');
+      expect(nameVar!.required).toBe(true);
+      expect(nameVar!.description).toBe('Full name');
+    });
+
+    it('adds missing placeholders without removing declared ones', async () => {
+      const template = await manager.create({
+        name: 'auto-derive-additive',
+        description: 'Test additive merge',
+        content: '{{declared}} and {{new_one}}',
+        metadata: {
+          variables: [{ name: 'declared', type: 'number', required: true }]
+        },
+      });
+      const declared = template.metadata.variables?.find(v => v.name === 'declared');
+      const newOne = template.metadata.variables?.find(v => v.name === 'new_one');
+      expect(declared!.type).toBe('number');  // original preserved
+      expect(newOne).toBeDefined();           // new one added
+      expect(newOne!.required).toBe(false);
+    });
+
+    it('auto-derives on subsequent save (edit path)', async () => {
+      const template = await manager.create({
+        name: 'auto-derive-edit',
+        description: 'Test edit re-derive',
+        content: 'Static content with {{original}}.',
+      });
+      expect(template.metadata.variables?.map(v => v.name)).toContain('original');
+
+      // Simulate an edit: update content to add a new placeholder.
+      // save() expects a relative filename, same as what create() uses internally.
+      template.content = 'Static content with {{original}} and {{added}}.';
+      await manager.save(template, 'auto-derive-edit.md');
+
+      const names = template.metadata.variables?.map(v => v.name) ?? [];
+      expect(names).toContain('original');
+      expect(names).toContain('added');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Templates with `{{placeholder}}` content but `variables: []` silently returned unfilled text on render — no error, no warning, just broken output. Discovered after 13 templates were created with correct content but empty variable schemas.
- `TemplateManager.save()` now calls `Template.deriveVariablesFromContent()` before every persist, covering both create and edit paths automatically
- Existing variable entries are **never overwritten** — user-set descriptions, types, and `required` flags survive; only missing placeholders are added, defaulting to `type: 'string', required: false`
- `TemplateRenderer.render()` now detects any remaining `{{placeholder}}` in the rendered output and surfaces them as advisory `warnings` in `RenderResult`; render always completes, warnings are non-blocking

## Changes

- `Template.ts` — add `static deriveVariablesFromContent(content, existingVariables)` (near `compile()`, reuses the same regex)
- `TemplateManager.ts` — hook derivation into existing `save()` override, runs on every create and edit
- `TemplateRenderer.ts` — add `warnings?: string[]` to `RenderResult`; detect unsubstituted placeholders post-render
- `Template.test.ts` — 9 new tests for `deriveVariablesFromContent()` covering deduplication, preservation, dot-notation, whitespace, and section mode
- `TemplateManager.test.ts` — 5 new integration tests covering create auto-derive, default values, preservation of existing vars, additive merge, and edit re-derive

## Test plan

- [ ] Create a template with `{{foo}}` and `variables: []` — confirm `variables` contains `foo` after create
- [ ] Edit a template's content to add `{{bar}}` — confirm `bar` is upserted into `variables`
- [ ] A variable already declared with `required: true` and a description survives a content re-save unchanged
- [ ] `render_template` with a missing variable returns output with warnings listing the unfilled placeholder(s)
- [ ] All existing templates with `variables: []` are unaffected until their content is next edited

Closes #1896

🤖 Generated with [Claude Code](https://claude.com/claude-code)