### PR TITLE
[codex] Fix console permissions and metrics reporting

### DIFF
--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -546,7 +546,9 @@ export class ElementCRUDHandler {
       type: entry.type,
       name: entry.name,
       metadata: entry.metadata,
-      ...(entry.sessionIds.size > 0 ? { sessionIds: Array.from(entry.sessionIds).sort() } : {}),
+      ...(entry.sessionIds.size > 0
+        ? { sessionIds: Array.from(entry.sessionIds).sort((a, b) => a.localeCompare(b)) }
+        : {}),
     }));
   }
 

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -51,7 +51,7 @@ import {
 } from './strategies/index.js';
 import { ElementQueryService } from '../services/query/ElementQueryService.js';
 import { ValidationRegistry } from '../services/validation/ValidationRegistry.js';
-import type { ActivationStore } from '../services/ActivationStore.js';
+import type { ActivationStore, PersistedActivation, PersistedActivationStateSnapshot } from '../services/ActivationStore.js';
 import type { BackupService } from '../services/BackupService.js';
 import type { PolicyExportService } from '../services/PolicyExportService.js';
 import type { BaseElementManager } from '../elements/base/BaseElementManager.js';
@@ -138,6 +138,34 @@ export class ElementCRUDHandler {
    */
   private sanitizeMetadata(metadata: Record<string, any>): Record<string, any> {
     return sanitizeMetadataRecord(metadata);
+  }
+
+  private normalizeLookupValue(value: unknown): string {
+    return typeof value === 'string'
+      ? value.normalize('NFC').trim()
+      : '';
+  }
+
+  private hasGatekeeperPolicy(metadata: Record<string, unknown> | undefined): boolean {
+    return Boolean(metadata?.['gatekeeper']);
+  }
+
+  private toPolicyElementType(type: string): string {
+    const normalizedType = this.normalizeLookupValue(type).toLowerCase();
+    switch (normalizedType) {
+      case 'personas':
+        return 'persona';
+      case 'skills':
+        return 'skill';
+      case 'agents':
+        return 'agent';
+      case 'memories':
+        return 'memory';
+      case 'ensembles':
+        return 'ensemble';
+      default:
+        return normalizedType;
+    }
   }
 
   /**
@@ -365,6 +393,22 @@ export class ElementCRUDHandler {
     }
 
     try {
+      // Active agents (async)
+      const agents = await this.agentManager.getActiveAgents();
+      for (const agent of agents) {
+        const key = `agent:${agent.metadata.name}`;
+        seen.add(key);
+        result.push({
+          type: 'agent',
+          name: agent.metadata.name,
+          metadata: agent.metadata as unknown as Record<string, unknown>,
+        });
+      }
+    } catch (error) {
+      logger.warn('Failed to gather active agents for policy evaluation', { error });
+    }
+
+    try {
       // Active ensembles (async)
       const ensembles = await this.ensembleManager.getActiveEnsembles();
       for (const e of ensembles) {
@@ -407,6 +451,128 @@ export class ElementCRUDHandler {
     }
 
     return result;
+  }
+
+  async getPolicyElementsForReport(sessionId?: string): Promise<Array<{
+    type: string;
+    name: string;
+    metadata: Record<string, unknown>;
+    sessionIds?: string[];
+  }>> {
+    const merged = new Map<string, {
+      type: string;
+      name: string;
+      metadata: Record<string, unknown>;
+      sessionIds: Set<string>;
+    }>();
+
+    const addElement = (
+      element: { type: string; name: string; metadata: Record<string, unknown> },
+      sessionIds: string[] = [],
+    ): void => {
+      if (!this.hasGatekeeperPolicy(element.metadata)) {
+        return;
+      }
+
+      const key = `${element.type}:${element.name}`;
+      const existing = merged.get(key);
+      if (existing) {
+        sessionIds.forEach(id => existing.sessionIds.add(id));
+        return;
+      }
+
+      merged.set(key, {
+        type: element.type,
+        name: element.name,
+        metadata: element.metadata,
+        sessionIds: new Set(sessionIds),
+      });
+    };
+
+    for (const activeElement of await this.getActiveElementsForPolicy()) {
+      addElement(activeElement, this.activationStore ? [this.activationStore.getSessionId()] : []);
+    }
+
+    if (this.activationStore?.isEnabled()) {
+      const persistedStates = await this.activationStore.listPersistedActivationStates(sessionId);
+      const catalogs = new Map<string, Array<{ metadata?: Record<string, unknown>; filename?: string }>>();
+
+      const getCatalog = async (type: string) => {
+        const normalizedType = this.normalizeElementType(type);
+        if (!catalogs.has(normalizedType)) {
+          catalogs.set(
+            normalizedType,
+            (await this.getElements(normalizedType)) as Array<{ metadata?: Record<string, unknown>; filename?: string }>,
+          );
+        }
+        return catalogs.get(normalizedType) ?? [];
+      };
+
+      const findPersistedElement = async (
+        type: string,
+        activation: PersistedActivation,
+      ): Promise<{ type: string; name: string; metadata: Record<string, unknown> } | null> => {
+        const catalog = await getCatalog(type);
+        const normalizedName = this.normalizeLookupValue(activation.name);
+        const normalizedFilename = this.normalizeLookupValue(activation.filename);
+
+        const found = catalog.find((element) => {
+          const metadata = element.metadata ?? {};
+          const elementName = this.normalizeLookupValue(metadata['name']);
+          const elementFilename = this.normalizeLookupValue(
+            element.filename ?? metadata['filename'] ?? metadata['sourceFile'],
+          );
+
+          return elementName === normalizedName || (normalizedFilename !== '' && elementFilename === normalizedFilename);
+        });
+
+        if (!found?.metadata || !this.hasGatekeeperPolicy(found.metadata)) {
+          return null;
+        }
+
+        return {
+          type: this.toPolicyElementType(type),
+          name: (found.metadata['name'] as string) ?? activation.name,
+          metadata: found.metadata,
+        };
+      };
+
+      for (const state of persistedStates) {
+        await this.mergePersistedPolicyState(state, addElement, findPersistedElement);
+      }
+    }
+
+    return Array.from(merged.values()).map((entry) => ({
+      type: entry.type,
+      name: entry.name,
+      metadata: entry.metadata,
+      ...(entry.sessionIds.size > 0 ? { sessionIds: Array.from(entry.sessionIds).sort() } : {}),
+    }));
+  }
+
+  private async mergePersistedPolicyState(
+    state: PersistedActivationStateSnapshot,
+    addElement: (element: { type: string; name: string; metadata: Record<string, unknown> }, sessionIds?: string[]) => void,
+    findPersistedElement: (type: string, activation: PersistedActivation) => Promise<{ type: string; name: string; metadata: Record<string, unknown> } | null>,
+  ): Promise<void> {
+    const pending: Promise<void>[] = [];
+
+    for (const [type, activations] of Object.entries(state.activations)) {
+      for (const activation of activations ?? []) {
+        pending.push((async () => {
+          const found = await findPersistedElement(type, activation);
+          if (found) {
+            addElement(found, [state.sessionId]);
+          }
+        })());
+      }
+    }
+
+    if (pending.length === 0) {
+      return;
+    }
+
+    await Promise.allSettled(pending);
   }
 
   async deactivateElement(name: string, type: string) {

--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -688,6 +688,27 @@ export class MCPAQLHandler {
     }
   }
 
+  private async getPolicyReportElements(sessionId?: string): Promise<ActiveElement[]> {
+    try {
+      const rawElements = await this.handlers.elementCRUD.getPolicyElementsForReport(sessionId);
+      return rawElements.map((el) => ({
+        type: el.type,
+        name: el.name,
+        metadata: {
+          name: el.name,
+          description: (el.metadata.description as string) ?? undefined,
+          gatekeeper: el.metadata?.gatekeeper as ActiveElement['metadata']['gatekeeper'] ?? undefined,
+          ...(Array.isArray((el as { sessionIds?: string[] }).sessionIds)
+            ? { sessionIds: (el as { sessionIds?: string[] }).sessionIds }
+            : {}),
+        },
+      }));
+    } catch (error) {
+      logger.warn('Failed to gather policy elements for dashboard reporting', { error, sessionId });
+      return this.getActiveElements();
+    }
+  }
+
   /**
    * Handle CREATE operations (additive, non-destructive)
    *
@@ -2932,21 +2953,28 @@ export class MCPAQLHandler {
         // Issue #625 Phase 2: Get effective CLI permission policies
         const toolName = params.tool_name as string | undefined;
         const toolInput = (params.tool_input as Record<string, unknown>) ?? {};
+        const reportSessionId = typeof params.session_id === 'string' ? params.session_id : undefined;
+        const reportingScope = params.reporting_scope === 'dashboard';
 
         // 1. Get all active elements
-        const policyElements = await this.getActiveElements();
+        const policyElements = reportingScope && !toolName
+          ? await this.getPolicyReportElements(reportSessionId)
+          : await this.getActiveElements();
 
         // 2. Extract externalRestrictions from each element
         const elementPolicies = policyElements.map(el => ({
           type: el.type,
           name: el.name,
           allowPatterns: el.metadata?.gatekeeper?.externalRestrictions?.allowPatterns ?? [],
+          confirmPatterns: el.metadata?.gatekeeper?.externalRestrictions?.confirmPatterns ?? [],
           denyPatterns: el.metadata?.gatekeeper?.externalRestrictions?.denyPatterns ?? [],
           description: el.metadata?.gatekeeper?.externalRestrictions?.description ?? null,
+          sessionIds: (el.metadata as Record<string, unknown>)?.sessionIds ?? undefined,
         }));
 
         // 3. Build combined view
         const combinedAllow = elementPolicies.flatMap(p => p.allowPatterns);
+        const combinedConfirm = elementPolicies.flatMap(p => p.confirmPatterns);
         const combinedDeny = elementPolicies.flatMap(p => p.denyPatterns);
         const hasAllowlist = combinedAllow.length > 0;
 
@@ -2989,6 +3017,7 @@ export class MCPAQLHandler {
           hasAllowlist,
           elements: elementPolicies,
           combinedAllowPatterns: combinedAllow,
+          combinedConfirmPatterns: combinedConfirm,
           combinedDenyPatterns: combinedDeny,
           evaluation,
           permissionPromptActive,

--- a/src/services/ActivationStore.ts
+++ b/src/services/ActivationStore.ts
@@ -331,64 +331,14 @@ export class ActivationStore {
       ? normalizeActivationIdentifier(sessionId)
       : undefined;
 
-    const states: PersistedActivationStateSnapshot[] = [];
-
     try {
-      const filenames = normalizedSessionId
-        ? [`activations-${normalizedSessionId}.json`]
-        : (await fs.readdir(this.stateDir)).filter(name => /^activations-[^.]+\.json$/u.test(name));
-
-      for (const filename of filenames) {
-        const filePath = path.join(this.stateDir, filename);
-        try {
-          const content = await this.fileOps.readFile(filePath);
-          const data = JSON.parse(content) as PersistedActivationState;
-          if (data.version !== 1 || typeof data.sessionId !== 'string' || !data.activations || typeof data.activations !== 'object') {
-            continue;
-          }
-
-          const activations: Record<string, PersistedActivation[]> = {};
-          for (const [type, entries] of Object.entries(data.activations)) {
-            if (!ACTIVATABLE_TYPES.has(type) || !Array.isArray(entries)) {
-              continue;
-            }
-
-            const normalizedEntries = entries.flatMap((entry) => {
-              if (!entry || typeof entry.name !== 'string') return [];
-
-              const normalizedName = normalizeActivationIdentifier(entry.name);
-              if (!normalizedName) return [];
-
-              const normalizedFilename = typeof entry.filename === 'string'
-                ? normalizeActivationIdentifier(entry.filename)
-                : undefined;
-
-              return [{
-                ...entry,
-                name: normalizedName,
-                ...(normalizedFilename ? { filename: normalizedFilename } : {}),
-              }];
-            });
-
-            if (normalizedEntries.length > 0) {
-              activations[type] = normalizedEntries;
-            }
-          }
-
-          states.push({
-            sessionId: data.sessionId,
-            lastUpdated: data.lastUpdated,
-            activations,
-          });
-        } catch (error) {
-          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-            logger.debug('[ActivationStore] Skipping unreadable activation snapshot during reporting', {
-              filePath,
-              error: error instanceof Error ? error.message : String(error),
-            });
-          }
-        }
-      }
+      const filenames = await this.getPersistedActivationFilenames(normalizedSessionId);
+      const states = await Promise.all(
+        filenames.map(filename => this.readPersistedActivationState(filename)),
+      );
+      return states
+        .flatMap((state) => (state ? [state] : []))
+        .sort((a, b) => a.sessionId.localeCompare(b.sessionId));
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
         logger.debug('[ActivationStore] Failed to enumerate activation snapshots for reporting', {
@@ -398,7 +348,93 @@ export class ActivationStore {
       }
     }
 
-    return states.sort((a, b) => a.sessionId.localeCompare(b.sessionId));
+    return [];
+  }
+
+  private async getPersistedActivationFilenames(sessionId?: string): Promise<string[]> {
+    if (sessionId) {
+      return [`activations-${sessionId}.json`];
+    }
+
+    const filenames = await fs.readdir(this.stateDir);
+    return filenames.filter(name => /^activations-[^.]+\.json$/u.test(name));
+  }
+
+  private async readPersistedActivationState(filename: string): Promise<PersistedActivationStateSnapshot | null> {
+    const filePath = path.join(this.stateDir, filename);
+
+    try {
+      const content = await this.fileOps.readFile(filePath);
+      const data = JSON.parse(content) as PersistedActivationState;
+      if (!this.isPersistedActivationState(data)) {
+        return null;
+      }
+
+      return {
+        sessionId: data.sessionId,
+        lastUpdated: data.lastUpdated,
+        activations: this.normalizePersistedActivations(data.activations),
+      };
+    } catch (error) {
+      this.logSnapshotReadError(filePath, error);
+      return null;
+    }
+  }
+
+  private isPersistedActivationState(data: PersistedActivationState): boolean {
+    return data.version === 1
+      && typeof data.sessionId === 'string'
+      && Boolean(data.activations)
+      && typeof data.activations === 'object';
+  }
+
+  private normalizePersistedActivations(activations: PersistedActivationState['activations']): Record<string, PersistedActivation[]> {
+    const normalized: Record<string, PersistedActivation[]> = {};
+
+    for (const [type, entries] of Object.entries(activations)) {
+      if (!ACTIVATABLE_TYPES.has(type) || !Array.isArray(entries)) {
+        continue;
+      }
+
+      const normalizedEntries = entries.flatMap((entry) => this.normalizePersistedActivation(entry));
+      if (normalizedEntries.length > 0) {
+        normalized[type] = normalizedEntries;
+      }
+    }
+
+    return normalized;
+  }
+
+  private normalizePersistedActivation(entry: PersistedActivation | null | undefined): PersistedActivation[] {
+    if (!entry || typeof entry.name !== 'string') {
+      return [];
+    }
+
+    const normalizedName = normalizeActivationIdentifier(entry.name);
+    if (!normalizedName) {
+      return [];
+    }
+
+    const normalizedFilename = typeof entry.filename === 'string'
+      ? normalizeActivationIdentifier(entry.filename)
+      : undefined;
+
+    return [{
+      ...entry,
+      name: normalizedName,
+      ...(normalizedFilename ? { filename: normalizedFilename } : {}),
+    }];
+  }
+
+  private logSnapshotReadError(filePath: string, error: unknown): void {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return;
+    }
+
+    logger.debug('[ActivationStore] Skipping unreadable activation snapshot during reporting', {
+      filePath,
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 
   /**

--- a/src/services/ActivationStore.ts
+++ b/src/services/ActivationStore.ts
@@ -49,6 +49,12 @@ interface PersistedActivationState {
   activations: Record<string, PersistedActivation[]>;
 }
 
+export interface PersistedActivationStateSnapshot {
+  sessionId: string;
+  lastUpdated: string;
+  activations: Record<string, PersistedActivation[]>;
+}
+
 /** Valid element types that support activation (stored in singular form) */
 const ACTIVATABLE_TYPES = new Set(['persona', 'skill', 'agent', 'memory', 'ensemble']);
 
@@ -306,6 +312,93 @@ export class ActivationStore {
   getActivations(elementType: string): PersistedActivation[] {
     const type = normalizeType(elementType);
     return this.state.activations[type] ? [...this.state.activations[type]!] : [];
+  }
+
+  /**
+   * Read persisted activation snapshots from disk for reporting/diagnostics.
+   *
+   * This intentionally does not mutate the store's in-memory state, and it is
+   * safe to call from the web console to inspect other sessions' persisted
+   * activations without changing live policy enforcement for the current
+   * process.
+   */
+  async listPersistedActivationStates(sessionId?: string): Promise<PersistedActivationStateSnapshot[]> {
+    if (!this.enabled) {
+      return [];
+    }
+
+    const normalizedSessionId = typeof sessionId === 'string' && sessionId.trim()
+      ? normalizeActivationIdentifier(sessionId)
+      : undefined;
+
+    const states: PersistedActivationStateSnapshot[] = [];
+
+    try {
+      const filenames = normalizedSessionId
+        ? [`activations-${normalizedSessionId}.json`]
+        : (await fs.readdir(this.stateDir)).filter(name => /^activations-[^.]+\.json$/u.test(name));
+
+      for (const filename of filenames) {
+        const filePath = path.join(this.stateDir, filename);
+        try {
+          const content = await this.fileOps.readFile(filePath);
+          const data = JSON.parse(content) as PersistedActivationState;
+          if (data.version !== 1 || typeof data.sessionId !== 'string' || !data.activations || typeof data.activations !== 'object') {
+            continue;
+          }
+
+          const activations: Record<string, PersistedActivation[]> = {};
+          for (const [type, entries] of Object.entries(data.activations)) {
+            if (!ACTIVATABLE_TYPES.has(type) || !Array.isArray(entries)) {
+              continue;
+            }
+
+            const normalizedEntries = entries.flatMap((entry) => {
+              if (!entry || typeof entry.name !== 'string') return [];
+
+              const normalizedName = normalizeActivationIdentifier(entry.name);
+              if (!normalizedName) return [];
+
+              const normalizedFilename = typeof entry.filename === 'string'
+                ? normalizeActivationIdentifier(entry.filename)
+                : undefined;
+
+              return [{
+                ...entry,
+                name: normalizedName,
+                ...(normalizedFilename ? { filename: normalizedFilename } : {}),
+              }];
+            });
+
+            if (normalizedEntries.length > 0) {
+              activations[type] = normalizedEntries;
+            }
+          }
+
+          states.push({
+            sessionId: data.sessionId,
+            lastUpdated: data.lastUpdated,
+            activations,
+          });
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+            logger.debug('[ActivationStore] Skipping unreadable activation snapshot during reporting', {
+              filePath,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        }
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        logger.debug('[ActivationStore] Failed to enumerate activation snapshots for reporting', {
+          stateDir: this.stateDir,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return states.sort((a, b) => a.sessionId.localeCompare(b.sessionId));
   }
 
   /**

--- a/src/web/console/IngestRoutes.ts
+++ b/src/web/console/IngestRoutes.ts
@@ -103,6 +103,7 @@ export interface SessionEventPayload {
 export interface IngestBroadcasts {
   logBroadcast: (entry: UnifiedLogEntry) => void;
   metricsOnSnapshot?: (snapshot: MetricSnapshot) => void;
+  storeMetricsSnapshot?: (snapshot: MetricSnapshot, sessionId: string) => void;
   sessionBroadcast?: (event: SessionInfo) => void;
 }
 
@@ -283,6 +284,9 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
 
     if (broadcasts.metricsOnSnapshot) {
       broadcasts.metricsOnSnapshot(payload.snapshot);
+    }
+    if (broadcasts.storeMetricsSnapshot) {
+      broadcasts.storeMetricsSnapshot(payload.snapshot, payload.sessionId);
     }
 
     // Update heartbeat, revive ended sessions, or auto-register orphans (#1870)

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -201,6 +201,7 @@ async function startAsLeader(
   const ingestResult = createIngestRoutes({
     logBroadcast: (entry) => liveBroadcast?.(entry),
     metricsOnSnapshot: (snapshot) => liveMetricsOnSnapshot?.(snapshot),
+    storeMetricsSnapshot: (snapshot) => options.metricsSink?.onSnapshot(snapshot),
   });
 
   // Register the leader as a session
@@ -322,4 +323,3 @@ async function startAsFollower(
     },
   };
 }
-

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -70,7 +70,9 @@
 
   async function poll() {
     try {
-      const res = await DollhouseAuth.apiFetch('/api/permissions/status');
+      const sessionId = window.DollhouseSessions?.getFilterSessionId?.() || '';
+      const query = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : '';
+      const res = await DollhouseAuth.apiFetch(`/api/permissions/status${query}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       render(data);

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -3,7 +3,7 @@
  *
  * Shows a labeled "N sessions" box in the header. Clicking opens a
  * dropdown with selectable sessions. Selecting a session filters
- * logs and metrics to that session only.
+ * logs and refreshes any session-aware dashboard tabs.
  *
  * @security-audit-suppress DMCP-SEC-004 Client-side JS — all session data is
  * pre-normalized server-side via UnicodeValidator. Browser String.normalize('NFC')
@@ -70,6 +70,9 @@
     // Trigger log re-filter with the selected session
     if (window.DollhouseConsole && window.DollhouseConsole.logs && window.DollhouseConsole.logs.refilter) {
       window.DollhouseConsole.logs.refilter(sessionId);
+    }
+    if (window.DollhouseConsole && window.DollhouseConsole.permissions && window.DollhouseConsole.permissions.refresh) {
+      window.DollhouseConsole.permissions.refresh();
     }
 
     refreshSelectionState();

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -130,10 +130,18 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
    * Returns current permission policies and recent decisions
    * for the live permissions dashboard.
    */
-  router.get('/permissions/status', async (_req, res) => {
+  router.get('/permissions/status', async (req, res) => {
     try {
+      const sessionId = typeof req.query['sessionId'] === 'string' && req.query['sessionId']
+        ? req.query['sessionId']
+        : undefined;
+
       const opResult = asSingleResult(await handler.handleRead({
         operation: 'get_effective_cli_policies',
+        params: {
+          reporting_scope: 'dashboard',
+          ...(sessionId ? { session_id: sessionId } : {}),
+        },
       }));
 
       if (!opResult.success) {
@@ -152,11 +160,14 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
       }
 
       res.json({
+        ...(sessionId ? { sessionId } : {}),
         activeElementCount: data.activeElementCount,
         hasAllowlist: data.hasAllowlist,
         denyPatterns: data.combinedDenyPatterns,
         allowPatterns: data.combinedAllowPatterns,
-        confirmPatterns,
+        confirmPatterns: confirmPatterns.length > 0
+          ? confirmPatterns
+          : ((data.combinedConfirmPatterns as string[] | undefined) ?? []),
         elements,
         permissionPromptActive: data.permissionPromptActive,
         recentDecisions,

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -630,6 +630,7 @@ async function startFallbackServer(options: OpenBrowserOptions, port: number): P
   const { createIngestRoutes } = await import('./console/IngestRoutes.js');
   const ingestResult = createIngestRoutes({
     logBroadcast: (entry) => liveBroadcast?.(entry),
+    storeMetricsSnapshot: (snapshot) => metricsSink?.onSnapshot(snapshot),
   });
   ingestResult.registerConsoleSession();
 

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -13,6 +13,7 @@ import type { PortfolioManager } from '../../../src/portfolio/PortfolioManager.j
 import type { InitializationService } from '../../../src/services/InitializationService.js';
 import type { PersonaIndicatorService } from '../../../src/services/PersonaIndicatorService.js';
 import type { IFileOperationsService } from '../../../src/services/FileOperationsService.js';
+import type { ActivationStore } from '../../../src/services/ActivationStore.js';
 
 describe('ElementCRUDHandler (DI)', () => {
   let handler: ElementCRUDHandler;
@@ -45,6 +46,8 @@ describe('ElementCRUDHandler (DI)', () => {
 
     agentManager = {
       create: jest.fn(),
+      getActiveAgents: jest.fn().mockResolvedValue([]),
+      list: jest.fn().mockResolvedValue([]),
     } as unknown as jest.Mocked<AgentManager>;
 
     memoryManager = {
@@ -57,6 +60,8 @@ describe('ElementCRUDHandler (DI)', () => {
 
     personaHandler = {
       getActivePersona: jest.fn(),
+      getActivePersonas: jest.fn().mockReturnValue([]),
+      list: jest.fn().mockReturnValue([]),
     } as unknown as jest.Mocked<PersonaHandler>;
 
     portfolioManager = {
@@ -210,6 +215,90 @@ describe('ElementCRUDHandler (DI)', () => {
       // Test with 'ensemble' (singular)
       const result2 = await handler.getElementDetails('Test', 'ensemble' as any);
       expect(result2.content[0].text).toContain('🎭');
+    });
+  });
+
+  describe('policy reporting helpers', () => {
+    it('includes active agents in getActiveElementsForPolicy()', async () => {
+      agentManager.getActiveAgents.mockResolvedValue([
+        {
+          metadata: {
+            name: 'autonomy-scout-demo',
+            gatekeeper: {
+              externalRestrictions: {
+                denyPatterns: ['Bash:rm*'],
+              },
+            },
+          },
+        } as any,
+      ]);
+
+      const result = await handler.getActiveElementsForPolicy();
+
+      expect(result).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent',
+          name: 'autonomy-scout-demo',
+        }),
+      ]));
+    });
+
+    it('merges persisted activation snapshots into reportable policy elements', async () => {
+      const activationStore = {
+        isEnabled: jest.fn().mockReturnValue(true),
+        getSessionId: jest.fn().mockReturnValue('leader-session'),
+        listPersistedActivationStates: jest.fn().mockResolvedValue([
+          {
+            sessionId: 'session-other',
+            lastUpdated: new Date().toISOString(),
+            activations: {
+              skill: [{ name: 'audit-trace-demo', activatedAt: new Date().toISOString() }],
+            },
+          },
+        ]),
+      } as unknown as jest.Mocked<ActivationStore>;
+
+      skillManager.getActiveSkills = jest.fn().mockResolvedValue([]);
+      skillManager.list = jest.fn().mockResolvedValue([
+        {
+          metadata: {
+            name: 'audit-trace-demo',
+            gatekeeper: {
+              externalRestrictions: {
+                confirmPatterns: ['Bash:git push*'],
+              },
+            },
+          },
+        } as any,
+      ]);
+
+      const reportHandler = new ElementCRUDHandler(
+        skillManager,
+        templateManager,
+        templateRenderer,
+        agentManager,
+        memoryManager,
+        ensembleManager,
+        personaHandler,
+        portfolioManager,
+        initService,
+        indicatorService,
+        fileOperations,
+        undefined as any,
+        undefined as any,
+        activationStore,
+      );
+
+      const result = await reportHandler.getPolicyElementsForReport('session-other');
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          type: 'skill',
+          name: 'audit-trace-demo',
+          sessionIds: ['session-other'],
+        }),
+      ]);
+      expect(activationStore.listPersistedActivationStates).toHaveBeenCalledWith('session-other');
     });
   });
 });

--- a/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
+++ b/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
@@ -61,6 +61,7 @@ describe('MCPAQLHandler', () => {
         deactivateElement: jest.fn().mockResolvedValue({ deactivated: true }),
         getActiveElements: jest.fn().mockResolvedValue([]),
         getActiveElementsForPolicy: jest.fn().mockResolvedValue([]),
+        getPolicyElementsForReport: jest.fn().mockResolvedValue([]),
       },
       memoryManager: {
         find: jest.fn().mockResolvedValue({
@@ -333,6 +334,79 @@ describe('MCPAQLHandler', () => {
           expect(result.error).toContain('mcp_aql_delete');
         }
       });
+    });
+  });
+
+  describe('get_effective_cli_policies', () => {
+    it('includes confirm patterns in the combined dashboard view', async () => {
+      (mockRegistry.elementCRUD.getActiveElementsForPolicy as jest.Mock).mockResolvedValue([
+        {
+          type: 'persona',
+          name: 'careful-persona',
+          metadata: {
+            name: 'careful-persona',
+            gatekeeper: {
+              externalRestrictions: {
+                allowPatterns: ['Bash:git status*'],
+                confirmPatterns: ['Bash:git push*'],
+                denyPatterns: ['Bash:rm*'],
+                description: 'Safer shell access',
+              },
+            },
+          },
+        },
+      ]);
+
+      const result = await handler.handleRead({
+        operation: 'get_effective_cli_policies',
+        params: {},
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as Record<string, unknown>;
+        expect(data.combinedConfirmPatterns).toEqual(['Bash:git push*']);
+        expect(data.elements).toEqual([
+          expect.objectContaining({
+            confirmPatterns: ['Bash:git push*'],
+          }),
+        ]);
+      }
+    });
+
+    it('uses reportable policy elements for dashboard session views', async () => {
+      (mockRegistry.elementCRUD.getPolicyElementsForReport as jest.Mock).mockResolvedValue([
+        {
+          type: 'skill',
+          name: 'audit-trace-demo',
+          metadata: {
+            name: 'audit-trace-demo',
+            gatekeeper: {
+              externalRestrictions: {
+                denyPatterns: ['Bash:curl*'],
+                confirmPatterns: ['Bash:git push*'],
+              },
+            },
+          },
+          sessionIds: ['session-demo-1'],
+        },
+      ]);
+
+      const result = await handler.handleRead({
+        operation: 'get_effective_cli_policies',
+        params: {
+          reporting_scope: 'dashboard',
+          session_id: 'session-demo-1',
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockRegistry.elementCRUD.getPolicyElementsForReport).toHaveBeenCalledWith('session-demo-1');
+      if (result.success) {
+        const data = result.data as Record<string, unknown>;
+        expect(data.combinedDenyPatterns).toEqual(['Bash:curl*']);
+        expect(data.combinedConfirmPatterns).toEqual(['Bash:git push*']);
+      }
     });
   });
 
@@ -1490,6 +1564,7 @@ describe('MCPAQLHandler', () => {
           deactivateElement: jest.fn().mockResolvedValue({ deactivated: true }),
           getActiveElements: jest.fn().mockResolvedValue([]),
           getActiveElementsForPolicy: jest.fn().mockResolvedValue([]),
+          getPolicyElementsForReport: jest.fn().mockResolvedValue([]),
         },
         memoryManager: {
           find: jest.fn().mockResolvedValue({

--- a/tests/unit/web/console/sessionRegistry.test.ts
+++ b/tests/unit/web/console/sessionRegistry.test.ts
@@ -49,6 +49,31 @@ describe('Session registry (#1805)', () => {
     });
   });
 
+  describe('metrics ingestion', () => {
+    it('stores follower snapshots in the provided metrics callback', async () => {
+      const storeMetricsSnapshot = jest.fn();
+      ingestResult = createIngestRoutes({
+        logBroadcast: () => {},
+        storeMetricsSnapshot,
+      });
+      const app = buildApp(ingestResult);
+      const snapshot = {
+        id: 'snap-1',
+        timestamp: new Date().toISOString(),
+        metrics: [],
+        errors: [],
+        durationMs: 7,
+      };
+
+      const res = await request(app)
+        .post('/api/ingest/metrics')
+        .send({ sessionId: 'metrics-1', snapshot });
+
+      expect(res.status).toBe(200);
+      expect(storeMetricsSnapshot).toHaveBeenCalledWith(snapshot, 'metrics-1');
+    });
+  });
+
   describe('registerConsoleSession', () => {
     it('registers a console session with authenticated=true and kind=console', () => {
       ingestResult.registerConsoleSession();

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -144,6 +144,43 @@ describe('permissionRoutes', () => {
       expect(res.body.allowPatterns).toEqual(['Bash:git *']);
       expect(res.body.confirmPatterns).toEqual(['Bash:git merge*']);
       expect(Array.isArray(res.body.recentDecisions)).toBe(true);
+      expect(handler.handleRead).toHaveBeenCalledWith({
+        operation: 'get_effective_cli_policies',
+        params: {
+          reporting_scope: 'dashboard',
+        },
+      });
+    });
+
+    it('should pass session selection through to the dashboard policy query', async () => {
+      const handler = {
+        handleRead: jest.fn().mockResolvedValue([{
+          success: true,
+          data: {
+            activeElementCount: 1,
+            hasAllowlist: false,
+            combinedDenyPatterns: ['Bash:rm*'],
+            combinedAllowPatterns: [],
+            combinedConfirmPatterns: ['Bash:git push*'],
+            elements: [],
+            permissionPromptActive: false,
+          },
+        }]),
+      } as any;
+      const app = createApp(handler);
+
+      const res = await request(app).get('/api/permissions/status?sessionId=session-abc');
+
+      expect(res.status).toBe(200);
+      expect(res.body.sessionId).toBe('session-abc');
+      expect(res.body.confirmPatterns).toEqual(['Bash:git push*']);
+      expect(handler.handleRead).toHaveBeenCalledWith({
+        operation: 'get_effective_cli_policies',
+        params: {
+          reporting_scope: 'dashboard',
+          session_id: 'session-abc',
+        },
+      });
     });
 
     it('should return 500 when handler fails', async () => {


### PR DESCRIPTION
## Summary

This fixes the web console reporting gap behind issue #1950 without changing the deeper session-runtime model that is in flight elsewhere.

## What Changed

- added a dashboard reporting path for effective CLI policies that can read persisted activation snapshots by session
- included active agents and confirm patterns in policy reporting so the Permissions tab reflects the full policy picture
- wired the Permissions tab to pass the selected session to `/api/permissions/status`
- stored follower metric snapshots in the leader's queryable metrics sink so the Metrics tab reports cross-session data again
- added targeted unit coverage for the new reporting and ingest behavior

## Root Cause

The Permissions tab was reading only the leader process's in-memory active elements, so policies activated in another session could be persisted on disk and still appear missing in the dashboard. The Metrics tab had a related reporting gap: follower snapshots were forwarded for SSE but not written into the leader's in-memory metrics query buffer, so polling `/api/metrics` missed them.

## Impact

- Permissions reporting is now much more accurate for selected sessions, even when the console leader did not activate those elements itself
- Metrics reporting is restored at the aggregate level across sessions
- true per-session metrics filtering is still out of scope for this change

## Validation

- `npx tsc -p tsconfig.json --noEmit`
- `npx jest --config tests/jest.config.cjs --runInBand --modulePathIgnorePatterns=.worktrees --runTestsByPath tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts tests/unit/handlers/ElementCRUDHandler.test.ts`
- `npx jest --config tests/jest.config.cjs --runInBand --modulePathIgnorePatterns=.worktrees --runTestsByPath tests/unit/web/permissionRoutes.test.ts tests/unit/web/console/sessionRegistry.test.ts`

Closes #1950.