### PR TITLE
Clarify persisted policy sessions in console picker

### DIFF
--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -702,8 +702,22 @@ jobs:
         if: always()
         run: |
           echo "🧹 Cleaning up Docker Compose..."
-          docker compose --project-name "$COMPOSE_PROJECT_NAME" --file docker/docker-compose.yml down
-          docker compose --project-name "$COMPOSE_PROJECT_NAME" --file docker/docker-compose.yml rm -f
+          cleanup_ok=false
+          for attempt in 1 2 3; do
+            if docker compose --project-name "$COMPOSE_PROJECT_NAME" --file docker/docker-compose.yml down --remove-orphans; then
+              cleanup_ok=true
+              break
+            fi
+            echo "::warning::Docker Compose cleanup attempt $attempt failed; waiting for endpoints to detach"
+            docker compose --project-name "$COMPOSE_PROJECT_NAME" --file docker/docker-compose.yml ps || true
+            sleep 2
+          done
+
+          if [ "$cleanup_ok" != "true" ]; then
+            echo "::warning::Docker Compose network cleanup remained busy after retries; continuing because test execution already completed"
+          fi
+
+          docker compose --project-name "$COMPOSE_PROJECT_NAME" --file docker/docker-compose.yml rm -f || true
 
       - name: Docker Compose testing complete
         shell: bash

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -700,6 +700,7 @@ jobs:
 
       - name: Cleanup Docker Compose
         if: always()
+        shell: bash
         run: |
           echo "🧹 Cleaning up Docker Compose..."
           cleanup_ok=false

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -120,6 +120,76 @@
   padding: 1rem;
 }
 
+.perm-selected-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.perm-selected-title {
+  font-family: var(--font-heading, 'Plus Jakarta Sans', sans-serif);
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--ink-900, #0f172a);
+}
+
+.perm-selected-subtitle {
+  margin-top: 0.35rem;
+  color: var(--ink-500, #64748b);
+  font-size: 0.8125rem;
+  max-width: 58rem;
+}
+
+.perm-selected-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: #fff7ed;
+  color: #9a3412;
+  border: 1px solid #fed7aa;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.perm-selected-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.perm-selected-panel {
+  border: 1px solid var(--ink-100, #e2e8f0);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: var(--paper-base, #f8fafc);
+}
+
+.perm-selected-panel-title {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--ink-100, #e2e8f0);
+  font-family: var(--font-heading, 'Plus Jakarta Sans', sans-serif);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: var(--ink-700, #334155);
+}
+
+.perm-source-item--selected {
+  background: color-mix(in srgb, var(--signal-2, #3b82f6) 10%, transparent);
+  border-left: 3px solid var(--signal-2, #3b82f6);
+  padding-left: calc(0.75rem - 3px);
+}
+
+.perm-source-item--detail {
+  background: transparent;
+}
+
 /* ── Stat Grid ─────────────────────────────────────────────── */
 
 .perm-stat-grid {
@@ -259,6 +329,12 @@
 .perm-feed-decision--allow { color: #22c55e; }
 .perm-feed-decision--deny { color: #ef4444; }
 .perm-feed-decision--ask { color: #f97316; }
+
+@media (max-width: 900px) {
+  .perm-selected-grid {
+    grid-template-columns: 1fr;
+  }
+}
 
 .perm-feed-tool {
   color: var(--ink-700, #334155);

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -59,11 +59,19 @@
 .perm-dashboard {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1rem;
+  gap: 0.875rem;
+}
+
+#tab-permissions {
+  padding-inline: clamp(0.25rem, 0.5vw, 0.5rem);
 }
 
 @media (max-width: 900px) {
   .perm-dashboard { grid-template-columns: 1fr; }
+
+  #tab-permissions {
+    padding-inline: 0;
+  }
 }
 
 /* ── Cards ─────────────────────────────────────────────────── */
@@ -73,6 +81,7 @@
   border: 1px solid var(--ink-100, #e2e8f0);
   border-radius: 0.5rem;
   overflow: hidden;
+  min-width: 0;
 }
 
 .perm-card--full {
@@ -83,7 +92,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.75rem 1rem;
+  padding: 0.65rem 0.875rem;
   background: var(--paper-base, #f8fafc);
   border-bottom: 1px solid var(--ink-100, #e2e8f0);
   cursor: pointer;
@@ -117,7 +126,7 @@
 }
 
 .perm-card-body {
-  padding: 1rem;
+  padding: 0.875rem;
 }
 
 .perm-selected-header {
@@ -127,6 +136,10 @@
   gap: 1rem;
   margin-bottom: 1rem;
   flex-wrap: wrap;
+}
+
+.perm-selected-header--compact {
+  margin-bottom: 0.875rem;
 }
 
 .perm-selected-title {
@@ -160,7 +173,7 @@
 .perm-selected-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .perm-selected-panel {
@@ -168,16 +181,40 @@
   border-radius: 0.5rem;
   overflow: hidden;
   background: var(--paper-base, #f8fafc);
+  min-width: 0;
+}
+
+.perm-selected-panel--wide {
+  grid-column: 1 / -1;
 }
 
 .perm-selected-panel-title {
   margin: 0;
-  padding: 0.75rem 1rem;
+  padding: 0.65rem 0.875rem;
   border-bottom: 1px solid var(--ink-100, #e2e8f0);
   font-family: var(--font-heading, 'Plus Jakarta Sans', sans-serif);
   font-size: 0.8125rem;
   font-weight: 700;
   color: var(--ink-700, #334155);
+}
+
+.perm-panel-action {
+  border: 1px solid var(--ink-100, #cbd5e1);
+  border-radius: 999px;
+  background: var(--paper-strong, #fff);
+  color: var(--ink-700, #334155);
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 0.72rem;
+  padding: 0.28rem 0.65rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.perm-panel-action:hover,
+.perm-panel-action:focus-visible {
+  border-color: var(--signal-2, #3b82f6);
+  color: var(--signal-2, #3b82f6);
+  outline: none;
 }
 
 .perm-source-item--selected {
@@ -194,9 +231,8 @@
 
 .perm-stat-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-  gap: 0.75rem;
-  margin-bottom: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(105px, 1fr));
+  gap: 0.625rem;
 }
 
 .perm-stat {
@@ -205,7 +241,7 @@
 
 .perm-stat-value {
   font-family: var(--font-mono, 'IBM Plex Mono', monospace);
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   font-weight: 700;
   line-height: 1.2;
   color: var(--ink-900, #0f172a);
@@ -230,13 +266,17 @@
   list-style: none;
   padding: 0;
   margin: 0;
+  max-height: 15rem;
+  overflow-y: scroll;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
 }
 
 .perm-pattern-item {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.375rem 0.5rem;
+  padding: 0.325rem 0.45rem;
   font-family: var(--font-mono, 'IBM Plex Mono', monospace);
   font-size: 0.8125rem;
   border-bottom: 1px solid var(--ink-50, #f1f5f9);
@@ -290,10 +330,18 @@
 /* ── Live Feed ─────────────────────────────────────────────── */
 
 .perm-feed {
-  max-height: 400px;
-  overflow-y: auto;
+  max-height: 20rem;
+  min-height: 8rem;
+  overflow-y: scroll;
+  overflow-x: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable both-edges;
   font-family: var(--font-mono, 'IBM Plex Mono', monospace);
   font-size: 0.8125rem;
+}
+
+.perm-card--audit .perm-feed {
+  max-height: 34rem;
 }
 
 .perm-feed-empty {
@@ -307,7 +355,7 @@
   display: grid;
   grid-template-columns: 80px 60px 1fr auto;
   gap: 0.5rem;
-  padding: 0.375rem 0.5rem;
+  padding: 0.325rem 0.45rem;
   border-bottom: 1px solid var(--ink-50, #f1f5f9);
   align-items: center;
 }
@@ -358,14 +406,20 @@
   list-style: none;
   padding: 0;
   margin: 0;
+  max-height: 16rem;
+  overflow-y: scroll;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
 }
 
 .perm-source-item {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.5rem;
+  padding: 0.425rem 0.5rem;
   border-bottom: 1px solid var(--ink-50, #f1f5f9);
+  min-width: 0;
+  flex-wrap: wrap;
 }
 
 .perm-source-item:last-child {
@@ -386,6 +440,8 @@
 .perm-source-name {
   font-weight: 500;
   color: var(--ink-800, #1e293b);
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 /* ── Dark Mode ─────────────────────────────────────────────── */

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -16,6 +16,13 @@
   let initialized = false;
   let lastDecisionId = null;
 
+  async function fetchPermissionStatus(sessionId) {
+    const query = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : '';
+    const res = await DollhouseAuth.apiFetch(`/api/permissions/status${query}`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json();
+  }
+
   // ── Public API ─────────────────────────────────────────────
 
   window.DollhouseConsole = window.DollhouseConsole || {};
@@ -71,12 +78,18 @@
   async function poll() {
     try {
       const sessionId = window.DollhouseSessions?.getFilterSessionId?.() || '';
-      const query = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : '';
-      const res = await DollhouseAuth.apiFetch(`/api/permissions/status${query}`);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
-      window.DollhouseSessions?.setPolicySessions?.(data.knownSessions || []);
-      render(data);
+      const [aggregateData, selectedData] = await Promise.all([
+        fetchPermissionStatus(''),
+        sessionId
+          ? fetchPermissionStatus(sessionId).catch(err => ({
+              error: err.message,
+              sessionId,
+            }))
+          : Promise.resolve(null),
+      ]);
+
+      window.DollhouseSessions?.setPolicySessions?.(aggregateData.knownSessions || []);
+      render(aggregateData, selectedData);
     } catch (err) {
       renderError(err.message);
     }
@@ -84,10 +97,11 @@
 
   // ── Rendering ──────────────────────────────────────────────
 
-  function render(data) {
+  function render(data, selectedData) {
     renderStatusBar(data);
     renderSummaryStats(data);
-    renderPolicySources(data);
+    renderPolicySources(data, selectedData);
+    renderSelectedSessionDetail(selectedData);
     renderDenyPatterns(data);
     renderAllowPatterns(data);
     renderConfirmPatterns(data);
@@ -146,23 +160,85 @@
     setText('perm-stat-asked', asked);
   }
 
-  function renderPolicySources(data) {
+  function renderPolicySources(data, selectedData) {
     const list = document.getElementById('perm-source-list');
     if (!list) return;
 
     const elements = data.elements || [];
+    const selectedSessionId = selectedData?.sessionId;
     if (elements.length === 0) {
       list.innerHTML = '<li class="perm-pattern-empty">No active elements with policies</li>';
       return;
     }
 
     list.innerHTML = elements.map(el => `
-      <li class="perm-source-item">
+      <li class="perm-source-item${elementMatchesSelected(el, selectedSessionId) ? ' perm-source-item--selected' : ''}">
         <span class="perm-source-type">${esc(el.type)}</span>
         <span class="perm-source-name">${esc(el.element_name)}</span>
         ${el.description ? `<span style="color:var(--ink-400);font-size:0.75rem;margin-left:auto">${esc(el.description)}</span>` : ''}
       </li>
     `).join('');
+  }
+
+  function renderSelectedSessionDetail(selectedData) {
+    const card = document.getElementById('perm-selected-card');
+    const title = document.getElementById('perm-selected-title');
+    const subtitle = document.getElementById('perm-selected-subtitle');
+    const badge = document.getElementById('perm-selected-badge');
+    const sourceList = document.getElementById('perm-selected-source-list');
+    const denyList = document.getElementById('perm-selected-deny-list');
+    const allowList = document.getElementById('perm-selected-allow-list');
+    const confirmList = document.getElementById('perm-selected-confirm-list');
+
+    if (!card || !title || !subtitle || !badge || !sourceList || !denyList || !allowList || !confirmList) {
+      return;
+    }
+
+    if (!selectedData?.sessionId) {
+      card.hidden = true;
+      return;
+    }
+
+    card.hidden = false;
+
+    const sessionInfo = window.DollhouseSessions?.getSelectableSessions?.()
+      ?.find(session => session.sessionId === selectedData.sessionId);
+    const sessionLabel = window.DollhouseSessions?.displayName?.(sessionInfo || selectedData.sessionId)
+      || selectedData.sessionId;
+    const policyOnly = !!sessionInfo?.isPolicyOnly;
+
+    title.textContent = `Selected Session: ${sessionLabel}`;
+    subtitle.textContent = policyOnly
+      ? `${selectedData.sessionId} is showing saved policy state from disk. This is not a live attached client.`
+      : `${selectedData.sessionId} is the current live policy view for this session.`;
+
+    badge.hidden = !policyOnly;
+    if (policyOnly) {
+      badge.textContent = 'Persisted Policy State (Debug Info)';
+    }
+
+    if (selectedData.error) {
+      sourceList.innerHTML = `<li class="perm-pattern-empty">${esc(selectedData.error)}</li>`;
+      denyList.innerHTML = '<li class="perm-pattern-empty">Unable to load selected session</li>';
+      allowList.innerHTML = '<li class="perm-pattern-empty">Unable to load selected session</li>';
+      confirmList.innerHTML = '<li class="perm-pattern-empty">Unable to load selected session</li>';
+      return;
+    }
+
+    const elements = selectedData.elements || [];
+    sourceList.innerHTML = elements.length === 0
+      ? '<li class="perm-pattern-empty">No policy-bearing elements found for this session</li>'
+      : elements.map(el => `
+          <li class="perm-source-item perm-source-item--detail">
+            <span class="perm-source-type">${esc(el.type)}</span>
+            <span class="perm-source-name">${esc(el.element_name)}</span>
+            ${el.description ? `<span style="color:var(--ink-400);font-size:0.75rem;margin-left:auto">${esc(el.description)}</span>` : ''}
+          </li>
+        `).join('');
+
+    renderPatternList('perm-selected-deny-list', selectedData.denyPatterns || [], 'deny');
+    renderPatternList('perm-selected-allow-list', selectedData.allowPatterns || [], 'allow');
+    renderPatternList('perm-selected-confirm-list', selectedData.confirmPatterns || [], 'confirm');
   }
 
   function renderDenyPatterns(data) {
@@ -289,10 +365,54 @@
           </div>
         </div>
 
+        <!-- Selected Session Detail -->
+        <div class="perm-card perm-card--full" data-collapsed="false" id="perm-selected-card" hidden>
+          <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
+            <h3 class="perm-card-title">Selected Session Detail</h3>
+            <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
+          </div>
+          <div class="perm-card-body">
+            <div class="perm-selected-header">
+              <div>
+                <div class="perm-selected-title" id="perm-selected-title">Selected Session</div>
+                <div class="perm-selected-subtitle" id="perm-selected-subtitle"></div>
+              </div>
+              <span class="perm-selected-badge" id="perm-selected-badge" hidden>Persisted Policy State (Debug Info)</span>
+            </div>
+
+            <div class="perm-selected-grid">
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Policy Sources</h4>
+                <ul class="perm-source-list" id="perm-selected-source-list">
+                  <li class="perm-pattern-empty">Loading...</li>
+                </ul>
+              </div>
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Deny Patterns</h4>
+                <ul class="perm-pattern-list" id="perm-selected-deny-list">
+                  <li class="perm-pattern-empty">Loading...</li>
+                </ul>
+              </div>
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Allow Patterns</h4>
+                <ul class="perm-pattern-list" id="perm-selected-allow-list">
+                  <li class="perm-pattern-empty">Loading...</li>
+                </ul>
+              </div>
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Confirm Patterns</h4>
+                <ul class="perm-pattern-list" id="perm-selected-confirm-list">
+                  <li class="perm-pattern-empty">Loading...</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <!-- Policy Sources -->
         <div class="perm-card" data-collapsed="false">
           <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
-            <h3 class="perm-card-title">Policy Sources</h3>
+            <h3 class="perm-card-title">All Policy Sources</h3>
             <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
           </div>
           <div class="perm-card-body">
@@ -378,6 +498,11 @@
   function setText(id, value) {
     const el = document.getElementById(id);
     if (el) el.textContent = String(value);
+  }
+
+  function elementMatchesSelected(element, sessionId) {
+    if (!sessionId || !Array.isArray(element?.sessionIds)) return false;
+    return element.sessionIds.includes(sessionId);
   }
 
   // dmcp-sec[DMCP-SEC-004] — Client-side JS: UnicodeValidator unavailable in browser.

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -75,6 +75,7 @@
       const res = await DollhouseAuth.apiFetch(`/api/permissions/status${query}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
+      window.DollhouseSessions?.setPolicySessions?.(data.knownSessions || []);
       render(data);
     } catch (err) {
       renderError(err.message);

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -15,6 +15,9 @@
   const POLL_INTERVAL_MS = 3000;
   let initialized = false;
   let lastDecisionId = null;
+  let latestAggregateData = null;
+  let latestSelectedData = null;
+  let latestPollRequestId = 0;
 
   async function fetchPermissionStatus(sessionId) {
     const query = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : '';
@@ -30,6 +33,7 @@
     init: initPermissions,
     destroy: destroyPermissions,
     refresh: function () { poll(); },
+    onSessionChange: function () { renderFromCache(); },
   };
 
   // Hook into tab switching — Todd's app.js lazyInitTab only knows logs/metrics,
@@ -76,23 +80,35 @@
   // ── Polling ────────────────────────────────────────────────
 
   async function poll() {
+    const requestId = ++latestPollRequestId;
     try {
-      const sessionId = window.DollhouseSessions?.getFilterSessionId?.() || '';
-      const [aggregateData, selectedData] = await Promise.all([
-        fetchPermissionStatus(''),
-        sessionId
-          ? fetchPermissionStatus(sessionId).catch(err => ({
-              error: err.message,
-              sessionId,
-            }))
-          : Promise.resolve(null),
-      ]);
+      const aggregateData = await fetchPermissionStatus('');
+      if (requestId !== latestPollRequestId) {
+        return;
+      }
 
+      const currentSessionId = window.DollhouseSessions?.getFilterSessionId?.() || '';
+      const selectedData = deriveSelectedSessionData(aggregateData, currentSessionId);
+
+      latestAggregateData = aggregateData;
+      latestSelectedData = selectedData;
       window.DollhouseSessions?.setPolicySessions?.(aggregateData.knownSessions || []);
       render(aggregateData, selectedData);
     } catch (err) {
       renderError(err.message);
     }
+  }
+
+  function renderFromCache() {
+    if (!latestAggregateData) {
+      poll();
+      return;
+    }
+
+    const sessionId = window.DollhouseSessions?.getFilterSessionId?.() || '';
+    latestSelectedData = deriveSelectedSessionData(latestAggregateData, sessionId);
+    renderPolicySources(latestAggregateData, latestSelectedData);
+    renderSelectedSessionDetail(latestSelectedData);
   }
 
   // ── Rendering ──────────────────────────────────────────────
@@ -145,9 +161,9 @@
   }
 
   function renderSummaryStats(data) {
-    setText('perm-stat-deny-count', data.denyPatterns?.length || 0);
-    setText('perm-stat-allow-count', data.allowPatterns?.length || 0);
-    setText('perm-stat-confirm-count', data.confirmPatterns?.length || 0);
+    setText('perm-stat-deny-count', getAggregatePatterns(data, 'denyPatterns').length);
+    setText('perm-stat-allow-count', getAggregatePatterns(data, 'allowPatterns').length);
+    setText('perm-stat-confirm-count', getAggregatePatterns(data, 'confirmPatterns').length);
     setText('perm-stat-decisions', data.recentDecisions?.length || 0);
 
     // Decision breakdown
@@ -210,19 +226,11 @@
     title.textContent = `Selected Session: ${sessionLabel}`;
     subtitle.textContent = policyOnly
       ? `${selectedData.sessionId} is showing saved policy state from disk. This is not a live attached client.`
-      : `${selectedData.sessionId} is the current live policy view for this session.`;
+      : `${selectedData.sessionId} is the current live policy view for this session. Decision activity is still shown in the All Sessions section below.`;
 
     badge.hidden = !policyOnly;
     if (policyOnly) {
       badge.textContent = 'Persisted Policy State (Debug Info)';
-    }
-
-    if (selectedData.error) {
-      sourceList.innerHTML = `<li class="perm-pattern-empty">${esc(selectedData.error)}</li>`;
-      denyList.innerHTML = '<li class="perm-pattern-empty">Unable to load selected session</li>';
-      allowList.innerHTML = '<li class="perm-pattern-empty">Unable to load selected session</li>';
-      confirmList.innerHTML = '<li class="perm-pattern-empty">Unable to load selected session</li>';
-      return;
     }
 
     const elements = selectedData.elements || [];
@@ -242,15 +250,15 @@
   }
 
   function renderDenyPatterns(data) {
-    renderPatternList('perm-deny-list', data.denyPatterns || [], 'deny');
+    renderPatternList('perm-deny-list', getAggregatePatterns(data, 'denyPatterns'), 'deny');
   }
 
   function renderAllowPatterns(data) {
-    renderPatternList('perm-allow-list', data.allowPatterns || [], 'allow');
+    renderPatternList('perm-allow-list', getAggregatePatterns(data, 'allowPatterns'), 'allow');
   }
 
   function renderConfirmPatterns(data) {
-    renderPatternList('perm-confirm-list', data.confirmPatterns || [], 'confirm');
+    renderPatternList('perm-confirm-list', getAggregatePatterns(data, 'confirmPatterns'), 'confirm');
   }
 
   function renderPatternList(elementId, patterns, type) {
@@ -302,6 +310,46 @@
     }).join('');
   }
 
+  function deriveSelectedSessionData(aggregateData, sessionId) {
+    if (!sessionId) return null;
+
+    const elements = (aggregateData?.elements || []).filter(function (element) {
+      return Array.isArray(element.sessionIds) && element.sessionIds.indexOf(sessionId) !== -1;
+    });
+
+    return {
+      sessionId: sessionId,
+      activeElementCount: elements.length,
+      hasAllowlist: elements.some(function (element) {
+        return Array.isArray(element.allowPatterns) && element.allowPatterns.length > 0;
+      }),
+      denyPatterns: flattenElementPatterns(elements, 'denyPatterns'),
+      allowPatterns: flattenElementPatterns(elements, 'allowPatterns'),
+      confirmPatterns: flattenElementPatterns(elements, 'confirmPatterns'),
+      elements: elements.map(function (element) {
+        return {
+          type: element.type,
+          element_name: element.element_name,
+          description: element.description,
+        };
+      }),
+      permissionPromptActive: !!aggregateData?.permissionPromptActive,
+      recentDecisions: aggregateData?.recentDecisions || [],
+    };
+  }
+
+  function flattenElementPatterns(elements, key) {
+    return elements.flatMap(function (element) {
+      return Array.isArray(element[key]) ? element[key] : [];
+    });
+  }
+
+  function getAggregatePatterns(data, key) {
+    const combined = Array.isArray(data && data[key]) ? data[key] : [];
+    const perElement = flattenElementPatterns((data && data.elements) || [], key);
+    return Array.from(new Set(combined.concat(perElement)));
+  }
+
   // ── Dashboard HTML ─────────────────────────────────────────
 
   function buildDashboardHTML() {
@@ -324,6 +372,33 @@
       </div>
 
       <div class="perm-dashboard">
+
+        <!-- All Sessions Live Decision Feed -->
+        <div class="perm-card perm-card--full" data-collapsed="false" id="perm-all-feed-card">
+          <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
+            <h3 class="perm-card-title">All Sessions Live Decision Feed</h3>
+            <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
+          </div>
+          <div class="perm-card-body">
+            <div class="perm-selected-header perm-selected-header--compact">
+              <div>
+                <div class="perm-selected-subtitle">Most recent first. This is the aggregate audit stream across all sessions.</div>
+              </div>
+              <button
+                type="button"
+                class="perm-panel-action"
+                id="perm-feed-expand-btn"
+                aria-expanded="false"
+                aria-controls="perm-feed"
+              >
+                Expand Audit View
+              </button>
+            </div>
+            <div class="perm-feed" id="perm-feed" role="log" aria-live="polite" aria-label="Permission decisions across all sessions">
+              <div class="perm-feed-empty">No permission decisions yet. Waiting for tool calls...</div>
+            </div>
+          </div>
+        </div>
 
         <!-- Summary Stats -->
         <div class="perm-card perm-card--full" data-collapsed="false">
@@ -409,67 +484,44 @@
           </div>
         </div>
 
-        <!-- Policy Sources -->
-        <div class="perm-card" data-collapsed="false">
-          <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
-            <h3 class="perm-card-title">All Policy Sources</h3>
-            <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
-          </div>
-          <div class="perm-card-body">
-            <ul class="perm-source-list" id="perm-source-list">
-              <li class="perm-pattern-empty">Loading...</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Deny Patterns -->
-        <div class="perm-card" data-collapsed="false">
-          <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
-            <h3 class="perm-card-title">Deny Patterns</h3>
-            <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
-          </div>
-          <div class="perm-card-body">
-            <ul class="perm-pattern-list" id="perm-deny-list">
-              <li class="perm-pattern-empty">Loading...</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Allow Patterns -->
-        <div class="perm-card" data-collapsed="true">
-          <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
-            <h3 class="perm-card-title">Allow Patterns</h3>
-            <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
-          </div>
-          <div class="perm-card-body">
-            <ul class="perm-pattern-list" id="perm-allow-list">
-              <li class="perm-pattern-empty">Loading...</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Confirm Patterns -->
-        <div class="perm-card" data-collapsed="false">
-          <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
-            <h3 class="perm-card-title">Confirm Patterns (Requires Approval)</h3>
-            <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
-          </div>
-          <div class="perm-card-body">
-            <ul class="perm-pattern-list" id="perm-confirm-list">
-              <li class="perm-pattern-empty">Loading...</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Live Decision Feed -->
         <div class="perm-card perm-card--full" data-collapsed="false">
           <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
-            <h3 class="perm-card-title">Live Decision Feed</h3>
+            <h3 class="perm-card-title">All Sessions Detail</h3>
             <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
           </div>
           <div class="perm-card-body">
-            <div class="perm-feed" id="perm-feed" role="log" aria-live="polite" aria-label="Permission decisions">
-              <div class="perm-feed-empty">No permission decisions yet. Waiting for tool calls...</div>
+            <div class="perm-selected-header perm-selected-header--compact">
+              <div>
+                <div class="perm-selected-title">All Sessions</div>
+                <div class="perm-selected-subtitle">Aggregate policy state across all live and persisted sessions. The decision feed below is currently aggregate, not selection-scoped.</div>
+              </div>
+            </div>
+
+            <div class="perm-selected-grid">
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Policy Sources</h4>
+                <ul class="perm-source-list" id="perm-source-list">
+                  <li class="perm-pattern-empty">Loading...</li>
+                </ul>
+              </div>
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Deny Patterns</h4>
+                <ul class="perm-pattern-list" id="perm-deny-list">
+                  <li class="perm-pattern-empty">Loading...</li>
+                </ul>
+              </div>
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Allow Patterns</h4>
+                <ul class="perm-pattern-list" id="perm-allow-list">
+                  <li class="perm-pattern-empty">Loading...</li>
+                </ul>
+              </div>
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Confirm Patterns</h4>
+                <ul class="perm-pattern-list" id="perm-confirm-list">
+                  <li class="perm-pattern-empty">Loading...</li>
+                </ul>
+              </div>
             </div>
           </div>
         </div>
@@ -493,6 +545,17 @@
         if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(); }
       });
     });
+
+    const expandBtn = document.getElementById('perm-feed-expand-btn');
+    const feedCard = document.getElementById('perm-all-feed-card');
+    if (expandBtn && feedCard) {
+      expandBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        const expanded = feedCard.classList.toggle('perm-card--audit');
+        expandBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        expandBtn.textContent = expanded ? 'Compact Audit View' : 'Expand Audit View';
+      });
+    }
   }
 
   function setText(id, value) {

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -73,6 +73,11 @@
     return merged;
   }
 
+  function getActiveTabName() {
+    var activeTab = document.querySelector('.console-tab.active');
+    return activeTab ? activeTab.dataset.tab || '' : '';
+  }
+
   function normalizePolicySessions(list) {
     if (!Array.isArray(list)) return [];
 
@@ -130,12 +135,22 @@
     var logSelect = document.getElementById('log-session-filter');
     if (logSelect) logSelect.value = sessionId;
 
-    // Trigger log re-filter with the selected session
-    if (window.DollhouseConsole && window.DollhouseConsole.logs && window.DollhouseConsole.logs.refilter) {
-      window.DollhouseConsole.logs.refilter(sessionId);
+    if (window.DollhouseConsole && window.DollhouseConsole.permissions) {
+      if (window.DollhouseConsole.permissions.onSessionChange) {
+        window.DollhouseConsole.permissions.onSessionChange(sessionId);
+      } else if (window.DollhouseConsole.permissions.refresh) {
+        window.DollhouseConsole.permissions.refresh();
+      }
     }
-    if (window.DollhouseConsole && window.DollhouseConsole.permissions && window.DollhouseConsole.permissions.refresh) {
-      window.DollhouseConsole.permissions.refresh();
+
+    // Trigger log re-filter only when the Logs tab is active. Refiltering the
+    // virtualized log buffer can be expensive, and it should not delay session
+    // switching on other tabs like Permissions.
+    if (getActiveTabName() === 'logs'
+      && window.DollhouseConsole
+      && window.DollhouseConsole.logs
+      && window.DollhouseConsole.logs.refilter) {
+      window.DollhouseConsole.logs.refilter(sessionId);
     }
 
     refreshSelectionState();

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -24,6 +24,7 @@
   var SESSION_FILTER_INJECTION_RETRY_INTERVAL = getConfiguredNumber('sessionFilterInjectionRetryIntervalMs', 500);
   var SESSION_FILTER_INJECTION_MAX_RETRIES = getConfiguredNumber('sessionFilterInjectionMaxRetries', 20);
   var sessions = [];
+  var policySessions = [];
   var filterSessionId = '';
   var dropdownBuilt = false;
   var lastSessionKey = ''; // tracks session list identity to avoid unnecessary rebuilds
@@ -47,6 +48,10 @@
   /** NFC-normalize a string safely */
   function nfc(s) { try { return s.normalize('NFC'); } catch(e) { return s; } }
 
+  function isPolicyOnlySession(session) {
+    return !!(session && session.isPolicyOnly);
+  }
+
   function displayName(session) {
     if (typeof session === 'object' && session.displayName) return nfc(session.displayName);
     var id = typeof session === 'string' ? nfc(session) : nfc((session && session.sessionId) || '');
@@ -54,9 +59,67 @@
     return parts.length >= 2 ? parts[1] : id.slice(0, 8);
   }
 
+  function getLiveSessions() {
+    return sessions.filter(function(s) { return s.status === 'active'; });
+  }
+
+  function getSelectableSessions() {
+    var live = getLiveSessions();
+    var liveIds = new Set(live.map(function(s) { return s.sessionId; }));
+    var merged = live.slice();
+    for (var i = 0; i < policySessions.length; i++) {
+      if (!liveIds.has(policySessions[i].sessionId)) merged.push(policySessions[i]);
+    }
+    return merged;
+  }
+
+  function normalizePolicySessions(list) {
+    if (!Array.isArray(list)) return [];
+
+    var seen = new Set();
+    var normalized = [];
+    for (var i = 0; i < list.length; i++) {
+      var item = list[i];
+      if (!item || typeof item.sessionId !== 'string') continue;
+      var sessionId = nfc(item.sessionId).trim();
+      if (!sessionId || seen.has(sessionId)) continue;
+      seen.add(sessionId);
+      normalized.push({
+        sessionId: sessionId,
+        displayName: nfc(typeof item.displayName === 'string' && item.displayName ? item.displayName : sessionId),
+        color: '#94a3b8',
+        pid: 0,
+        startedAt: '',
+        lastHeartbeat: '',
+        status: 'policy',
+        isLeader: false,
+        authenticated: false,
+        kind: 'policy',
+        isPolicyOnly: true,
+      });
+    }
+
+    normalized.sort(function(a, b) { return a.sessionId.localeCompare(b.sessionId); });
+    return normalized;
+  }
+
+  function setPolicySessions(nextSessions) {
+    policySessions = normalizePolicySessions(nextSessions);
+    updateSessionIndicator();
+    updateSessionFilterOptions();
+  }
+
+  function allSessionsSummary(liveCount, policyCount) {
+    if (policyCount <= 0) return liveCount + ' total';
+    if (liveCount <= 0) return policyCount + ' saved';
+    return liveCount + ' live, ' + policyCount + ' saved';
+  }
+
   // Build a key from current sessions to detect changes
   function sessionListKey(list) {
-    return list.map(function(s) { return s.sessionId + ':' + s.status; }).join(',');
+    return list.map(function(s) {
+      return s.sessionId + ':' + s.status + ':' + (isPolicyOnlySession(s) ? 'policy' : 'live');
+    }).join(',');
   }
 
   // Apply session filter and update all UI to reflect it
@@ -120,7 +183,7 @@
     // Tick uptimes
     var uptimes = document.querySelectorAll('.session-dropdown-uptime');
     for (var j = 0; j < uptimes.length; j++) {
-      uptimes[j].textContent = formatUptime(uptimes[j].dataset.startedAt);
+      uptimes[j].textContent = uptimes[j].dataset.startedAt ? formatUptime(uptimes[j].dataset.startedAt) : 'saved';
     }
 
     // Update box label
@@ -128,7 +191,18 @@
     var labelEl = document.querySelector('.session-box-label');
     if (!countEl || !labelEl) return;
 
-    var active = sessions.filter(function(s) { return s.status === 'active'; });
+    var active = getLiveSessions();
+    var selectable = getSelectableSessions();
+
+    if (filterSessionId) {
+      var filtered = selectable.find(function(s) { return s.sessionId === filterSessionId; });
+      if (filtered) {
+        countEl.textContent = displayName(filtered);
+        if (filtered.color) countEl.style.color = filtered.color;
+        labelEl.textContent = isPolicyOnlySession(filtered) ? 'policy only' : ('1/' + active.length);
+        return;
+      }
+    }
 
     if (active.length === 1) {
       countEl.textContent = displayName(active[0]);
@@ -139,24 +213,16 @@
 
     // Reset color when showing count
     countEl.style.color = '';
-
-    if (filterSessionId) {
-      var filtered = active.find(function(s) { return s.sessionId === filterSessionId; });
-      if (filtered) {
-        countEl.textContent = displayName(filtered);
-        if (filtered.color) countEl.style.color = filtered.color;
-        labelEl.textContent = '1/' + active.length;
-        return;
-      }
-    }
     countEl.textContent = String(active.length);
     labelEl.textContent = active.length === 1 ? 'session' : 'sessions';
   }
 
   // Build or rebuild the session indicator — only when session list actually changes
   function updateSessionIndicator() {
-    var active = sessions.filter(function(s) { return s.status === 'active'; });
-    var key = sessionListKey(active);
+    var active = getLiveSessions();
+    var selectable = getSelectableSessions();
+    var policyOnly = selectable.filter(function(s) { return isPolicyOnlySession(s); });
+    var key = sessionListKey(selectable);
 
     // If sessions haven't changed, just refresh selection state
     if (key === lastSessionKey && dropdownBuilt) {
@@ -212,7 +278,7 @@
 
     var allCount = document.createElement('span');
     allCount.className = 'session-dropdown-role';
-    allCount.textContent = count + ' total';
+    allCount.textContent = allSessionsSummary(count, policyOnly.length);
     allItem.appendChild(allCount);
 
     allItem.addEventListener('click', function(e) {
@@ -221,10 +287,18 @@
     });
     dropdown.appendChild(allItem);
 
-    // Divider
-    var divider = document.createElement('div');
-    divider.className = 'session-dropdown-divider';
-    dropdown.appendChild(divider);
+    function appendDivider() {
+      var divider = document.createElement('div');
+      divider.className = 'session-dropdown-divider';
+      dropdown.appendChild(divider);
+    }
+
+    function appendHeading(text) {
+      var heading = document.createElement('div');
+      heading.className = 'session-dropdown-heading';
+      heading.textContent = text;
+      dropdown.appendChild(heading);
+    }
 
     // Session items — leader first, then followers
     var sorted = active.slice().sort(function(a, b) {
@@ -233,70 +307,78 @@
       return 0;
     });
 
-    for (var i = 0; i < sorted.length; i++) {
-      (function(s) {
-        var item = document.createElement('div');
-        item.className = 'session-dropdown-item';
-        item.dataset.sessionId = s.sessionId;
-        item.setAttribute('role', 'option');
+    function appendSessionItem(s) {
+      var item = document.createElement('div');
+      item.className = 'session-dropdown-item';
+      item.dataset.sessionId = s.sessionId;
+      item.setAttribute('role', 'option');
 
-        var check = document.createElement('span');
-        check.className = 'session-dropdown-check';
-        item.appendChild(check);
+      var check = document.createElement('span');
+      check.className = 'session-dropdown-check';
+      item.appendChild(check);
 
-        var dot = document.createElement('span');
-        dot.className = 'session-dot';
-        if (s.color) dot.style.background = s.color;
-        item.appendChild(dot);
+      var dot = document.createElement('span');
+      dot.className = 'session-dot';
+      if (s.color) dot.style.background = s.color;
+      item.appendChild(dot);
 
-        var nameEl = document.createElement('span');
-        nameEl.className = 'session-dropdown-name';
-        nameEl.textContent = displayName(s);
-        if (s.color) nameEl.style.color = s.color;
-        item.appendChild(nameEl);
+      var nameEl = document.createElement('span');
+      nameEl.className = 'session-dropdown-name';
+      nameEl.textContent = displayName(s);
+      if (s.color) nameEl.style.color = s.color;
+      item.appendChild(nameEl);
 
-        // Session status badges (#1805) — two independent dimensions:
-        // 1. Auth status (filled/empty circle + text)
-        // 2. Client attachment (checkmark/X + text)
-        // Shape + text + colorblind-safe color (blue/orange) = three
-        // independent channels so no single channel carries meaning alone.
-        var authBadge = document.createElement('span');
-        authBadge.className = 'session-status-badge';
-        if (s.authenticated) {
-          authBadge.textContent = '\u25CF Auth';
-          authBadge.dataset.status = 'positive';
-          authBadge.title = 'Authenticated session';
-        } else {
-          authBadge.textContent = '\u25CB No auth';
-          authBadge.dataset.status = 'negative';
-          authBadge.title = 'Unauthenticated session';
-        }
-        item.appendChild(authBadge);
+      // Session status badges (#1805) — for persisted policy sessions we
+      // switch from "live/authenticated" semantics to "saved/no client".
+      var authBadge = document.createElement('span');
+      authBadge.className = 'session-status-badge';
+      if (isPolicyOnlySession(s)) {
+        authBadge.textContent = 'Saved';
+        authBadge.dataset.status = 'positive';
+        authBadge.title = 'Persisted policy state from a prior session';
+      } else if (s.authenticated) {
+        authBadge.textContent = '\u25CF Auth';
+        authBadge.dataset.status = 'positive';
+        authBadge.title = 'Authenticated session';
+      } else {
+        authBadge.textContent = '\u25CB No auth';
+        authBadge.dataset.status = 'negative';
+        authBadge.title = 'Unauthenticated session';
+      }
+      item.appendChild(authBadge);
 
-        var clientBadge = document.createElement('span');
-        clientBadge.className = 'session-status-badge';
-        if (s.kind === 'mcp') {
-          clientBadge.textContent = '\u2713 Client';
-          clientBadge.dataset.status = 'positive';
-          clientBadge.title = 'MCP client attached';
-        } else {
-          clientBadge.textContent = '\u2717 No client';
-          clientBadge.dataset.status = 'negative';
-          clientBadge.title = 'No MCP client attached';
-        }
-        item.appendChild(clientBadge);
+      var clientBadge = document.createElement('span');
+      clientBadge.className = 'session-status-badge';
+      if (isPolicyOnlySession(s)) {
+        clientBadge.textContent = 'No client';
+        clientBadge.dataset.status = 'negative';
+        clientBadge.title = 'No live MCP client is currently attached';
+      } else if (s.kind === 'mcp') {
+        clientBadge.textContent = '\u2713 Client';
+        clientBadge.dataset.status = 'positive';
+        clientBadge.title = 'MCP client attached';
+      } else {
+        clientBadge.textContent = '\u2717 No client';
+        clientBadge.dataset.status = 'negative';
+        clientBadge.title = 'No MCP client attached';
+      }
+      item.appendChild(clientBadge);
 
-        var uptimeEl = document.createElement('span');
-        uptimeEl.className = 'session-dropdown-uptime';
-        uptimeEl.dataset.startedAt = s.startedAt;
-        uptimeEl.textContent = formatUptime(s.startedAt);
-        item.appendChild(uptimeEl);
+      var uptimeEl = document.createElement('span');
+      uptimeEl.className = 'session-dropdown-uptime';
+      uptimeEl.dataset.startedAt = s.startedAt;
+      uptimeEl.textContent = isPolicyOnlySession(s) ? 'saved' : formatUptime(s.startedAt);
+      item.appendChild(uptimeEl);
 
-        var killBtn = document.createElement('button');
-        killBtn.className = 'session-kill-btn';
-        killBtn.type = 'button';
+      var killBtn = document.createElement('button');
+      killBtn.className = 'session-kill-btn';
+      killBtn.type = 'button';
+      killBtn.textContent = '\u00D7';
+      if (isPolicyOnlySession(s)) {
+        killBtn.disabled = true;
+        killBtn.style.visibility = 'hidden';
+      } else {
         killBtn.title = 'Stop ' + displayName(s);
-        killBtn.textContent = '\u00D7';
         killBtn.addEventListener('click', function(e) {
           e.stopPropagation();
           if (!confirm('Stop session ' + displayName(s) + '?')) return;
@@ -320,15 +402,31 @@
               alert('Failed to stop session ' + displayName(s) + ': ' + (err.message || 'network error'));
             });
         });
-        item.appendChild(killBtn);
+      }
+      item.appendChild(killBtn);
 
-        item.addEventListener('click', function(e) {
-          e.stopPropagation();
-          applyFilter(filterSessionId === s.sessionId ? '' : s.sessionId);
-        });
+      item.addEventListener('click', function(e) {
+        e.stopPropagation();
+        applyFilter(filterSessionId === s.sessionId ? '' : s.sessionId);
+      });
 
-        dropdown.appendChild(item);
-      })(sorted[i]);
+      dropdown.appendChild(item);
+    }
+
+    if (sorted.length > 0) {
+      appendDivider();
+      appendHeading('Live Sessions');
+      for (var i = 0; i < sorted.length; i++) {
+        appendSessionItem(sorted[i]);
+      }
+    }
+
+    if (policyOnly.length > 0) {
+      appendDivider();
+      appendHeading('Persisted Policy State');
+      for (var j = 0; j < policyOnly.length; j++) {
+        appendSessionItem(policyOnly[j]);
+      }
     }
 
     var wrapper = document.createElement('div');
@@ -394,14 +492,16 @@
     if (!select) return;
 
     var current = select.value;
-    var active = sessions.filter(function(s) { return s.status === 'active'; });
+    var selectable = getSelectableSessions();
 
     select.innerHTML = '<option value="">All Sessions</option>';
-    for (var i = 0; i < active.length; i++) {
+    for (var i = 0; i < selectable.length; i++) {
       var opt = document.createElement('option');
-      opt.value = active[i].sessionId;
-      opt.textContent = displayName(active[i]) + (active[i].isLeader ? ' (leader)' : '');
-      if (active[i].sessionId === current) opt.selected = true;
+      opt.value = selectable[i].sessionId;
+      opt.textContent = displayName(selectable[i])
+        + (selectable[i].isLeader ? ' (leader)' : '')
+        + (isPolicyOnlySession(selectable[i]) ? ' (policy only)' : '');
+      if (selectable[i].sessionId === current) opt.selected = true;
       select.appendChild(opt);
     }
   }
@@ -435,6 +535,8 @@
     getFilterSessionId: function() { return filterSessionId; },
     displayName: displayName,
     getSessions: function() { return sessions; },
+    getSelectableSessions: getSelectableSessions,
+    setPolicySessions: setPolicySessions,
   };
 
   function init() {

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -423,7 +423,7 @@
 
     if (policyOnly.length > 0) {
       appendDivider();
-      appendHeading('Persisted Policy State');
+      appendHeading('Persisted Policy State (Debug Info)');
       for (var j = 0; j < policyOnly.length; j++) {
         appendSessionItem(policyOnly[j]);
       }

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -69,6 +69,8 @@ html { scroll-behavior: smooth; }
 body {
   margin: 0;
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
   color-scheme: light;
   color: var(--ink-900);
   background:
@@ -249,6 +251,7 @@ p, li { max-width: 69ch; }
 .site-main {
   width: min(var(--max-width), calc(100% - 2 * var(--gutter)));
   margin: 0 auto;
+  flex: 1 0 auto;
   padding: clamp(1.1rem, 3vw, 2rem) 0 3rem;
 }
 
@@ -1375,8 +1378,8 @@ body.modal-open { overflow: hidden; }
 .site-footer {
   border-top: 1px solid var(--line);
   padding: 0.85rem 0 1.35rem;
-  position: sticky;
-  bottom: 0;
+  margin-top: auto;
+  position: static;
   background: var(--paper);
   z-index: 10;
 }

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -25,6 +25,12 @@ interface PermissionDecision {
   reason?: string;
 }
 
+interface KnownPolicySession {
+  sessionId: string;
+  displayName: string;
+  source: 'policy';
+}
+
 const DECISION_BUFFER_SIZE = 200;
 const recentDecisions: PermissionDecision[] = [];
 let decisionCounter = 0;
@@ -57,6 +63,29 @@ function trackDecision(toolName: string, input: Record<string, unknown>, result:
 function asSingleResult(results: unknown): { success: boolean; data?: unknown; error?: string } {
   if (Array.isArray(results)) return results[0] || { success: false, error: 'Empty result' };
   return results as { success: boolean; data?: unknown; error?: string };
+}
+
+function extractKnownPolicySessions(elements: Array<Record<string, unknown>>): KnownPolicySession[] {
+  const seen = new Set<string>();
+  const knownSessions: KnownPolicySession[] = [];
+
+  for (const element of elements) {
+    const sessionIds = Array.isArray(element.sessionIds) ? element.sessionIds : [];
+    for (const sessionId of sessionIds) {
+      if (typeof sessionId !== 'string' || sessionId === '' || seen.has(sessionId)) {
+        continue;
+      }
+
+      seen.add(sessionId);
+      knownSessions.push({
+        sessionId,
+        displayName: sessionId,
+        source: 'policy',
+      });
+    }
+  }
+
+  return knownSessions.sort((a, b) => a.sessionId.localeCompare(b.sessionId));
 }
 
 /**
@@ -169,6 +198,7 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
           ? confirmPatterns
           : ((data.combinedConfirmPatterns as string[] | undefined) ?? []),
         elements,
+        knownSessions: extractKnownPolicySessions(elements),
         permissionPromptActive: data.permissionPromptActive,
         recentDecisions,
       });

--- a/tests/unit/di/deferredPermissionServer.test.ts
+++ b/tests/unit/di/deferredPermissionServer.test.ts
@@ -42,14 +42,22 @@ describe('Permission Server Wiring', () => {
     it('should write port file with correct content', async () => {
       const { writePortFile } = await import('../../../src/auto-dollhouse/portDiscovery.js');
       const runDir = path.join(os.homedir(), '.dollhouse', 'run');
+      const pidPortFile = path.join(runDir, `permission-server-${process.pid}.port`);
       const portFile = path.join(runDir, 'permission-server.port');
 
-      await writePortFile(49999);
+      const writtenFile = await writePortFile(49999);
 
-      const content = await fs.readFile(portFile, 'utf-8');
+      // Read the PID-keyed file returned by writePortFile() to avoid races with
+      // other suites that also update the shared latest-file path in CI.
+      const content = await fs.readFile(writtenFile, 'utf-8');
       expect(content.trim()).toBe('49999');
 
+      // The convenience "latest" file should still exist, but other suites may
+      // update it concurrently so we only assert presence here.
+      await expect(fs.stat(portFile)).resolves.toBeDefined();
+
       // Clean up test artifact
+      await fs.unlink(pidPortFile).catch(() => {});
       await fs.unlink(portFile).catch(() => {});
     });
   });

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -347,7 +347,10 @@ describe('Web console cleanup regressions', () => {
     expect(win.document.getElementById('perm-selected-badge')?.textContent).toContain('Persisted Policy State (Debug Info)');
     expect(win.document.getElementById('perm-selected-source-list')?.textContent).toContain('autonomy-scout-demo');
     expect(win.document.getElementById('perm-selected-deny-list')?.textContent).toContain('mcp__DollhouseMCP__mcp_aql_delete*');
-    expect(apiFetch).not.toHaveBeenCalledWith('/api/permissions/status?sessionId=session-focus');
+    const selectedSessionRequests = apiFetch.mock.calls
+      .map(([url]) => url)
+      .filter((url): url is string => typeof url === 'string' && url.includes('sessionId=session-focus'));
+    expect(selectedSessionRequests).toHaveLength(0);
 
     cleanup();
   });

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -262,27 +262,6 @@ describe('Web console cleanup regressions', () => {
         });
       }
 
-      if (url === '/api/permissions/status?sessionId=session-focus') {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({
-            sessionId: 'session-focus',
-            activeElementCount: 1,
-            hasAllowlist: false,
-            denyPatterns: ['mcp__DollhouseMCP__mcp_aql_delete*'],
-            allowPatterns: ['mcp__DollhouseMCP__mcp_aql_read*'],
-            confirmPatterns: ['mcp__DollhouseMCP__mcp_aql_execute*'],
-            elements: [{
-              type: 'agent',
-              element_name: 'autonomy-scout-demo',
-              description: 'Selected session details',
-            }],
-            recentDecisions: [],
-            permissionPromptActive: false,
-          }),
-        });
-      }
-
       if (url === '/api/permissions/status') {
         return Promise.resolve({
           ok: true,
@@ -290,19 +269,25 @@ describe('Web console cleanup regressions', () => {
             activeElementCount: 2,
             hasAllowlist: true,
             denyPatterns: ['Bash:rm -rf *', 'Bash:git clean -f*'],
-            allowPatterns: ['Bash:git status*'],
+            allowPatterns: [],
             confirmPatterns: ['Bash:git push*'],
             elements: [
               {
                 type: 'ensemble',
                 element_name: 'drawing-room-safety',
                 description: 'Shared baseline restrictions',
+                allowPatterns: ['Bash:git status*'],
+                confirmPatterns: [],
+                denyPatterns: [],
                 sessionIds: ['session-alpha'],
               },
               {
                 type: 'agent',
                 element_name: 'autonomy-scout-demo',
                 description: 'Selected session details',
+                allowPatterns: ['mcp__DollhouseMCP__mcp_aql_read*'],
+                confirmPatterns: ['mcp__DollhouseMCP__mcp_aql_execute*'],
+                denyPatterns: ['mcp__DollhouseMCP__mcp_aql_delete*'],
                 sessionIds: ['session-focus'],
               },
             ],
@@ -350,6 +335,7 @@ describe('Web console cleanup regressions', () => {
     expect(sourceItems).toHaveLength(2);
     expect(win.document.getElementById('perm-source-list')?.textContent).toContain('drawing-room-safety');
     expect(win.document.getElementById('perm-source-list')?.textContent).toContain('autonomy-scout-demo');
+    expect(win.document.getElementById('perm-allow-list')?.textContent).toContain('Bash:git status*');
 
     const highlighted = win.document.querySelectorAll('#perm-source-list .perm-source-item--selected');
     expect(highlighted).toHaveLength(1);
@@ -361,6 +347,7 @@ describe('Web console cleanup regressions', () => {
     expect(win.document.getElementById('perm-selected-badge')?.textContent).toContain('Persisted Policy State (Debug Info)');
     expect(win.document.getElementById('perm-selected-source-list')?.textContent).toContain('autonomy-scout-demo');
     expect(win.document.getElementById('perm-selected-deny-list')?.textContent).toContain('mcp__DollhouseMCP__mcp_aql_delete*');
+    expect(apiFetch).not.toHaveBeenCalledWith('/api/permissions/status?sessionId=session-focus');
 
     cleanup();
   });

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -15,6 +15,7 @@ let appSource = '';
 let sessionsSource = '';
 let logsSource = '';
 let metricsSource = '';
+let permissionsSource = '';
 
 type TestWindow = JSDOM['window'] & typeof globalThis & Record<string, any>;
 
@@ -24,11 +25,12 @@ const SESSION_FILTER_INJECTION_WAIT_MS = 40;
 
 beforeAll(async () => {
   const base = join(process.cwd(), 'src/web/public');
-  [appSource, sessionsSource, logsSource, metricsSource] = await Promise.all([
+  [appSource, sessionsSource, logsSource, metricsSource, permissionsSource] = await Promise.all([
     readFile(join(base, 'app.js'), 'utf8'),
     readFile(join(base, 'sessions.js'), 'utf8'),
     readFile(join(base, 'logs.js'), 'utf8'),
     readFile(join(base, 'metrics.js'), 'utf8'),
+    readFile(join(base, 'permissions.js'), 'utf8'),
   ]);
 });
 
@@ -229,6 +231,191 @@ describe('Web console cleanup regressions', () => {
     expect(select?.options[1].value).toBe('session-1');
     expect(select?.options[1].textContent).toContain('Barbie');
     expect(select?.options[1].textContent).toContain('(leader)');
+
+    cleanup();
+  });
+
+  it('keeps aggregate policy sources visible when selecting a persisted policy session', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="session-indicator"></div>
+      <div id="tab-logs"><div class="log-controls"></div></div>
+      <div id="console-tabs"><button class="console-tab" data-tab="permissions">Permissions</button></div>
+      <div id="permissions-dashboard-root"></div>
+    `);
+
+    const apiFetch = jest.fn((url: string) => {
+      if (url === '/api/sessions') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            sessions: [{
+              sessionId: 'console-1',
+              status: 'active',
+              displayName: 'Web Console',
+              startedAt: '2026-04-13T20:00:00.000Z',
+              isLeader: false,
+              authenticated: true,
+              kind: 'console',
+              color: '#6366f1',
+            }],
+          }),
+        });
+      }
+
+      if (url === '/api/permissions/status?sessionId=session-focus') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            sessionId: 'session-focus',
+            activeElementCount: 1,
+            hasAllowlist: false,
+            denyPatterns: ['mcp__DollhouseMCP__mcp_aql_delete*'],
+            allowPatterns: ['mcp__DollhouseMCP__mcp_aql_read*'],
+            confirmPatterns: ['mcp__DollhouseMCP__mcp_aql_execute*'],
+            elements: [{
+              type: 'agent',
+              element_name: 'autonomy-scout-demo',
+              description: 'Selected session details',
+            }],
+            recentDecisions: [],
+            permissionPromptActive: false,
+          }),
+        });
+      }
+
+      if (url === '/api/permissions/status') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            activeElementCount: 2,
+            hasAllowlist: true,
+            denyPatterns: ['Bash:rm -rf *', 'Bash:git clean -f*'],
+            allowPatterns: ['Bash:git status*'],
+            confirmPatterns: ['Bash:git push*'],
+            elements: [
+              {
+                type: 'ensemble',
+                element_name: 'drawing-room-safety',
+                description: 'Shared baseline restrictions',
+                sessionIds: ['session-alpha'],
+              },
+              {
+                type: 'agent',
+                element_name: 'autonomy-scout-demo',
+                description: 'Selected session details',
+                sessionIds: ['session-focus'],
+              },
+            ],
+            knownSessions: [
+              { sessionId: 'session-alpha', displayName: 'session-alpha', source: 'policy' },
+              { sessionId: 'session-focus', displayName: 'session-focus', source: 'policy' },
+            ],
+            recentDecisions: [],
+            permissionPromptActive: false,
+          }),
+        });
+      }
+
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    win.DollhouseAuth.apiFetch = apiFetch;
+    win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+    win.DollhouseConsoleConfig = {
+      sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
+      sessionFilterInjectionMaxRetries: 5,
+    };
+
+    win.eval(sessionsSource);
+    win.eval(permissionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    win.DollhouseConsole.permissions.init();
+    await wait(SESSION_FILTER_INJECTION_WAIT_MS);
+
+    const sessionBox = win.document.querySelector('.session-box') as HTMLButtonElement | null;
+    expect(sessionBox).not.toBeNull();
+    sessionBox?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    const debugHeading = Array.from(win.document.querySelectorAll('.session-dropdown-heading'))
+      .map(node => node.textContent);
+    expect(debugHeading).toContain('Persisted Policy State (Debug Info)');
+
+    const persistedItem = win.document.querySelector('.session-dropdown-item[data-session-id="session-focus"]') as HTMLElement | null;
+    expect(persistedItem).not.toBeNull();
+    persistedItem?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    const sourceItems = Array.from(win.document.querySelectorAll('#perm-source-list .perm-source-item'));
+    expect(sourceItems).toHaveLength(2);
+    expect(win.document.getElementById('perm-source-list')?.textContent).toContain('drawing-room-safety');
+    expect(win.document.getElementById('perm-source-list')?.textContent).toContain('autonomy-scout-demo');
+
+    const highlighted = win.document.querySelectorAll('#perm-source-list .perm-source-item--selected');
+    expect(highlighted).toHaveLength(1);
+    expect(highlighted[0]?.textContent).toContain('autonomy-scout-demo');
+
+    const selectedCard = win.document.getElementById('perm-selected-card');
+    expect(selectedCard?.hidden).toBe(false);
+    expect(win.document.getElementById('perm-selected-title')?.textContent).toContain('session-focus');
+    expect(win.document.getElementById('perm-selected-badge')?.textContent).toContain('Persisted Policy State (Debug Info)');
+    expect(win.document.getElementById('perm-selected-source-list')?.textContent).toContain('autonomy-scout-demo');
+    expect(win.document.getElementById('perm-selected-deny-list')?.textContent).toContain('mcp__DollhouseMCP__mcp_aql_delete*');
+
+    cleanup();
+  });
+
+  it('ignores malformed persisted policy session entries in the picker', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="session-indicator"></div>
+      <div id="tab-logs"><div class="log-controls"></div></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        sessions: [{
+          sessionId: 'console-1',
+          status: 'active',
+          displayName: 'Web Console',
+          startedAt: '2026-04-13T20:00:00.000Z',
+          isLeader: false,
+          authenticated: true,
+          kind: 'console',
+          color: '#6366f1',
+        }],
+      }),
+    });
+    win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+    win.DollhouseConsoleConfig = {
+      sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
+      sessionFilterInjectionMaxRetries: 5,
+    };
+
+    win.eval(sessionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    await wait(SESSION_FILTER_INJECTION_WAIT_MS);
+
+    win.DollhouseSessions.setPolicySessions([
+      null,
+      { sessionId: '', displayName: 'empty' },
+      { sessionId: 'session-good', displayName: 'session-good' },
+      { sessionId: 'session-good', displayName: 'duplicate' },
+      { sessionId: 42, displayName: 'bad-type' },
+    ]);
+
+    const select = win.document.getElementById('log-session-filter') as HTMLSelectElement | null;
+    expect(select).not.toBeNull();
+    const options = Array.from(select?.options ?? []).map(option => ({
+      value: option.value,
+      label: option.textContent,
+    }));
+
+    expect(options).toEqual([
+      { value: '', label: 'All Sessions' },
+      { value: 'console-1', label: 'Web Console' },
+      { value: 'session-good', label: 'session-good (policy only)' },
+    ]);
 
     cleanup();
   });

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -183,6 +183,36 @@ describe('permissionRoutes', () => {
       });
     });
 
+    it('should expose known persisted policy sessions for the session picker', async () => {
+      const handler = {
+        handleRead: jest.fn().mockResolvedValue([{
+          success: true,
+          data: {
+            activeElementCount: 2,
+            hasAllowlist: false,
+            combinedDenyPatterns: [],
+            combinedAllowPatterns: [],
+            combinedConfirmPatterns: [],
+            elements: [
+              { name: 'guard-a', sessionIds: ['session-b', 'session-a'] },
+              { name: 'guard-b', sessionIds: ['session-a'] },
+              { name: 'guard-c' },
+            ],
+            permissionPromptActive: false,
+          },
+        }]),
+      } as any;
+      const app = createApp(handler);
+
+      const res = await request(app).get('/api/permissions/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.knownSessions).toEqual([
+        { sessionId: 'session-a', displayName: 'session-a', source: 'policy' },
+        { sessionId: 'session-b', displayName: 'session-b', source: 'policy' },
+      ]);
+    });
+
     it('should return 500 when handler fails', async () => {
       const handler = {
         handleRead: jest.fn().mockResolvedValue([{


### PR DESCRIPTION
## Summary
- surface persisted policy sessions in the permissions status payload
- teach the shared session picker to show policy-only sessions separately from live sessions
- label saved sessions clearly so the dropdown matches what the permissions dashboard is reporting

## Testing
- npx jest --config tests/jest.config.cjs --runInBand --modulePathIgnorePatterns=.worktrees --runTestsByPath tests/unit/web/permissionRoutes.test.ts
- node --check src/web/public/sessions.js
- node --check src/web/public/permissions.js
- npx tsc -p tsconfig.json --noEmit

## Notes
- /api/sessions still reflects only live sessions
- persisted sessions come from the permissions reporting path and are presented as policy-only entries in the picker