### PR TITLE
Fix live permission decision feed routing

### DIFF
--- a/src/di/Container.ts
+++ b/src/di/Container.ts
@@ -99,6 +99,7 @@ import { TriggerMetricsTracker } from "../portfolio/enhanced-index/TriggerMetric
 import { SemanticRelationshipService } from "../portfolio/enhanced-index/SemanticRelationshipService.js";
 import { ElementEventDispatcher } from '../events/ElementEventDispatcher.js';
 import { TokenManager } from "../security/tokenManager.js";
+import type { UnifiedConsoleResult } from "../web/console/UnifiedConsole.js";
 import {
   PaginationService,
   FilterService,
@@ -901,8 +902,8 @@ export class DollhouseContainer {
       await sweepStalePortFiles();
     } catch { /* sweep failure is non-fatal */ }
 
-    await this.deferredWebConsole(timer);
-    await this.deferredPermissionServer(timer);
+    const consoleResult = await this.deferredWebConsole(timer);
+    await this.deferredPermissionServer(consoleResult, timer);
   }
 
   private async deferredMemoryAutoload(timer?: StartupTimer): Promise<void> {
@@ -1006,10 +1007,10 @@ export class DollhouseContainer {
     }
   }
 
-  private async deferredWebConsole(timer?: StartupTimer): Promise<void> {
+  private async deferredWebConsole(timer?: StartupTimer): Promise<UnifiedConsoleResult | null> {
     timer?.startPhase('web_console', false);
     try {
-      if (!env.DOLLHOUSE_WEB_CONSOLE) return;
+      if (!env.DOLLHOUSE_WEB_CONSOLE) return null;
 
       const activationStore = this.resolve<ActivationStore>('ActivationStore');
       const sessionId = activationStore.getSessionId();
@@ -1036,13 +1037,16 @@ export class DollhouseContainer {
       });
 
       logger.info(`[Container] Web console started as ${result.role}`);
+      return result;
     } catch (error) {
       logger.warn('[Container] Web console startup failed:', error);
+      return null;
+    } finally {
+      timer?.endPhase('web_console');
     }
-    timer?.endPhase('web_console');
   }
 
-  private async deferredPermissionServer(timer?: StartupTimer): Promise<void> {
+  private async deferredPermissionServer(consoleResult: UnifiedConsoleResult | null, timer?: StartupTimer): Promise<void> {
     timer?.startPhase('permission_server', false);
     try {
       if (!env.DOLLHOUSE_PERMISSION_SERVER) {
@@ -1056,9 +1060,17 @@ export class DollhouseContainer {
       }
 
       // Permission routes are already mounted on the unified web console.
-      // We just need to write the port file so the PreToolUse hook script
-      // can discover it. No separate server — use the existing console port.
-      const port = env.DOLLHOUSE_WEB_CONSOLE_PORT;
+      // We just need to write the active leader port so the PreToolUse hook
+      // script reaches the same console instance that owns the live audit feed.
+      const port = consoleResult?.role === 'leader'
+        ? consoleResult.port
+        : consoleResult?.election.leaderInfo.port;
+
+      if (!port) {
+        logger.debug('[Container] Permission server skipped — no active web console port available');
+        return;
+      }
+
       const startMs = Date.now();
 
       const { writePortFile, registerPortCleanup } = await import('../auto-dollhouse/portDiscovery.js');

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -341,8 +341,8 @@
 }
 
 .perm-card--audit .perm-feed {
-  height: var(--perm-audit-feed-height, 34rem);
-  max-height: var(--perm-audit-feed-height, 34rem);
+  height: clamp(16rem, 36vh, 24rem);
+  max-height: clamp(16rem, 36vh, 24rem);
 }
 
 .perm-card--audit .perm-selected-header--compact {

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -341,7 +341,8 @@
 }
 
 .perm-card--audit .perm-feed {
-  max-height: 34rem;
+  height: var(--perm-audit-feed-height, 34rem);
+  max-height: var(--perm-audit-feed-height, 34rem);
 }
 
 .perm-feed-empty {

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -345,6 +345,14 @@
   max-height: var(--perm-audit-feed-height, 34rem);
 }
 
+.perm-card--audit .perm-selected-header--compact {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--paper-strong, #fff);
+  padding-bottom: 0.5rem;
+}
+
 .perm-feed-empty {
   padding: 2rem;
   text-align: center;

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -63,14 +63,16 @@
 }
 
 #tab-permissions {
-  padding-inline: clamp(0.25rem, 0.5vw, 0.5rem);
+  padding-inline: clamp(0.5rem, 1vw, 1rem);
+  padding-bottom: calc(var(--site-footer-height, 4.5rem) + 1.5rem);
 }
 
 @media (max-width: 900px) {
   .perm-dashboard { grid-template-columns: 1fr; }
 
   #tab-permissions {
-    padding-inline: 0;
+    padding-inline: 0.375rem;
+    padding-bottom: calc(var(--site-footer-height, 4.5rem) + 1.25rem);
   }
 }
 
@@ -330,8 +332,9 @@
 /* ── Live Feed ─────────────────────────────────────────────── */
 
 .perm-feed {
-  max-height: 20rem;
-  min-height: 8rem;
+  height: 15rem;
+  max-height: 15rem;
+  min-height: 15rem;
   overflow-y: scroll;
   overflow-x: auto;
   overscroll-behavior: contain;
@@ -340,17 +343,10 @@
   font-size: 0.8125rem;
 }
 
-.perm-card--audit .perm-feed {
-  height: clamp(16rem, 36vh, 24rem);
-  max-height: clamp(16rem, 36vh, 24rem);
-}
-
-.perm-card--audit .perm-selected-header--compact {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  background: var(--paper-strong, #fff);
-  padding-bottom: 0.5rem;
+.perm-feed--modal {
+  height: calc(100vh - 11rem);
+  max-height: none;
+  min-height: 0;
 }
 
 .perm-feed-empty {
@@ -407,6 +403,10 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 200px;
+}
+
+.perm-audit-modal-dialog {
+  width: min(82rem, 100%);
 }
 
 /* ── Source Elements ───────────────────────────────────────── */

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -18,6 +18,8 @@
   let latestAggregateData = null;
   let latestSelectedData = null;
   let latestPollRequestId = 0;
+  const AUDIT_FEED_MIN_HEIGHT_PX = 320;
+  const AUDIT_FEED_MARGIN_PX = 24;
 
   async function fetchPermissionStatus(sessionId) {
     const query = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : '';
@@ -65,6 +67,7 @@
 
     root.innerHTML = buildDashboardHTML();
     attachCardToggles();
+    window.addEventListener('resize', scheduleAuditFeedLayout);
     poll(); // immediate first fetch
     pollTimer = setInterval(poll, POLL_INTERVAL_MS);
   }
@@ -74,6 +77,7 @@
       clearInterval(pollTimer);
       pollTimer = null;
     }
+    window.removeEventListener('resize', scheduleAuditFeedLayout);
     initialized = false;
   }
 
@@ -109,6 +113,7 @@
     latestSelectedData = deriveSelectedSessionData(latestAggregateData, sessionId);
     renderPolicySources(latestAggregateData, latestSelectedData);
     renderSelectedSessionDetail(latestSelectedData);
+    scheduleAuditFeedLayout();
   }
 
   // ── Rendering ──────────────────────────────────────────────
@@ -122,6 +127,7 @@
     renderAllowPatterns(data);
     renderConfirmPatterns(data);
     renderLiveFeed(data);
+    scheduleAuditFeedLayout();
   }
 
   function renderError(message) {
@@ -539,6 +545,7 @@
         const collapsed = card.dataset.collapsed === 'true';
         card.dataset.collapsed = collapsed ? 'false' : 'true';
         header.setAttribute('aria-expanded', collapsed ? 'true' : 'false');
+        scheduleAuditFeedLayout();
       };
       header.addEventListener('click', toggle);
       header.addEventListener('keydown', (e) => {
@@ -554,8 +561,46 @@
         const expanded = feedCard.classList.toggle('perm-card--audit');
         expandBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
         expandBtn.textContent = expanded ? 'Compact Audit View' : 'Expand Audit View';
+        scheduleAuditFeedLayout();
       });
     }
+  }
+
+  function scheduleAuditFeedLayout() {
+    window.requestAnimationFrame(updateAuditFeedLayout);
+  }
+
+  function updateAuditFeedLayout() {
+    const feedCard = document.getElementById('perm-all-feed-card');
+    const feed = document.getElementById('perm-feed');
+    if (!feedCard || !feed) return;
+
+    if (!feedCard.classList.contains('perm-card--audit') || feedCard.dataset.collapsed === 'true') {
+      feed.style.removeProperty('--perm-audit-feed-height');
+      return;
+    }
+
+    const cards = Array.from(document.querySelectorAll('.perm-dashboard > .perm-card'));
+    const feedCardIndex = cards.indexOf(feedCard);
+    if (feedCardIndex === -1) return;
+
+    const reserveHeight = cards.slice(feedCardIndex + 1).reduce(function (total, card) {
+      if (card.hidden) return total;
+      const header = card.querySelector('.perm-card-header');
+      if (card.dataset.collapsed === 'true') {
+        return total + (header ? header.getBoundingClientRect().height : 0);
+      }
+      return total + card.getBoundingClientRect().height;
+    }, 0);
+
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const cardTop = feedCard.getBoundingClientRect().top;
+    const availableHeight = Math.max(
+      AUDIT_FEED_MIN_HEIGHT_PX,
+      viewportHeight - cardTop - reserveHeight - AUDIT_FEED_MARGIN_PX
+    );
+
+    feed.style.setProperty('--perm-audit-feed-height', `${Math.floor(availableHeight)}px`);
   }
 
   function setText(id, value) {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -280,11 +280,16 @@
 
   function renderLiveFeed(data) {
     const feed = document.getElementById('perm-feed');
+    const modalFeed = document.getElementById('perm-audit-modal-feed');
+    const modalCount = document.getElementById('perm-audit-modal-count');
     if (!feed) return;
 
     const decisions = data.recentDecisions || [];
     if (decisions.length === 0) {
-      feed.innerHTML = '<div class="perm-feed-empty">No permission decisions yet. Waiting for tool calls...</div>';
+      const empty = '<div class="perm-feed-empty">No permission decisions yet. Waiting for tool calls...</div>';
+      feed.innerHTML = empty;
+      if (modalFeed) modalFeed.innerHTML = empty;
+      if (modalCount) modalCount.textContent = '0 captured entries';
       return;
     }
 
@@ -293,7 +298,7 @@
     if (latestId === lastDecisionId) return; // no change
     lastDecisionId = latestId;
 
-    feed.innerHTML = decisions.map(d => {
+    const html = decisions.map(d => {
       const time = new Date(d.timestamp).toLocaleTimeString();
       const toolDisplay = d.tool_name === 'Bash'
         ? `Bash: ${esc(truncate(d.command || '', 60))}`
@@ -308,6 +313,12 @@
         </div>
       `;
     }).join('');
+
+    feed.innerHTML = html;
+    if (modalFeed) modalFeed.innerHTML = html;
+    if (modalCount) {
+      modalCount.textContent = `${decisions.length} captured ${decisions.length === 1 ? 'entry' : 'entries'}`;
+    }
   }
 
   function deriveSelectedSessionData(aggregateData, sessionId) {
@@ -382,16 +393,16 @@
           <div class="perm-card-body">
             <div class="perm-selected-header perm-selected-header--compact">
               <div>
-                <div class="perm-selected-subtitle">Most recent first. This is the aggregate audit stream across all sessions.</div>
+                <div class="perm-selected-subtitle">Aggregate audit stream across all sessions. Newest decisions appear first.</div>
               </div>
               <button
                 type="button"
                 class="perm-panel-action"
                 id="perm-feed-expand-btn"
-                aria-expanded="false"
-                aria-controls="perm-feed"
+                aria-haspopup="dialog"
+                aria-controls="perm-audit-modal"
               >
-                Expand Audit View
+                Open Audit View
               </button>
             </div>
             <div class="perm-feed" id="perm-feed" role="log" aria-live="polite" aria-label="Permission decisions across all sessions">
@@ -401,7 +412,7 @@
         </div>
 
         <!-- Summary Stats -->
-        <div class="perm-card perm-card--full" data-collapsed="false">
+        <div class="perm-card perm-card--full" data-collapsed="false" id="perm-autonomy-card">
           <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
             <h3 class="perm-card-title">Autonomy Overview</h3>
             <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
@@ -484,7 +495,7 @@
           </div>
         </div>
 
-        <div class="perm-card perm-card--full" data-collapsed="false">
+        <div class="perm-card perm-card--full" data-collapsed="false" id="perm-all-detail-card">
           <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
             <h3 class="perm-card-title">All Sessions Detail</h3>
             <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
@@ -527,6 +538,28 @@
         </div>
 
       </div>
+
+      <dialog class="modal perm-audit-modal" id="perm-audit-modal" aria-labelledby="perm-audit-modal-title">
+        <div class="modal-overlay" data-close-audit-modal></div>
+        <div class="modal-dialog perm-audit-modal-dialog" role="document">
+          <header class="modal-header">
+            <div class="modal-heading">
+              <h2 class="modal-title" id="perm-audit-modal-title">All Sessions Audit View</h2>
+              <span class="modal-type">Permissions</span>
+            </div>
+            <div class="modal-meta">
+              <span>Aggregate decision log across all sessions</span>
+              <span id="perm-audit-modal-count">0 captured entries</span>
+            </div>
+            <button type="button" class="modal-close" id="perm-audit-modal-close" aria-label="Close audit view">✕</button>
+          </header>
+          <div class="modal-body">
+            <div class="perm-feed perm-feed--modal" id="perm-audit-modal-feed" role="log" aria-live="polite" aria-label="Full permission decision audit feed">
+              <div class="perm-feed-empty">No permission decisions yet. Waiting for tool calls...</div>
+            </div>
+          </div>
+        </div>
+      </dialog>
     `;
   }
 
@@ -547,18 +580,54 @@
     });
 
     const expandBtn = document.getElementById('perm-feed-expand-btn');
-    const feedCard = document.getElementById('perm-all-feed-card');
-    if (expandBtn && feedCard) {
+    const auditModal = document.getElementById('perm-audit-modal');
+    const closeBtn = document.getElementById('perm-audit-modal-close');
+    if (expandBtn && auditModal) {
       expandBtn.addEventListener('click', function (e) {
         e.stopPropagation();
-        const expanded = feedCard.classList.toggle('perm-card--audit');
-        expandBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
-        expandBtn.textContent = expanded ? 'Compact Audit View' : 'Expand Audit View';
-        if (expanded) {
-          feedCard.scrollIntoView({ block: 'start', behavior: 'smooth' });
-        }
+        openAuditModal();
       });
     }
+
+    if (closeBtn) {
+      closeBtn.addEventListener('click', closeAuditModal);
+    }
+
+    if (auditModal) {
+      auditModal.addEventListener('click', function (e) {
+        if (e.target === auditModal || e.target.hasAttribute('data-close-audit-modal')) {
+          closeAuditModal();
+        }
+      });
+      auditModal.addEventListener('close', function () {
+        document.body.classList.remove('modal-open');
+      });
+      auditModal.addEventListener('cancel', function () {
+        document.body.classList.remove('modal-open');
+      });
+    }
+  }
+
+  function openAuditModal() {
+    const auditModal = document.getElementById('perm-audit-modal');
+    if (!auditModal) return;
+    if (typeof auditModal.showModal === 'function') {
+      auditModal.showModal();
+    } else {
+      auditModal.setAttribute('open', '');
+    }
+    document.body.classList.add('modal-open');
+  }
+
+  function closeAuditModal() {
+    const auditModal = document.getElementById('perm-audit-modal');
+    if (!auditModal) return;
+    if (typeof auditModal.close === 'function') {
+      auditModal.close();
+    } else {
+      auditModal.removeAttribute('open');
+    }
+    document.body.classList.remove('modal-open');
   }
 
   function setText(id, value) {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -18,9 +18,6 @@
   let latestAggregateData = null;
   let latestSelectedData = null;
   let latestPollRequestId = 0;
-  const AUDIT_FEED_DEFAULT_HEIGHT_PX = 544;
-  const AUDIT_FEED_MIN_HEIGHT_PX = 220;
-  const AUDIT_FEED_MARGIN_PX = 24;
 
   async function fetchPermissionStatus(sessionId) {
     const query = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : '';
@@ -68,7 +65,6 @@
 
     root.innerHTML = buildDashboardHTML();
     attachCardToggles();
-    window.addEventListener('resize', scheduleAuditFeedLayout);
     poll(); // immediate first fetch
     pollTimer = setInterval(poll, POLL_INTERVAL_MS);
   }
@@ -78,7 +74,6 @@
       clearInterval(pollTimer);
       pollTimer = null;
     }
-    window.removeEventListener('resize', scheduleAuditFeedLayout);
     initialized = false;
   }
 
@@ -544,7 +539,6 @@
         const collapsed = card.dataset.collapsed === 'true';
         card.dataset.collapsed = collapsed ? 'false' : 'true';
         header.setAttribute('aria-expanded', collapsed ? 'true' : 'false');
-        scheduleAuditFeedLayout();
       };
       header.addEventListener('click', toggle);
       header.addEventListener('keydown', (e) => {
@@ -560,51 +554,11 @@
         const expanded = feedCard.classList.toggle('perm-card--audit');
         expandBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
         expandBtn.textContent = expanded ? 'Compact Audit View' : 'Expand Audit View';
-        scheduleAuditFeedLayout();
         if (expanded) {
           feedCard.scrollIntoView({ block: 'start', behavior: 'smooth' });
         }
       });
     }
-  }
-
-  function scheduleAuditFeedLayout() {
-    window.requestAnimationFrame(updateAuditFeedLayout);
-  }
-
-  function updateAuditFeedLayout() {
-    const feedCard = document.getElementById('perm-all-feed-card');
-    const feed = document.getElementById('perm-feed');
-    if (!feedCard || !feed) return;
-
-    if (!feedCard.classList.contains('perm-card--audit') || feedCard.dataset.collapsed === 'true') {
-      feed.style.removeProperty('--perm-audit-feed-height');
-      return;
-    }
-
-    const cards = Array.from(document.querySelectorAll('.perm-dashboard > .perm-card'));
-    const feedCardIndex = cards.indexOf(feedCard);
-    if (feedCardIndex === -1) return;
-
-    const reserveHeight = cards.slice(feedCardIndex + 1).reduce(function (total, card) {
-      if (card.hidden) return total;
-      const header = card.querySelector('.perm-card-header');
-      if (card.dataset.collapsed === 'true') {
-        return total + (header ? header.getBoundingClientRect().height : 0);
-      }
-      return total + card.getBoundingClientRect().height;
-    }, 0);
-
-    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
-    const cardTop = Math.max(feedCard.getBoundingClientRect().top, 0);
-    const availableHeight = viewportHeight - cardTop - reserveHeight - AUDIT_FEED_MARGIN_PX;
-    const fallbackHeight = reserveHeight > 0 ? AUDIT_FEED_MIN_HEIGHT_PX : AUDIT_FEED_DEFAULT_HEIGHT_PX;
-    const clampedHeight = Math.max(
-      AUDIT_FEED_MIN_HEIGHT_PX,
-      Math.min(Math.max(availableHeight, fallbackHeight), viewportHeight - cardTop - AUDIT_FEED_MARGIN_PX)
-    );
-
-    feed.style.setProperty('--perm-audit-feed-height', `${Math.floor(clampedHeight)}px`);
   }
 
   function setText(id, value) {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -18,7 +18,8 @@
   let latestAggregateData = null;
   let latestSelectedData = null;
   let latestPollRequestId = 0;
-  const AUDIT_FEED_MIN_HEIGHT_PX = 320;
+  const AUDIT_FEED_DEFAULT_HEIGHT_PX = 544;
+  const AUDIT_FEED_MIN_HEIGHT_PX = 220;
   const AUDIT_FEED_MARGIN_PX = 24;
 
   async function fetchPermissionStatus(sessionId) {
@@ -113,7 +114,6 @@
     latestSelectedData = deriveSelectedSessionData(latestAggregateData, sessionId);
     renderPolicySources(latestAggregateData, latestSelectedData);
     renderSelectedSessionDetail(latestSelectedData);
-    scheduleAuditFeedLayout();
   }
 
   // ── Rendering ──────────────────────────────────────────────
@@ -127,7 +127,6 @@
     renderAllowPatterns(data);
     renderConfirmPatterns(data);
     renderLiveFeed(data);
-    scheduleAuditFeedLayout();
   }
 
   function renderError(message) {
@@ -562,6 +561,9 @@
         expandBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
         expandBtn.textContent = expanded ? 'Compact Audit View' : 'Expand Audit View';
         scheduleAuditFeedLayout();
+        if (expanded) {
+          feedCard.scrollIntoView({ block: 'start', behavior: 'smooth' });
+        }
       });
     }
   }
@@ -594,13 +596,15 @@
     }, 0);
 
     const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
-    const cardTop = feedCard.getBoundingClientRect().top;
-    const availableHeight = Math.max(
+    const cardTop = Math.max(feedCard.getBoundingClientRect().top, 0);
+    const availableHeight = viewportHeight - cardTop - reserveHeight - AUDIT_FEED_MARGIN_PX;
+    const fallbackHeight = reserveHeight > 0 ? AUDIT_FEED_MIN_HEIGHT_PX : AUDIT_FEED_DEFAULT_HEIGHT_PX;
+    const clampedHeight = Math.max(
       AUDIT_FEED_MIN_HEIGHT_PX,
-      viewportHeight - cardTop - reserveHeight - AUDIT_FEED_MARGIN_PX
+      Math.min(Math.max(availableHeight, fallbackHeight), viewportHeight - cardTop - AUDIT_FEED_MARGIN_PX)
     );
 
-    feed.style.setProperty('--perm-audit-feed-height', `${Math.floor(availableHeight)}px`);
+    feed.style.setProperty('--perm-audit-feed-height', `${Math.floor(clampedHeight)}px`);
   }
 
   function setText(id, value) {

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -952,7 +952,7 @@ dialog.modal {
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  padding: 1rem var(--gutter) 0;
+  padding: 1rem var(--gutter) calc(var(--site-footer-height, 4.5rem) + 0.5rem);
   width: 100%;
 }
 dialog.modal::backdrop { display: none; }
@@ -972,14 +972,12 @@ body.modal-open { overflow: hidden; }
   position: relative;
   width: min(72rem, 100%);
   margin: 0 auto;
-  /* Fixed height = viewport minus top padding; content scrolls inside.
-     This keeps the header and toolbar at a stable screen position
-     regardless of content length or raw/rendered toggle. */
-  height: calc(100vh - 1rem);
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  /* Keep the dialog fully inside the viewport and above the fixed footer. */
+  height: calc(100dvh - var(--site-footer-height, 4.5rem) - 1.5rem);
+  max-height: calc(100dvh - var(--site-footer-height, 4.5rem) - 1.5rem);
+  border-radius: var(--radius-lg);
   background: var(--paper-strong);
   border: 1px solid var(--line);
-  border-bottom: none;
   box-shadow: var(--shadow-card);
   overflow: hidden;
   display: flex;
@@ -1378,10 +1376,14 @@ body.modal-open { overflow: hidden; }
 .site-footer {
   border-top: 1px solid var(--line);
   padding: 0.85rem 0 1.35rem;
-  margin-top: auto;
-  position: static;
-  background: var(--paper);
-  z-index: 10;
+  margin-top: 0;
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: color-mix(in srgb, var(--paper) 92%, transparent);
+  backdrop-filter: blur(10px);
+  z-index: 40;
 }
 
 .footer-inner {

--- a/tests/unit/di/deferredPermissionServer.test.ts
+++ b/tests/unit/di/deferredPermissionServer.test.ts
@@ -62,18 +62,21 @@ describe('Permission Server Wiring', () => {
       );
 
       expect(containerSource).toContain('private async deferredPermissionServer');
-      expect(containerSource).toContain('await this.deferredPermissionServer(timer)');
+      expect(containerSource).toContain('const consoleResult = await this.deferredWebConsole(timer);');
+      expect(containerSource).toContain('await this.deferredPermissionServer(consoleResult, timer);');
       expect(containerSource).toContain('DOLLHOUSE_PERMISSION_SERVER');
     });
 
-    it('should use the existing web console port, not start a new server', async () => {
+    it('should use the elected web console port, not the default env port', async () => {
       const containerSource = await fs.readFile(
         path.join(process.cwd(), 'src/di/Container.ts'),
         'utf-8'
       );
 
-      // Should reference the console port, not start a new server
-      expect(containerSource).toContain('DOLLHOUSE_WEB_CONSOLE_PORT');
+      // Should reference the live console result, not a guessed env/default port
+      expect(containerSource).toContain("consoleResult?.role === 'leader'");
+      expect(containerSource).toContain('consoleResult.port');
+      expect(containerSource).toContain('consoleResult?.election.leaderInfo.port');
       expect(containerSource).toContain('writePortFile');
       expect(containerSource).toContain('registerPortCleanup');
 
@@ -90,7 +93,7 @@ describe('Permission Server Wiring', () => {
       // After #1866 split: webConsole and permServer are in completeConsoleSetup,
       // dangerZone is in completeSinkSetup. Verify console-group ordering.
       const webConsoleIdx = containerSource.indexOf('deferredWebConsole(timer)');
-      const permServerIdx = containerSource.indexOf('deferredPermissionServer(timer)');
+      const permServerIdx = containerSource.indexOf('deferredPermissionServer(consoleResult, timer)');
 
       expect(permServerIdx).toBeGreaterThan(webConsoleIdx);
     });


### PR DESCRIPTION
## Summary
- write the permission hook port file from the actual unified console result instead of the default env port
- ensure evaluate_permission traffic reaches the same live console instance that owns the audit feed
- update deferred permission server wiring coverage for leader and follower port selection

## Testing
- npx jest --config tests/jest.config.cjs --runInBand --modulePathIgnorePatterns=.worktrees --runTestsByPath tests/unit/di/deferredPermissionServer.test.ts tests/unit/di/permissionServerIntegration.test.ts
- npx tsc -p tsconfig.json --noEmit

## Notes
- this addresses the split-brain behavior where permission evaluations could succeed on one console instance while another browser-visible console showed a stale live decision feed
- follow-up issue #1954 covers the broader live decision feed correctness work