### PR TITLE
Fix stale permission decision accumulation

### DIFF
--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -32,8 +32,11 @@ interface KnownPolicySession {
 }
 
 const DECISION_BUFFER_SIZE = 200;
-const recentDecisions: PermissionDecision[] = [];
-let decisionCounter = 0;
+
+interface PermissionDecisionTracker {
+  trackDecision(toolName: string, input: Record<string, unknown>, result: Record<string, unknown>): void;
+  getRecentDecisions(): PermissionDecision[];
+}
 
 /** Extract a string field from a record, trying multiple keys in order */
 function extractString(obj: Record<string, unknown>, keys: string[], fallback: string): string {
@@ -44,19 +47,29 @@ function extractString(obj: Record<string, unknown>, keys: string[], fallback: s
   return fallback;
 }
 
-function trackDecision(toolName: string, input: Record<string, unknown>, result: Record<string, unknown>): void {
-  const entry: PermissionDecision = {
-    id: `d-${++decisionCounter}`,
-    timestamp: new Date().toISOString(),
-    tool_name: toolName,
-    command: toolName === 'Bash' && typeof input?.command === 'string' ? input.command : undefined,
-    decision: extractString(result, ['decision', 'behavior'], 'unknown'),
-    reason: extractString(result, ['reason', 'message'], ''),
+function createPermissionDecisionTracker(bufferSize = DECISION_BUFFER_SIZE): PermissionDecisionTracker {
+  const recentDecisions: PermissionDecision[] = [];
+  let decisionCounter = 0;
+
+  return {
+    trackDecision(toolName: string, input: Record<string, unknown>, result: Record<string, unknown>): void {
+      const entry: PermissionDecision = {
+        id: `d-${++decisionCounter}`,
+        timestamp: new Date().toISOString(),
+        tool_name: toolName,
+        command: toolName === 'Bash' && typeof input?.command === 'string' ? input.command : undefined,
+        decision: extractString(result, ['decision', 'behavior'], 'unknown'),
+        reason: extractString(result, ['reason', 'message'], ''),
+      };
+      recentDecisions.unshift(entry);
+      if (recentDecisions.length > bufferSize) {
+        recentDecisions.length = bufferSize;
+      }
+    },
+    getRecentDecisions(): PermissionDecision[] {
+      return recentDecisions;
+    },
   };
-  recentDecisions.unshift(entry);
-  if (recentDecisions.length > DECISION_BUFFER_SIZE) {
-    recentDecisions.length = DECISION_BUFFER_SIZE;
-  }
 }
 
 /** Helper to extract single result from MCP-AQL batch response */
@@ -93,6 +106,7 @@ function extractKnownPolicySessions(elements: Array<Record<string, unknown>>): K
  * Must be called with the MCP-AQL handler for policy evaluation.
  */
 export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler): void {
+  const decisionTracker = createPermissionDecisionTracker();
   /**
    * POST /api/evaluate_permission
    * Permission evaluation endpoint for PreToolUse hooks.
@@ -144,7 +158,7 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
       logger.debug(`[WebUI/Gateway] evaluate_permission: ${tool_name} → ${decision} (${elapsedMs}ms)`);
 
       // Track decision for live dashboard feed
-      trackDecision(tool_name, input || {}, opResult.data as Record<string, unknown>);
+      decisionTracker.trackDecision(tool_name, input || {}, opResult.data as Record<string, unknown>);
 
       res.json(opResult.data);
     } catch (err) {
@@ -200,7 +214,7 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
         elements,
         knownSessions: extractKnownPolicySessions(elements),
         permissionPromptActive: data.permissionPromptActive,
-        recentDecisions,
+        recentDecisions: decisionTracker.getRecentDecisions(),
       });
     } catch (err) {
       logger.error('[WebUI/Gateway] permissions/status error:', err);

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -230,27 +230,93 @@ describe('permissionRoutes', () => {
   });
 
   describe('decision tracking', () => {
-    it('should track decisions in recent decisions feed', async () => {
-      const handler = createMockHandler([{
-        success: true,
-        data: { decision: 'deny', reason: 'Blocked' },
-      }]);
+    it('should accumulate recent decisions newest-first within one app instance', async () => {
+      const handler = {
+        handleRead: jest
+          .fn()
+          .mockResolvedValueOnce([{ success: true, data: { decision: 'allow', reason: 'Safe read' } }])
+          .mockResolvedValueOnce([{ success: true, data: { decision: 'deny', reason: 'Blocked delete' } }])
+          .mockResolvedValueOnce([{
+            success: true,
+            data: {
+              activeElementCount: 0,
+              hasAllowlist: false,
+              combinedDenyPatterns: [],
+              combinedAllowPatterns: [],
+              combinedConfirmPatterns: [],
+              elements: [],
+              permissionPromptActive: false,
+            },
+          }]),
+      } as any;
       const app = createApp(handler);
 
-      // Make a permission evaluation
       await request(app)
+        .post('/api/evaluate_permission')
+        .send({ tool_name: 'Read', input: { file_path: './README.md' } });
+
+      await request(app)
+        .post('/api/evaluate_permission')
+        .send({ tool_name: 'Bash', input: { command: 'rm -rf /tmp/demo' } });
+
+      const res = await request(app).get('/api/permissions/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.recentDecisions).toHaveLength(2);
+      expect(res.body.recentDecisions.map((entry: any) => entry.tool_name)).toEqual(['Bash', 'Read']);
+      expect(res.body.recentDecisions.map((entry: any) => entry.decision)).toEqual(['deny', 'allow']);
+      expect(res.body.recentDecisions[0].command).toBe('rm -rf /tmp/demo');
+    });
+
+    it('should isolate recent decisions between separate router instances', async () => {
+      const firstHandler = {
+        handleRead: jest
+          .fn()
+          .mockResolvedValueOnce([{ success: true, data: { decision: 'deny', reason: 'Blocked' } }])
+          .mockResolvedValue([{
+            success: true,
+            data: {
+              activeElementCount: 0,
+              hasAllowlist: false,
+              combinedDenyPatterns: [],
+              combinedAllowPatterns: [],
+              combinedConfirmPatterns: [],
+              elements: [],
+              permissionPromptActive: false,
+            },
+          }]),
+      } as any;
+      const secondHandler = {
+        handleRead: jest.fn().mockResolvedValue([{
+          success: true,
+          data: {
+            activeElementCount: 0,
+            hasAllowlist: false,
+            combinedDenyPatterns: [],
+            combinedAllowPatterns: [],
+            combinedConfirmPatterns: [],
+            elements: [],
+            permissionPromptActive: false,
+          },
+        }]),
+      } as any;
+
+      const firstApp = createApp(firstHandler);
+      const secondApp = createApp(secondHandler);
+
+      await request(firstApp)
         .post('/api/evaluate_permission')
         .send({ tool_name: 'Bash', input: { command: 'rm -rf /' } });
 
-      // The decision tracking is module-scoped, so it persists across requests
-      const res = await request(app).get('/api/permissions/status');
+      const firstStatus = await request(firstApp).get('/api/permissions/status');
+      const secondStatus = await request(secondApp).get('/api/permissions/status');
 
-      // recentDecisions should have the tracked entry
-      if (res.status === 200 && res.body.recentDecisions) {
-        expect(res.body.recentDecisions.length).toBeGreaterThanOrEqual(1);
-        expect(res.body.recentDecisions[0].tool_name).toBe('Bash');
-        expect(res.body.recentDecisions[0].decision).toBe('deny');
-      }
+      expect(firstStatus.status).toBe(200);
+      expect(firstStatus.body.recentDecisions).toHaveLength(1);
+      expect(firstStatus.body.recentDecisions[0].tool_name).toBe('Bash');
+
+      expect(secondStatus.status).toBe(200);
+      expect(secondStatus.body.recentDecisions).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- move permission decision tracking off module-global state and onto the registered console router instance
- keep recent decision accumulation local to the active console instance serving both evaluate and status routes
- add regression coverage for newest-first accumulation and router-instance isolation

## Testing
- npx jest --config tests/jest.config.cjs --runInBand --modulePathIgnorePatterns=.worktrees --runTestsByPath tests/unit/web/permissionRoutes.test.ts
- npx tsc -p tsconfig.json --noEmit

## Notes
- this follows up on #1954
- live verification on a fresh local console showed repeated /api/evaluate_permission calls appearing in /api/permissions/status as d-1 through d-4, newest first