### PR TITLE
Fix numeric YAML version deserialization

### DIFF
--- a/src/elements/BaseElement.ts
+++ b/src/elements/BaseElement.ts
@@ -397,7 +397,7 @@ export abstract class BaseElement implements IElement {
       // Update properties
       this.id = parsed.id;
       this.type = parsed.type;
-      this.version = parsed.version || '1.0.0';
+      this.version = normalizeVersion(String(parsed.version ?? '1.0.0'));
       this.metadata = parsed.metadata;
       this.references = parsed.references || [];
       this.extensions = parsed.extensions || {};

--- a/src/elements/memories/Memory.ts
+++ b/src/elements/memories/Memory.ts
@@ -13,7 +13,7 @@
  * 6. Audit logging for all operations
  */
 
-import { BaseElement } from '../BaseElement.js';
+import { BaseElement, normalizeVersion } from '../BaseElement.js';
 import { IElement, ElementValidationResult, ValidationError } from '../../types/elements/index.js';
 import { ElementType } from '../../portfolio/types.js';
 import { IElementMetadata } from '../../types/elements/IElement.js';
@@ -938,7 +938,7 @@ export class Memory extends BaseElement implements IElement {
 
       // Update properties
       this.id = parsed.id;
-      this.version = parsed.version || '1.0.0';
+      this.version = normalizeVersion(String(parsed.version ?? '1.0.0'));
       this.metadata = parsed.metadata || {};
       this.extensions = parsed.extensions || {};
 

--- a/src/elements/skills/Skill.ts
+++ b/src/elements/skills/Skill.ts
@@ -10,7 +10,7 @@
  * 5. MEDIUM: Added XSS protection through input sanitization
  */
 
-import { BaseElement } from '../BaseElement.js';
+import { BaseElement, normalizeVersion } from '../BaseElement.js';
 import { IElement, IElementMetadata, ElementValidationResult } from '../../types/elements/index.js';
 import { ElementType } from '../../portfolio/types.js';
 import { logger } from '../../utils/logger.js';
@@ -450,7 +450,7 @@ export class Skill extends BaseElement implements IElement {
       
       // Update ID and version if provided
       if (parsed.id) this.id = parsed.id;
-      if (parsed.version) this.version = parsed.version;
+      if (parsed.version != null) this.version = normalizeVersion(String(parsed.version));
       
       // Restore parameters
       if (parsed.parameters) {

--- a/src/elements/templates/Template.ts
+++ b/src/elements/templates/Template.ts
@@ -11,7 +11,7 @@
  * 6. MEDIUM: Unicode normalization to prevent homograph attacks
  */
 
-import { BaseElement } from '../BaseElement.js';
+import { BaseElement, normalizeVersion } from '../BaseElement.js';
 import { IElement, IElementMetadata, ElementValidationResult } from '../../types/elements/index.js';
 import { ElementType } from '../../portfolio/types.js';
 import { logger } from '../../utils/logger.js';
@@ -957,7 +957,7 @@ export class Template extends BaseElement implements IElement {
       
       // Update ID and version if provided
       if (parsed.id) this.id = parsed.id;
-      if (parsed.version) this.version = parsed.version;
+      if (parsed.version != null) this.version = normalizeVersion(String(parsed.version));
       
       // Clear compiled template and section caches (content changed)
       this.compiledTemplate = undefined;

--- a/tests/unit/elements/BaseElement.test.ts
+++ b/tests/unit/elements/BaseElement.test.ts
@@ -5,10 +5,10 @@
 import { BaseElement, normalizeVersion } from '../../../src/elements/BaseElement.js';
 import { ElementType } from '../../../src/portfolio/types.js';
 import { ElementStatus } from '../../../src/types/elements/index.js';
-import { createTestMetadataService } from '../../helpers/di-mocks.js';
+import { MetadataService } from '../../../src/services/MetadataService.js';
 
 // Create a shared MetadataService instance for all tests
-const metadataService = createTestMetadataService();
+const metadataService = new MetadataService();
 
 // Create a concrete implementation for testing
 class TestElement extends BaseElement {
@@ -261,6 +261,28 @@ describe('BaseElement', () => {
       expect(element.id).toBe(original.id);
       expect(element.metadata.name).toBe('Original');
       expect(element.metadata.description).toBe('Original description');
+    });
+
+    it('should coerce numeric versions during deserialization', () => {
+      const original = new TestElement({
+        name: 'Original',
+        description: 'Original description'
+      });
+
+      const json = JSON.stringify({
+        id: original.id,
+        type: original.type,
+        version: 1.1,
+        metadata: original.metadata,
+        references: original.references,
+        extensions: original.extensions,
+        ratings: original.ratings
+      });
+
+      const element = new TestElement();
+      element.deserialize(json);
+
+      expect(element.version).toBe('1.1.0');
     });
     
     it('should throw on invalid JSON', () => {


### PR DESCRIPTION
## Summary
- coerce and normalize numeric `parsed.version` values during element deserialization
- cover the shared `BaseElement` path plus the Memory, Skill, and Template overrides that had the same unsafe assignment pattern
- add a regression test proving `version: 1.1` style values deserialize safely as `1.1.0`

## Root cause
Two-component YAML versions like `1.1` parse as numbers instead of strings. Several deserialize paths assigned `parsed.version` directly, which let numeric versions bypass normalization and reach later string-only logic as numbers.

## Testing
- `npx jest --config tests/jest.config.cjs --runInBand --modulePathIgnorePatterns=.worktrees --runTestsByPath tests/unit/elements/BaseElement.test.ts`
- `npx tsc -p tsconfig.json --noEmit`

## Notes
- fixes #1942
- the regression test now instantiates `MetadataService` directly so the focused BaseElement suite can run without unrelated DI helper dependencies