### PR TITLE
release: 2.0.14

### DIFF
--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -702,8 +702,22 @@ jobs:
         if: always()
         run: |
           echo "🧹 Cleaning up Docker Compose..."
-          docker compose --project-name "$COMPOSE_PROJECT_NAME" --file docker/docker-compose.yml down
-          docker compose --project-name "$COMPOSE_PROJECT_NAME" --file docker/docker-compose.yml rm -f
+          cleanup_ok=false
+          for attempt in 1 2 3; do
+            if docker compose --project-name "$COMPOSE_PROJECT_NAME" --file docker/docker-compose.yml down --remove-orphans; then
+              cleanup_ok=true
+              break
+            fi
+            echo "::warning::Docker Compose cleanup attempt $attempt failed; waiting for endpoints to detach"
+            docker compose --project-name "$COMPOSE_PROJECT_NAME" --file docker/docker-compose.yml ps || true
+            sleep 2
+          done
+
+          if [ "$cleanup_ok" != "true" ]; then
+            echo "::warning::Docker Compose network cleanup remained busy after retries; continuing because test execution already completed"
+          fi
+
+          docker compose --project-name "$COMPOSE_PROJECT_NAME" --file docker/docker-compose.yml rm -f || true
 
       - name: Docker Compose testing complete
         shell: bash

--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -700,6 +700,7 @@ jobs:
 
       - name: Cleanup Docker Compose
         if: always()
+        shell: bash
         run: |
           echo "🧹 Cleaning up Docker Compose..."
           cleanup_ok=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.0.14] - 2026-04-14
+
+### Fixes
+
+- Permissions console reporting, audit feed routing, and session UX hardening
+- Permissions tab dark mode rendering fixes
+- Numeric YAML version deserialization fix for two-component versions like `1.1`
+
 ## [2.0.13] - 2026-04-13
 
 ### Security Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "transport": {
         "type": "stdio"
       }

--- a/src/di/Container.ts
+++ b/src/di/Container.ts
@@ -99,6 +99,7 @@ import { TriggerMetricsTracker } from "../portfolio/enhanced-index/TriggerMetric
 import { SemanticRelationshipService } from "../portfolio/enhanced-index/SemanticRelationshipService.js";
 import { ElementEventDispatcher } from '../events/ElementEventDispatcher.js';
 import { TokenManager } from "../security/tokenManager.js";
+import type { UnifiedConsoleResult } from "../web/console/UnifiedConsole.js";
 import {
   PaginationService,
   FilterService,
@@ -901,8 +902,8 @@ export class DollhouseContainer {
       await sweepStalePortFiles();
     } catch { /* sweep failure is non-fatal */ }
 
-    await this.deferredWebConsole(timer);
-    await this.deferredPermissionServer(timer);
+    const consoleResult = await this.deferredWebConsole(timer);
+    await this.deferredPermissionServer(consoleResult, timer);
   }
 
   private async deferredMemoryAutoload(timer?: StartupTimer): Promise<void> {
@@ -1006,10 +1007,10 @@ export class DollhouseContainer {
     }
   }
 
-  private async deferredWebConsole(timer?: StartupTimer): Promise<void> {
+  private async deferredWebConsole(timer?: StartupTimer): Promise<UnifiedConsoleResult | null> {
     timer?.startPhase('web_console', false);
     try {
-      if (!env.DOLLHOUSE_WEB_CONSOLE) return;
+      if (!env.DOLLHOUSE_WEB_CONSOLE) return null;
 
       const activationStore = this.resolve<ActivationStore>('ActivationStore');
       const sessionId = activationStore.getSessionId();
@@ -1036,13 +1037,16 @@ export class DollhouseContainer {
       });
 
       logger.info(`[Container] Web console started as ${result.role}`);
+      return result;
     } catch (error) {
       logger.warn('[Container] Web console startup failed:', error);
+      return null;
+    } finally {
+      timer?.endPhase('web_console');
     }
-    timer?.endPhase('web_console');
   }
 
-  private async deferredPermissionServer(timer?: StartupTimer): Promise<void> {
+  private async deferredPermissionServer(consoleResult: UnifiedConsoleResult | null, timer?: StartupTimer): Promise<void> {
     timer?.startPhase('permission_server', false);
     try {
       if (!env.DOLLHOUSE_PERMISSION_SERVER) {
@@ -1056,9 +1060,17 @@ export class DollhouseContainer {
       }
 
       // Permission routes are already mounted on the unified web console.
-      // We just need to write the port file so the PreToolUse hook script
-      // can discover it. No separate server — use the existing console port.
-      const port = env.DOLLHOUSE_WEB_CONSOLE_PORT;
+      // We just need to write the active leader port so the PreToolUse hook
+      // script reaches the same console instance that owns the live audit feed.
+      const port = consoleResult?.role === 'leader'
+        ? consoleResult.port
+        : consoleResult?.election.leaderInfo.port;
+
+      if (!port) {
+        logger.debug('[Container] Permission server skipped — no active web console port available');
+        return;
+      }
+
       const startMs = Date.now();
 
       const { writePortFile, registerPortCleanup } = await import('../auto-dollhouse/portDiscovery.js');

--- a/src/elements/BaseElement.ts
+++ b/src/elements/BaseElement.ts
@@ -397,7 +397,7 @@ export abstract class BaseElement implements IElement {
       // Update properties
       this.id = parsed.id;
       this.type = parsed.type;
-      this.version = parsed.version || '1.0.0';
+      this.version = normalizeVersion(String(parsed.version ?? '1.0.0'));
       this.metadata = parsed.metadata;
       this.references = parsed.references || [];
       this.extensions = parsed.extensions || {};

--- a/src/elements/memories/Memory.ts
+++ b/src/elements/memories/Memory.ts
@@ -13,7 +13,7 @@
  * 6. Audit logging for all operations
  */
 
-import { BaseElement } from '../BaseElement.js';
+import { BaseElement, normalizeVersion } from '../BaseElement.js';
 import { IElement, ElementValidationResult, ValidationError } from '../../types/elements/index.js';
 import { ElementType } from '../../portfolio/types.js';
 import { IElementMetadata } from '../../types/elements/IElement.js';
@@ -938,7 +938,7 @@ export class Memory extends BaseElement implements IElement {
 
       // Update properties
       this.id = parsed.id;
-      this.version = parsed.version || '1.0.0';
+      this.version = normalizeVersion(String(parsed.version ?? '1.0.0'));
       this.metadata = parsed.metadata || {};
       this.extensions = parsed.extensions || {};
 

--- a/src/elements/skills/Skill.ts
+++ b/src/elements/skills/Skill.ts
@@ -10,7 +10,7 @@
  * 5. MEDIUM: Added XSS protection through input sanitization
  */
 
-import { BaseElement } from '../BaseElement.js';
+import { BaseElement, normalizeVersion } from '../BaseElement.js';
 import { IElement, IElementMetadata, ElementValidationResult } from '../../types/elements/index.js';
 import { ElementType } from '../../portfolio/types.js';
 import { logger } from '../../utils/logger.js';
@@ -450,7 +450,7 @@ export class Skill extends BaseElement implements IElement {
       
       // Update ID and version if provided
       if (parsed.id) this.id = parsed.id;
-      if (parsed.version) this.version = parsed.version;
+      if (parsed.version != null) this.version = normalizeVersion(String(parsed.version));
       
       // Restore parameters
       if (parsed.parameters) {

--- a/src/elements/templates/Template.ts
+++ b/src/elements/templates/Template.ts
@@ -11,7 +11,7 @@
  * 6. MEDIUM: Unicode normalization to prevent homograph attacks
  */
 
-import { BaseElement } from '../BaseElement.js';
+import { BaseElement, normalizeVersion } from '../BaseElement.js';
 import { IElement, IElementMetadata, ElementValidationResult } from '../../types/elements/index.js';
 import { ElementType } from '../../portfolio/types.js';
 import { logger } from '../../utils/logger.js';
@@ -957,7 +957,7 @@ export class Template extends BaseElement implements IElement {
       
       // Update ID and version if provided
       if (parsed.id) this.id = parsed.id;
-      if (parsed.version) this.version = parsed.version;
+      if (parsed.version != null) this.version = normalizeVersion(String(parsed.version));
       
       // Clear compiled template and section caches (content changed)
       this.compiledTemplate = undefined;

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.13';
-export const BUILD_TIMESTAMP = '2026-04-13T16:14:45.248Z';
+export const PACKAGE_VERSION = '2.0.14';
+export const BUILD_TIMESTAMP = '2026-04-14T03:07:36.405Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -546,7 +546,9 @@ export class ElementCRUDHandler {
       type: entry.type,
       name: entry.name,
       metadata: entry.metadata,
-      ...(entry.sessionIds.size > 0 ? { sessionIds: Array.from(entry.sessionIds).sort() } : {}),
+      ...(entry.sessionIds.size > 0
+        ? { sessionIds: Array.from(entry.sessionIds).sort((a, b) => a.localeCompare(b)) }
+        : {}),
     }));
   }
 

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -51,7 +51,7 @@ import {
 } from './strategies/index.js';
 import { ElementQueryService } from '../services/query/ElementQueryService.js';
 import { ValidationRegistry } from '../services/validation/ValidationRegistry.js';
-import type { ActivationStore } from '../services/ActivationStore.js';
+import type { ActivationStore, PersistedActivation, PersistedActivationStateSnapshot } from '../services/ActivationStore.js';
 import type { BackupService } from '../services/BackupService.js';
 import type { PolicyExportService } from '../services/PolicyExportService.js';
 import type { BaseElementManager } from '../elements/base/BaseElementManager.js';
@@ -138,6 +138,34 @@ export class ElementCRUDHandler {
    */
   private sanitizeMetadata(metadata: Record<string, any>): Record<string, any> {
     return sanitizeMetadataRecord(metadata);
+  }
+
+  private normalizeLookupValue(value: unknown): string {
+    return typeof value === 'string'
+      ? value.normalize('NFC').trim()
+      : '';
+  }
+
+  private hasGatekeeperPolicy(metadata: Record<string, unknown> | undefined): boolean {
+    return Boolean(metadata?.['gatekeeper']);
+  }
+
+  private toPolicyElementType(type: string): string {
+    const normalizedType = this.normalizeLookupValue(type).toLowerCase();
+    switch (normalizedType) {
+      case 'personas':
+        return 'persona';
+      case 'skills':
+        return 'skill';
+      case 'agents':
+        return 'agent';
+      case 'memories':
+        return 'memory';
+      case 'ensembles':
+        return 'ensemble';
+      default:
+        return normalizedType;
+    }
   }
 
   /**
@@ -365,6 +393,22 @@ export class ElementCRUDHandler {
     }
 
     try {
+      // Active agents (async)
+      const agents = await this.agentManager.getActiveAgents();
+      for (const agent of agents) {
+        const key = `agent:${agent.metadata.name}`;
+        seen.add(key);
+        result.push({
+          type: 'agent',
+          name: agent.metadata.name,
+          metadata: agent.metadata as unknown as Record<string, unknown>,
+        });
+      }
+    } catch (error) {
+      logger.warn('Failed to gather active agents for policy evaluation', { error });
+    }
+
+    try {
       // Active ensembles (async)
       const ensembles = await this.ensembleManager.getActiveEnsembles();
       for (const e of ensembles) {
@@ -407,6 +451,128 @@ export class ElementCRUDHandler {
     }
 
     return result;
+  }
+
+  async getPolicyElementsForReport(sessionId?: string): Promise<Array<{
+    type: string;
+    name: string;
+    metadata: Record<string, unknown>;
+    sessionIds?: string[];
+  }>> {
+    const merged = new Map<string, {
+      type: string;
+      name: string;
+      metadata: Record<string, unknown>;
+      sessionIds: Set<string>;
+    }>();
+
+    const addElement = (
+      element: { type: string; name: string; metadata: Record<string, unknown> },
+      sessionIds: string[] = [],
+    ): void => {
+      if (!this.hasGatekeeperPolicy(element.metadata)) {
+        return;
+      }
+
+      const key = `${element.type}:${element.name}`;
+      const existing = merged.get(key);
+      if (existing) {
+        sessionIds.forEach(id => existing.sessionIds.add(id));
+        return;
+      }
+
+      merged.set(key, {
+        type: element.type,
+        name: element.name,
+        metadata: element.metadata,
+        sessionIds: new Set(sessionIds),
+      });
+    };
+
+    for (const activeElement of await this.getActiveElementsForPolicy()) {
+      addElement(activeElement, this.activationStore ? [this.activationStore.getSessionId()] : []);
+    }
+
+    if (this.activationStore?.isEnabled()) {
+      const persistedStates = await this.activationStore.listPersistedActivationStates(sessionId);
+      const catalogs = new Map<string, Array<{ metadata?: Record<string, unknown>; filename?: string }>>();
+
+      const getCatalog = async (type: string) => {
+        const normalizedType = this.normalizeElementType(type);
+        if (!catalogs.has(normalizedType)) {
+          catalogs.set(
+            normalizedType,
+            (await this.getElements(normalizedType)) as Array<{ metadata?: Record<string, unknown>; filename?: string }>,
+          );
+        }
+        return catalogs.get(normalizedType) ?? [];
+      };
+
+      const findPersistedElement = async (
+        type: string,
+        activation: PersistedActivation,
+      ): Promise<{ type: string; name: string; metadata: Record<string, unknown> } | null> => {
+        const catalog = await getCatalog(type);
+        const normalizedName = this.normalizeLookupValue(activation.name);
+        const normalizedFilename = this.normalizeLookupValue(activation.filename);
+
+        const found = catalog.find((element) => {
+          const metadata = element.metadata ?? {};
+          const elementName = this.normalizeLookupValue(metadata['name']);
+          const elementFilename = this.normalizeLookupValue(
+            element.filename ?? metadata['filename'] ?? metadata['sourceFile'],
+          );
+
+          return elementName === normalizedName || (normalizedFilename !== '' && elementFilename === normalizedFilename);
+        });
+
+        if (!found?.metadata || !this.hasGatekeeperPolicy(found.metadata)) {
+          return null;
+        }
+
+        return {
+          type: this.toPolicyElementType(type),
+          name: (found.metadata['name'] as string) ?? activation.name,
+          metadata: found.metadata,
+        };
+      };
+
+      for (const state of persistedStates) {
+        await this.mergePersistedPolicyState(state, addElement, findPersistedElement);
+      }
+    }
+
+    return Array.from(merged.values()).map((entry) => ({
+      type: entry.type,
+      name: entry.name,
+      metadata: entry.metadata,
+      ...(entry.sessionIds.size > 0 ? { sessionIds: Array.from(entry.sessionIds).sort() } : {}),
+    }));
+  }
+
+  private async mergePersistedPolicyState(
+    state: PersistedActivationStateSnapshot,
+    addElement: (element: { type: string; name: string; metadata: Record<string, unknown> }, sessionIds?: string[]) => void,
+    findPersistedElement: (type: string, activation: PersistedActivation) => Promise<{ type: string; name: string; metadata: Record<string, unknown> } | null>,
+  ): Promise<void> {
+    const pending: Promise<void>[] = [];
+
+    for (const [type, activations] of Object.entries(state.activations)) {
+      for (const activation of activations ?? []) {
+        pending.push((async () => {
+          const found = await findPersistedElement(type, activation);
+          if (found) {
+            addElement(found, [state.sessionId]);
+          }
+        })());
+      }
+    }
+
+    if (pending.length === 0) {
+      return;
+    }
+
+    await Promise.allSettled(pending);
   }
 
   async deactivateElement(name: string, type: string) {

--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -688,6 +688,27 @@ export class MCPAQLHandler {
     }
   }
 
+  private async getPolicyReportElements(sessionId?: string): Promise<ActiveElement[]> {
+    try {
+      const rawElements = await this.handlers.elementCRUD.getPolicyElementsForReport(sessionId);
+      return rawElements.map((el) => ({
+        type: el.type,
+        name: el.name,
+        metadata: {
+          name: el.name,
+          description: (el.metadata.description as string) ?? undefined,
+          gatekeeper: el.metadata?.gatekeeper as ActiveElement['metadata']['gatekeeper'] ?? undefined,
+          ...(Array.isArray((el as { sessionIds?: string[] }).sessionIds)
+            ? { sessionIds: (el as { sessionIds?: string[] }).sessionIds }
+            : {}),
+        },
+      }));
+    } catch (error) {
+      logger.warn('Failed to gather policy elements for dashboard reporting', { error, sessionId });
+      return this.getActiveElements();
+    }
+  }
+
   /**
    * Handle CREATE operations (additive, non-destructive)
    *
@@ -2932,21 +2953,28 @@ export class MCPAQLHandler {
         // Issue #625 Phase 2: Get effective CLI permission policies
         const toolName = params.tool_name as string | undefined;
         const toolInput = (params.tool_input as Record<string, unknown>) ?? {};
+        const reportSessionId = typeof params.session_id === 'string' ? params.session_id : undefined;
+        const reportingScope = params.reporting_scope === 'dashboard';
 
         // 1. Get all active elements
-        const policyElements = await this.getActiveElements();
+        const policyElements = reportingScope && !toolName
+          ? await this.getPolicyReportElements(reportSessionId)
+          : await this.getActiveElements();
 
         // 2. Extract externalRestrictions from each element
         const elementPolicies = policyElements.map(el => ({
           type: el.type,
           name: el.name,
           allowPatterns: el.metadata?.gatekeeper?.externalRestrictions?.allowPatterns ?? [],
+          confirmPatterns: el.metadata?.gatekeeper?.externalRestrictions?.confirmPatterns ?? [],
           denyPatterns: el.metadata?.gatekeeper?.externalRestrictions?.denyPatterns ?? [],
           description: el.metadata?.gatekeeper?.externalRestrictions?.description ?? null,
+          sessionIds: (el.metadata as Record<string, unknown>)?.sessionIds ?? undefined,
         }));
 
         // 3. Build combined view
         const combinedAllow = elementPolicies.flatMap(p => p.allowPatterns);
+        const combinedConfirm = elementPolicies.flatMap(p => p.confirmPatterns);
         const combinedDeny = elementPolicies.flatMap(p => p.denyPatterns);
         const hasAllowlist = combinedAllow.length > 0;
 
@@ -2989,6 +3017,7 @@ export class MCPAQLHandler {
           hasAllowlist,
           elements: elementPolicies,
           combinedAllowPatterns: combinedAllow,
+          combinedConfirmPatterns: combinedConfirm,
           combinedDenyPatterns: combinedDeny,
           evaluation,
           permissionPromptActive,

--- a/src/services/ActivationStore.ts
+++ b/src/services/ActivationStore.ts
@@ -331,64 +331,14 @@ export class ActivationStore {
       ? normalizeActivationIdentifier(sessionId)
       : undefined;
 
-    const states: PersistedActivationStateSnapshot[] = [];
-
     try {
-      const filenames = normalizedSessionId
-        ? [`activations-${normalizedSessionId}.json`]
-        : (await fs.readdir(this.stateDir)).filter(name => /^activations-[^.]+\.json$/u.test(name));
-
-      for (const filename of filenames) {
-        const filePath = path.join(this.stateDir, filename);
-        try {
-          const content = await this.fileOps.readFile(filePath);
-          const data = JSON.parse(content) as PersistedActivationState;
-          if (data.version !== 1 || typeof data.sessionId !== 'string' || !data.activations || typeof data.activations !== 'object') {
-            continue;
-          }
-
-          const activations: Record<string, PersistedActivation[]> = {};
-          for (const [type, entries] of Object.entries(data.activations)) {
-            if (!ACTIVATABLE_TYPES.has(type) || !Array.isArray(entries)) {
-              continue;
-            }
-
-            const normalizedEntries = entries.flatMap((entry) => {
-              if (!entry || typeof entry.name !== 'string') return [];
-
-              const normalizedName = normalizeActivationIdentifier(entry.name);
-              if (!normalizedName) return [];
-
-              const normalizedFilename = typeof entry.filename === 'string'
-                ? normalizeActivationIdentifier(entry.filename)
-                : undefined;
-
-              return [{
-                ...entry,
-                name: normalizedName,
-                ...(normalizedFilename ? { filename: normalizedFilename } : {}),
-              }];
-            });
-
-            if (normalizedEntries.length > 0) {
-              activations[type] = normalizedEntries;
-            }
-          }
-
-          states.push({
-            sessionId: data.sessionId,
-            lastUpdated: data.lastUpdated,
-            activations,
-          });
-        } catch (error) {
-          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-            logger.debug('[ActivationStore] Skipping unreadable activation snapshot during reporting', {
-              filePath,
-              error: error instanceof Error ? error.message : String(error),
-            });
-          }
-        }
-      }
+      const filenames = await this.getPersistedActivationFilenames(normalizedSessionId);
+      const states = await Promise.all(
+        filenames.map(filename => this.readPersistedActivationState(filename)),
+      );
+      return states
+        .flatMap((state) => (state ? [state] : []))
+        .sort((a, b) => a.sessionId.localeCompare(b.sessionId));
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
         logger.debug('[ActivationStore] Failed to enumerate activation snapshots for reporting', {
@@ -398,7 +348,93 @@ export class ActivationStore {
       }
     }
 
-    return states.sort((a, b) => a.sessionId.localeCompare(b.sessionId));
+    return [];
+  }
+
+  private async getPersistedActivationFilenames(sessionId?: string): Promise<string[]> {
+    if (sessionId) {
+      return [`activations-${sessionId}.json`];
+    }
+
+    const filenames = await fs.readdir(this.stateDir);
+    return filenames.filter(name => /^activations-[^.]+\.json$/u.test(name));
+  }
+
+  private async readPersistedActivationState(filename: string): Promise<PersistedActivationStateSnapshot | null> {
+    const filePath = path.join(this.stateDir, filename);
+
+    try {
+      const content = await this.fileOps.readFile(filePath);
+      const data = JSON.parse(content) as PersistedActivationState;
+      if (!this.isPersistedActivationState(data)) {
+        return null;
+      }
+
+      return {
+        sessionId: data.sessionId,
+        lastUpdated: data.lastUpdated,
+        activations: this.normalizePersistedActivations(data.activations),
+      };
+    } catch (error) {
+      this.logSnapshotReadError(filePath, error);
+      return null;
+    }
+  }
+
+  private isPersistedActivationState(data: PersistedActivationState): boolean {
+    return data.version === 1
+      && typeof data.sessionId === 'string'
+      && Boolean(data.activations)
+      && typeof data.activations === 'object';
+  }
+
+  private normalizePersistedActivations(activations: PersistedActivationState['activations']): Record<string, PersistedActivation[]> {
+    const normalized: Record<string, PersistedActivation[]> = {};
+
+    for (const [type, entries] of Object.entries(activations)) {
+      if (!ACTIVATABLE_TYPES.has(type) || !Array.isArray(entries)) {
+        continue;
+      }
+
+      const normalizedEntries = entries.flatMap((entry) => this.normalizePersistedActivation(entry));
+      if (normalizedEntries.length > 0) {
+        normalized[type] = normalizedEntries;
+      }
+    }
+
+    return normalized;
+  }
+
+  private normalizePersistedActivation(entry: PersistedActivation | null | undefined): PersistedActivation[] {
+    if (!entry || typeof entry.name !== 'string') {
+      return [];
+    }
+
+    const normalizedName = normalizeActivationIdentifier(entry.name);
+    if (!normalizedName) {
+      return [];
+    }
+
+    const normalizedFilename = typeof entry.filename === 'string'
+      ? normalizeActivationIdentifier(entry.filename)
+      : undefined;
+
+    return [{
+      ...entry,
+      name: normalizedName,
+      ...(normalizedFilename ? { filename: normalizedFilename } : {}),
+    }];
+  }
+
+  private logSnapshotReadError(filePath: string, error: unknown): void {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return;
+    }
+
+    logger.debug('[ActivationStore] Skipping unreadable activation snapshot during reporting', {
+      filePath,
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 
   /**

--- a/src/services/ActivationStore.ts
+++ b/src/services/ActivationStore.ts
@@ -49,6 +49,12 @@ interface PersistedActivationState {
   activations: Record<string, PersistedActivation[]>;
 }
 
+export interface PersistedActivationStateSnapshot {
+  sessionId: string;
+  lastUpdated: string;
+  activations: Record<string, PersistedActivation[]>;
+}
+
 /** Valid element types that support activation (stored in singular form) */
 const ACTIVATABLE_TYPES = new Set(['persona', 'skill', 'agent', 'memory', 'ensemble']);
 
@@ -306,6 +312,93 @@ export class ActivationStore {
   getActivations(elementType: string): PersistedActivation[] {
     const type = normalizeType(elementType);
     return this.state.activations[type] ? [...this.state.activations[type]!] : [];
+  }
+
+  /**
+   * Read persisted activation snapshots from disk for reporting/diagnostics.
+   *
+   * This intentionally does not mutate the store's in-memory state, and it is
+   * safe to call from the web console to inspect other sessions' persisted
+   * activations without changing live policy enforcement for the current
+   * process.
+   */
+  async listPersistedActivationStates(sessionId?: string): Promise<PersistedActivationStateSnapshot[]> {
+    if (!this.enabled) {
+      return [];
+    }
+
+    const normalizedSessionId = typeof sessionId === 'string' && sessionId.trim()
+      ? normalizeActivationIdentifier(sessionId)
+      : undefined;
+
+    const states: PersistedActivationStateSnapshot[] = [];
+
+    try {
+      const filenames = normalizedSessionId
+        ? [`activations-${normalizedSessionId}.json`]
+        : (await fs.readdir(this.stateDir)).filter(name => /^activations-[^.]+\.json$/u.test(name));
+
+      for (const filename of filenames) {
+        const filePath = path.join(this.stateDir, filename);
+        try {
+          const content = await this.fileOps.readFile(filePath);
+          const data = JSON.parse(content) as PersistedActivationState;
+          if (data.version !== 1 || typeof data.sessionId !== 'string' || !data.activations || typeof data.activations !== 'object') {
+            continue;
+          }
+
+          const activations: Record<string, PersistedActivation[]> = {};
+          for (const [type, entries] of Object.entries(data.activations)) {
+            if (!ACTIVATABLE_TYPES.has(type) || !Array.isArray(entries)) {
+              continue;
+            }
+
+            const normalizedEntries = entries.flatMap((entry) => {
+              if (!entry || typeof entry.name !== 'string') return [];
+
+              const normalizedName = normalizeActivationIdentifier(entry.name);
+              if (!normalizedName) return [];
+
+              const normalizedFilename = typeof entry.filename === 'string'
+                ? normalizeActivationIdentifier(entry.filename)
+                : undefined;
+
+              return [{
+                ...entry,
+                name: normalizedName,
+                ...(normalizedFilename ? { filename: normalizedFilename } : {}),
+              }];
+            });
+
+            if (normalizedEntries.length > 0) {
+              activations[type] = normalizedEntries;
+            }
+          }
+
+          states.push({
+            sessionId: data.sessionId,
+            lastUpdated: data.lastUpdated,
+            activations,
+          });
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+            logger.debug('[ActivationStore] Skipping unreadable activation snapshot during reporting', {
+              filePath,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        }
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        logger.debug('[ActivationStore] Failed to enumerate activation snapshots for reporting', {
+          stateDir: this.stateDir,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return states.sort((a, b) => a.sessionId.localeCompare(b.sessionId));
   }
 
   /**

--- a/src/web/console/IngestRoutes.ts
+++ b/src/web/console/IngestRoutes.ts
@@ -103,6 +103,7 @@ export interface SessionEventPayload {
 export interface IngestBroadcasts {
   logBroadcast: (entry: UnifiedLogEntry) => void;
   metricsOnSnapshot?: (snapshot: MetricSnapshot) => void;
+  storeMetricsSnapshot?: (snapshot: MetricSnapshot, sessionId: string) => void;
   sessionBroadcast?: (event: SessionInfo) => void;
 }
 
@@ -283,6 +284,9 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
 
     if (broadcasts.metricsOnSnapshot) {
       broadcasts.metricsOnSnapshot(payload.snapshot);
+    }
+    if (broadcasts.storeMetricsSnapshot) {
+      broadcasts.storeMetricsSnapshot(payload.snapshot, payload.sessionId);
     }
 
     // Update heartbeat, revive ended sessions, or auto-register orphans (#1870)

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -201,6 +201,7 @@ async function startAsLeader(
   const ingestResult = createIngestRoutes({
     logBroadcast: (entry) => liveBroadcast?.(entry),
     metricsOnSnapshot: (snapshot) => liveMetricsOnSnapshot?.(snapshot),
+    storeMetricsSnapshot: (snapshot) => options.metricsSink?.onSnapshot(snapshot),
   });
 
   // Register the leader as a session
@@ -322,4 +323,3 @@ async function startAsFollower(
     },
   };
 }
-

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -120,6 +120,76 @@
   padding: 1rem;
 }
 
+.perm-selected-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.perm-selected-title {
+  font-family: var(--font-heading, 'Plus Jakarta Sans', sans-serif);
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--ink-900, #0f172a);
+}
+
+.perm-selected-subtitle {
+  margin-top: 0.35rem;
+  color: var(--ink-500, #64748b);
+  font-size: 0.8125rem;
+  max-width: 58rem;
+}
+
+.perm-selected-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: #fff7ed;
+  color: #9a3412;
+  border: 1px solid #fed7aa;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.perm-selected-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.perm-selected-panel {
+  border: 1px solid var(--ink-100, #e2e8f0);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: var(--paper-base, #f8fafc);
+}
+
+.perm-selected-panel-title {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--ink-100, #e2e8f0);
+  font-family: var(--font-heading, 'Plus Jakarta Sans', sans-serif);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: var(--ink-700, #334155);
+}
+
+.perm-source-item--selected {
+  background: color-mix(in srgb, var(--signal-2, #3b82f6) 10%, transparent);
+  border-left: 3px solid var(--signal-2, #3b82f6);
+  padding-left: calc(0.75rem - 3px);
+}
+
+.perm-source-item--detail {
+  background: transparent;
+}
+
 /* ── Stat Grid ─────────────────────────────────────────────── */
 
 .perm-stat-grid {
@@ -259,6 +329,12 @@
 .perm-feed-decision--allow { color: #22c55e; }
 .perm-feed-decision--deny { color: #ef4444; }
 .perm-feed-decision--ask { color: #f97316; }
+
+@media (max-width: 900px) {
+  .perm-selected-grid {
+    grid-template-columns: 1fr;
+  }
+}
 
 .perm-feed-tool {
   color: var(--ink-700, #334155);

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -341,8 +341,8 @@
 }
 
 .perm-card--audit .perm-feed {
-  height: var(--perm-audit-feed-height, 34rem);
-  max-height: var(--perm-audit-feed-height, 34rem);
+  height: clamp(16rem, 36vh, 24rem);
+  max-height: clamp(16rem, 36vh, 24rem);
 }
 
 .perm-card--audit .perm-selected-header--compact {

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -341,7 +341,8 @@
 }
 
 .perm-card--audit .perm-feed {
-  max-height: 34rem;
+  height: var(--perm-audit-feed-height, 34rem);
+  max-height: var(--perm-audit-feed-height, 34rem);
 }
 
 .perm-feed-empty {

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -345,6 +345,14 @@
   max-height: var(--perm-audit-feed-height, 34rem);
 }
 
+.perm-card--audit .perm-selected-header--compact {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--paper-strong, #fff);
+  padding-bottom: 0.5rem;
+}
+
 .perm-feed-empty {
   padding: 2rem;
   text-align: center;

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -63,14 +63,16 @@
 }
 
 #tab-permissions {
-  padding-inline: clamp(0.25rem, 0.5vw, 0.5rem);
+  padding-inline: clamp(0.5rem, 1vw, 1rem);
+  padding-bottom: calc(var(--site-footer-height, 4.5rem) + 1.5rem);
 }
 
 @media (max-width: 900px) {
   .perm-dashboard { grid-template-columns: 1fr; }
 
   #tab-permissions {
-    padding-inline: 0;
+    padding-inline: 0.375rem;
+    padding-bottom: calc(var(--site-footer-height, 4.5rem) + 1.25rem);
   }
 }
 
@@ -330,8 +332,9 @@
 /* ── Live Feed ─────────────────────────────────────────────── */
 
 .perm-feed {
-  max-height: 20rem;
-  min-height: 8rem;
+  height: 15rem;
+  max-height: 15rem;
+  min-height: 15rem;
   overflow-y: scroll;
   overflow-x: auto;
   overscroll-behavior: contain;
@@ -340,17 +343,10 @@
   font-size: 0.8125rem;
 }
 
-.perm-card--audit .perm-feed {
-  height: clamp(16rem, 36vh, 24rem);
-  max-height: clamp(16rem, 36vh, 24rem);
-}
-
-.perm-card--audit .perm-selected-header--compact {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  background: var(--paper-strong, #fff);
-  padding-bottom: 0.5rem;
+.perm-feed--modal {
+  height: calc(100vh - 11rem);
+  max-height: none;
+  min-height: 0;
 }
 
 .perm-feed-empty {
@@ -407,6 +403,10 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 200px;
+}
+
+.perm-audit-modal-dialog {
+  width: min(82rem, 100%);
 }
 
 /* ── Source Elements ───────────────────────────────────────── */

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -59,11 +59,19 @@
 .perm-dashboard {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1rem;
+  gap: 0.875rem;
+}
+
+#tab-permissions {
+  padding-inline: clamp(0.25rem, 0.5vw, 0.5rem);
 }
 
 @media (max-width: 900px) {
   .perm-dashboard { grid-template-columns: 1fr; }
+
+  #tab-permissions {
+    padding-inline: 0;
+  }
 }
 
 /* ── Cards ─────────────────────────────────────────────────── */
@@ -73,6 +81,7 @@
   border: 1px solid var(--ink-100, #e2e8f0);
   border-radius: 0.5rem;
   overflow: hidden;
+  min-width: 0;
 }
 
 .perm-card--full {
@@ -83,7 +92,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.75rem 1rem;
+  padding: 0.65rem 0.875rem;
   background: var(--paper-base, #f8fafc);
   border-bottom: 1px solid var(--ink-100, #e2e8f0);
   cursor: pointer;
@@ -117,7 +126,7 @@
 }
 
 .perm-card-body {
-  padding: 1rem;
+  padding: 0.875rem;
 }
 
 .perm-selected-header {
@@ -127,6 +136,10 @@
   gap: 1rem;
   margin-bottom: 1rem;
   flex-wrap: wrap;
+}
+
+.perm-selected-header--compact {
+  margin-bottom: 0.875rem;
 }
 
 .perm-selected-title {
@@ -160,7 +173,7 @@
 .perm-selected-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .perm-selected-panel {
@@ -168,16 +181,40 @@
   border-radius: 0.5rem;
   overflow: hidden;
   background: var(--paper-base, #f8fafc);
+  min-width: 0;
+}
+
+.perm-selected-panel--wide {
+  grid-column: 1 / -1;
 }
 
 .perm-selected-panel-title {
   margin: 0;
-  padding: 0.75rem 1rem;
+  padding: 0.65rem 0.875rem;
   border-bottom: 1px solid var(--ink-100, #e2e8f0);
   font-family: var(--font-heading, 'Plus Jakarta Sans', sans-serif);
   font-size: 0.8125rem;
   font-weight: 700;
   color: var(--ink-700, #334155);
+}
+
+.perm-panel-action {
+  border: 1px solid var(--ink-100, #cbd5e1);
+  border-radius: 999px;
+  background: var(--paper-strong, #fff);
+  color: var(--ink-700, #334155);
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 0.72rem;
+  padding: 0.28rem 0.65rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.perm-panel-action:hover,
+.perm-panel-action:focus-visible {
+  border-color: var(--signal-2, #3b82f6);
+  color: var(--signal-2, #3b82f6);
+  outline: none;
 }
 
 .perm-source-item--selected {
@@ -194,9 +231,8 @@
 
 .perm-stat-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-  gap: 0.75rem;
-  margin-bottom: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(105px, 1fr));
+  gap: 0.625rem;
 }
 
 .perm-stat {
@@ -205,7 +241,7 @@
 
 .perm-stat-value {
   font-family: var(--font-mono, 'IBM Plex Mono', monospace);
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   font-weight: 700;
   line-height: 1.2;
   color: var(--ink-900, #0f172a);
@@ -230,13 +266,17 @@
   list-style: none;
   padding: 0;
   margin: 0;
+  max-height: 15rem;
+  overflow-y: scroll;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
 }
 
 .perm-pattern-item {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.375rem 0.5rem;
+  padding: 0.325rem 0.45rem;
   font-family: var(--font-mono, 'IBM Plex Mono', monospace);
   font-size: 0.8125rem;
   border-bottom: 1px solid var(--ink-50, #f1f5f9);
@@ -290,10 +330,18 @@
 /* ── Live Feed ─────────────────────────────────────────────── */
 
 .perm-feed {
-  max-height: 400px;
-  overflow-y: auto;
+  max-height: 20rem;
+  min-height: 8rem;
+  overflow-y: scroll;
+  overflow-x: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable both-edges;
   font-family: var(--font-mono, 'IBM Plex Mono', monospace);
   font-size: 0.8125rem;
+}
+
+.perm-card--audit .perm-feed {
+  max-height: 34rem;
 }
 
 .perm-feed-empty {
@@ -307,7 +355,7 @@
   display: grid;
   grid-template-columns: 80px 60px 1fr auto;
   gap: 0.5rem;
-  padding: 0.375rem 0.5rem;
+  padding: 0.325rem 0.45rem;
   border-bottom: 1px solid var(--ink-50, #f1f5f9);
   align-items: center;
 }
@@ -358,14 +406,20 @@
   list-style: none;
   padding: 0;
   margin: 0;
+  max-height: 16rem;
+  overflow-y: scroll;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
 }
 
 .perm-source-item {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.5rem;
+  padding: 0.425rem 0.5rem;
   border-bottom: 1px solid var(--ink-50, #f1f5f9);
+  min-width: 0;
+  flex-wrap: wrap;
 }
 
 .perm-source-item:last-child {
@@ -386,6 +440,8 @@
 .perm-source-name {
   font-weight: 500;
   color: var(--ink-800, #1e293b);
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 /* ── Dark Mode ─────────────────────────────────────────────── */

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -462,28 +462,95 @@
 }
 
 [data-theme="dark"] .perm-card-header {
-  background: var(--paper-strong, #1e293b);
+  background: color-mix(in srgb, var(--surface-1) 72%, var(--paper-strong));
   border-color: var(--ink-100, #334155);
   color: var(--ink-50, #f1f5f9);
 }
 
 [data-theme="dark"] .perm-card-header:hover {
-  background: var(--ink-100, #334155);
+  background: color-mix(in srgb, var(--surface-2) 82%, var(--paper-strong));
+}
+
+[data-theme="dark"] .perm-card-body {
+  background: color-mix(in srgb, var(--paper) 25%, var(--paper-strong));
+}
+
+[data-theme="dark"] .perm-selected-panel {
+  background: color-mix(in srgb, var(--surface-1) 82%, var(--paper-strong));
+  border-color: var(--line, #2b3445);
+}
+
+[data-theme="dark"] .perm-selected-panel-title {
+  background: color-mix(in srgb, var(--surface-2) 62%, var(--paper-strong));
+  border-color: var(--line, #2b3445);
+  color: var(--ink-900, #dce6f2);
+}
+
+[data-theme="dark"] .perm-panel-action {
+  background: color-mix(in srgb, var(--surface-2) 58%, var(--paper-strong));
+  border-color: var(--line, #2b3445);
+  color: var(--ink-900, #dce6f2);
+}
+
+[data-theme="dark"] .perm-panel-action:hover,
+[data-theme="dark"] .perm-panel-action:focus-visible {
+  background: color-mix(in srgb, var(--surface-2) 78%, var(--paper-strong));
 }
 
 [data-theme="dark"] .perm-stat-value {
   color: var(--ink-50, #f1f5f9);
 }
 
+[data-theme="dark"] .perm-status-updated,
+[data-theme="dark"] .perm-selected-subtitle,
+[data-theme="dark"] .perm-feed-time,
+[data-theme="dark"] .perm-feed-reason,
+[data-theme="dark"] .perm-pattern-empty,
+[data-theme="dark"] .perm-feed-empty,
+[data-theme="dark"] .perm-card-toggle {
+  color: var(--ink-500, #7b93a7);
+}
+
 [data-theme="dark"] .perm-stat-label,
 [data-theme="dark"] .perm-card-title,
+[data-theme="dark"] .perm-selected-title,
+[data-theme="dark"] .perm-feed-tool,
 [data-theme="dark"] .perm-pattern-text,
 [data-theme="dark"] .perm-source-name {
   color: var(--ink-200, #e2e8f0);
 }
 
-[data-theme="dark"] .perm-feed-entry {
-  border-color: var(--ink-100, #334155);
+[data-theme="dark"] .perm-source-list,
+[data-theme="dark"] .perm-pattern-list,
+[data-theme="dark"] .perm-feed {
+  background: color-mix(in srgb, var(--paper) 36%, var(--surface-1));
+}
+
+[data-theme="dark"] .perm-source-item,
+[data-theme="dark"] .perm-pattern-item,
+[data-theme="dark"] .perm-feed-row {
+  border-color: color-mix(in srgb, var(--line) 92%, transparent);
+}
+
+[data-theme="dark"] .perm-source-item:hover,
+[data-theme="dark"] .perm-feed-row:hover {
+  background: color-mix(in srgb, var(--surface-2) 72%, var(--paper-strong));
+}
+
+[data-theme="dark"] .perm-source-type {
+  background: color-mix(in srgb, var(--surface-2) 90%, var(--paper-strong));
+  color: var(--ink-900, #dce6f2);
+  border: 1px solid color-mix(in srgb, var(--line) 80%, transparent);
+}
+
+[data-theme="dark"] .perm-source-item--selected {
+  background: color-mix(in srgb, var(--signal-2) 18%, var(--surface-1));
+}
+
+[data-theme="dark"] .perm-selected-badge {
+  background: color-mix(in srgb, var(--accent-soft) 92%, var(--paper-strong));
+  color: #fdba74;
+  border-color: color-mix(in srgb, #fdba74 35%, var(--line));
 }
 
 [data-theme="dark"] .perm-pattern-badge--deny {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -18,6 +18,8 @@
   let latestAggregateData = null;
   let latestSelectedData = null;
   let latestPollRequestId = 0;
+  const AUDIT_FEED_MIN_HEIGHT_PX = 320;
+  const AUDIT_FEED_MARGIN_PX = 24;
 
   async function fetchPermissionStatus(sessionId) {
     const query = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : '';
@@ -65,6 +67,7 @@
 
     root.innerHTML = buildDashboardHTML();
     attachCardToggles();
+    window.addEventListener('resize', scheduleAuditFeedLayout);
     poll(); // immediate first fetch
     pollTimer = setInterval(poll, POLL_INTERVAL_MS);
   }
@@ -74,6 +77,7 @@
       clearInterval(pollTimer);
       pollTimer = null;
     }
+    window.removeEventListener('resize', scheduleAuditFeedLayout);
     initialized = false;
   }
 
@@ -109,6 +113,7 @@
     latestSelectedData = deriveSelectedSessionData(latestAggregateData, sessionId);
     renderPolicySources(latestAggregateData, latestSelectedData);
     renderSelectedSessionDetail(latestSelectedData);
+    scheduleAuditFeedLayout();
   }
 
   // ── Rendering ──────────────────────────────────────────────
@@ -122,6 +127,7 @@
     renderAllowPatterns(data);
     renderConfirmPatterns(data);
     renderLiveFeed(data);
+    scheduleAuditFeedLayout();
   }
 
   function renderError(message) {
@@ -539,6 +545,7 @@
         const collapsed = card.dataset.collapsed === 'true';
         card.dataset.collapsed = collapsed ? 'false' : 'true';
         header.setAttribute('aria-expanded', collapsed ? 'true' : 'false');
+        scheduleAuditFeedLayout();
       };
       header.addEventListener('click', toggle);
       header.addEventListener('keydown', (e) => {
@@ -554,8 +561,46 @@
         const expanded = feedCard.classList.toggle('perm-card--audit');
         expandBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
         expandBtn.textContent = expanded ? 'Compact Audit View' : 'Expand Audit View';
+        scheduleAuditFeedLayout();
       });
     }
+  }
+
+  function scheduleAuditFeedLayout() {
+    window.requestAnimationFrame(updateAuditFeedLayout);
+  }
+
+  function updateAuditFeedLayout() {
+    const feedCard = document.getElementById('perm-all-feed-card');
+    const feed = document.getElementById('perm-feed');
+    if (!feedCard || !feed) return;
+
+    if (!feedCard.classList.contains('perm-card--audit') || feedCard.dataset.collapsed === 'true') {
+      feed.style.removeProperty('--perm-audit-feed-height');
+      return;
+    }
+
+    const cards = Array.from(document.querySelectorAll('.perm-dashboard > .perm-card'));
+    const feedCardIndex = cards.indexOf(feedCard);
+    if (feedCardIndex === -1) return;
+
+    const reserveHeight = cards.slice(feedCardIndex + 1).reduce(function (total, card) {
+      if (card.hidden) return total;
+      const header = card.querySelector('.perm-card-header');
+      if (card.dataset.collapsed === 'true') {
+        return total + (header ? header.getBoundingClientRect().height : 0);
+      }
+      return total + card.getBoundingClientRect().height;
+    }, 0);
+
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const cardTop = feedCard.getBoundingClientRect().top;
+    const availableHeight = Math.max(
+      AUDIT_FEED_MIN_HEIGHT_PX,
+      viewportHeight - cardTop - reserveHeight - AUDIT_FEED_MARGIN_PX
+    );
+
+    feed.style.setProperty('--perm-audit-feed-height', `${Math.floor(availableHeight)}px`);
   }
 
   function setText(id, value) {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -280,11 +280,16 @@
 
   function renderLiveFeed(data) {
     const feed = document.getElementById('perm-feed');
+    const modalFeed = document.getElementById('perm-audit-modal-feed');
+    const modalCount = document.getElementById('perm-audit-modal-count');
     if (!feed) return;
 
     const decisions = data.recentDecisions || [];
     if (decisions.length === 0) {
-      feed.innerHTML = '<div class="perm-feed-empty">No permission decisions yet. Waiting for tool calls...</div>';
+      const empty = '<div class="perm-feed-empty">No permission decisions yet. Waiting for tool calls...</div>';
+      feed.innerHTML = empty;
+      if (modalFeed) modalFeed.innerHTML = empty;
+      if (modalCount) modalCount.textContent = '0 captured entries';
       return;
     }
 
@@ -293,7 +298,7 @@
     if (latestId === lastDecisionId) return; // no change
     lastDecisionId = latestId;
 
-    feed.innerHTML = decisions.map(d => {
+    const html = decisions.map(d => {
       const time = new Date(d.timestamp).toLocaleTimeString();
       const toolDisplay = d.tool_name === 'Bash'
         ? `Bash: ${esc(truncate(d.command || '', 60))}`
@@ -308,6 +313,12 @@
         </div>
       `;
     }).join('');
+
+    feed.innerHTML = html;
+    if (modalFeed) modalFeed.innerHTML = html;
+    if (modalCount) {
+      modalCount.textContent = `${decisions.length} captured ${decisions.length === 1 ? 'entry' : 'entries'}`;
+    }
   }
 
   function deriveSelectedSessionData(aggregateData, sessionId) {
@@ -382,16 +393,16 @@
           <div class="perm-card-body">
             <div class="perm-selected-header perm-selected-header--compact">
               <div>
-                <div class="perm-selected-subtitle">Most recent first. This is the aggregate audit stream across all sessions.</div>
+                <div class="perm-selected-subtitle">Aggregate audit stream across all sessions. Newest decisions appear first.</div>
               </div>
               <button
                 type="button"
                 class="perm-panel-action"
                 id="perm-feed-expand-btn"
-                aria-expanded="false"
-                aria-controls="perm-feed"
+                aria-haspopup="dialog"
+                aria-controls="perm-audit-modal"
               >
-                Expand Audit View
+                Open Audit View
               </button>
             </div>
             <div class="perm-feed" id="perm-feed" role="log" aria-live="polite" aria-label="Permission decisions across all sessions">
@@ -401,7 +412,7 @@
         </div>
 
         <!-- Summary Stats -->
-        <div class="perm-card perm-card--full" data-collapsed="false">
+        <div class="perm-card perm-card--full" data-collapsed="false" id="perm-autonomy-card">
           <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
             <h3 class="perm-card-title">Autonomy Overview</h3>
             <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
@@ -484,7 +495,7 @@
           </div>
         </div>
 
-        <div class="perm-card perm-card--full" data-collapsed="false">
+        <div class="perm-card perm-card--full" data-collapsed="false" id="perm-all-detail-card">
           <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
             <h3 class="perm-card-title">All Sessions Detail</h3>
             <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
@@ -527,6 +538,28 @@
         </div>
 
       </div>
+
+      <dialog class="modal perm-audit-modal" id="perm-audit-modal" aria-labelledby="perm-audit-modal-title">
+        <div class="modal-overlay" data-close-audit-modal></div>
+        <div class="modal-dialog perm-audit-modal-dialog" role="document">
+          <header class="modal-header">
+            <div class="modal-heading">
+              <h2 class="modal-title" id="perm-audit-modal-title">All Sessions Audit View</h2>
+              <span class="modal-type">Permissions</span>
+            </div>
+            <div class="modal-meta">
+              <span>Aggregate decision log across all sessions</span>
+              <span id="perm-audit-modal-count">0 captured entries</span>
+            </div>
+            <button type="button" class="modal-close" id="perm-audit-modal-close" aria-label="Close audit view">✕</button>
+          </header>
+          <div class="modal-body">
+            <div class="perm-feed perm-feed--modal" id="perm-audit-modal-feed" role="log" aria-live="polite" aria-label="Full permission decision audit feed">
+              <div class="perm-feed-empty">No permission decisions yet. Waiting for tool calls...</div>
+            </div>
+          </div>
+        </div>
+      </dialog>
     `;
   }
 
@@ -547,18 +580,54 @@
     });
 
     const expandBtn = document.getElementById('perm-feed-expand-btn');
-    const feedCard = document.getElementById('perm-all-feed-card');
-    if (expandBtn && feedCard) {
+    const auditModal = document.getElementById('perm-audit-modal');
+    const closeBtn = document.getElementById('perm-audit-modal-close');
+    if (expandBtn && auditModal) {
       expandBtn.addEventListener('click', function (e) {
         e.stopPropagation();
-        const expanded = feedCard.classList.toggle('perm-card--audit');
-        expandBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
-        expandBtn.textContent = expanded ? 'Compact Audit View' : 'Expand Audit View';
-        if (expanded) {
-          feedCard.scrollIntoView({ block: 'start', behavior: 'smooth' });
-        }
+        openAuditModal();
       });
     }
+
+    if (closeBtn) {
+      closeBtn.addEventListener('click', closeAuditModal);
+    }
+
+    if (auditModal) {
+      auditModal.addEventListener('click', function (e) {
+        if (e.target === auditModal || e.target.hasAttribute('data-close-audit-modal')) {
+          closeAuditModal();
+        }
+      });
+      auditModal.addEventListener('close', function () {
+        document.body.classList.remove('modal-open');
+      });
+      auditModal.addEventListener('cancel', function () {
+        document.body.classList.remove('modal-open');
+      });
+    }
+  }
+
+  function openAuditModal() {
+    const auditModal = document.getElementById('perm-audit-modal');
+    if (!auditModal) return;
+    if (typeof auditModal.showModal === 'function') {
+      auditModal.showModal();
+    } else {
+      auditModal.setAttribute('open', '');
+    }
+    document.body.classList.add('modal-open');
+  }
+
+  function closeAuditModal() {
+    const auditModal = document.getElementById('perm-audit-modal');
+    if (!auditModal) return;
+    if (typeof auditModal.close === 'function') {
+      auditModal.close();
+    } else {
+      auditModal.removeAttribute('open');
+    }
+    document.body.classList.remove('modal-open');
   }
 
   function setText(id, value) {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -16,6 +16,13 @@
   let initialized = false;
   let lastDecisionId = null;
 
+  async function fetchPermissionStatus(sessionId) {
+    const query = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : '';
+    const res = await DollhouseAuth.apiFetch(`/api/permissions/status${query}`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json();
+  }
+
   // ── Public API ─────────────────────────────────────────────
 
   window.DollhouseConsole = window.DollhouseConsole || {};
@@ -71,12 +78,18 @@
   async function poll() {
     try {
       const sessionId = window.DollhouseSessions?.getFilterSessionId?.() || '';
-      const query = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : '';
-      const res = await DollhouseAuth.apiFetch(`/api/permissions/status${query}`);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
-      window.DollhouseSessions?.setPolicySessions?.(data.knownSessions || []);
-      render(data);
+      const [aggregateData, selectedData] = await Promise.all([
+        fetchPermissionStatus(''),
+        sessionId
+          ? fetchPermissionStatus(sessionId).catch(err => ({
+              error: err.message,
+              sessionId,
+            }))
+          : Promise.resolve(null),
+      ]);
+
+      window.DollhouseSessions?.setPolicySessions?.(aggregateData.knownSessions || []);
+      render(aggregateData, selectedData);
     } catch (err) {
       renderError(err.message);
     }
@@ -84,10 +97,11 @@
 
   // ── Rendering ──────────────────────────────────────────────
 
-  function render(data) {
+  function render(data, selectedData) {
     renderStatusBar(data);
     renderSummaryStats(data);
-    renderPolicySources(data);
+    renderPolicySources(data, selectedData);
+    renderSelectedSessionDetail(selectedData);
     renderDenyPatterns(data);
     renderAllowPatterns(data);
     renderConfirmPatterns(data);
@@ -146,23 +160,85 @@
     setText('perm-stat-asked', asked);
   }
 
-  function renderPolicySources(data) {
+  function renderPolicySources(data, selectedData) {
     const list = document.getElementById('perm-source-list');
     if (!list) return;
 
     const elements = data.elements || [];
+    const selectedSessionId = selectedData?.sessionId;
     if (elements.length === 0) {
       list.innerHTML = '<li class="perm-pattern-empty">No active elements with policies</li>';
       return;
     }
 
     list.innerHTML = elements.map(el => `
-      <li class="perm-source-item">
+      <li class="perm-source-item${elementMatchesSelected(el, selectedSessionId) ? ' perm-source-item--selected' : ''}">
         <span class="perm-source-type">${esc(el.type)}</span>
         <span class="perm-source-name">${esc(el.element_name)}</span>
         ${el.description ? `<span style="color:var(--ink-400);font-size:0.75rem;margin-left:auto">${esc(el.description)}</span>` : ''}
       </li>
     `).join('');
+  }
+
+  function renderSelectedSessionDetail(selectedData) {
+    const card = document.getElementById('perm-selected-card');
+    const title = document.getElementById('perm-selected-title');
+    const subtitle = document.getElementById('perm-selected-subtitle');
+    const badge = document.getElementById('perm-selected-badge');
+    const sourceList = document.getElementById('perm-selected-source-list');
+    const denyList = document.getElementById('perm-selected-deny-list');
+    const allowList = document.getElementById('perm-selected-allow-list');
+    const confirmList = document.getElementById('perm-selected-confirm-list');
+
+    if (!card || !title || !subtitle || !badge || !sourceList || !denyList || !allowList || !confirmList) {
+      return;
+    }
+
+    if (!selectedData?.sessionId) {
+      card.hidden = true;
+      return;
+    }
+
+    card.hidden = false;
+
+    const sessionInfo = window.DollhouseSessions?.getSelectableSessions?.()
+      ?.find(session => session.sessionId === selectedData.sessionId);
+    const sessionLabel = window.DollhouseSessions?.displayName?.(sessionInfo || selectedData.sessionId)
+      || selectedData.sessionId;
+    const policyOnly = !!sessionInfo?.isPolicyOnly;
+
+    title.textContent = `Selected Session: ${sessionLabel}`;
+    subtitle.textContent = policyOnly
+      ? `${selectedData.sessionId} is showing saved policy state from disk. This is not a live attached client.`
+      : `${selectedData.sessionId} is the current live policy view for this session.`;
+
+    badge.hidden = !policyOnly;
+    if (policyOnly) {
+      badge.textContent = 'Persisted Policy State (Debug Info)';
+    }
+
+    if (selectedData.error) {
+      sourceList.innerHTML = `<li class="perm-pattern-empty">${esc(selectedData.error)}</li>`;
+      denyList.innerHTML = '<li class="perm-pattern-empty">Unable to load selected session</li>';
+      allowList.innerHTML = '<li class="perm-pattern-empty">Unable to load selected session</li>';
+      confirmList.innerHTML = '<li class="perm-pattern-empty">Unable to load selected session</li>';
+      return;
+    }
+
+    const elements = selectedData.elements || [];
+    sourceList.innerHTML = elements.length === 0
+      ? '<li class="perm-pattern-empty">No policy-bearing elements found for this session</li>'
+      : elements.map(el => `
+          <li class="perm-source-item perm-source-item--detail">
+            <span class="perm-source-type">${esc(el.type)}</span>
+            <span class="perm-source-name">${esc(el.element_name)}</span>
+            ${el.description ? `<span style="color:var(--ink-400);font-size:0.75rem;margin-left:auto">${esc(el.description)}</span>` : ''}
+          </li>
+        `).join('');
+
+    renderPatternList('perm-selected-deny-list', selectedData.denyPatterns || [], 'deny');
+    renderPatternList('perm-selected-allow-list', selectedData.allowPatterns || [], 'allow');
+    renderPatternList('perm-selected-confirm-list', selectedData.confirmPatterns || [], 'confirm');
   }
 
   function renderDenyPatterns(data) {
@@ -289,10 +365,54 @@
           </div>
         </div>
 
+        <!-- Selected Session Detail -->
+        <div class="perm-card perm-card--full" data-collapsed="false" id="perm-selected-card" hidden>
+          <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
+            <h3 class="perm-card-title">Selected Session Detail</h3>
+            <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
+          </div>
+          <div class="perm-card-body">
+            <div class="perm-selected-header">
+              <div>
+                <div class="perm-selected-title" id="perm-selected-title">Selected Session</div>
+                <div class="perm-selected-subtitle" id="perm-selected-subtitle"></div>
+              </div>
+              <span class="perm-selected-badge" id="perm-selected-badge" hidden>Persisted Policy State (Debug Info)</span>
+            </div>
+
+            <div class="perm-selected-grid">
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Policy Sources</h4>
+                <ul class="perm-source-list" id="perm-selected-source-list">
+                  <li class="perm-pattern-empty">Loading...</li>
+                </ul>
+              </div>
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Deny Patterns</h4>
+                <ul class="perm-pattern-list" id="perm-selected-deny-list">
+                  <li class="perm-pattern-empty">Loading...</li>
+                </ul>
+              </div>
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Allow Patterns</h4>
+                <ul class="perm-pattern-list" id="perm-selected-allow-list">
+                  <li class="perm-pattern-empty">Loading...</li>
+                </ul>
+              </div>
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Confirm Patterns</h4>
+                <ul class="perm-pattern-list" id="perm-selected-confirm-list">
+                  <li class="perm-pattern-empty">Loading...</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <!-- Policy Sources -->
         <div class="perm-card" data-collapsed="false">
           <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
-            <h3 class="perm-card-title">Policy Sources</h3>
+            <h3 class="perm-card-title">All Policy Sources</h3>
             <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
           </div>
           <div class="perm-card-body">
@@ -378,6 +498,11 @@
   function setText(id, value) {
     const el = document.getElementById(id);
     if (el) el.textContent = String(value);
+  }
+
+  function elementMatchesSelected(element, sessionId) {
+    if (!sessionId || !Array.isArray(element?.sessionIds)) return false;
+    return element.sessionIds.includes(sessionId);
   }
 
   // dmcp-sec[DMCP-SEC-004] — Client-side JS: UnicodeValidator unavailable in browser.

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -18,9 +18,6 @@
   let latestAggregateData = null;
   let latestSelectedData = null;
   let latestPollRequestId = 0;
-  const AUDIT_FEED_DEFAULT_HEIGHT_PX = 544;
-  const AUDIT_FEED_MIN_HEIGHT_PX = 220;
-  const AUDIT_FEED_MARGIN_PX = 24;
 
   async function fetchPermissionStatus(sessionId) {
     const query = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : '';
@@ -68,7 +65,6 @@
 
     root.innerHTML = buildDashboardHTML();
     attachCardToggles();
-    window.addEventListener('resize', scheduleAuditFeedLayout);
     poll(); // immediate first fetch
     pollTimer = setInterval(poll, POLL_INTERVAL_MS);
   }
@@ -78,7 +74,6 @@
       clearInterval(pollTimer);
       pollTimer = null;
     }
-    window.removeEventListener('resize', scheduleAuditFeedLayout);
     initialized = false;
   }
 
@@ -544,7 +539,6 @@
         const collapsed = card.dataset.collapsed === 'true';
         card.dataset.collapsed = collapsed ? 'false' : 'true';
         header.setAttribute('aria-expanded', collapsed ? 'true' : 'false');
-        scheduleAuditFeedLayout();
       };
       header.addEventListener('click', toggle);
       header.addEventListener('keydown', (e) => {
@@ -560,51 +554,11 @@
         const expanded = feedCard.classList.toggle('perm-card--audit');
         expandBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
         expandBtn.textContent = expanded ? 'Compact Audit View' : 'Expand Audit View';
-        scheduleAuditFeedLayout();
         if (expanded) {
           feedCard.scrollIntoView({ block: 'start', behavior: 'smooth' });
         }
       });
     }
-  }
-
-  function scheduleAuditFeedLayout() {
-    window.requestAnimationFrame(updateAuditFeedLayout);
-  }
-
-  function updateAuditFeedLayout() {
-    const feedCard = document.getElementById('perm-all-feed-card');
-    const feed = document.getElementById('perm-feed');
-    if (!feedCard || !feed) return;
-
-    if (!feedCard.classList.contains('perm-card--audit') || feedCard.dataset.collapsed === 'true') {
-      feed.style.removeProperty('--perm-audit-feed-height');
-      return;
-    }
-
-    const cards = Array.from(document.querySelectorAll('.perm-dashboard > .perm-card'));
-    const feedCardIndex = cards.indexOf(feedCard);
-    if (feedCardIndex === -1) return;
-
-    const reserveHeight = cards.slice(feedCardIndex + 1).reduce(function (total, card) {
-      if (card.hidden) return total;
-      const header = card.querySelector('.perm-card-header');
-      if (card.dataset.collapsed === 'true') {
-        return total + (header ? header.getBoundingClientRect().height : 0);
-      }
-      return total + card.getBoundingClientRect().height;
-    }, 0);
-
-    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
-    const cardTop = Math.max(feedCard.getBoundingClientRect().top, 0);
-    const availableHeight = viewportHeight - cardTop - reserveHeight - AUDIT_FEED_MARGIN_PX;
-    const fallbackHeight = reserveHeight > 0 ? AUDIT_FEED_MIN_HEIGHT_PX : AUDIT_FEED_DEFAULT_HEIGHT_PX;
-    const clampedHeight = Math.max(
-      AUDIT_FEED_MIN_HEIGHT_PX,
-      Math.min(Math.max(availableHeight, fallbackHeight), viewportHeight - cardTop - AUDIT_FEED_MARGIN_PX)
-    );
-
-    feed.style.setProperty('--perm-audit-feed-height', `${Math.floor(clampedHeight)}px`);
   }
 
   function setText(id, value) {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -75,6 +75,7 @@
       const res = await DollhouseAuth.apiFetch(`/api/permissions/status${query}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
+      window.DollhouseSessions?.setPolicySessions?.(data.knownSessions || []);
       render(data);
     } catch (err) {
       renderError(err.message);

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -15,6 +15,9 @@
   const POLL_INTERVAL_MS = 3000;
   let initialized = false;
   let lastDecisionId = null;
+  let latestAggregateData = null;
+  let latestSelectedData = null;
+  let latestPollRequestId = 0;
 
   async function fetchPermissionStatus(sessionId) {
     const query = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : '';
@@ -30,6 +33,7 @@
     init: initPermissions,
     destroy: destroyPermissions,
     refresh: function () { poll(); },
+    onSessionChange: function () { renderFromCache(); },
   };
 
   // Hook into tab switching — Todd's app.js lazyInitTab only knows logs/metrics,
@@ -76,23 +80,35 @@
   // ── Polling ────────────────────────────────────────────────
 
   async function poll() {
+    const requestId = ++latestPollRequestId;
     try {
-      const sessionId = window.DollhouseSessions?.getFilterSessionId?.() || '';
-      const [aggregateData, selectedData] = await Promise.all([
-        fetchPermissionStatus(''),
-        sessionId
-          ? fetchPermissionStatus(sessionId).catch(err => ({
-              error: err.message,
-              sessionId,
-            }))
-          : Promise.resolve(null),
-      ]);
+      const aggregateData = await fetchPermissionStatus('');
+      if (requestId !== latestPollRequestId) {
+        return;
+      }
 
+      const currentSessionId = window.DollhouseSessions?.getFilterSessionId?.() || '';
+      const selectedData = deriveSelectedSessionData(aggregateData, currentSessionId);
+
+      latestAggregateData = aggregateData;
+      latestSelectedData = selectedData;
       window.DollhouseSessions?.setPolicySessions?.(aggregateData.knownSessions || []);
       render(aggregateData, selectedData);
     } catch (err) {
       renderError(err.message);
     }
+  }
+
+  function renderFromCache() {
+    if (!latestAggregateData) {
+      poll();
+      return;
+    }
+
+    const sessionId = window.DollhouseSessions?.getFilterSessionId?.() || '';
+    latestSelectedData = deriveSelectedSessionData(latestAggregateData, sessionId);
+    renderPolicySources(latestAggregateData, latestSelectedData);
+    renderSelectedSessionDetail(latestSelectedData);
   }
 
   // ── Rendering ──────────────────────────────────────────────
@@ -145,9 +161,9 @@
   }
 
   function renderSummaryStats(data) {
-    setText('perm-stat-deny-count', data.denyPatterns?.length || 0);
-    setText('perm-stat-allow-count', data.allowPatterns?.length || 0);
-    setText('perm-stat-confirm-count', data.confirmPatterns?.length || 0);
+    setText('perm-stat-deny-count', getAggregatePatterns(data, 'denyPatterns').length);
+    setText('perm-stat-allow-count', getAggregatePatterns(data, 'allowPatterns').length);
+    setText('perm-stat-confirm-count', getAggregatePatterns(data, 'confirmPatterns').length);
     setText('perm-stat-decisions', data.recentDecisions?.length || 0);
 
     // Decision breakdown
@@ -210,19 +226,11 @@
     title.textContent = `Selected Session: ${sessionLabel}`;
     subtitle.textContent = policyOnly
       ? `${selectedData.sessionId} is showing saved policy state from disk. This is not a live attached client.`
-      : `${selectedData.sessionId} is the current live policy view for this session.`;
+      : `${selectedData.sessionId} is the current live policy view for this session. Decision activity is still shown in the All Sessions section below.`;
 
     badge.hidden = !policyOnly;
     if (policyOnly) {
       badge.textContent = 'Persisted Policy State (Debug Info)';
-    }
-
-    if (selectedData.error) {
-      sourceList.innerHTML = `<li class="perm-pattern-empty">${esc(selectedData.error)}</li>`;
-      denyList.innerHTML = '<li class="perm-pattern-empty">Unable to load selected session</li>';
-      allowList.innerHTML = '<li class="perm-pattern-empty">Unable to load selected session</li>';
-      confirmList.innerHTML = '<li class="perm-pattern-empty">Unable to load selected session</li>';
-      return;
     }
 
     const elements = selectedData.elements || [];
@@ -242,15 +250,15 @@
   }
 
   function renderDenyPatterns(data) {
-    renderPatternList('perm-deny-list', data.denyPatterns || [], 'deny');
+    renderPatternList('perm-deny-list', getAggregatePatterns(data, 'denyPatterns'), 'deny');
   }
 
   function renderAllowPatterns(data) {
-    renderPatternList('perm-allow-list', data.allowPatterns || [], 'allow');
+    renderPatternList('perm-allow-list', getAggregatePatterns(data, 'allowPatterns'), 'allow');
   }
 
   function renderConfirmPatterns(data) {
-    renderPatternList('perm-confirm-list', data.confirmPatterns || [], 'confirm');
+    renderPatternList('perm-confirm-list', getAggregatePatterns(data, 'confirmPatterns'), 'confirm');
   }
 
   function renderPatternList(elementId, patterns, type) {
@@ -302,6 +310,46 @@
     }).join('');
   }
 
+  function deriveSelectedSessionData(aggregateData, sessionId) {
+    if (!sessionId) return null;
+
+    const elements = (aggregateData?.elements || []).filter(function (element) {
+      return Array.isArray(element.sessionIds) && element.sessionIds.indexOf(sessionId) !== -1;
+    });
+
+    return {
+      sessionId: sessionId,
+      activeElementCount: elements.length,
+      hasAllowlist: elements.some(function (element) {
+        return Array.isArray(element.allowPatterns) && element.allowPatterns.length > 0;
+      }),
+      denyPatterns: flattenElementPatterns(elements, 'denyPatterns'),
+      allowPatterns: flattenElementPatterns(elements, 'allowPatterns'),
+      confirmPatterns: flattenElementPatterns(elements, 'confirmPatterns'),
+      elements: elements.map(function (element) {
+        return {
+          type: element.type,
+          element_name: element.element_name,
+          description: element.description,
+        };
+      }),
+      permissionPromptActive: !!aggregateData?.permissionPromptActive,
+      recentDecisions: aggregateData?.recentDecisions || [],
+    };
+  }
+
+  function flattenElementPatterns(elements, key) {
+    return elements.flatMap(function (element) {
+      return Array.isArray(element[key]) ? element[key] : [];
+    });
+  }
+
+  function getAggregatePatterns(data, key) {
+    const combined = Array.isArray(data && data[key]) ? data[key] : [];
+    const perElement = flattenElementPatterns((data && data.elements) || [], key);
+    return Array.from(new Set(combined.concat(perElement)));
+  }
+
   // ── Dashboard HTML ─────────────────────────────────────────
 
   function buildDashboardHTML() {
@@ -324,6 +372,33 @@
       </div>
 
       <div class="perm-dashboard">
+
+        <!-- All Sessions Live Decision Feed -->
+        <div class="perm-card perm-card--full" data-collapsed="false" id="perm-all-feed-card">
+          <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
+            <h3 class="perm-card-title">All Sessions Live Decision Feed</h3>
+            <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
+          </div>
+          <div class="perm-card-body">
+            <div class="perm-selected-header perm-selected-header--compact">
+              <div>
+                <div class="perm-selected-subtitle">Most recent first. This is the aggregate audit stream across all sessions.</div>
+              </div>
+              <button
+                type="button"
+                class="perm-panel-action"
+                id="perm-feed-expand-btn"
+                aria-expanded="false"
+                aria-controls="perm-feed"
+              >
+                Expand Audit View
+              </button>
+            </div>
+            <div class="perm-feed" id="perm-feed" role="log" aria-live="polite" aria-label="Permission decisions across all sessions">
+              <div class="perm-feed-empty">No permission decisions yet. Waiting for tool calls...</div>
+            </div>
+          </div>
+        </div>
 
         <!-- Summary Stats -->
         <div class="perm-card perm-card--full" data-collapsed="false">
@@ -409,67 +484,44 @@
           </div>
         </div>
 
-        <!-- Policy Sources -->
-        <div class="perm-card" data-collapsed="false">
-          <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
-            <h3 class="perm-card-title">All Policy Sources</h3>
-            <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
-          </div>
-          <div class="perm-card-body">
-            <ul class="perm-source-list" id="perm-source-list">
-              <li class="perm-pattern-empty">Loading...</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Deny Patterns -->
-        <div class="perm-card" data-collapsed="false">
-          <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
-            <h3 class="perm-card-title">Deny Patterns</h3>
-            <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
-          </div>
-          <div class="perm-card-body">
-            <ul class="perm-pattern-list" id="perm-deny-list">
-              <li class="perm-pattern-empty">Loading...</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Allow Patterns -->
-        <div class="perm-card" data-collapsed="true">
-          <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
-            <h3 class="perm-card-title">Allow Patterns</h3>
-            <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
-          </div>
-          <div class="perm-card-body">
-            <ul class="perm-pattern-list" id="perm-allow-list">
-              <li class="perm-pattern-empty">Loading...</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Confirm Patterns -->
-        <div class="perm-card" data-collapsed="false">
-          <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
-            <h3 class="perm-card-title">Confirm Patterns (Requires Approval)</h3>
-            <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
-          </div>
-          <div class="perm-card-body">
-            <ul class="perm-pattern-list" id="perm-confirm-list">
-              <li class="perm-pattern-empty">Loading...</li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Live Decision Feed -->
         <div class="perm-card perm-card--full" data-collapsed="false">
           <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
-            <h3 class="perm-card-title">Live Decision Feed</h3>
+            <h3 class="perm-card-title">All Sessions Detail</h3>
             <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
           </div>
           <div class="perm-card-body">
-            <div class="perm-feed" id="perm-feed" role="log" aria-live="polite" aria-label="Permission decisions">
-              <div class="perm-feed-empty">No permission decisions yet. Waiting for tool calls...</div>
+            <div class="perm-selected-header perm-selected-header--compact">
+              <div>
+                <div class="perm-selected-title">All Sessions</div>
+                <div class="perm-selected-subtitle">Aggregate policy state across all live and persisted sessions. The decision feed below is currently aggregate, not selection-scoped.</div>
+              </div>
+            </div>
+
+            <div class="perm-selected-grid">
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Policy Sources</h4>
+                <ul class="perm-source-list" id="perm-source-list">
+                  <li class="perm-pattern-empty">Loading...</li>
+                </ul>
+              </div>
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Deny Patterns</h4>
+                <ul class="perm-pattern-list" id="perm-deny-list">
+                  <li class="perm-pattern-empty">Loading...</li>
+                </ul>
+              </div>
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Allow Patterns</h4>
+                <ul class="perm-pattern-list" id="perm-allow-list">
+                  <li class="perm-pattern-empty">Loading...</li>
+                </ul>
+              </div>
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Confirm Patterns</h4>
+                <ul class="perm-pattern-list" id="perm-confirm-list">
+                  <li class="perm-pattern-empty">Loading...</li>
+                </ul>
+              </div>
             </div>
           </div>
         </div>
@@ -493,6 +545,17 @@
         if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(); }
       });
     });
+
+    const expandBtn = document.getElementById('perm-feed-expand-btn');
+    const feedCard = document.getElementById('perm-all-feed-card');
+    if (expandBtn && feedCard) {
+      expandBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        const expanded = feedCard.classList.toggle('perm-card--audit');
+        expandBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        expandBtn.textContent = expanded ? 'Compact Audit View' : 'Expand Audit View';
+      });
+    }
   }
 
   function setText(id, value) {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -70,7 +70,9 @@
 
   async function poll() {
     try {
-      const res = await DollhouseAuth.apiFetch('/api/permissions/status');
+      const sessionId = window.DollhouseSessions?.getFilterSessionId?.() || '';
+      const query = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : '';
+      const res = await DollhouseAuth.apiFetch(`/api/permissions/status${query}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       render(data);

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -18,7 +18,8 @@
   let latestAggregateData = null;
   let latestSelectedData = null;
   let latestPollRequestId = 0;
-  const AUDIT_FEED_MIN_HEIGHT_PX = 320;
+  const AUDIT_FEED_DEFAULT_HEIGHT_PX = 544;
+  const AUDIT_FEED_MIN_HEIGHT_PX = 220;
   const AUDIT_FEED_MARGIN_PX = 24;
 
   async function fetchPermissionStatus(sessionId) {
@@ -113,7 +114,6 @@
     latestSelectedData = deriveSelectedSessionData(latestAggregateData, sessionId);
     renderPolicySources(latestAggregateData, latestSelectedData);
     renderSelectedSessionDetail(latestSelectedData);
-    scheduleAuditFeedLayout();
   }
 
   // ── Rendering ──────────────────────────────────────────────
@@ -127,7 +127,6 @@
     renderAllowPatterns(data);
     renderConfirmPatterns(data);
     renderLiveFeed(data);
-    scheduleAuditFeedLayout();
   }
 
   function renderError(message) {
@@ -562,6 +561,9 @@
         expandBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
         expandBtn.textContent = expanded ? 'Compact Audit View' : 'Expand Audit View';
         scheduleAuditFeedLayout();
+        if (expanded) {
+          feedCard.scrollIntoView({ block: 'start', behavior: 'smooth' });
+        }
       });
     }
   }
@@ -594,13 +596,15 @@
     }, 0);
 
     const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
-    const cardTop = feedCard.getBoundingClientRect().top;
-    const availableHeight = Math.max(
+    const cardTop = Math.max(feedCard.getBoundingClientRect().top, 0);
+    const availableHeight = viewportHeight - cardTop - reserveHeight - AUDIT_FEED_MARGIN_PX;
+    const fallbackHeight = reserveHeight > 0 ? AUDIT_FEED_MIN_HEIGHT_PX : AUDIT_FEED_DEFAULT_HEIGHT_PX;
+    const clampedHeight = Math.max(
       AUDIT_FEED_MIN_HEIGHT_PX,
-      viewportHeight - cardTop - reserveHeight - AUDIT_FEED_MARGIN_PX
+      Math.min(Math.max(availableHeight, fallbackHeight), viewportHeight - cardTop - AUDIT_FEED_MARGIN_PX)
     );
 
-    feed.style.setProperty('--perm-audit-feed-height', `${Math.floor(availableHeight)}px`);
+    feed.style.setProperty('--perm-audit-feed-height', `${Math.floor(clampedHeight)}px`);
   }
 
   function setText(id, value) {

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -73,6 +73,11 @@
     return merged;
   }
 
+  function getActiveTabName() {
+    var activeTab = document.querySelector('.console-tab.active');
+    return activeTab ? activeTab.dataset.tab || '' : '';
+  }
+
   function normalizePolicySessions(list) {
     if (!Array.isArray(list)) return [];
 
@@ -130,12 +135,22 @@
     var logSelect = document.getElementById('log-session-filter');
     if (logSelect) logSelect.value = sessionId;
 
-    // Trigger log re-filter with the selected session
-    if (window.DollhouseConsole && window.DollhouseConsole.logs && window.DollhouseConsole.logs.refilter) {
-      window.DollhouseConsole.logs.refilter(sessionId);
+    if (window.DollhouseConsole && window.DollhouseConsole.permissions) {
+      if (window.DollhouseConsole.permissions.onSessionChange) {
+        window.DollhouseConsole.permissions.onSessionChange(sessionId);
+      } else if (window.DollhouseConsole.permissions.refresh) {
+        window.DollhouseConsole.permissions.refresh();
+      }
     }
-    if (window.DollhouseConsole && window.DollhouseConsole.permissions && window.DollhouseConsole.permissions.refresh) {
-      window.DollhouseConsole.permissions.refresh();
+
+    // Trigger log re-filter only when the Logs tab is active. Refiltering the
+    // virtualized log buffer can be expensive, and it should not delay session
+    // switching on other tabs like Permissions.
+    if (getActiveTabName() === 'logs'
+      && window.DollhouseConsole
+      && window.DollhouseConsole.logs
+      && window.DollhouseConsole.logs.refilter) {
+      window.DollhouseConsole.logs.refilter(sessionId);
     }
 
     refreshSelectionState();

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -24,6 +24,7 @@
   var SESSION_FILTER_INJECTION_RETRY_INTERVAL = getConfiguredNumber('sessionFilterInjectionRetryIntervalMs', 500);
   var SESSION_FILTER_INJECTION_MAX_RETRIES = getConfiguredNumber('sessionFilterInjectionMaxRetries', 20);
   var sessions = [];
+  var policySessions = [];
   var filterSessionId = '';
   var dropdownBuilt = false;
   var lastSessionKey = ''; // tracks session list identity to avoid unnecessary rebuilds
@@ -47,6 +48,10 @@
   /** NFC-normalize a string safely */
   function nfc(s) { try { return s.normalize('NFC'); } catch(e) { return s; } }
 
+  function isPolicyOnlySession(session) {
+    return !!(session && session.isPolicyOnly);
+  }
+
   function displayName(session) {
     if (typeof session === 'object' && session.displayName) return nfc(session.displayName);
     var id = typeof session === 'string' ? nfc(session) : nfc((session && session.sessionId) || '');
@@ -54,9 +59,67 @@
     return parts.length >= 2 ? parts[1] : id.slice(0, 8);
   }
 
+  function getLiveSessions() {
+    return sessions.filter(function(s) { return s.status === 'active'; });
+  }
+
+  function getSelectableSessions() {
+    var live = getLiveSessions();
+    var liveIds = new Set(live.map(function(s) { return s.sessionId; }));
+    var merged = live.slice();
+    for (var i = 0; i < policySessions.length; i++) {
+      if (!liveIds.has(policySessions[i].sessionId)) merged.push(policySessions[i]);
+    }
+    return merged;
+  }
+
+  function normalizePolicySessions(list) {
+    if (!Array.isArray(list)) return [];
+
+    var seen = new Set();
+    var normalized = [];
+    for (var i = 0; i < list.length; i++) {
+      var item = list[i];
+      if (!item || typeof item.sessionId !== 'string') continue;
+      var sessionId = nfc(item.sessionId).trim();
+      if (!sessionId || seen.has(sessionId)) continue;
+      seen.add(sessionId);
+      normalized.push({
+        sessionId: sessionId,
+        displayName: nfc(typeof item.displayName === 'string' && item.displayName ? item.displayName : sessionId),
+        color: '#94a3b8',
+        pid: 0,
+        startedAt: '',
+        lastHeartbeat: '',
+        status: 'policy',
+        isLeader: false,
+        authenticated: false,
+        kind: 'policy',
+        isPolicyOnly: true,
+      });
+    }
+
+    normalized.sort(function(a, b) { return a.sessionId.localeCompare(b.sessionId); });
+    return normalized;
+  }
+
+  function setPolicySessions(nextSessions) {
+    policySessions = normalizePolicySessions(nextSessions);
+    updateSessionIndicator();
+    updateSessionFilterOptions();
+  }
+
+  function allSessionsSummary(liveCount, policyCount) {
+    if (policyCount <= 0) return liveCount + ' total';
+    if (liveCount <= 0) return policyCount + ' saved';
+    return liveCount + ' live, ' + policyCount + ' saved';
+  }
+
   // Build a key from current sessions to detect changes
   function sessionListKey(list) {
-    return list.map(function(s) { return s.sessionId + ':' + s.status; }).join(',');
+    return list.map(function(s) {
+      return s.sessionId + ':' + s.status + ':' + (isPolicyOnlySession(s) ? 'policy' : 'live');
+    }).join(',');
   }
 
   // Apply session filter and update all UI to reflect it
@@ -120,7 +183,7 @@
     // Tick uptimes
     var uptimes = document.querySelectorAll('.session-dropdown-uptime');
     for (var j = 0; j < uptimes.length; j++) {
-      uptimes[j].textContent = formatUptime(uptimes[j].dataset.startedAt);
+      uptimes[j].textContent = uptimes[j].dataset.startedAt ? formatUptime(uptimes[j].dataset.startedAt) : 'saved';
     }
 
     // Update box label
@@ -128,7 +191,18 @@
     var labelEl = document.querySelector('.session-box-label');
     if (!countEl || !labelEl) return;
 
-    var active = sessions.filter(function(s) { return s.status === 'active'; });
+    var active = getLiveSessions();
+    var selectable = getSelectableSessions();
+
+    if (filterSessionId) {
+      var filtered = selectable.find(function(s) { return s.sessionId === filterSessionId; });
+      if (filtered) {
+        countEl.textContent = displayName(filtered);
+        if (filtered.color) countEl.style.color = filtered.color;
+        labelEl.textContent = isPolicyOnlySession(filtered) ? 'policy only' : ('1/' + active.length);
+        return;
+      }
+    }
 
     if (active.length === 1) {
       countEl.textContent = displayName(active[0]);
@@ -139,24 +213,16 @@
 
     // Reset color when showing count
     countEl.style.color = '';
-
-    if (filterSessionId) {
-      var filtered = active.find(function(s) { return s.sessionId === filterSessionId; });
-      if (filtered) {
-        countEl.textContent = displayName(filtered);
-        if (filtered.color) countEl.style.color = filtered.color;
-        labelEl.textContent = '1/' + active.length;
-        return;
-      }
-    }
     countEl.textContent = String(active.length);
     labelEl.textContent = active.length === 1 ? 'session' : 'sessions';
   }
 
   // Build or rebuild the session indicator — only when session list actually changes
   function updateSessionIndicator() {
-    var active = sessions.filter(function(s) { return s.status === 'active'; });
-    var key = sessionListKey(active);
+    var active = getLiveSessions();
+    var selectable = getSelectableSessions();
+    var policyOnly = selectable.filter(function(s) { return isPolicyOnlySession(s); });
+    var key = sessionListKey(selectable);
 
     // If sessions haven't changed, just refresh selection state
     if (key === lastSessionKey && dropdownBuilt) {
@@ -212,7 +278,7 @@
 
     var allCount = document.createElement('span');
     allCount.className = 'session-dropdown-role';
-    allCount.textContent = count + ' total';
+    allCount.textContent = allSessionsSummary(count, policyOnly.length);
     allItem.appendChild(allCount);
 
     allItem.addEventListener('click', function(e) {
@@ -221,10 +287,18 @@
     });
     dropdown.appendChild(allItem);
 
-    // Divider
-    var divider = document.createElement('div');
-    divider.className = 'session-dropdown-divider';
-    dropdown.appendChild(divider);
+    function appendDivider() {
+      var divider = document.createElement('div');
+      divider.className = 'session-dropdown-divider';
+      dropdown.appendChild(divider);
+    }
+
+    function appendHeading(text) {
+      var heading = document.createElement('div');
+      heading.className = 'session-dropdown-heading';
+      heading.textContent = text;
+      dropdown.appendChild(heading);
+    }
 
     // Session items — leader first, then followers
     var sorted = active.slice().sort(function(a, b) {
@@ -233,70 +307,78 @@
       return 0;
     });
 
-    for (var i = 0; i < sorted.length; i++) {
-      (function(s) {
-        var item = document.createElement('div');
-        item.className = 'session-dropdown-item';
-        item.dataset.sessionId = s.sessionId;
-        item.setAttribute('role', 'option');
+    function appendSessionItem(s) {
+      var item = document.createElement('div');
+      item.className = 'session-dropdown-item';
+      item.dataset.sessionId = s.sessionId;
+      item.setAttribute('role', 'option');
 
-        var check = document.createElement('span');
-        check.className = 'session-dropdown-check';
-        item.appendChild(check);
+      var check = document.createElement('span');
+      check.className = 'session-dropdown-check';
+      item.appendChild(check);
 
-        var dot = document.createElement('span');
-        dot.className = 'session-dot';
-        if (s.color) dot.style.background = s.color;
-        item.appendChild(dot);
+      var dot = document.createElement('span');
+      dot.className = 'session-dot';
+      if (s.color) dot.style.background = s.color;
+      item.appendChild(dot);
 
-        var nameEl = document.createElement('span');
-        nameEl.className = 'session-dropdown-name';
-        nameEl.textContent = displayName(s);
-        if (s.color) nameEl.style.color = s.color;
-        item.appendChild(nameEl);
+      var nameEl = document.createElement('span');
+      nameEl.className = 'session-dropdown-name';
+      nameEl.textContent = displayName(s);
+      if (s.color) nameEl.style.color = s.color;
+      item.appendChild(nameEl);
 
-        // Session status badges (#1805) — two independent dimensions:
-        // 1. Auth status (filled/empty circle + text)
-        // 2. Client attachment (checkmark/X + text)
-        // Shape + text + colorblind-safe color (blue/orange) = three
-        // independent channels so no single channel carries meaning alone.
-        var authBadge = document.createElement('span');
-        authBadge.className = 'session-status-badge';
-        if (s.authenticated) {
-          authBadge.textContent = '\u25CF Auth';
-          authBadge.dataset.status = 'positive';
-          authBadge.title = 'Authenticated session';
-        } else {
-          authBadge.textContent = '\u25CB No auth';
-          authBadge.dataset.status = 'negative';
-          authBadge.title = 'Unauthenticated session';
-        }
-        item.appendChild(authBadge);
+      // Session status badges (#1805) — for persisted policy sessions we
+      // switch from "live/authenticated" semantics to "saved/no client".
+      var authBadge = document.createElement('span');
+      authBadge.className = 'session-status-badge';
+      if (isPolicyOnlySession(s)) {
+        authBadge.textContent = 'Saved';
+        authBadge.dataset.status = 'positive';
+        authBadge.title = 'Persisted policy state from a prior session';
+      } else if (s.authenticated) {
+        authBadge.textContent = '\u25CF Auth';
+        authBadge.dataset.status = 'positive';
+        authBadge.title = 'Authenticated session';
+      } else {
+        authBadge.textContent = '\u25CB No auth';
+        authBadge.dataset.status = 'negative';
+        authBadge.title = 'Unauthenticated session';
+      }
+      item.appendChild(authBadge);
 
-        var clientBadge = document.createElement('span');
-        clientBadge.className = 'session-status-badge';
-        if (s.kind === 'mcp') {
-          clientBadge.textContent = '\u2713 Client';
-          clientBadge.dataset.status = 'positive';
-          clientBadge.title = 'MCP client attached';
-        } else {
-          clientBadge.textContent = '\u2717 No client';
-          clientBadge.dataset.status = 'negative';
-          clientBadge.title = 'No MCP client attached';
-        }
-        item.appendChild(clientBadge);
+      var clientBadge = document.createElement('span');
+      clientBadge.className = 'session-status-badge';
+      if (isPolicyOnlySession(s)) {
+        clientBadge.textContent = 'No client';
+        clientBadge.dataset.status = 'negative';
+        clientBadge.title = 'No live MCP client is currently attached';
+      } else if (s.kind === 'mcp') {
+        clientBadge.textContent = '\u2713 Client';
+        clientBadge.dataset.status = 'positive';
+        clientBadge.title = 'MCP client attached';
+      } else {
+        clientBadge.textContent = '\u2717 No client';
+        clientBadge.dataset.status = 'negative';
+        clientBadge.title = 'No MCP client attached';
+      }
+      item.appendChild(clientBadge);
 
-        var uptimeEl = document.createElement('span');
-        uptimeEl.className = 'session-dropdown-uptime';
-        uptimeEl.dataset.startedAt = s.startedAt;
-        uptimeEl.textContent = formatUptime(s.startedAt);
-        item.appendChild(uptimeEl);
+      var uptimeEl = document.createElement('span');
+      uptimeEl.className = 'session-dropdown-uptime';
+      uptimeEl.dataset.startedAt = s.startedAt;
+      uptimeEl.textContent = isPolicyOnlySession(s) ? 'saved' : formatUptime(s.startedAt);
+      item.appendChild(uptimeEl);
 
-        var killBtn = document.createElement('button');
-        killBtn.className = 'session-kill-btn';
-        killBtn.type = 'button';
+      var killBtn = document.createElement('button');
+      killBtn.className = 'session-kill-btn';
+      killBtn.type = 'button';
+      killBtn.textContent = '\u00D7';
+      if (isPolicyOnlySession(s)) {
+        killBtn.disabled = true;
+        killBtn.style.visibility = 'hidden';
+      } else {
         killBtn.title = 'Stop ' + displayName(s);
-        killBtn.textContent = '\u00D7';
         killBtn.addEventListener('click', function(e) {
           e.stopPropagation();
           if (!confirm('Stop session ' + displayName(s) + '?')) return;
@@ -320,15 +402,31 @@
               alert('Failed to stop session ' + displayName(s) + ': ' + (err.message || 'network error'));
             });
         });
-        item.appendChild(killBtn);
+      }
+      item.appendChild(killBtn);
 
-        item.addEventListener('click', function(e) {
-          e.stopPropagation();
-          applyFilter(filterSessionId === s.sessionId ? '' : s.sessionId);
-        });
+      item.addEventListener('click', function(e) {
+        e.stopPropagation();
+        applyFilter(filterSessionId === s.sessionId ? '' : s.sessionId);
+      });
 
-        dropdown.appendChild(item);
-      })(sorted[i]);
+      dropdown.appendChild(item);
+    }
+
+    if (sorted.length > 0) {
+      appendDivider();
+      appendHeading('Live Sessions');
+      for (var i = 0; i < sorted.length; i++) {
+        appendSessionItem(sorted[i]);
+      }
+    }
+
+    if (policyOnly.length > 0) {
+      appendDivider();
+      appendHeading('Persisted Policy State');
+      for (var j = 0; j < policyOnly.length; j++) {
+        appendSessionItem(policyOnly[j]);
+      }
     }
 
     var wrapper = document.createElement('div');
@@ -394,14 +492,16 @@
     if (!select) return;
 
     var current = select.value;
-    var active = sessions.filter(function(s) { return s.status === 'active'; });
+    var selectable = getSelectableSessions();
 
     select.innerHTML = '<option value="">All Sessions</option>';
-    for (var i = 0; i < active.length; i++) {
+    for (var i = 0; i < selectable.length; i++) {
       var opt = document.createElement('option');
-      opt.value = active[i].sessionId;
-      opt.textContent = displayName(active[i]) + (active[i].isLeader ? ' (leader)' : '');
-      if (active[i].sessionId === current) opt.selected = true;
+      opt.value = selectable[i].sessionId;
+      opt.textContent = displayName(selectable[i])
+        + (selectable[i].isLeader ? ' (leader)' : '')
+        + (isPolicyOnlySession(selectable[i]) ? ' (policy only)' : '');
+      if (selectable[i].sessionId === current) opt.selected = true;
       select.appendChild(opt);
     }
   }
@@ -435,6 +535,8 @@
     getFilterSessionId: function() { return filterSessionId; },
     displayName: displayName,
     getSessions: function() { return sessions; },
+    getSelectableSessions: getSelectableSessions,
+    setPolicySessions: setPolicySessions,
   };
 
   function init() {

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -423,7 +423,7 @@
 
     if (policyOnly.length > 0) {
       appendDivider();
-      appendHeading('Persisted Policy State');
+      appendHeading('Persisted Policy State (Debug Info)');
       for (var j = 0; j < policyOnly.length; j++) {
         appendSessionItem(policyOnly[j]);
       }

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -3,7 +3,7 @@
  *
  * Shows a labeled "N sessions" box in the header. Clicking opens a
  * dropdown with selectable sessions. Selecting a session filters
- * logs and metrics to that session only.
+ * logs and refreshes any session-aware dashboard tabs.
  *
  * @security-audit-suppress DMCP-SEC-004 Client-side JS — all session data is
  * pre-normalized server-side via UnicodeValidator. Browser String.normalize('NFC')
@@ -70,6 +70,9 @@
     // Trigger log re-filter with the selected session
     if (window.DollhouseConsole && window.DollhouseConsole.logs && window.DollhouseConsole.logs.refilter) {
       window.DollhouseConsole.logs.refilter(sessionId);
+    }
+    if (window.DollhouseConsole && window.DollhouseConsole.permissions && window.DollhouseConsole.permissions.refresh) {
+      window.DollhouseConsole.permissions.refresh();
     }
 
     refreshSelectionState();

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -69,6 +69,8 @@ html { scroll-behavior: smooth; }
 body {
   margin: 0;
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
   color-scheme: light;
   color: var(--ink-900);
   background:
@@ -249,6 +251,7 @@ p, li { max-width: 69ch; }
 .site-main {
   width: min(var(--max-width), calc(100% - 2 * var(--gutter)));
   margin: 0 auto;
+  flex: 1 0 auto;
   padding: clamp(1.1rem, 3vw, 2rem) 0 3rem;
 }
 
@@ -1375,8 +1378,8 @@ body.modal-open { overflow: hidden; }
 .site-footer {
   border-top: 1px solid var(--line);
   padding: 0.85rem 0 1.35rem;
-  position: sticky;
-  bottom: 0;
+  margin-top: auto;
+  position: static;
   background: var(--paper);
   z-index: 10;
 }

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -952,7 +952,7 @@ dialog.modal {
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  padding: 1rem var(--gutter) 0;
+  padding: 1rem var(--gutter) calc(var(--site-footer-height, 4.5rem) + 0.5rem);
   width: 100%;
 }
 dialog.modal::backdrop { display: none; }
@@ -972,14 +972,12 @@ body.modal-open { overflow: hidden; }
   position: relative;
   width: min(72rem, 100%);
   margin: 0 auto;
-  /* Fixed height = viewport minus top padding; content scrolls inside.
-     This keeps the header and toolbar at a stable screen position
-     regardless of content length or raw/rendered toggle. */
-  height: calc(100vh - 1rem);
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  /* Keep the dialog fully inside the viewport and above the fixed footer. */
+  height: calc(100dvh - var(--site-footer-height, 4.5rem) - 1.5rem);
+  max-height: calc(100dvh - var(--site-footer-height, 4.5rem) - 1.5rem);
+  border-radius: var(--radius-lg);
   background: var(--paper-strong);
   border: 1px solid var(--line);
-  border-bottom: none;
   box-shadow: var(--shadow-card);
   overflow: hidden;
   display: flex;
@@ -1378,10 +1376,14 @@ body.modal-open { overflow: hidden; }
 .site-footer {
   border-top: 1px solid var(--line);
   padding: 0.85rem 0 1.35rem;
-  margin-top: auto;
-  position: static;
-  background: var(--paper);
-  z-index: 10;
+  margin-top: 0;
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: color-mix(in srgb, var(--paper) 92%, transparent);
+  backdrop-filter: blur(10px);
+  z-index: 40;
 }
 
 .footer-inner {

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -25,6 +25,12 @@ interface PermissionDecision {
   reason?: string;
 }
 
+interface KnownPolicySession {
+  sessionId: string;
+  displayName: string;
+  source: 'policy';
+}
+
 const DECISION_BUFFER_SIZE = 200;
 const recentDecisions: PermissionDecision[] = [];
 let decisionCounter = 0;
@@ -57,6 +63,29 @@ function trackDecision(toolName: string, input: Record<string, unknown>, result:
 function asSingleResult(results: unknown): { success: boolean; data?: unknown; error?: string } {
   if (Array.isArray(results)) return results[0] || { success: false, error: 'Empty result' };
   return results as { success: boolean; data?: unknown; error?: string };
+}
+
+function extractKnownPolicySessions(elements: Array<Record<string, unknown>>): KnownPolicySession[] {
+  const seen = new Set<string>();
+  const knownSessions: KnownPolicySession[] = [];
+
+  for (const element of elements) {
+    const sessionIds = Array.isArray(element.sessionIds) ? element.sessionIds : [];
+    for (const sessionId of sessionIds) {
+      if (typeof sessionId !== 'string' || sessionId === '' || seen.has(sessionId)) {
+        continue;
+      }
+
+      seen.add(sessionId);
+      knownSessions.push({
+        sessionId,
+        displayName: sessionId,
+        source: 'policy',
+      });
+    }
+  }
+
+  return knownSessions.sort((a, b) => a.sessionId.localeCompare(b.sessionId));
 }
 
 /**
@@ -169,6 +198,7 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
           ? confirmPatterns
           : ((data.combinedConfirmPatterns as string[] | undefined) ?? []),
         elements,
+        knownSessions: extractKnownPolicySessions(elements),
         permissionPromptActive: data.permissionPromptActive,
         recentDecisions,
       });

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -32,8 +32,11 @@ interface KnownPolicySession {
 }
 
 const DECISION_BUFFER_SIZE = 200;
-const recentDecisions: PermissionDecision[] = [];
-let decisionCounter = 0;
+
+interface PermissionDecisionTracker {
+  trackDecision(toolName: string, input: Record<string, unknown>, result: Record<string, unknown>): void;
+  getRecentDecisions(): PermissionDecision[];
+}
 
 /** Extract a string field from a record, trying multiple keys in order */
 function extractString(obj: Record<string, unknown>, keys: string[], fallback: string): string {
@@ -44,19 +47,29 @@ function extractString(obj: Record<string, unknown>, keys: string[], fallback: s
   return fallback;
 }
 
-function trackDecision(toolName: string, input: Record<string, unknown>, result: Record<string, unknown>): void {
-  const entry: PermissionDecision = {
-    id: `d-${++decisionCounter}`,
-    timestamp: new Date().toISOString(),
-    tool_name: toolName,
-    command: toolName === 'Bash' && typeof input?.command === 'string' ? input.command : undefined,
-    decision: extractString(result, ['decision', 'behavior'], 'unknown'),
-    reason: extractString(result, ['reason', 'message'], ''),
+function createPermissionDecisionTracker(bufferSize = DECISION_BUFFER_SIZE): PermissionDecisionTracker {
+  const recentDecisions: PermissionDecision[] = [];
+  let decisionCounter = 0;
+
+  return {
+    trackDecision(toolName: string, input: Record<string, unknown>, result: Record<string, unknown>): void {
+      const entry: PermissionDecision = {
+        id: `d-${++decisionCounter}`,
+        timestamp: new Date().toISOString(),
+        tool_name: toolName,
+        command: toolName === 'Bash' && typeof input?.command === 'string' ? input.command : undefined,
+        decision: extractString(result, ['decision', 'behavior'], 'unknown'),
+        reason: extractString(result, ['reason', 'message'], ''),
+      };
+      recentDecisions.unshift(entry);
+      if (recentDecisions.length > bufferSize) {
+        recentDecisions.length = bufferSize;
+      }
+    },
+    getRecentDecisions(): PermissionDecision[] {
+      return recentDecisions;
+    },
   };
-  recentDecisions.unshift(entry);
-  if (recentDecisions.length > DECISION_BUFFER_SIZE) {
-    recentDecisions.length = DECISION_BUFFER_SIZE;
-  }
 }
 
 /** Helper to extract single result from MCP-AQL batch response */
@@ -93,6 +106,7 @@ function extractKnownPolicySessions(elements: Array<Record<string, unknown>>): K
  * Must be called with the MCP-AQL handler for policy evaluation.
  */
 export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler): void {
+  const decisionTracker = createPermissionDecisionTracker();
   /**
    * POST /api/evaluate_permission
    * Permission evaluation endpoint for PreToolUse hooks.
@@ -144,7 +158,7 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
       logger.debug(`[WebUI/Gateway] evaluate_permission: ${tool_name} → ${decision} (${elapsedMs}ms)`);
 
       // Track decision for live dashboard feed
-      trackDecision(tool_name, input || {}, opResult.data as Record<string, unknown>);
+      decisionTracker.trackDecision(tool_name, input || {}, opResult.data as Record<string, unknown>);
 
       res.json(opResult.data);
     } catch (err) {
@@ -200,7 +214,7 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
         elements,
         knownSessions: extractKnownPolicySessions(elements),
         permissionPromptActive: data.permissionPromptActive,
-        recentDecisions,
+        recentDecisions: decisionTracker.getRecentDecisions(),
       });
     } catch (err) {
       logger.error('[WebUI/Gateway] permissions/status error:', err);

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -130,10 +130,18 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
    * Returns current permission policies and recent decisions
    * for the live permissions dashboard.
    */
-  router.get('/permissions/status', async (_req, res) => {
+  router.get('/permissions/status', async (req, res) => {
     try {
+      const sessionId = typeof req.query['sessionId'] === 'string' && req.query['sessionId']
+        ? req.query['sessionId']
+        : undefined;
+
       const opResult = asSingleResult(await handler.handleRead({
         operation: 'get_effective_cli_policies',
+        params: {
+          reporting_scope: 'dashboard',
+          ...(sessionId ? { session_id: sessionId } : {}),
+        },
       }));
 
       if (!opResult.success) {
@@ -152,11 +160,14 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
       }
 
       res.json({
+        ...(sessionId ? { sessionId } : {}),
         activeElementCount: data.activeElementCount,
         hasAllowlist: data.hasAllowlist,
         denyPatterns: data.combinedDenyPatterns,
         allowPatterns: data.combinedAllowPatterns,
-        confirmPatterns,
+        confirmPatterns: confirmPatterns.length > 0
+          ? confirmPatterns
+          : ((data.combinedConfirmPatterns as string[] | undefined) ?? []),
         elements,
         permissionPromptActive: data.permissionPromptActive,
         recentDecisions,

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -630,6 +630,7 @@ async function startFallbackServer(options: OpenBrowserOptions, port: number): P
   const { createIngestRoutes } = await import('./console/IngestRoutes.js');
   const ingestResult = createIngestRoutes({
     logBroadcast: (entry) => liveBroadcast?.(entry),
+    storeMetricsSnapshot: (snapshot) => metricsSink?.onSnapshot(snapshot),
   });
   ingestResult.registerConsoleSession();
 

--- a/tests/unit/di/deferredPermissionServer.test.ts
+++ b/tests/unit/di/deferredPermissionServer.test.ts
@@ -42,14 +42,22 @@ describe('Permission Server Wiring', () => {
     it('should write port file with correct content', async () => {
       const { writePortFile } = await import('../../../src/auto-dollhouse/portDiscovery.js');
       const runDir = path.join(os.homedir(), '.dollhouse', 'run');
+      const pidPortFile = path.join(runDir, `permission-server-${process.pid}.port`);
       const portFile = path.join(runDir, 'permission-server.port');
 
-      await writePortFile(49999);
+      const writtenFile = await writePortFile(49999);
 
-      const content = await fs.readFile(portFile, 'utf-8');
+      // Read the PID-keyed file returned by writePortFile() to avoid races with
+      // other suites that also update the shared latest-file path in CI.
+      const content = await fs.readFile(writtenFile, 'utf-8');
       expect(content.trim()).toBe('49999');
 
+      // The convenience "latest" file should still exist, but other suites may
+      // update it concurrently so we only assert presence here.
+      await expect(fs.stat(portFile)).resolves.toBeDefined();
+
       // Clean up test artifact
+      await fs.unlink(pidPortFile).catch(() => {});
       await fs.unlink(portFile).catch(() => {});
     });
   });

--- a/tests/unit/di/deferredPermissionServer.test.ts
+++ b/tests/unit/di/deferredPermissionServer.test.ts
@@ -62,18 +62,21 @@ describe('Permission Server Wiring', () => {
       );
 
       expect(containerSource).toContain('private async deferredPermissionServer');
-      expect(containerSource).toContain('await this.deferredPermissionServer(timer)');
+      expect(containerSource).toContain('const consoleResult = await this.deferredWebConsole(timer);');
+      expect(containerSource).toContain('await this.deferredPermissionServer(consoleResult, timer);');
       expect(containerSource).toContain('DOLLHOUSE_PERMISSION_SERVER');
     });
 
-    it('should use the existing web console port, not start a new server', async () => {
+    it('should use the elected web console port, not the default env port', async () => {
       const containerSource = await fs.readFile(
         path.join(process.cwd(), 'src/di/Container.ts'),
         'utf-8'
       );
 
-      // Should reference the console port, not start a new server
-      expect(containerSource).toContain('DOLLHOUSE_WEB_CONSOLE_PORT');
+      // Should reference the live console result, not a guessed env/default port
+      expect(containerSource).toContain("consoleResult?.role === 'leader'");
+      expect(containerSource).toContain('consoleResult.port');
+      expect(containerSource).toContain('consoleResult?.election.leaderInfo.port');
       expect(containerSource).toContain('writePortFile');
       expect(containerSource).toContain('registerPortCleanup');
 
@@ -90,7 +93,7 @@ describe('Permission Server Wiring', () => {
       // After #1866 split: webConsole and permServer are in completeConsoleSetup,
       // dangerZone is in completeSinkSetup. Verify console-group ordering.
       const webConsoleIdx = containerSource.indexOf('deferredWebConsole(timer)');
-      const permServerIdx = containerSource.indexOf('deferredPermissionServer(timer)');
+      const permServerIdx = containerSource.indexOf('deferredPermissionServer(consoleResult, timer)');
 
       expect(permServerIdx).toBeGreaterThan(webConsoleIdx);
     });

--- a/tests/unit/elements/BaseElement.test.ts
+++ b/tests/unit/elements/BaseElement.test.ts
@@ -5,10 +5,10 @@
 import { BaseElement, normalizeVersion } from '../../../src/elements/BaseElement.js';
 import { ElementType } from '../../../src/portfolio/types.js';
 import { ElementStatus } from '../../../src/types/elements/index.js';
-import { createTestMetadataService } from '../../helpers/di-mocks.js';
+import { MetadataService } from '../../../src/services/MetadataService.js';
 
 // Create a shared MetadataService instance for all tests
-const metadataService = createTestMetadataService();
+const metadataService = new MetadataService();
 
 // Create a concrete implementation for testing
 class TestElement extends BaseElement {
@@ -261,6 +261,28 @@ describe('BaseElement', () => {
       expect(element.id).toBe(original.id);
       expect(element.metadata.name).toBe('Original');
       expect(element.metadata.description).toBe('Original description');
+    });
+
+    it('should coerce numeric versions during deserialization', () => {
+      const original = new TestElement({
+        name: 'Original',
+        description: 'Original description'
+      });
+
+      const json = JSON.stringify({
+        id: original.id,
+        type: original.type,
+        version: 1.1,
+        metadata: original.metadata,
+        references: original.references,
+        extensions: original.extensions,
+        ratings: original.ratings
+      });
+
+      const element = new TestElement();
+      element.deserialize(json);
+
+      expect(element.version).toBe('1.1.0');
     });
     
     it('should throw on invalid JSON', () => {

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -13,6 +13,7 @@ import type { PortfolioManager } from '../../../src/portfolio/PortfolioManager.j
 import type { InitializationService } from '../../../src/services/InitializationService.js';
 import type { PersonaIndicatorService } from '../../../src/services/PersonaIndicatorService.js';
 import type { IFileOperationsService } from '../../../src/services/FileOperationsService.js';
+import type { ActivationStore } from '../../../src/services/ActivationStore.js';
 
 describe('ElementCRUDHandler (DI)', () => {
   let handler: ElementCRUDHandler;
@@ -45,6 +46,8 @@ describe('ElementCRUDHandler (DI)', () => {
 
     agentManager = {
       create: jest.fn(),
+      getActiveAgents: jest.fn().mockResolvedValue([]),
+      list: jest.fn().mockResolvedValue([]),
     } as unknown as jest.Mocked<AgentManager>;
 
     memoryManager = {
@@ -57,6 +60,8 @@ describe('ElementCRUDHandler (DI)', () => {
 
     personaHandler = {
       getActivePersona: jest.fn(),
+      getActivePersonas: jest.fn().mockReturnValue([]),
+      list: jest.fn().mockReturnValue([]),
     } as unknown as jest.Mocked<PersonaHandler>;
 
     portfolioManager = {
@@ -210,6 +215,90 @@ describe('ElementCRUDHandler (DI)', () => {
       // Test with 'ensemble' (singular)
       const result2 = await handler.getElementDetails('Test', 'ensemble' as any);
       expect(result2.content[0].text).toContain('🎭');
+    });
+  });
+
+  describe('policy reporting helpers', () => {
+    it('includes active agents in getActiveElementsForPolicy()', async () => {
+      agentManager.getActiveAgents.mockResolvedValue([
+        {
+          metadata: {
+            name: 'autonomy-scout-demo',
+            gatekeeper: {
+              externalRestrictions: {
+                denyPatterns: ['Bash:rm*'],
+              },
+            },
+          },
+        } as any,
+      ]);
+
+      const result = await handler.getActiveElementsForPolicy();
+
+      expect(result).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent',
+          name: 'autonomy-scout-demo',
+        }),
+      ]));
+    });
+
+    it('merges persisted activation snapshots into reportable policy elements', async () => {
+      const activationStore = {
+        isEnabled: jest.fn().mockReturnValue(true),
+        getSessionId: jest.fn().mockReturnValue('leader-session'),
+        listPersistedActivationStates: jest.fn().mockResolvedValue([
+          {
+            sessionId: 'session-other',
+            lastUpdated: new Date().toISOString(),
+            activations: {
+              skill: [{ name: 'audit-trace-demo', activatedAt: new Date().toISOString() }],
+            },
+          },
+        ]),
+      } as unknown as jest.Mocked<ActivationStore>;
+
+      skillManager.getActiveSkills = jest.fn().mockResolvedValue([]);
+      skillManager.list = jest.fn().mockResolvedValue([
+        {
+          metadata: {
+            name: 'audit-trace-demo',
+            gatekeeper: {
+              externalRestrictions: {
+                confirmPatterns: ['Bash:git push*'],
+              },
+            },
+          },
+        } as any,
+      ]);
+
+      const reportHandler = new ElementCRUDHandler(
+        skillManager,
+        templateManager,
+        templateRenderer,
+        agentManager,
+        memoryManager,
+        ensembleManager,
+        personaHandler,
+        portfolioManager,
+        initService,
+        indicatorService,
+        fileOperations,
+        undefined as any,
+        undefined as any,
+        activationStore,
+      );
+
+      const result = await reportHandler.getPolicyElementsForReport('session-other');
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          type: 'skill',
+          name: 'audit-trace-demo',
+          sessionIds: ['session-other'],
+        }),
+      ]);
+      expect(activationStore.listPersistedActivationStates).toHaveBeenCalledWith('session-other');
     });
   });
 });

--- a/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
+++ b/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
@@ -61,6 +61,7 @@ describe('MCPAQLHandler', () => {
         deactivateElement: jest.fn().mockResolvedValue({ deactivated: true }),
         getActiveElements: jest.fn().mockResolvedValue([]),
         getActiveElementsForPolicy: jest.fn().mockResolvedValue([]),
+        getPolicyElementsForReport: jest.fn().mockResolvedValue([]),
       },
       memoryManager: {
         find: jest.fn().mockResolvedValue({
@@ -333,6 +334,79 @@ describe('MCPAQLHandler', () => {
           expect(result.error).toContain('mcp_aql_delete');
         }
       });
+    });
+  });
+
+  describe('get_effective_cli_policies', () => {
+    it('includes confirm patterns in the combined dashboard view', async () => {
+      (mockRegistry.elementCRUD.getActiveElementsForPolicy as jest.Mock).mockResolvedValue([
+        {
+          type: 'persona',
+          name: 'careful-persona',
+          metadata: {
+            name: 'careful-persona',
+            gatekeeper: {
+              externalRestrictions: {
+                allowPatterns: ['Bash:git status*'],
+                confirmPatterns: ['Bash:git push*'],
+                denyPatterns: ['Bash:rm*'],
+                description: 'Safer shell access',
+              },
+            },
+          },
+        },
+      ]);
+
+      const result = await handler.handleRead({
+        operation: 'get_effective_cli_policies',
+        params: {},
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as Record<string, unknown>;
+        expect(data.combinedConfirmPatterns).toEqual(['Bash:git push*']);
+        expect(data.elements).toEqual([
+          expect.objectContaining({
+            confirmPatterns: ['Bash:git push*'],
+          }),
+        ]);
+      }
+    });
+
+    it('uses reportable policy elements for dashboard session views', async () => {
+      (mockRegistry.elementCRUD.getPolicyElementsForReport as jest.Mock).mockResolvedValue([
+        {
+          type: 'skill',
+          name: 'audit-trace-demo',
+          metadata: {
+            name: 'audit-trace-demo',
+            gatekeeper: {
+              externalRestrictions: {
+                denyPatterns: ['Bash:curl*'],
+                confirmPatterns: ['Bash:git push*'],
+              },
+            },
+          },
+          sessionIds: ['session-demo-1'],
+        },
+      ]);
+
+      const result = await handler.handleRead({
+        operation: 'get_effective_cli_policies',
+        params: {
+          reporting_scope: 'dashboard',
+          session_id: 'session-demo-1',
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockRegistry.elementCRUD.getPolicyElementsForReport).toHaveBeenCalledWith('session-demo-1');
+      if (result.success) {
+        const data = result.data as Record<string, unknown>;
+        expect(data.combinedDenyPatterns).toEqual(['Bash:curl*']);
+        expect(data.combinedConfirmPatterns).toEqual(['Bash:git push*']);
+      }
     });
   });
 
@@ -1490,6 +1564,7 @@ describe('MCPAQLHandler', () => {
           deactivateElement: jest.fn().mockResolvedValue({ deactivated: true }),
           getActiveElements: jest.fn().mockResolvedValue([]),
           getActiveElementsForPolicy: jest.fn().mockResolvedValue([]),
+          getPolicyElementsForReport: jest.fn().mockResolvedValue([]),
         },
         memoryManager: {
           find: jest.fn().mockResolvedValue({

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -347,7 +347,10 @@ describe('Web console cleanup regressions', () => {
     expect(win.document.getElementById('perm-selected-badge')?.textContent).toContain('Persisted Policy State (Debug Info)');
     expect(win.document.getElementById('perm-selected-source-list')?.textContent).toContain('autonomy-scout-demo');
     expect(win.document.getElementById('perm-selected-deny-list')?.textContent).toContain('mcp__DollhouseMCP__mcp_aql_delete*');
-    expect(apiFetch).not.toHaveBeenCalledWith('/api/permissions/status?sessionId=session-focus');
+    const selectedSessionRequests = apiFetch.mock.calls
+      .map(([url]) => url)
+      .filter((url): url is string => typeof url === 'string' && url.includes('sessionId=session-focus'));
+    expect(selectedSessionRequests).toHaveLength(0);
 
     cleanup();
   });

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -262,27 +262,6 @@ describe('Web console cleanup regressions', () => {
         });
       }
 
-      if (url === '/api/permissions/status?sessionId=session-focus') {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({
-            sessionId: 'session-focus',
-            activeElementCount: 1,
-            hasAllowlist: false,
-            denyPatterns: ['mcp__DollhouseMCP__mcp_aql_delete*'],
-            allowPatterns: ['mcp__DollhouseMCP__mcp_aql_read*'],
-            confirmPatterns: ['mcp__DollhouseMCP__mcp_aql_execute*'],
-            elements: [{
-              type: 'agent',
-              element_name: 'autonomy-scout-demo',
-              description: 'Selected session details',
-            }],
-            recentDecisions: [],
-            permissionPromptActive: false,
-          }),
-        });
-      }
-
       if (url === '/api/permissions/status') {
         return Promise.resolve({
           ok: true,
@@ -290,19 +269,25 @@ describe('Web console cleanup regressions', () => {
             activeElementCount: 2,
             hasAllowlist: true,
             denyPatterns: ['Bash:rm -rf *', 'Bash:git clean -f*'],
-            allowPatterns: ['Bash:git status*'],
+            allowPatterns: [],
             confirmPatterns: ['Bash:git push*'],
             elements: [
               {
                 type: 'ensemble',
                 element_name: 'drawing-room-safety',
                 description: 'Shared baseline restrictions',
+                allowPatterns: ['Bash:git status*'],
+                confirmPatterns: [],
+                denyPatterns: [],
                 sessionIds: ['session-alpha'],
               },
               {
                 type: 'agent',
                 element_name: 'autonomy-scout-demo',
                 description: 'Selected session details',
+                allowPatterns: ['mcp__DollhouseMCP__mcp_aql_read*'],
+                confirmPatterns: ['mcp__DollhouseMCP__mcp_aql_execute*'],
+                denyPatterns: ['mcp__DollhouseMCP__mcp_aql_delete*'],
                 sessionIds: ['session-focus'],
               },
             ],
@@ -350,6 +335,7 @@ describe('Web console cleanup regressions', () => {
     expect(sourceItems).toHaveLength(2);
     expect(win.document.getElementById('perm-source-list')?.textContent).toContain('drawing-room-safety');
     expect(win.document.getElementById('perm-source-list')?.textContent).toContain('autonomy-scout-demo');
+    expect(win.document.getElementById('perm-allow-list')?.textContent).toContain('Bash:git status*');
 
     const highlighted = win.document.querySelectorAll('#perm-source-list .perm-source-item--selected');
     expect(highlighted).toHaveLength(1);
@@ -361,6 +347,7 @@ describe('Web console cleanup regressions', () => {
     expect(win.document.getElementById('perm-selected-badge')?.textContent).toContain('Persisted Policy State (Debug Info)');
     expect(win.document.getElementById('perm-selected-source-list')?.textContent).toContain('autonomy-scout-demo');
     expect(win.document.getElementById('perm-selected-deny-list')?.textContent).toContain('mcp__DollhouseMCP__mcp_aql_delete*');
+    expect(apiFetch).not.toHaveBeenCalledWith('/api/permissions/status?sessionId=session-focus');
 
     cleanup();
   });

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -15,6 +15,7 @@ let appSource = '';
 let sessionsSource = '';
 let logsSource = '';
 let metricsSource = '';
+let permissionsSource = '';
 
 type TestWindow = JSDOM['window'] & typeof globalThis & Record<string, any>;
 
@@ -24,11 +25,12 @@ const SESSION_FILTER_INJECTION_WAIT_MS = 40;
 
 beforeAll(async () => {
   const base = join(process.cwd(), 'src/web/public');
-  [appSource, sessionsSource, logsSource, metricsSource] = await Promise.all([
+  [appSource, sessionsSource, logsSource, metricsSource, permissionsSource] = await Promise.all([
     readFile(join(base, 'app.js'), 'utf8'),
     readFile(join(base, 'sessions.js'), 'utf8'),
     readFile(join(base, 'logs.js'), 'utf8'),
     readFile(join(base, 'metrics.js'), 'utf8'),
+    readFile(join(base, 'permissions.js'), 'utf8'),
   ]);
 });
 
@@ -229,6 +231,191 @@ describe('Web console cleanup regressions', () => {
     expect(select?.options[1].value).toBe('session-1');
     expect(select?.options[1].textContent).toContain('Barbie');
     expect(select?.options[1].textContent).toContain('(leader)');
+
+    cleanup();
+  });
+
+  it('keeps aggregate policy sources visible when selecting a persisted policy session', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="session-indicator"></div>
+      <div id="tab-logs"><div class="log-controls"></div></div>
+      <div id="console-tabs"><button class="console-tab" data-tab="permissions">Permissions</button></div>
+      <div id="permissions-dashboard-root"></div>
+    `);
+
+    const apiFetch = jest.fn((url: string) => {
+      if (url === '/api/sessions') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            sessions: [{
+              sessionId: 'console-1',
+              status: 'active',
+              displayName: 'Web Console',
+              startedAt: '2026-04-13T20:00:00.000Z',
+              isLeader: false,
+              authenticated: true,
+              kind: 'console',
+              color: '#6366f1',
+            }],
+          }),
+        });
+      }
+
+      if (url === '/api/permissions/status?sessionId=session-focus') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            sessionId: 'session-focus',
+            activeElementCount: 1,
+            hasAllowlist: false,
+            denyPatterns: ['mcp__DollhouseMCP__mcp_aql_delete*'],
+            allowPatterns: ['mcp__DollhouseMCP__mcp_aql_read*'],
+            confirmPatterns: ['mcp__DollhouseMCP__mcp_aql_execute*'],
+            elements: [{
+              type: 'agent',
+              element_name: 'autonomy-scout-demo',
+              description: 'Selected session details',
+            }],
+            recentDecisions: [],
+            permissionPromptActive: false,
+          }),
+        });
+      }
+
+      if (url === '/api/permissions/status') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            activeElementCount: 2,
+            hasAllowlist: true,
+            denyPatterns: ['Bash:rm -rf *', 'Bash:git clean -f*'],
+            allowPatterns: ['Bash:git status*'],
+            confirmPatterns: ['Bash:git push*'],
+            elements: [
+              {
+                type: 'ensemble',
+                element_name: 'drawing-room-safety',
+                description: 'Shared baseline restrictions',
+                sessionIds: ['session-alpha'],
+              },
+              {
+                type: 'agent',
+                element_name: 'autonomy-scout-demo',
+                description: 'Selected session details',
+                sessionIds: ['session-focus'],
+              },
+            ],
+            knownSessions: [
+              { sessionId: 'session-alpha', displayName: 'session-alpha', source: 'policy' },
+              { sessionId: 'session-focus', displayName: 'session-focus', source: 'policy' },
+            ],
+            recentDecisions: [],
+            permissionPromptActive: false,
+          }),
+        });
+      }
+
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    win.DollhouseAuth.apiFetch = apiFetch;
+    win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+    win.DollhouseConsoleConfig = {
+      sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
+      sessionFilterInjectionMaxRetries: 5,
+    };
+
+    win.eval(sessionsSource);
+    win.eval(permissionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    win.DollhouseConsole.permissions.init();
+    await wait(SESSION_FILTER_INJECTION_WAIT_MS);
+
+    const sessionBox = win.document.querySelector('.session-box') as HTMLButtonElement | null;
+    expect(sessionBox).not.toBeNull();
+    sessionBox?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    const debugHeading = Array.from(win.document.querySelectorAll('.session-dropdown-heading'))
+      .map(node => node.textContent);
+    expect(debugHeading).toContain('Persisted Policy State (Debug Info)');
+
+    const persistedItem = win.document.querySelector('.session-dropdown-item[data-session-id="session-focus"]') as HTMLElement | null;
+    expect(persistedItem).not.toBeNull();
+    persistedItem?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    const sourceItems = Array.from(win.document.querySelectorAll('#perm-source-list .perm-source-item'));
+    expect(sourceItems).toHaveLength(2);
+    expect(win.document.getElementById('perm-source-list')?.textContent).toContain('drawing-room-safety');
+    expect(win.document.getElementById('perm-source-list')?.textContent).toContain('autonomy-scout-demo');
+
+    const highlighted = win.document.querySelectorAll('#perm-source-list .perm-source-item--selected');
+    expect(highlighted).toHaveLength(1);
+    expect(highlighted[0]?.textContent).toContain('autonomy-scout-demo');
+
+    const selectedCard = win.document.getElementById('perm-selected-card');
+    expect(selectedCard?.hidden).toBe(false);
+    expect(win.document.getElementById('perm-selected-title')?.textContent).toContain('session-focus');
+    expect(win.document.getElementById('perm-selected-badge')?.textContent).toContain('Persisted Policy State (Debug Info)');
+    expect(win.document.getElementById('perm-selected-source-list')?.textContent).toContain('autonomy-scout-demo');
+    expect(win.document.getElementById('perm-selected-deny-list')?.textContent).toContain('mcp__DollhouseMCP__mcp_aql_delete*');
+
+    cleanup();
+  });
+
+  it('ignores malformed persisted policy session entries in the picker', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="session-indicator"></div>
+      <div id="tab-logs"><div class="log-controls"></div></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        sessions: [{
+          sessionId: 'console-1',
+          status: 'active',
+          displayName: 'Web Console',
+          startedAt: '2026-04-13T20:00:00.000Z',
+          isLeader: false,
+          authenticated: true,
+          kind: 'console',
+          color: '#6366f1',
+        }],
+      }),
+    });
+    win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+    win.DollhouseConsoleConfig = {
+      sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
+      sessionFilterInjectionMaxRetries: 5,
+    };
+
+    win.eval(sessionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    await wait(SESSION_FILTER_INJECTION_WAIT_MS);
+
+    win.DollhouseSessions.setPolicySessions([
+      null,
+      { sessionId: '', displayName: 'empty' },
+      { sessionId: 'session-good', displayName: 'session-good' },
+      { sessionId: 'session-good', displayName: 'duplicate' },
+      { sessionId: 42, displayName: 'bad-type' },
+    ]);
+
+    const select = win.document.getElementById('log-session-filter') as HTMLSelectElement | null;
+    expect(select).not.toBeNull();
+    const options = Array.from(select?.options ?? []).map(option => ({
+      value: option.value,
+      label: option.textContent,
+    }));
+
+    expect(options).toEqual([
+      { value: '', label: 'All Sessions' },
+      { value: 'console-1', label: 'Web Console' },
+      { value: 'session-good', label: 'session-good (policy only)' },
+    ]);
 
     cleanup();
   });

--- a/tests/unit/web/console/sessionRegistry.test.ts
+++ b/tests/unit/web/console/sessionRegistry.test.ts
@@ -49,6 +49,31 @@ describe('Session registry (#1805)', () => {
     });
   });
 
+  describe('metrics ingestion', () => {
+    it('stores follower snapshots in the provided metrics callback', async () => {
+      const storeMetricsSnapshot = jest.fn();
+      ingestResult = createIngestRoutes({
+        logBroadcast: () => {},
+        storeMetricsSnapshot,
+      });
+      const app = buildApp(ingestResult);
+      const snapshot = {
+        id: 'snap-1',
+        timestamp: new Date().toISOString(),
+        metrics: [],
+        errors: [],
+        durationMs: 7,
+      };
+
+      const res = await request(app)
+        .post('/api/ingest/metrics')
+        .send({ sessionId: 'metrics-1', snapshot });
+
+      expect(res.status).toBe(200);
+      expect(storeMetricsSnapshot).toHaveBeenCalledWith(snapshot, 'metrics-1');
+    });
+  });
+
   describe('registerConsoleSession', () => {
     it('registers a console session with authenticated=true and kind=console', () => {
       ingestResult.registerConsoleSession();

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -144,6 +144,43 @@ describe('permissionRoutes', () => {
       expect(res.body.allowPatterns).toEqual(['Bash:git *']);
       expect(res.body.confirmPatterns).toEqual(['Bash:git merge*']);
       expect(Array.isArray(res.body.recentDecisions)).toBe(true);
+      expect(handler.handleRead).toHaveBeenCalledWith({
+        operation: 'get_effective_cli_policies',
+        params: {
+          reporting_scope: 'dashboard',
+        },
+      });
+    });
+
+    it('should pass session selection through to the dashboard policy query', async () => {
+      const handler = {
+        handleRead: jest.fn().mockResolvedValue([{
+          success: true,
+          data: {
+            activeElementCount: 1,
+            hasAllowlist: false,
+            combinedDenyPatterns: ['Bash:rm*'],
+            combinedAllowPatterns: [],
+            combinedConfirmPatterns: ['Bash:git push*'],
+            elements: [],
+            permissionPromptActive: false,
+          },
+        }]),
+      } as any;
+      const app = createApp(handler);
+
+      const res = await request(app).get('/api/permissions/status?sessionId=session-abc');
+
+      expect(res.status).toBe(200);
+      expect(res.body.sessionId).toBe('session-abc');
+      expect(res.body.confirmPatterns).toEqual(['Bash:git push*']);
+      expect(handler.handleRead).toHaveBeenCalledWith({
+        operation: 'get_effective_cli_policies',
+        params: {
+          reporting_scope: 'dashboard',
+          session_id: 'session-abc',
+        },
+      });
     });
 
     it('should return 500 when handler fails', async () => {

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -183,6 +183,36 @@ describe('permissionRoutes', () => {
       });
     });
 
+    it('should expose known persisted policy sessions for the session picker', async () => {
+      const handler = {
+        handleRead: jest.fn().mockResolvedValue([{
+          success: true,
+          data: {
+            activeElementCount: 2,
+            hasAllowlist: false,
+            combinedDenyPatterns: [],
+            combinedAllowPatterns: [],
+            combinedConfirmPatterns: [],
+            elements: [
+              { name: 'guard-a', sessionIds: ['session-b', 'session-a'] },
+              { name: 'guard-b', sessionIds: ['session-a'] },
+              { name: 'guard-c' },
+            ],
+            permissionPromptActive: false,
+          },
+        }]),
+      } as any;
+      const app = createApp(handler);
+
+      const res = await request(app).get('/api/permissions/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.knownSessions).toEqual([
+        { sessionId: 'session-a', displayName: 'session-a', source: 'policy' },
+        { sessionId: 'session-b', displayName: 'session-b', source: 'policy' },
+      ]);
+    });
+
     it('should return 500 when handler fails', async () => {
       const handler = {
         handleRead: jest.fn().mockResolvedValue([{

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -230,27 +230,93 @@ describe('permissionRoutes', () => {
   });
 
   describe('decision tracking', () => {
-    it('should track decisions in recent decisions feed', async () => {
-      const handler = createMockHandler([{
-        success: true,
-        data: { decision: 'deny', reason: 'Blocked' },
-      }]);
+    it('should accumulate recent decisions newest-first within one app instance', async () => {
+      const handler = {
+        handleRead: jest
+          .fn()
+          .mockResolvedValueOnce([{ success: true, data: { decision: 'allow', reason: 'Safe read' } }])
+          .mockResolvedValueOnce([{ success: true, data: { decision: 'deny', reason: 'Blocked delete' } }])
+          .mockResolvedValueOnce([{
+            success: true,
+            data: {
+              activeElementCount: 0,
+              hasAllowlist: false,
+              combinedDenyPatterns: [],
+              combinedAllowPatterns: [],
+              combinedConfirmPatterns: [],
+              elements: [],
+              permissionPromptActive: false,
+            },
+          }]),
+      } as any;
       const app = createApp(handler);
 
-      // Make a permission evaluation
       await request(app)
+        .post('/api/evaluate_permission')
+        .send({ tool_name: 'Read', input: { file_path: './README.md' } });
+
+      await request(app)
+        .post('/api/evaluate_permission')
+        .send({ tool_name: 'Bash', input: { command: 'rm -rf /tmp/demo' } });
+
+      const res = await request(app).get('/api/permissions/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.recentDecisions).toHaveLength(2);
+      expect(res.body.recentDecisions.map((entry: any) => entry.tool_name)).toEqual(['Bash', 'Read']);
+      expect(res.body.recentDecisions.map((entry: any) => entry.decision)).toEqual(['deny', 'allow']);
+      expect(res.body.recentDecisions[0].command).toBe('rm -rf /tmp/demo');
+    });
+
+    it('should isolate recent decisions between separate router instances', async () => {
+      const firstHandler = {
+        handleRead: jest
+          .fn()
+          .mockResolvedValueOnce([{ success: true, data: { decision: 'deny', reason: 'Blocked' } }])
+          .mockResolvedValue([{
+            success: true,
+            data: {
+              activeElementCount: 0,
+              hasAllowlist: false,
+              combinedDenyPatterns: [],
+              combinedAllowPatterns: [],
+              combinedConfirmPatterns: [],
+              elements: [],
+              permissionPromptActive: false,
+            },
+          }]),
+      } as any;
+      const secondHandler = {
+        handleRead: jest.fn().mockResolvedValue([{
+          success: true,
+          data: {
+            activeElementCount: 0,
+            hasAllowlist: false,
+            combinedDenyPatterns: [],
+            combinedAllowPatterns: [],
+            combinedConfirmPatterns: [],
+            elements: [],
+            permissionPromptActive: false,
+          },
+        }]),
+      } as any;
+
+      const firstApp = createApp(firstHandler);
+      const secondApp = createApp(secondHandler);
+
+      await request(firstApp)
         .post('/api/evaluate_permission')
         .send({ tool_name: 'Bash', input: { command: 'rm -rf /' } });
 
-      // The decision tracking is module-scoped, so it persists across requests
-      const res = await request(app).get('/api/permissions/status');
+      const firstStatus = await request(firstApp).get('/api/permissions/status');
+      const secondStatus = await request(secondApp).get('/api/permissions/status');
 
-      // recentDecisions should have the tracked entry
-      if (res.status === 200 && res.body.recentDecisions) {
-        expect(res.body.recentDecisions.length).toBeGreaterThanOrEqual(1);
-        expect(res.body.recentDecisions[0].tool_name).toBe('Bash');
-        expect(res.body.recentDecisions[0].decision).toBe('deny');
-      }
+      expect(firstStatus.status).toBe(200);
+      expect(firstStatus.body.recentDecisions).toHaveLength(1);
+      expect(firstStatus.body.recentDecisions[0].tool_name).toBe('Bash');
+
+      expect(secondStatus.status).toBe(200);
+      expect(secondStatus.body.recentDecisions).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary

Prepare the `2.0.14` point release from `develop` to `main`.

Included in this release:
- Permissions console reporting, audit feed routing, and session UX hardening
- Permissions tab dark mode rendering fixes
- Numeric YAML version deserialization fix for two-component versions like `1.1`

## Validation

- `npx tsc -p tsconfig.json --noEmit`
