### PR TITLE
fix: automate MCP bundle release flow

### DIFF
--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -1,0 +1,70 @@
+name: Publish MCP Bundle
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag to upload the bundle to (e.g., v2.0.15)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  publish-mcpb:
+    name: Build and upload .mcpb
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Resolve release metadata
+        id: release_meta
+        shell: bash
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag_name }}
+        run: |
+          TAG_NAME="${EVENT_TAG:-$INPUT_TAG}"
+          if [ -z "$TAG_NAME" ]; then
+            echo "❌ No tag name available for MCP bundle publication"
+            exit 1
+          fi
+
+          VERSION=$(node -p "require('./package.json').version")
+          EXPECTED_TAG="v${VERSION}"
+
+          if [ "$TAG_NAME" != "$EXPECTED_TAG" ]; then
+            echo "❌ Tag/version mismatch: release tag is $TAG_NAME but package.json is $EXPECTED_TAG"
+            exit 1
+          fi
+
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "asset_path=dollhousemcp-${VERSION}.mcpb" >> "$GITHUB_OUTPUT"
+
+      - name: Build MCP bundle
+        shell: bash
+        run: ./scripts/build-mcpb.sh
+
+      - name: Upload MCP bundle to GitHub release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ steps.release_meta.outputs.tag_name }}
+          ASSET_PATH: ${{ steps.release_meta.outputs.asset_path }}
+        run: |
+          gh release upload "$TAG_NAME" "$ASSET_PATH" --clobber

--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -117,6 +117,7 @@ jobs:
             ### Files Updated
             - package.json
             - package-lock.json
+            - manifest.json
             - README.md
             - CHANGELOG.md
             - Documentation files

--- a/docs/developer-guide/workflow.md
+++ b/docs/developer-guide/workflow.md
@@ -135,6 +135,9 @@ Follow semantic versioning (MAJOR.MINOR.PATCH):
    gh release create v1.1.0 --title "v1.1.0 - CI/CD Reliability" \
      --notes "## Highlights\n- Fixed ARM64 Docker builds\n- Added MCP protocol tests\n\n## Full Changelog\n..."
    ```
+5. **Publishing happens from the release event**:
+   - pushing the `vX.Y.Z` tag triggers tag-based workflows like GitHub Packages
+   - publishing the GitHub release triggers npm Trusted Publishing, MCP Registry publication, and `.mcpb` bundle upload
 
 ## 👥 Collaboration Guidelines
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dollhousemcp",
   "display_name": "DollhouseMCP",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "Open-source AI customization through modular Dollhouse elements — personas, skills, templates, agents, memories, and ensembles.",
   "long_description": "DollhouseMCP is an MCP server that lets you customize your AI with modular Dollhouse elements. Create personas that shape behavior and permissions, skills that add capabilities, templates for consistent outputs, agents for autonomous multi-step goals, memories for persistent context, and ensembles that bundle elements together. Includes MCP-AQL query language with 5 semantic CRUDE endpoints, Gatekeeper permission system, community collection, and a built-in portfolio browser.",
   "author": {

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -18,8 +18,15 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 STAGING_DIR="$PROJECT_DIR/.mcpb-staging"
 VERSION=$(node -e "console.log(require('$PROJECT_DIR/package.json').version)")
+MANIFEST_VERSION=$(node -e "console.log(require('$PROJECT_DIR/manifest.json').version)")
 
 cd "$PROJECT_DIR"
+
+if [ "$VERSION" != "$MANIFEST_VERSION" ]; then
+    echo "Error: package.json version ($VERSION) does not match manifest.json version ($MANIFEST_VERSION)"
+    echo "Update manifest.json before building the .mcpb bundle."
+    exit 1
+fi
 
 # Verify mcpb is installed
 if ! command -v mcpb &> /dev/null && ! npx @anthropic-ai/mcpb --version &> /dev/null; then

--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -160,6 +160,16 @@ const updateConfigs = [
     required: true
   },
   {
+    name: 'manifest.json',
+    updates: [
+      {
+        pattern: /"version":\s*"[\d.]+(-[\w.]+)?"/,
+        replacement: `"version": "${newVersion}"`
+      }
+    ],
+    required: true
+  },
+  {
     name: 'Dockerfile',
     updates: [
       {

--- a/tests/scripts/update-version.test.ts
+++ b/tests/scripts/update-version.test.ts
@@ -84,6 +84,7 @@ describe('update-version.mjs functionality validation', () => {
     // Check for expected file patterns
     expect(scriptContent).toMatch(/package\.json/);
     expect(scriptContent).toMatch(/package-lock\.json/);
+    expect(scriptContent).toMatch(/manifest\.json/);
     expect(scriptContent).toMatch(/README\.md/);
     expect(scriptContent).toMatch(/CHANGELOG\.md/);
     expect(scriptContent).toMatch(/docs\/\*\*\/\*\.md/);


### PR DESCRIPTION
## Summary

Fix the point-release automation so future stable releases publish complete, internally consistent artifacts.

This hotfix:
- adds `manifest.json` to the version propagation flow
- adds a dedicated release workflow to build and upload the `.mcpb` bundle asset on published GitHub releases
- makes `scripts/build-mcpb.sh` fail fast if `package.json` and `manifest.json` drift
- aligns `manifest.json` with the current `2.0.14` release so the MCP bundle build is healthy on `main`
- updates the release workflow docs to reflect the automated publish path

## Validation

- `npx jest --config tests/jest.config.cjs --runInBand --modulePathIgnorePatterns=.worktrees --runTestsByPath tests/scripts/update-version.test.ts tests/unit/github-workflow-validation.test.ts`
- `node scripts/update-version.mjs 2.0.15 --dry-run`
- `./scripts/build-mcpb.sh` (verified generated bundle metadata reports `2.0.14`)
