### PR TITLE
fix: automate MCP bundle release flow

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -42,7 +42,7 @@ jobs:
         run: npm run build
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
       - name: Download mcp-publisher CLI
         shell: bash

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -11,6 +11,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: release-publish-${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   id-token: write  # Required for OIDC authentication
   contents: read   # Required for checkout

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -41,27 +41,29 @@ jobs:
       - name: Build package
         run: npm run build
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4
+
       - name: Download mcp-publisher CLI
         shell: bash
         run: |
           # Pinned to v1.3.3 for reproducibility
           VERSION="v1.3.3"
           ARCHIVE="mcp-publisher_linux_amd64.tar.gz"
-          EXPECTED_SHA256="1113b9d6bf59b000966c4f17752cf87b51db03dcc5482721421fd843ce3bf048"
 
-          # Download archive and checksums
+          # Download archive and signature material
           curl -L "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/${ARCHIVE}" -o /tmp/mcp-publisher.tar.gz
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/registry_${VERSION#v}_checksums.txt" -o /tmp/checksums.txt
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/${ARCHIVE}.sig" -o /tmp/mcp-publisher.tar.gz.sig
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/mcp-publisher_linux_amd64.pem" -o /tmp/mcp-publisher.pem
 
-          # Verify checksum
-          cd /tmp
-          echo "${EXPECTED_SHA256}  mcp-publisher.tar.gz" | sha256sum --check --status
-          if [ $? -ne 0 ]; then
-            echo "::error::Checksum verification failed for mcp-publisher"
-            exit 1
-          fi
+          # Verify signature using the release-provided public key
+          cosign verify-blob \
+            --key /tmp/mcp-publisher.pem \
+            --signature /tmp/mcp-publisher.tar.gz.sig \
+            /tmp/mcp-publisher.tar.gz
 
           # Extract and install
+          cd /tmp
           tar -xzf mcp-publisher.tar.gz
           chmod +x mcp-publisher
           sudo mv mcp-publisher /usr/local/bin/mcp-publisher

--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -95,5 +95,20 @@ jobs:
           TAG_NAME: ${{ steps.release_meta.outputs.tag_name }}
           ASSET_PATH: ${{ steps.release_meta.outputs.asset_path }}
         run: |
-          gh release upload "$TAG_NAME" "$ASSET_PATH" --clobber
-          gh release upload "$TAG_NAME" "${ASSET_PATH}.sha256" --clobber
+          for asset in "$ASSET_PATH" "${ASSET_PATH}.sha256"; do
+            success=false
+            for attempt in 1 2 3; do
+              if gh release upload "$TAG_NAME" "$asset" --clobber; then
+                echo "✅ Uploaded $asset"
+                success=true
+                break
+              fi
+              echo "⚠️ Upload attempt $attempt failed for $asset"
+              sleep 5
+            done
+
+            if [[ "$success" != "true" ]]; then
+              echo "❌ Failed to upload $asset after 3 attempts"
+              exit 1
+            fi
+          done

--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -1,0 +1,70 @@
+name: Publish MCP Bundle
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag to upload the bundle to (e.g., v2.0.15)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  publish-mcpb:
+    name: Build and upload .mcpb
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Resolve release metadata
+        id: release_meta
+        shell: bash
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag_name }}
+        run: |
+          TAG_NAME="${EVENT_TAG:-$INPUT_TAG}"
+          if [ -z "$TAG_NAME" ]; then
+            echo "❌ No tag name available for MCP bundle publication"
+            exit 1
+          fi
+
+          VERSION=$(node -p "require('./package.json').version")
+          EXPECTED_TAG="v${VERSION}"
+
+          if [ "$TAG_NAME" != "$EXPECTED_TAG" ]; then
+            echo "❌ Tag/version mismatch: release tag is $TAG_NAME but package.json is $EXPECTED_TAG"
+            exit 1
+          fi
+
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "asset_path=dollhousemcp-${VERSION}.mcpb" >> "$GITHUB_OUTPUT"
+
+      - name: Build MCP bundle
+        shell: bash
+        run: ./scripts/build-mcpb.sh
+
+      - name: Upload MCP bundle to GitHub release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ steps.release_meta.outputs.tag_name }}
+          ASSET_PATH: ${{ steps.release_meta.outputs.asset_path }}
+        run: |
+          gh release upload "$TAG_NAME" "$ASSET_PATH" --clobber

--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -10,6 +10,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: release-publish-${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -44,6 +48,11 @@ jobs:
             exit 1
           fi
 
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "❌ Invalid tag format for MCP bundle publication: $TAG_NAME"
+            exit 1
+          fi
+
           VERSION=$(node -p "require('./package.json').version")
           EXPECTED_TAG="v${VERSION}"
 
@@ -60,6 +69,15 @@ jobs:
         shell: bash
         run: ./scripts/build-mcpb.sh
 
+      - name: Generate MCP bundle checksum
+        id: checksum
+        shell: bash
+        env:
+          ASSET_PATH: ${{ steps.release_meta.outputs.asset_path }}
+        run: |
+          sha256sum "$ASSET_PATH" > "${ASSET_PATH}.sha256"
+          echo "checksum_path=${ASSET_PATH}.sha256" >> "$GITHUB_OUTPUT"
+
       - name: Upload MCP bundle to GitHub release
         shell: bash
         env:
@@ -68,3 +86,4 @@ jobs:
           ASSET_PATH: ${{ steps.release_meta.outputs.asset_path }}
         run: |
           gh release upload "$TAG_NAME" "$ASSET_PATH" --clobber
+          gh release upload "$TAG_NAME" "${ASSET_PATH}.sha256" --clobber

--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -16,6 +16,9 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 
 jobs:
   publish-mcpb:
@@ -77,6 +80,13 @@ jobs:
         run: |
           sha256sum "$ASSET_PATH" > "${ASSET_PATH}.sha256"
           echo "checksum_path=${ASSET_PATH}.sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Attest MCP bundle provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            ${{ steps.release_meta.outputs.asset_path }}
+            ${{ steps.checksum.outputs.checksum_path }}
 
       - name: Upload MCP bundle to GitHub release
         shell: bash

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -23,6 +23,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: release-publish-${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   id-token: write   # Required for OIDC/Trusted Publishing
   contents: read    # Required for checkout

--- a/.github/workflows/version-update.yml
+++ b/.github/workflows/version-update.yml
@@ -117,6 +117,7 @@ jobs:
             ### Files Updated
             - package.json
             - package-lock.json
+            - manifest.json
             - README.md
             - CHANGELOG.md
             - Documentation files

--- a/docs/developer-guide/workflow.md
+++ b/docs/developer-guide/workflow.md
@@ -135,6 +135,9 @@ Follow semantic versioning (MAJOR.MINOR.PATCH):
    gh release create v1.1.0 --title "v1.1.0 - CI/CD Reliability" \
      --notes "## Highlights\n- Fixed ARM64 Docker builds\n- Added MCP protocol tests\n\n## Full Changelog\n..."
    ```
+5. **Publishing happens from the release event**:
+   - pushing the `vX.Y.Z` tag triggers tag-based workflows like GitHub Packages
+   - publishing the GitHub release triggers npm Trusted Publishing, MCP Registry publication, and `.mcpb` bundle upload
 
 ## 👥 Collaboration Guidelines
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dollhousemcp",
   "display_name": "DollhouseMCP",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "Open-source AI customization through modular Dollhouse elements — personas, skills, templates, agents, memories, and ensembles.",
   "long_description": "DollhouseMCP is an MCP server that lets you customize your AI with modular Dollhouse elements. Create personas that shape behavior and permissions, skills that add capabilities, templates for consistent outputs, agents for autonomous multi-step goals, memories for persistent context, and ensembles that bundle elements together. Includes MCP-AQL query language with 5 semantic CRUDE endpoints, Gatekeeper permission system, community collection, and a built-in portfolio browser.",
   "author": {

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -22,15 +22,15 @@ MANIFEST_VERSION=$(node -e "console.log(require('$PROJECT_DIR/manifest.json').ve
 
 cd "$PROJECT_DIR"
 
-if [ "$VERSION" != "$MANIFEST_VERSION" ]; then
-    echo "Error: package.json version ($VERSION) does not match manifest.json version ($MANIFEST_VERSION)"
-    echo "Update manifest.json before building the .mcpb bundle."
+if [[ "$VERSION" != "$MANIFEST_VERSION" ]]; then
+    echo "Error: package.json version ($VERSION) does not match manifest.json version ($MANIFEST_VERSION)" >&2
+    echo "Update manifest.json before building the .mcpb bundle." >&2
     exit 1
 fi
 
 # Verify mcpb is installed
-if ! command -v mcpb &> /dev/null && ! npx @anthropic-ai/mcpb --version &> /dev/null; then
-    echo "Error: mcpb CLI not found. Install with: npm install -g @anthropic-ai/mcpb"
+if ! command -v mcpb > /dev/null 2>&1 && ! npx --yes @anthropic-ai/mcpb --version > /dev/null 2>&1; then
+    echo "Error: mcpb CLI not found. Install with: npm install -g @anthropic-ai/mcpb" >&2
     exit 1
 fi
 

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -18,8 +18,15 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 STAGING_DIR="$PROJECT_DIR/.mcpb-staging"
 VERSION=$(node -e "console.log(require('$PROJECT_DIR/package.json').version)")
+MANIFEST_VERSION=$(node -e "console.log(require('$PROJECT_DIR/manifest.json').version)")
 
 cd "$PROJECT_DIR"
+
+if [ "$VERSION" != "$MANIFEST_VERSION" ]; then
+    echo "Error: package.json version ($VERSION) does not match manifest.json version ($MANIFEST_VERSION)"
+    echo "Update manifest.json before building the .mcpb bundle."
+    exit 1
+fi
 
 # Verify mcpb is installed
 if ! command -v mcpb &> /dev/null && ! npx @anthropic-ai/mcpb --version &> /dev/null; then

--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -160,6 +160,16 @@ const updateConfigs = [
     required: true
   },
   {
+    name: 'manifest.json',
+    updates: [
+      {
+        pattern: /"version":\s*"[\d.]+(-[\w.]+)?"/,
+        replacement: `"version": "${newVersion}"`
+      }
+    ],
+    required: true
+  },
+  {
     name: 'Dockerfile',
     updates: [
       {

--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -29,6 +29,13 @@ const newVersion = args[0];
 const isDryRun = args.includes('--dry-run');
 const notesIndex = args.indexOf('--notes');
 const releaseNotes = notesIndex !== -1 && args[notesIndex + 1] ? args[notesIndex + 1] : '';
+const maxFilesEnv = process.env.MAX_FILES;
+const maxMatchedFiles = maxFilesEnv ? Number.parseInt(maxFilesEnv, 10) : 1000;
+
+if (!Number.isInteger(maxMatchedFiles) || maxMatchedFiles <= 0) {
+  console.error('❌ MAX_FILES must be a positive integer');
+  process.exit(1);
+}
 
 // Security: Validate release notes length to prevent injection attacks
 if (releaseNotes.length > 1000) {
@@ -319,8 +326,8 @@ async function handleGlobPattern(pattern, config) {
   const files = await glob(fullPattern);
   
   // Security: Limit number of files to prevent DoS
-  if (files.length > 1000) {
-    console.error(`❌ Too many files matched (${files.length}). Maximum is 1000.`);
+  if (files.length > maxMatchedFiles) {
+    console.error(`❌ Too many files matched (${files.length}). Maximum is ${maxMatchedFiles}.`);
     process.exit(1);
   }
   let updated = 0;

--- a/tests/scripts/update-version.test.ts
+++ b/tests/scripts/update-version.test.ts
@@ -84,6 +84,7 @@ describe('update-version.mjs functionality validation', () => {
     // Check for expected file patterns
     expect(scriptContent).toMatch(/package\.json/);
     expect(scriptContent).toMatch(/package-lock\.json/);
+    expect(scriptContent).toMatch(/manifest\.json/);
     expect(scriptContent).toMatch(/README\.md/);
     expect(scriptContent).toMatch(/CHANGELOG\.md/);
     expect(scriptContent).toMatch(/docs\/\*\*\/\*\.md/);

--- a/tests/scripts/update-version.test.ts
+++ b/tests/scripts/update-version.test.ts
@@ -34,7 +34,8 @@ describe('update-version.mjs security validation', () => {
     expect(scriptContent).toMatch(/File too large/);
     
     // Check for file count limit
-    expect(scriptContent).toMatch(/files\.length > 1000/);
+    expect(scriptContent).toMatch(/MAX_FILES/);
+    expect(scriptContent).toMatch(/maxMatchedFiles/);
     expect(scriptContent).toMatch(/Too many files matched/);
     
     // Check for proper escaping function


### PR DESCRIPTION
## Summary

Fix the point-release automation so future stable releases publish complete, internally consistent artifacts.

This hotfix:
- adds `manifest.json` to the version propagation flow
- adds a dedicated release workflow to build and upload the `.mcpb` bundle asset on published GitHub releases
- hardens the publish workflows with release concurrency guards
- adds checksum generation/upload for the `.mcpb` asset
- makes `scripts/build-mcpb.sh` fail fast if `package.json` and `manifest.json` drift
- aligns `manifest.json` with the current `2.0.14` release so the MCP bundle build is healthy on `main`
- updates the release workflow docs to reflect the automated publish path

## Validation

- `npx jest --config tests/jest.config.cjs --runInBand --modulePathIgnorePatterns=.worktrees --runTestsByPath tests/scripts/update-version.test.ts tests/unit/github-workflow-validation.test.ts`
- `node scripts/update-version.mjs 2.0.15 --dry-run`
- `./scripts/build-mcpb.sh` (verified generated bundle metadata reports `2.0.14`)
