### PR TITLE
Fix MCP Registry publish verification

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -5,6 +5,10 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
+      release_ref:
+        description: 'Optional git ref to publish (for example refs/tags/v2.0.15)'
+        required: false
+        type: string
       dry_run:
         description: 'Run in dry-run mode (test without publishing)'
         required: false
@@ -24,10 +28,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Resolve source ref
+        id: source-ref
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.release_ref }}" ]]; then
+            echo "ref=${{ github.event.inputs.release_ref }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "ref=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ github.ref }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ steps.source-ref.outputs.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -41,25 +58,31 @@ jobs:
       - name: Build package
         run: npm run build
 
-      - name: Install cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
       - name: Download mcp-publisher CLI
         shell: bash
         run: |
           # Pinned to v1.3.3 for reproducibility
           VERSION="v1.3.3"
           ARCHIVE="mcp-publisher_linux_amd64.tar.gz"
+          EXPECTED_SHA256="1113b9d6bf59b000966c4f17752cf87b51db03dcc5482721421fd843ce3bf048"
 
-          # Download archive and signature material
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/${ARCHIVE}" -o /tmp/mcp-publisher.tar.gz
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/${ARCHIVE}.sig" -o /tmp/mcp-publisher.tar.gz.sig
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/mcp-publisher_linux_amd64.pem" -o /tmp/mcp-publisher.pem
+          # Download archive and signature material.
+          curl --retry 3 --retry-delay 5 -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/${ARCHIVE}" -o /tmp/mcp-publisher.tar.gz
+          curl --retry 3 --retry-delay 5 -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/${ARCHIVE}.sig" -o /tmp/mcp-publisher.tar.gz.sig.b64
+          curl --retry 3 --retry-delay 5 -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/mcp-publisher_linux_amd64.pem" -o /tmp/mcp-publisher.cert.b64
 
-          # Verify signature using the release-provided public key
-          cosign verify-blob \
-            --key /tmp/mcp-publisher.pem \
-            --signature /tmp/mcp-publisher.tar.gz.sig \
+          # Verify the pinned archive digest first for deterministic release inputs.
+          echo "${EXPECTED_SHA256}  /tmp/mcp-publisher.tar.gz" | sha256sum --check --status
+
+          # The upstream .pem and .sig assets are base64-encoded; decode them before verifying.
+          base64 -d /tmp/mcp-publisher.cert.b64 > /tmp/mcp-publisher.cert.pem
+          base64 -d /tmp/mcp-publisher.tar.gz.sig.b64 > /tmp/mcp-publisher.tar.gz.sig
+
+          # Verify the archive signature using the public key embedded in the release certificate.
+          openssl x509 -in /tmp/mcp-publisher.cert.pem -pubkey -noout > /tmp/mcp-publisher.pub
+          openssl dgst -sha256 \
+            -verify /tmp/mcp-publisher.pub \
+            -signature /tmp/mcp-publisher.tar.gz.sig \
             /tmp/mcp-publisher.tar.gz
 
           # Extract and install

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -28,17 +28,30 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Resolve source ref
+      - name: Resolve and validate source ref
         id: source-ref
         shell: bash
         run: |
+          RAW_REF=""
+
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.release_ref }}" ]]; then
-            echo "ref=${{ github.event.inputs.release_ref }}" >> "$GITHUB_OUTPUT"
+            RAW_REF="${{ github.event.inputs.release_ref }}"
           elif [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "ref=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+            RAW_REF="refs/tags/${{ github.event.release.tag_name }}"
           else
-            echo "ref=${{ github.ref }}" >> "$GITHUB_OUTPUT"
+            RAW_REF="${{ github.ref }}"
           fi
+
+          if [[ "$RAW_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][A-Za-z0-9._-]+)?$ ]]; then
+            RAW_REF="refs/tags/${RAW_REF}"
+          fi
+
+          if [[ ! "$RAW_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+([-.][A-Za-z0-9._-]+)?$ && ! "$RAW_REF" =~ ^refs/heads/[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::Unsupported release ref '$RAW_REF'. Use refs/tags/vX.Y.Z, vX.Y.Z, or a refs/heads/* branch."
+            exit 1
+          fi
+
+          echo "ref=$RAW_REF" >> "$GITHUB_OUTPUT"
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -61,29 +74,68 @@ jobs:
       - name: Download mcp-publisher CLI
         shell: bash
         run: |
+          set -euo pipefail
+
           # Pinned to v1.3.3 for reproducibility
           VERSION="v1.3.3"
           ARCHIVE="mcp-publisher_linux_amd64.tar.gz"
           EXPECTED_SHA256="1113b9d6bf59b000966c4f17752cf87b51db03dcc5482721421fd843ce3bf048"
+          CERT_B64="/tmp/mcp-publisher.cert.b64"
+          CERT_PEM="/tmp/mcp-publisher.cert.pem"
+          PUBKEY_FILE="/tmp/mcp-publisher.pub"
+          SIG_B64="/tmp/mcp-publisher.tar.gz.sig.b64"
+          SIG_FILE="/tmp/mcp-publisher.tar.gz.sig"
+          ARCHIVE_FILE="/tmp/mcp-publisher.tar.gz"
+          EXPECTED_ISSUER="sigstore-intermediate"
+          EXPECTED_SAN_URI="https://github.com/modelcontextprotocol/registry/.github/workflows/release.yml@refs/tags/${VERSION}"
 
           # Download archive and signature material.
-          curl --retry 3 --retry-delay 5 -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/${ARCHIVE}" -o /tmp/mcp-publisher.tar.gz
-          curl --retry 3 --retry-delay 5 -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/${ARCHIVE}.sig" -o /tmp/mcp-publisher.tar.gz.sig.b64
-          curl --retry 3 --retry-delay 5 -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/mcp-publisher_linux_amd64.pem" -o /tmp/mcp-publisher.cert.b64
+          curl --retry 3 --retry-delay 5 -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/${ARCHIVE}" -o "$ARCHIVE_FILE"
+          curl --retry 3 --retry-delay 5 -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/${ARCHIVE}.sig" -o "$SIG_B64"
+          curl --retry 3 --retry-delay 5 -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/mcp-publisher_linux_amd64.pem" -o "$CERT_B64"
 
           # Verify the pinned archive digest first for deterministic release inputs.
-          echo "${EXPECTED_SHA256}  /tmp/mcp-publisher.tar.gz" | sha256sum --check --status
+          if ! echo "${EXPECTED_SHA256}  ${ARCHIVE_FILE}" | sha256sum --check --status; then
+            echo "::error::SHA256 verification failed for ${ARCHIVE}"
+            exit 1
+          fi
 
-          # The upstream .pem and .sig assets are base64-encoded; decode them before verifying.
-          base64 -d /tmp/mcp-publisher.cert.b64 > /tmp/mcp-publisher.cert.pem
-          base64 -d /tmp/mcp-publisher.tar.gz.sig.b64 > /tmp/mcp-publisher.tar.gz.sig
+          # The upstream release assets (.pem and .sig) are base64-encoded; decode them for OpenSSL verification.
+          if ! base64 -d "$CERT_B64" > "$CERT_PEM"; then
+            echo "::error::Failed to decode upstream certificate asset"
+            exit 1
+          fi
+          if ! base64 -d "$SIG_B64" > "$SIG_FILE"; then
+            echo "::error::Failed to decode upstream signature asset"
+            exit 1
+          fi
+
+          # Confirm the signing certificate parses cleanly and is tied to the expected upstream workflow.
+          if ! openssl x509 -in "$CERT_PEM" -noout >/dev/null; then
+            echo "::error::Upstream signing certificate could not be parsed"
+            exit 1
+          fi
+          if ! openssl x509 -in "$CERT_PEM" -noout -issuer | grep -F "$EXPECTED_ISSUER" >/dev/null; then
+            echo "::error::Upstream signing certificate issuer did not contain ${EXPECTED_ISSUER}"
+            exit 1
+          fi
+          if ! openssl x509 -in "$CERT_PEM" -noout -ext subjectAltName | grep -F "$EXPECTED_SAN_URI" >/dev/null; then
+            echo "::error::Upstream signing certificate SAN does not match ${EXPECTED_SAN_URI}"
+            exit 1
+          fi
 
           # Verify the archive signature using the public key embedded in the release certificate.
-          openssl x509 -in /tmp/mcp-publisher.cert.pem -pubkey -noout > /tmp/mcp-publisher.pub
-          openssl dgst -sha256 \
-            -verify /tmp/mcp-publisher.pub \
-            -signature /tmp/mcp-publisher.tar.gz.sig \
-            /tmp/mcp-publisher.tar.gz
+          if ! openssl x509 -in "$CERT_PEM" -pubkey -noout > "$PUBKEY_FILE"; then
+            echo "::error::Failed to extract public key from upstream signing certificate"
+            exit 1
+          fi
+          if ! openssl dgst -sha256 \
+            -verify "$PUBKEY_FILE" \
+            -signature "$SIG_FILE" \
+            "$ARCHIVE_FILE"; then
+            echo "::error::Signature verification failed for ${ARCHIVE}"
+            exit 1
+          fi
 
           # Extract and install
           cd /tmp

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -154,6 +154,48 @@ describe('GitHub Workflow Validation', () => {
       });
     });
   });
+
+  describe('Publish to MCP Registry Workflow', () => {
+    let workflow: Workflow;
+    let workflowContent: string;
+
+    beforeAll(() => {
+      const workflowPath = path.join(workflowDir, 'publish-mcp-registry.yml');
+      workflowContent = fs.readFileSync(workflowPath, 'utf8');
+      workflow = yaml.load(workflowContent) as Workflow;
+    });
+
+    it('should allow workflow_dispatch reruns against an explicit release ref', () => {
+      const dispatchInputs = workflow.on?.workflow_dispatch?.inputs;
+
+      expect(dispatchInputs?.release_ref).toBeDefined();
+      expect(dispatchInputs?.release_ref.type).toBe('string');
+      expect(dispatchInputs?.dry_run).toBeDefined();
+    });
+
+    it('should validate and normalize release refs before checkout', () => {
+      const publishJob = workflow.jobs.publish;
+      const resolveStep = publishJob.steps.find(step => step.name === 'Resolve and validate source ref');
+      const checkoutStep = publishJob.steps.find(step => step.name === 'Checkout code');
+
+      expect(resolveStep?.run).toContain("Unsupported release ref");
+      expect(resolveStep?.run).toContain("refs/tags/");
+      expect(resolveStep?.run).toContain("refs/heads/");
+      expect(checkoutStep?.with?.ref).toBe('${{ steps.source-ref.outputs.ref }}');
+    });
+
+    it('should verify publisher downloads with explicit certificate and signature checks', () => {
+      const publishJob = workflow.jobs.publish;
+      const downloadStep = publishJob.steps.find(step => step.name === 'Download mcp-publisher CLI');
+
+      expect(downloadStep?.run).toContain('set -euo pipefail');
+      expect(downloadStep?.run).toContain('SHA256 verification failed');
+      expect(downloadStep?.run).toContain('openssl x509 -in "$CERT_PEM" -noout >/dev/null');
+      expect(downloadStep?.run).toContain('EXPECTED_ISSUER');
+      expect(downloadStep?.run).toContain('subjectAltName');
+      expect(downloadStep?.run).toContain('Signature verification failed');
+    });
+  });
 });
 
 // Helper functions


### PR DESCRIPTION
## Summary
- fix MCP publisher verification by decoding the upstream base64 certificate and signature assets before verifying with OpenSSL
- keep the pinned archive digest check in place for deterministic release inputs
- add an optional workflow_dispatch ref input so we can safely rerun publishing for a specific release tag like v2.0.15

## Validation
- npx jest --config tests/jest.config.cjs --runInBand --modulePathIgnorePatterns=.worktrees --runTestsByPath tests/unit/github-workflow-validation.test.ts
- validated the exact v1.3.3 archive and signature flow locally against the upstream release assets