### PR TITLE
Automate npm propagation wait for MCP Registry publish

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -149,6 +149,35 @@ jobs:
       - name: Login to MCP Registry (OIDC)
         run: mcp-publisher login github-oidc
 
+      - name: Wait for npm package propagation
+        if: ${{ github.event.inputs.dry_run != 'true' && startsWith(steps.source-ref.outputs.ref, 'refs/tags/') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PACKAGE_NAME="$(node -p "require('./package.json').name")"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          MAX_ATTEMPTS=20
+          SLEEP_SECONDS=30
+
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            if PUBLISHED_VERSION="$(npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version --registry https://registry.npmjs.org --silent 2>/dev/null)" \
+              && [[ "$PUBLISHED_VERSION" == "$PACKAGE_VERSION" ]]; then
+              echo "Detected ${PACKAGE_NAME}@${PACKAGE_VERSION} on npm."
+              exit 0
+            fi
+
+            if [[ "$attempt" -eq "$MAX_ATTEMPTS" ]]; then
+              break
+            fi
+
+            echo "Waiting for ${PACKAGE_NAME}@${PACKAGE_VERSION} to propagate to npm (${attempt}/${MAX_ATTEMPTS})..."
+            sleep "$SLEEP_SECONDS"
+          done
+
+          echo "::error::Timed out waiting for ${PACKAGE_NAME}@${PACKAGE_VERSION} to appear on npm. Rerun the workflow after npm propagation completes."
+          exit 1
+
       - name: Publish to MCP Registry
         shell: bash
         run: |

--- a/tests/workflows/mcp-registry-workflow.test.ts
+++ b/tests/workflows/mcp-registry-workflow.test.ts
@@ -174,6 +174,13 @@ describe('MCP Registry Workflow Configuration', () => {
       expect(hasDryRun).toBe(true);
     });
 
+    test('should wait for npm package propagation before publishing tags', () => {
+      expect(workflowContent).toMatch(/name:\s*Wait for npm package propagation/);
+      expect(workflowContent).toMatch(/npm view "\$\{PACKAGE_NAME\}@\$\{PACKAGE_VERSION\}" version/);
+      expect(workflowContent).toMatch(/startsWith\(steps\.source-ref\.outputs\.ref,\s*'refs\/tags\/'\)/);
+      expect(workflowContent).toMatch(/github\.event\.inputs\.dry_run != 'true'/);
+    });
+
     test('should use workflow_dispatch for manual triggers', () => {
       expect(workflowContent).toMatch(/workflow_dispatch/);
     });

--- a/tests/workflows/test-mcp-registry-workflow.sh
+++ b/tests/workflows/test-mcp-registry-workflow.sh
@@ -243,13 +243,13 @@ validate_workflow_oidc_permissions() {
 validate_workflow_uses_pinned_version() {
     print_test "Workflow uses pinned mcp-publisher version (not latest)"
 
-    if grep -q "releases/download/v[0-9]" "$WORKFLOW_FILE"; then
-        local version=$(grep -o "releases/download/v[0-9]\.[0-9]\.[0-9]" "$WORKFLOW_FILE" | head -1)
+    if grep -Eq 'VERSION[[:space:]]*=[[:space:]]*["'\'']v[0-9]+\.[0-9]+\.[0-9]+([-.][A-Za-z0-9._-]+)?["'\'']' "$WORKFLOW_FILE"; then
+        local version=$(grep -Eo 'VERSION[[:space:]]*=[[:space:]]*["'\'']v[0-9]+\.[0-9]+\.[0-9]+([-.][A-Za-z0-9._-]+)?["'\'']' "$WORKFLOW_FILE" | head -1)
         print_pass
-        print_info "Using pinned version: $version"
+        print_info "Using pinned version declaration: $version"
         return 0
     else
-        print_fail "Workflow not using pinned version (should use releases/download/vX.Y.Z, not latest)"
+        print_fail "Workflow not using pinned VERSION declaration (should use VERSION=\"vX.Y.Z\", not latest)"
         return 1
     fi
 }


### PR DESCRIPTION
## Summary
- wait for tagged npm releases to appear on npm before publishing to the MCP Registry
- skip the wait for dry runs and branch refs so manual testing stays fast
- extend workflow validation coverage for the new propagation guard and update the shell validator to match the pinned VERSION pattern

## Testing
- npx jest --config tests/jest.config.cjs --runInBand --modulePathIgnorePatterns=.worktrees --runTestsByPath tests/workflows/mcp-registry-workflow.test.ts tests/unit/github-workflow-validation.test.ts
- bash tests/workflows/test-mcp-registry-workflow.sh