### PR TITLE
Warn on invalid gatekeeper policy activation

### DIFF
--- a/src/elements/BaseElement.ts
+++ b/src/elements/BaseElement.ts
@@ -58,6 +58,9 @@ export function normalizeVersion(version: string): string {
 }
 
 export abstract class BaseElement implements IElement {
+  private static readonly TRANSIENT_METADATA_FIELDS = new Set([
+    'gatekeeperDiagnostics',
+  ]);
   // Identity
   public id: string;
   public type: ElementType;
@@ -368,6 +371,10 @@ export abstract class BaseElement implements IElement {
     if (typeof obj === 'object') {
       const cleaned: any = {};
       for (const [key, value] of Object.entries(obj)) {
+        if (BaseElement.TRANSIENT_METADATA_FIELDS.has(key)) {
+          continue;
+        }
+
         const cleanedValue = this.deepCleanObject(value);
         if (cleanedValue !== undefined) {
           cleaned[key] = cleanedValue;

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -1860,7 +1860,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     // Issue #676: Sanitize gatekeeper policy on load to prevent prompt-injection attacks
     // Malformed policies are stripped and logged as security events (never reach enforcement)
     if (metadata.gatekeeper) {
-      metadata.gatekeeper = sanitizeGatekeeperPolicy(metadata.gatekeeper, metadata.name || 'unknown', 'agent');
+      metadata.gatekeeper = sanitizeGatekeeperPolicy(metadata.gatekeeper, metadata.name || 'unknown', 'agent', metadata as Record<string, unknown>);
     }
 
     // Issue #722: Validate V2 agent fields on load — structural checks, strip malformed data.

--- a/src/elements/base/ElementFileOperations.ts
+++ b/src/elements/base/ElementFileOperations.ts
@@ -158,7 +158,7 @@ export class ElementFileOperations {
 
     // Clean metadata to remove undefined values
     const cleanMetadata = Object.entries(metadata).reduce((acc, [key, value]) => {
-      if (value !== undefined) {
+      if (key !== 'gatekeeperDiagnostics' && value !== undefined) {
         acc[key] = value;
       }
       return acc;

--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -386,7 +386,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       allowNested,
       maxNestingDepth,
       elements,
-      gatekeeper: sanitizeGatekeeperPolicy(data.gatekeeper, name, 'ensemble'),  // Issue #524
+      gatekeeper: sanitizeGatekeeperPolicy(data.gatekeeper, name, 'ensemble', data as Record<string, unknown>),  // Issue #524
     };
 
     return metadata;
@@ -689,7 +689,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       maxNestingDepth: metadata.maxNestingDepth || ENSEMBLE_DEFAULTS.MAX_NESTING_DEPTH,
       elements: migratedElements,
       // Issue #524 — Gatekeeper policy (symmetric with buildMetadata deserialization)
-      gatekeeper: sanitizeGatekeeperPolicy((metadata as any).gatekeeper, metadata.name!, 'ensemble'),
+      gatekeeper: sanitizeGatekeeperPolicy((metadata as any).gatekeeper, metadata.name!, 'ensemble', metadata as unknown as Record<string, unknown>),
     };
 
     // Use inherited getElementFilename() for consistent filename normalization

--- a/src/elements/memories/MemoryManager.ts
+++ b/src/elements/memories/MemoryManager.ts
@@ -1952,7 +1952,7 @@ export class MemoryManager extends BaseElementManager<Memory> {
       // Memory type classification
       memoryType: metadataSource.memoryType,
       // Issue #524 — Gatekeeper policy (all element types)
-      gatekeeper: sanitizeGatekeeperPolicy(metadataSource.gatekeeper, nameResult.sanitizedValue || 'unknown', 'memory'),
+      gatekeeper: sanitizeGatekeeperPolicy(metadataSource.gatekeeper, nameResult.sanitizedValue || 'unknown', 'memory', metadataSource as Record<string, unknown>),
     };
 
     // Enhanced trigger validation and logging

--- a/src/elements/skills/SkillManager.ts
+++ b/src/elements/skills/SkillManager.ts
@@ -229,7 +229,7 @@ export class SkillManager extends BaseElementManager<Skill> {
     // Issue #676: Sanitize gatekeeper policy on load to prevent prompt-injection attacks
     // Malformed policies are stripped and logged as security events (never reach enforcement)
     if (metadata.gatekeeper) {
-      metadata.gatekeeper = sanitizeGatekeeperPolicy(metadata.gatekeeper, metadata.name || 'unknown', 'skill');
+      metadata.gatekeeper = sanitizeGatekeeperPolicy(metadata.gatekeeper, metadata.name || 'unknown', 'skill', metadata as Record<string, unknown>);
     }
 
     return metadata;

--- a/src/elements/templates/TemplateManager.ts
+++ b/src/elements/templates/TemplateManager.ts
@@ -450,7 +450,7 @@ export class TemplateManager extends BaseElementManager<Template> {
     metadata.version = data.version ? sanitizeInput(data.version, 20) : undefined;
 
     // Issue #524 — Gatekeeper policy (all element types)
-    metadata.gatekeeper = sanitizeGatekeeperPolicy(data.gatekeeper, metadata.name || 'unknown', 'template');
+    metadata.gatekeeper = sanitizeGatekeeperPolicy(data.gatekeeper, metadata.name || 'unknown', 'template', metadata as Record<string, unknown>);
 
     metadata.name = metadata.name ?? 'Untitled Template';
     metadata.description = metadata.description ?? '';

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -56,6 +56,7 @@ import type { BackupService } from '../services/BackupService.js';
 import type { PolicyExportService } from '../services/PolicyExportService.js';
 import type { BaseElementManager } from '../elements/base/BaseElementManager.js';
 import { formatValidationFailedError } from './element-crud/responseFormatter.js';
+import { getGatekeeperDiagnostics } from './mcp-aql/policies/ElementPolicies.js';
 
 export class ElementCRUDHandler {
   private readonly strategies: Map<string, ElementActivationStrategy>;
@@ -147,7 +148,7 @@ export class ElementCRUDHandler {
   }
 
   private hasGatekeeperPolicy(metadata: Record<string, unknown> | undefined): boolean {
-    return Boolean(metadata?.['gatekeeper']);
+    return Boolean(metadata?.['gatekeeper'] || getGatekeeperDiagnostics(metadata));
   }
 
   private toPolicyElementType(type: string): string {

--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -667,6 +667,7 @@ export class MCPAQLHandler {
           name: el.name,
           description: (el.metadata.description as string) ?? undefined,
           gatekeeper: el.metadata?.gatekeeper as ActiveElement['metadata']['gatekeeper'] ?? undefined,
+          ...this.copyGatekeeperDiagnostics(el.metadata),
         },
       }));
 
@@ -703,6 +704,7 @@ export class MCPAQLHandler {
           name: el.name,
           description: (el.metadata.description as string) ?? undefined,
           gatekeeper: el.metadata?.gatekeeper as ActiveElement['metadata']['gatekeeper'] ?? undefined,
+          ...this.copyGatekeeperDiagnostics(el.metadata),
           ...(Array.isArray((el as { sessionIds?: string[] }).sessionIds)
             ? { sessionIds: (el as { sessionIds?: string[] }).sessionIds }
             : {}),
@@ -712,6 +714,11 @@ export class MCPAQLHandler {
       logger.warn('Failed to gather policy elements for dashboard reporting', { error, sessionId });
       return sessionId ? [] : this.getActiveElements();
     }
+  }
+
+  private copyGatekeeperDiagnostics(metadata: unknown): Record<string, unknown> {
+    const diagnostics = getGatekeeperDiagnostics(metadata);
+    return diagnostics ? { gatekeeperDiagnostics: diagnostics } : {};
   }
 
   /**
@@ -2967,20 +2974,23 @@ export class MCPAQLHandler {
           : await this.getActiveElements();
 
         // 2. Extract externalRestrictions from each element
-        const elementPolicies = policyElements.map(el => ({
-          type: el.type,
-          name: el.name,
-          allowPatterns: el.metadata?.gatekeeper?.externalRestrictions?.allowPatterns ?? [],
-          confirmPatterns: el.metadata?.gatekeeper?.externalRestrictions?.confirmPatterns ?? [],
-          denyPatterns: el.metadata?.gatekeeper?.externalRestrictions?.denyPatterns ?? [],
-          allowOperations: el.metadata?.gatekeeper?.allow ?? [],
-          confirmOperations: el.metadata?.gatekeeper?.confirm ?? [],
-          denyOperations: el.metadata?.gatekeeper?.deny ?? [],
-          description: el.metadata?.gatekeeper?.externalRestrictions?.description ?? null,
-          invalidGatekeeperPolicy: !!getGatekeeperDiagnostics(el.metadata),
-          invalidGatekeeperMessage: getGatekeeperDiagnostics(el.metadata)?.message,
-          sessionIds: (el.metadata as Record<string, unknown>)?.sessionIds ?? undefined,
-        }));
+        const elementPolicies = policyElements.map(el => {
+          const diagnostics = getGatekeeperDiagnostics(el.metadata);
+          return {
+            type: el.type,
+            name: el.name,
+            allowPatterns: el.metadata?.gatekeeper?.externalRestrictions?.allowPatterns ?? [],
+            confirmPatterns: el.metadata?.gatekeeper?.externalRestrictions?.confirmPatterns ?? [],
+            denyPatterns: el.metadata?.gatekeeper?.externalRestrictions?.denyPatterns ?? [],
+            allowOperations: el.metadata?.gatekeeper?.allow ?? [],
+            confirmOperations: el.metadata?.gatekeeper?.confirm ?? [],
+            denyOperations: el.metadata?.gatekeeper?.deny ?? [],
+            description: el.metadata?.gatekeeper?.externalRestrictions?.description ?? null,
+            invalidGatekeeperPolicy: !!diagnostics,
+            invalidGatekeeperMessage: diagnostics?.message,
+            sessionIds: (el.metadata as Record<string, unknown>)?.sessionIds ?? undefined,
+          };
+        });
 
         // 3. Build combined view
         const combinedAllow = elementPolicies.flatMap(p => p.allowPatterns);
@@ -3039,7 +3049,7 @@ export class MCPAQLHandler {
         }
 
         if (invalidPolicyElements.length > 0) {
-          const invalidAdvisory = `${invalidPolicyElements.length} active element${invalidPolicyElements.length === 1 ? '' : 's'} ha${invalidPolicyElements.length === 1 ? 's' : 've'} malformed gatekeeper policy. The element${invalidPolicyElements.length === 1 ? ' remains' : 's remain'} active, but that policy is not enforceable until fixed.`;
+          const invalidAdvisory = buildInvalidPolicyAdvisory(invalidPolicyElements.length);
           advisory = advisory ? `${advisory} ${invalidAdvisory}` : invalidAdvisory;
         }
 
@@ -4319,6 +4329,11 @@ export class MCPAQLHandler {
       Array.isArray((result as Record<string, unknown>).content)
     );
   }
+}
+
+function buildInvalidPolicyAdvisory(invalidPolicyCount: number): string {
+  const singular = invalidPolicyCount === 1;
+  return `${invalidPolicyCount} active element${singular ? '' : 's'} ha${singular ? 's' : 've'} malformed gatekeeper policy. The element${singular ? ' remains' : 's remain'} active, but that policy is not enforceable until fixed.`;
 }
 
 /**

--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -24,7 +24,7 @@
 import { CRUDEndpoint } from './OperationRouter.js';
 import { Gatekeeper } from './Gatekeeper.js';
 import { type ActiveElement, translateToolConfigToPolicy, canOperationBeElevated } from './policies/index.js';
-import { isGatekeeperInfraOperation, findConfirmDenyingElement, findConfirmAdvisoryElements } from './policies/ElementPolicies.js';
+import { isGatekeeperInfraOperation, findConfirmDenyingElement, findConfirmAdvisoryElements, getGatekeeperDiagnostics } from './policies/ElementPolicies.js';
 import { PermissionLevel, GatekeeperErrorCode } from './GatekeeperTypes.js';
 import { getRoute } from './OperationRouter.js';
 import { ALL_OPERATION_SCHEMAS } from './OperationSchema.js';
@@ -2977,6 +2977,8 @@ export class MCPAQLHandler {
           confirmOperations: el.metadata?.gatekeeper?.confirm ?? [],
           denyOperations: el.metadata?.gatekeeper?.deny ?? [],
           description: el.metadata?.gatekeeper?.externalRestrictions?.description ?? null,
+          invalidGatekeeperPolicy: !!getGatekeeperDiagnostics(el.metadata),
+          invalidGatekeeperMessage: getGatekeeperDiagnostics(el.metadata)?.message,
           sessionIds: (el.metadata as Record<string, unknown>)?.sessionIds ?? undefined,
         }));
 
@@ -3024,6 +3026,7 @@ export class MCPAQLHandler {
         const hasOperationRestrictions = combinedAllowOperations.length > 0
           || combinedDenyOperations.length > 0
           || combinedConfirmOperations.length > 0;
+        const invalidPolicyElements = elementPolicies.filter(policy => policy.invalidGatekeeperPolicy);
         let advisory: string | undefined;
         if (hasCliRestrictions) {
           if (!enforcementReady) {
@@ -3033,6 +3036,11 @@ export class MCPAQLHandler {
           }
         } else if (hasOperationRestrictions) {
           advisory = 'MCP-AQL operation policies are active for Dollhouse actions in this session.';
+        }
+
+        if (invalidPolicyElements.length > 0) {
+          const invalidAdvisory = `${invalidPolicyElements.length} active element${invalidPolicyElements.length === 1 ? '' : 's'} ha${invalidPolicyElements.length === 1 ? 's' : 've'} malformed gatekeeper policy. The element${invalidPolicyElements.length === 1 ? ' remains' : 's remain'} active, but that policy is not enforceable until fixed.`;
+          advisory = advisory ? `${advisory} ${invalidAdvisory}` : invalidAdvisory;
         }
 
         return {
@@ -3050,6 +3058,7 @@ export class MCPAQLHandler {
           hookInstalled,
           enforcementReady,
           hookHost: hookStatus.host,
+          invalidPolicyElementCount: invalidPolicyElements.length,
           advisory,
         };
       }

--- a/src/handlers/mcp-aql/policies/ElementPolicies.ts
+++ b/src/handlers/mcp-aql/policies/ElementPolicies.ts
@@ -757,7 +757,7 @@ export function sanitizeGatekeeperPolicy(
     }
     return validated;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = formatGatekeeperDiagnosticMessage(error instanceof Error ? error.message : String(error));
     SecurityMonitor.logSecurityEvent({
       type: 'YAML_PARSING_WARNING',
       severity: 'MEDIUM',
@@ -768,6 +768,36 @@ export function sanitizeGatekeeperPolicy(
     attachGatekeeperDiagnostics(diagnosticsTarget ?? rawPolicy, message);
     return undefined;
   }
+}
+
+function formatGatekeeperDiagnosticMessage(message: string): string {
+  const normalized = message.trim();
+  const guidance = getGatekeeperFixGuidance(normalized);
+  return guidance ? `${normalized} Fix: ${guidance}` : normalized;
+}
+
+function getGatekeeperFixGuidance(message: string): string | undefined {
+  if (message.includes('externalRestrictions must be nested under gatekeeper.externalRestrictions')) {
+    return 'Move externalRestrictions under gatekeeper.externalRestrictions and keep allowPatterns, confirmPatterns, and denyPatterns inside that nested object.';
+  }
+
+  if (message.includes('externalRestrictions.description is required')) {
+    return 'Add gatekeeper.externalRestrictions.description with a short explanation, for example description: "Read-only shell policy".';
+  }
+
+  if (message.includes('must be an array') || message.includes('must contain only strings')) {
+    return 'Use YAML arrays of strings, for example denyPatterns: ["Bash:rm *"] or allow: ["read_*"].';
+  }
+
+  if (message.includes('scopeRestrictions must be an object')) {
+    return 'Use scopeRestrictions as an object, for example scopeRestrictions: { allowedTypes: ["persona", "skill"] }.';
+  }
+
+  if (message.includes('must be an object')) {
+    return 'Use gatekeeper as an object, for example gatekeeper: { deny: ["delete_element"] }.';
+  }
+
+  return 'Compare the element against the gatekeeper examples from introspection or the security docs, then reactivate it after fixing the structure.';
 }
 
 export function attachGatekeeperDiagnostics(target: unknown, message: string): void {

--- a/src/handlers/mcp-aql/policies/ElementPolicies.ts
+++ b/src/handlers/mcp-aql/policies/ElementPolicies.ts
@@ -45,6 +45,12 @@ export interface ActiveElement {
   metadata: ElementMetadataWithPolicy;
 }
 
+export interface GatekeeperPolicyDiagnostics {
+  valid: false;
+  enforceable: false;
+  message: string;
+}
+
 /**
  * Result of element policy resolution.
  * Contains the effective permission level and policy source.
@@ -725,14 +731,16 @@ export function sanitizeGatekeeperPolicy(
   rawPolicy: unknown,
   elementName: string,
   elementType: string,
+  diagnosticsTarget?: Record<string, unknown>,
 ): ElementGatekeeperPolicy | undefined {
-  if (!rawPolicy || typeof rawPolicy !== 'object') {
+  if (rawPolicy === undefined || rawPolicy === null) {
     return undefined;
   }
 
   try {
     // Wrap in a metadata envelope so parseElementPolicy can extract it
     const validated = parseElementPolicy({ gatekeeper: rawPolicy });
+    clearGatekeeperDiagnostics(diagnosticsTarget ?? rawPolicy);
     if (validated) {
       // Issue #758: Strip gatekeeper infrastructure operations from element policies
       // to prevent cascading confirmation loops
@@ -757,6 +765,49 @@ export function sanitizeGatekeeperPolicy(
       details: `Malformed gatekeeper policy in "${elementName}" stripped during load: ${message}`,
     });
     logger.warn(`Stripped malformed gatekeeper policy from ${elementType} "${elementName}": ${message}`);
+    attachGatekeeperDiagnostics(diagnosticsTarget ?? rawPolicy, message);
     return undefined;
   }
+}
+
+export function attachGatekeeperDiagnostics(target: unknown, message: string): void {
+  if (!target || typeof target !== 'object') {
+    return;
+  }
+
+  (target as Record<string, unknown>).gatekeeperDiagnostics = {
+    valid: false,
+    enforceable: false,
+    message,
+  } satisfies GatekeeperPolicyDiagnostics;
+}
+
+export function clearGatekeeperDiagnostics(target: unknown): void {
+  if (!target || typeof target !== 'object') {
+    return;
+  }
+
+  delete (target as Record<string, unknown>).gatekeeperDiagnostics;
+}
+
+export function getGatekeeperDiagnostics(target: unknown): GatekeeperPolicyDiagnostics | undefined {
+  if (!target || typeof target !== 'object') {
+    return undefined;
+  }
+
+  const diagnostics = (target as Record<string, unknown>).gatekeeperDiagnostics;
+  if (!diagnostics || typeof diagnostics !== 'object') {
+    return undefined;
+  }
+
+  const record = diagnostics as Record<string, unknown>;
+  if (record.valid === false && record.enforceable === false && typeof record.message === 'string' && record.message.trim() !== '') {
+    return {
+      valid: false,
+      enforceable: false,
+      message: record.message,
+    };
+  }
+
+  return undefined;
 }

--- a/src/handlers/strategies/AgentActivationStrategy.ts
+++ b/src/handlers/strategies/AgentActivationStrategy.ts
@@ -202,6 +202,11 @@ export class AgentActivationStrategy extends BaseActivationStrategy implements E
       parts.push(restrictionWarning);
     }
 
+    const gatekeeperWarning = this.formatGatekeeperValidityWarning(agent.metadata as unknown as Record<string, unknown>);
+    if (gatekeeperWarning) {
+      parts.push(gatekeeperWarning);
+    }
+
     return {
       content: [{
         type: "text",

--- a/src/handlers/strategies/BaseActivationStrategy.ts
+++ b/src/handlers/strategies/BaseActivationStrategy.ts
@@ -10,6 +10,7 @@ import { findElementFlexibly as findHelper } from '../element-crud/helpers.js';
 import { ElementNotFoundError } from '../../utils/ErrorHandler.js';
 import { MCPResponse } from './ElementActivationStrategy.js';
 import { getPermissionHookStatus } from '../../utils/permissionHooks.js';
+import { getGatekeeperDiagnostics } from '../mcp-aql/policies/ElementPolicies.js';
 
 /**
  * Base class with shared utilities for activation strategies
@@ -124,5 +125,20 @@ export abstract class BaseActivationStrategy {
       );
     }
     return parts.join('\n');
+  }
+
+  protected formatGatekeeperValidityWarning(metadata: Record<string, unknown>): string {
+    const diagnostics = getGatekeeperDiagnostics(metadata);
+    if (!diagnostics) {
+      return '';
+    }
+
+    return [
+      '\n---',
+      '**Gatekeeper Policy Warning:**',
+      `> ${diagnostics.message}`,
+      '> This element can still activate and do its normal work, but its malformed gatekeeper policy is not being enforced.',
+      '> Fix the policy structure and reactivate if you want permission rules to apply.',
+    ].join('\n');
   }
 }

--- a/src/handlers/strategies/EnsembleActivationStrategy.ts
+++ b/src/handlers/strategies/EnsembleActivationStrategy.ts
@@ -80,6 +80,11 @@ export class EnsembleActivationStrategy extends BaseActivationStrategy implement
         details.push(restrictionWarning);
       }
 
+      const gatekeeperWarning = this.formatGatekeeperValidityWarning(ensemble.metadata as unknown as Record<string, unknown>);
+      if (gatekeeperWarning) {
+        details.push(gatekeeperWarning);
+      }
+
       return {
         content: [{
           type: "text",

--- a/src/handlers/strategies/MemoryActivationStrategy.ts
+++ b/src/handlers/strategies/MemoryActivationStrategy.ts
@@ -69,6 +69,11 @@ export class MemoryActivationStrategy extends BaseActivationStrategy implements 
     parts.push('');
     parts.push('This memory is now available for context and will be used to enhance responses.');
 
+    const gatekeeperWarning = this.formatGatekeeperValidityWarning(memory.metadata as unknown as Record<string, unknown>);
+    if (gatekeeperWarning) {
+      parts.push(gatekeeperWarning);
+    }
+
     return {
       content: [{
         type: "text",

--- a/src/handlers/strategies/PersonaActivationStrategy.ts
+++ b/src/handlers/strategies/PersonaActivationStrategy.ts
@@ -57,6 +57,11 @@ export class PersonaActivationStrategy extends BaseActivationStrategy implements
       text += restrictionWarning;
     }
 
+    const gatekeeperWarning = this.formatGatekeeperValidityWarning(persona.metadata as unknown as Record<string, unknown>);
+    if (gatekeeperWarning) {
+      text += gatekeeperWarning;
+    }
+
     return {
       content: [{
         type: "text",

--- a/src/handlers/strategies/SkillActivationStrategy.ts
+++ b/src/handlers/strategies/SkillActivationStrategy.ts
@@ -58,6 +58,11 @@ export class SkillActivationStrategy extends BaseActivationStrategy implements E
       parts.push(restrictionWarning);
     }
 
+    const gatekeeperWarning = this.formatGatekeeperValidityWarning(skill.metadata as unknown as Record<string, unknown>);
+    if (gatekeeperWarning) {
+      parts.push(gatekeeperWarning);
+    }
+
     return {
       content: [{
         type: "text",

--- a/src/handlers/strategies/TemplateActivationStrategy.ts
+++ b/src/handlers/strategies/TemplateActivationStrategy.ts
@@ -31,9 +31,12 @@ export class TemplateActivationStrategy extends BaseActivationStrategy implement
     }
 
     const variables = template.metadata.variables?.map((v: any) => v.name).join(', ') || 'none';
-    return this.createSuccessResponse(
-      `✅ Template '${name}' ready to use\nVariables: ${variables}\n\nUse 'render_template' to generate content with this template.`
-    );
+    let text = `✅ Template '${name}' ready to use\nVariables: ${variables}\n\nUse 'render_template' to generate content with this template.`;
+    const gatekeeperWarning = this.formatGatekeeperValidityWarning(template.metadata as unknown as Record<string, unknown>);
+    if (gatekeeperWarning) {
+      text += gatekeeperWarning;
+    }
+    return this.createSuccessResponse(text);
   }
 
   /**

--- a/src/persona/PersonaElement.ts
+++ b/src/persona/PersonaElement.ts
@@ -262,7 +262,7 @@ export class PersonaElement extends BaseElement implements IElement {
         revenue_split: metadata.revenue_split,
         license: metadata.license,
         created_date: metadata.created_date,
-        gatekeeper: sanitizeGatekeeperPolicy((metadata as any).gatekeeper, metadata.name || 'unknown', 'persona'),
+        gatekeeper: sanitizeGatekeeperPolicy((metadata as any).gatekeeper, metadata.name || 'unknown', 'persona', metadata as unknown as Record<string, unknown>),
       };
 
       // Dual-field loading: detect v2 format (instructions in YAML frontmatter)

--- a/src/services/SerializationService.ts
+++ b/src/services/SerializationService.ts
@@ -277,6 +277,10 @@ export const METADATA_FIELD_ORDER: readonly string[] = [
   'unique_id',
 ];
 
+const TRANSIENT_METADATA_FIELDS = new Set([
+  'gatekeeperDiagnostics',
+]);
+
 // Pre-created Set for O(1) lookup in orderMetadataFields (avoids allocation per call)
 const METADATA_FIELD_ORDER_SET = new Set(METADATA_FIELD_ORDER);
 
@@ -791,6 +795,10 @@ export class SerializationService {
     const cleaned: Record<string, any> = {};
 
     for (const [key, value] of Object.entries(metadata)) {
+      if (TRANSIENT_METADATA_FIELDS.has(key)) {
+        continue;
+      }
+
       const shouldRemove =
         (strategy === 'remove-undefined' && value === undefined) ||
         (strategy === 'remove-null' && value === null) ||
@@ -990,4 +998,3 @@ export class SerializationService {
     }
   }
 }
-

--- a/src/types/elements/IElement.ts
+++ b/src/types/elements/IElement.ts
@@ -93,6 +93,16 @@ export interface IElementMetadata {
    * @see resolveElementPolicy
    */
   gatekeeper?: ElementGatekeeperPolicy;
+
+  /**
+   * Runtime-only diagnostics for malformed gatekeeper policy discovered during load.
+   * This is reporting state, not enforceable policy, and must never be persisted.
+   */
+  gatekeeperDiagnostics?: {
+    valid: false;
+    enforceable: false;
+    message: string;
+  };
 }
 
 // Reference to external or internal resources

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -470,7 +470,7 @@
   padding: 0.125rem 0.375rem;
   border-radius: 999px;
   background: color-mix(in srgb, #f59e0b 16%, white);
-  color: #b45309;
+  color: #7c2d12;
   font-size: 0.6875rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -482,7 +482,7 @@
   border: 1px solid color-mix(in srgb, #f59e0b 35%, white);
   border-radius: 0.75rem;
   background: color-mix(in srgb, #f59e0b 10%, white);
-  color: #92400e;
+  color: #7c2d12;
   font-size: 0.8125rem;
   line-height: 1.45;
 }

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -464,6 +464,29 @@
   overflow-wrap: anywhere;
 }
 
+.perm-source-warning {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.375rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, #f59e0b 16%, white);
+  color: #b45309;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.perm-inline-warning {
+  margin-top: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid color-mix(in srgb, #f59e0b 35%, white);
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, #f59e0b 10%, white);
+  color: #92400e;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+}
+
 /* ── Dark Mode ─────────────────────────────────────────────── */
 
 [data-theme="dark"] .perm-status-bar,

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -470,7 +470,7 @@
   padding: 0.125rem 0.375rem;
   border-radius: 999px;
   background: color-mix(in srgb, #f59e0b 16%, white);
-  color: #7c2d12;
+  color: #431407;
   font-size: 0.6875rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -482,7 +482,7 @@
   border: 1px solid color-mix(in srgb, #f59e0b 35%, white);
   border-radius: 0.75rem;
   background: color-mix(in srgb, #f59e0b 10%, white);
-  color: #7c2d12;
+  color: #431407;
   font-size: 0.8125rem;
   line-height: 1.45;
 }

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -217,13 +217,16 @@
     const selectedSessionId = selectedData?.sessionId;
     if (elements.length === 0) {
       list.innerHTML = '<li class="perm-pattern-empty">No active elements with policies</li>';
+      renderInvalidPolicySummary('perm-all-invalid-policy-summary', []);
       return;
     }
 
+    renderInvalidPolicySummary('perm-all-invalid-policy-summary', elements);
     list.innerHTML = elements.map(el => `
       <li class="perm-source-item${elementMatchesSelected(el, selectedSessionId) ? ' perm-source-item--selected' : ''}">
         <span class="perm-source-type">${esc(el.type)}</span>
         <span class="perm-source-name">${esc(el.element_name || el.name || '')}</span>
+        ${el.invalidGatekeeperPolicy ? `<span class="perm-source-warning" title="${esc(el.invalidGatekeeperMessage || '')}">policy invalid</span>` : ''}
         ${el.description ? `<span style="color:var(--ink-400);font-size:0.75rem;margin-left:auto">${esc(el.description)}</span>` : ''}
       </li>
     `).join('');
@@ -267,12 +270,14 @@
     }
 
     const elements = selectedData.elements || [];
+    renderInvalidPolicySummary('perm-selected-invalid-policy-summary', elements);
     sourceList.innerHTML = elements.length === 0
       ? '<li class="perm-pattern-empty">No policy-bearing elements found for this session</li>'
       : elements.map(el => `
           <li class="perm-source-item perm-source-item--detail">
             <span class="perm-source-type">${esc(el.type)}</span>
             <span class="perm-source-name">${esc(el.element_name || el.name || '')}</span>
+            ${el.invalidGatekeeperPolicy ? `<span class="perm-source-warning" title="${esc(el.invalidGatekeeperMessage || '')}">policy invalid</span>` : ''}
             ${el.description ? `<span style="color:var(--ink-400);font-size:0.75rem;margin-left:auto">${esc(el.description)}</span>` : ''}
           </li>
         `).join('');
@@ -375,6 +380,8 @@
           type: element.type,
           element_name: element.element_name,
           description: element.description,
+          invalidGatekeeperPolicy: !!element.invalidGatekeeperPolicy,
+          invalidGatekeeperMessage: element.invalidGatekeeperMessage,
         };
       }),
       permissionPromptActive: !!aggregateData?.permissionPromptActive,
@@ -501,6 +508,7 @@
               <div>
                 <div class="perm-selected-title" id="perm-selected-title">Selected Session</div>
                 <div class="perm-selected-subtitle" id="perm-selected-subtitle"></div>
+                <div class="perm-inline-warning" id="perm-selected-invalid-policy-summary" hidden></div>
               </div>
               <span class="perm-selected-badge" id="perm-selected-badge" hidden>Persisted Policy State (Debug Info)</span>
             </div>
@@ -544,6 +552,7 @@
               <div>
                 <div class="perm-selected-title">All Sessions</div>
                 <div class="perm-selected-subtitle">${esc('Aggregate policy state across all live and persisted sessions. Rules shown here include both Dollhouse operation policies and external tool restrictions.')}${dataAdvisoryPlaceholder()}</div>
+                <div class="perm-inline-warning" id="perm-all-invalid-policy-summary" hidden></div>
               </div>
             </div>
 
@@ -695,6 +704,27 @@
 
   function dataAdvisoryPlaceholder() {
     return '<span id="perm-all-sessions-advisory" class="perm-inline-advisory" hidden></span>';
+  }
+
+  function renderInvalidPolicySummary(elementId, elements) {
+    const banner = document.getElementById(elementId);
+    if (!banner) return;
+
+    const invalid = (elements || []).filter(function (element) {
+      return !!element.invalidGatekeeperPolicy;
+    });
+
+    if (invalid.length === 0) {
+      banner.hidden = true;
+      banner.textContent = '';
+      return;
+    }
+
+    const names = invalid.map(function (element) {
+      return element.element_name || element.name || 'unknown';
+    });
+    banner.hidden = false;
+    banner.textContent = `${invalid.length} active element${invalid.length === 1 ? '' : 's'} ha${invalid.length === 1 ? 's' : 've'} malformed gatekeeper policy. These elements remain active, but that policy is not being enforced: ${names.join(', ')}`;
   }
 
 })();

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -222,14 +222,9 @@
     }
 
     renderInvalidPolicySummary('perm-all-invalid-policy-summary', elements);
-    list.innerHTML = elements.map(el => `
-      <li class="perm-source-item${elementMatchesSelected(el, selectedSessionId) ? ' perm-source-item--selected' : ''}">
-        <span class="perm-source-type">${esc(el.type)}</span>
-        <span class="perm-source-name">${esc(el.element_name || el.name || '')}</span>
-        ${el.invalidGatekeeperPolicy ? `<span class="perm-source-warning" title="${esc(el.invalidGatekeeperMessage || '')}">policy invalid</span>` : ''}
-        ${el.description ? `<span style="color:var(--ink-400);font-size:0.75rem;margin-left:auto">${esc(el.description)}</span>` : ''}
-      </li>
-    `).join('');
+    list.innerHTML = elements.map(el =>
+      renderPolicySourceItem(el, elementMatchesSelected(el, selectedSessionId) ? ' perm-source-item--selected' : '')
+    ).join('');
   }
 
   function renderSelectedSessionDetail(selectedData) {
@@ -273,14 +268,7 @@
     renderInvalidPolicySummary('perm-selected-invalid-policy-summary', elements);
     sourceList.innerHTML = elements.length === 0
       ? '<li class="perm-pattern-empty">No policy-bearing elements found for this session</li>'
-      : elements.map(el => `
-          <li class="perm-source-item perm-source-item--detail">
-            <span class="perm-source-type">${esc(el.type)}</span>
-            <span class="perm-source-name">${esc(el.element_name || el.name || '')}</span>
-            ${el.invalidGatekeeperPolicy ? `<span class="perm-source-warning" title="${esc(el.invalidGatekeeperMessage || '')}">policy invalid</span>` : ''}
-            ${el.description ? `<span style="color:var(--ink-400);font-size:0.75rem;margin-left:auto">${esc(el.description)}</span>` : ''}
-          </li>
-        `).join('');
+      : elements.map(el => renderPolicySourceItem(el, ' perm-source-item--detail')).join('');
 
     renderPatternList('perm-selected-deny-list', selectedData.denyRules || [], 'deny');
     renderPatternList('perm-selected-allow-list', selectedData.allowRules || [], 'allow');
@@ -357,6 +345,24 @@
     if (modalCount) {
       modalCount.textContent = `${decisions.length} captured ${decisions.length === 1 ? 'entry' : 'entries'}`;
     }
+  }
+
+  function renderPolicySourceItem(el, extraClass = '') {
+    const invalidBadge = el.invalidGatekeeperPolicy
+      ? `<span class="perm-source-warning" title="${esc(el.invalidGatekeeperMessage || '')}">policy invalid</span>`
+      : '';
+    const description = el.description
+      ? `<span style="color:var(--ink-400);font-size:0.75rem;margin-left:auto">${esc(el.description)}</span>`
+      : '';
+
+    return `
+      <li class="perm-source-item${extraClass}">
+        <span class="perm-source-type">${esc(el.type)}</span>
+        <span class="perm-source-name">${esc(el.element_name || el.name || '')}</span>
+        ${invalidBadge}
+        ${description}
+      </li>
+    `;
   }
 
   function deriveSelectedSessionData(aggregateData, sessionId) {

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -121,6 +121,8 @@ function normalizePolicyElements(elements: Array<Record<string, unknown>>): Arra
     allowRules: mergeRuleArrays(element.allowPatterns, element.allowOperations),
     confirmRules: mergeRuleArrays(element.confirmPatterns, element.confirmOperations),
     denyRules: mergeRuleArrays(element.denyPatterns, element.denyOperations),
+    invalidGatekeeperPolicy: !!element.invalidGatekeeperPolicy,
+    invalidGatekeeperMessage: typeof element.invalidGatekeeperMessage === 'string' ? element.invalidGatekeeperMessage : undefined,
   }));
 }
 
@@ -285,6 +287,7 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
         hookInstalled: data.hookInstalled,
         hookHost: data.hookHost,
         enforcementReady: data.enforcementReady,
+        invalidPolicyElementCount: data.invalidPolicyElementCount ?? 0,
         advisory: data.advisory,
         recentDecisions: decisionTracker.getRecentDecisions(),
       });

--- a/tests/integration/mcp-aql/permission-prompt.test.ts
+++ b/tests/integration/mcp-aql/permission-prompt.test.ts
@@ -7,6 +7,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
 import { DollhouseMCPServer } from '../../../src/index.js';
 import { DollhouseContainer } from '../../../src/di/Container.js';
 import { MCPAQLHandler } from '../../../src/handlers/mcp-aql/MCPAQLHandler.js';
@@ -1224,6 +1226,62 @@ describe('permission_prompt Integration', () => {
         expect(text).toContain('CLI Policies Loaded');
         expect(text).toContain('Hook Not Detected');
         expect(text).toContain('No network access');
+      }
+    });
+
+    it('should warn on malformed gatekeeper policy while keeping the element active and reportable', async () => {
+      const malformedSkillPath = path.join(env.testDir, 'skills', 'broken-gatekeeper.md');
+      await writeFile(
+        malformedSkillPath,
+        `---
+name: broken-gatekeeper
+description: Skill with malformed gatekeeper policy
+gatekeeper:
+  externalRestrictions:
+    denyPatterns:
+      - Bash:rm *
+---
+# Broken Gatekeeper
+
+This skill should still activate.
+`,
+        'utf8',
+      );
+
+      await waitForCacheSettle();
+
+      const activateResult = await mcpAqlHandler.handleRead({
+        operation: 'activate_element',
+        params: { element_name: 'broken-gatekeeper', element_type: 'skills' },
+      });
+
+      expect(activateResult.success).toBe(true);
+      if (activateResult.success) {
+        const text = JSON.stringify(activateResult.data);
+        expect(text).toContain('Gatekeeper Policy Warning');
+        expect(text).toContain('externalRestrictions.description is required');
+        expect(text).toContain('Fix: Add gatekeeper.externalRestrictions.description');
+      }
+
+      const policiesResult = await mcpAqlHandler.handleRead({
+        operation: 'get_effective_cli_policies',
+        params: {},
+      });
+
+      expect(policiesResult.success).toBe(true);
+      if (policiesResult.success) {
+        const data = policiesResult.data as Record<string, unknown>;
+        expect(data.invalidPolicyElementCount).toBe(1);
+        expect(data.advisory).toEqual(expect.stringContaining('malformed gatekeeper policy'));
+        expect(data.elements).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              element_name: 'broken-gatekeeper',
+              invalidGatekeeperPolicy: true,
+              invalidGatekeeperMessage: expect.stringContaining('Fix: Add gatekeeper.externalRestrictions.description'),
+            }),
+          ]),
+        );
       }
     });
 

--- a/tests/unit/elements/gatekeeper-policy-roundtrip.test.ts
+++ b/tests/unit/elements/gatekeeper-policy-roundtrip.test.ts
@@ -14,7 +14,7 @@ import * as yaml from 'js-yaml';
 import { createTestMetadataService } from '../../helpers/di-mocks.js';
 import type { MetadataService } from '../../../src/services/MetadataService.js';
 import type { ElementGatekeeperPolicy } from '../../../src/handlers/mcp-aql/GatekeeperTypes.js';
-import { sanitizeGatekeeperPolicy } from '../../../src/handlers/mcp-aql/policies/ElementPolicies.js';
+import { getGatekeeperDiagnostics, sanitizeGatekeeperPolicy } from '../../../src/handlers/mcp-aql/policies/ElementPolicies.js';
 
 let metadataService: MetadataService;
 
@@ -183,6 +183,41 @@ describe('Gatekeeper policy round-trip (Issue #524)', () => {
       expect(result).toBeUndefined();
     });
 
+    it('should attach diagnostics to metadata targets for malformed policies', () => {
+      const metadata: Record<string, unknown> = {};
+
+      const result = sanitizeGatekeeperPolicy(
+        { deny: 42 },
+        'bad-element',
+        'skill',
+        metadata,
+      );
+
+      expect(result).toBeUndefined();
+      expect(getGatekeeperDiagnostics(metadata)).toEqual({
+        valid: false,
+        enforceable: false,
+        message: expect.stringContaining('gatekeeper'),
+      });
+    });
+
+    it('should clear diagnostics when the policy is later valid', () => {
+      const metadata: Record<string, unknown> = {};
+
+      sanitizeGatekeeperPolicy({ deny: 42 }, 'bad-element', 'skill', metadata);
+      expect(getGatekeeperDiagnostics(metadata)).toBeDefined();
+
+      const result = sanitizeGatekeeperPolicy(
+        { deny: ['delete_element'] },
+        'good-element',
+        'skill',
+        metadata,
+      );
+
+      expect(result).toBeDefined();
+      expect(getGatekeeperDiagnostics(metadata)).toBeUndefined();
+    });
+
     it('should validate scopeRestrictions', () => {
       const result = sanitizeGatekeeperPolicy(
         {
@@ -194,6 +229,30 @@ describe('Gatekeeper policy round-trip (Issue #524)', () => {
       );
       expect(result).toBeDefined();
       expect(result!.scopeRestrictions?.allowedTypes).toEqual(['persona', 'skill']);
+    });
+  });
+
+  describe('transient diagnostics', () => {
+    it('should not serialize gatekeeper diagnostics into frontmatter', () => {
+      const skill = new Skill(
+        {
+          name: 'Transient Diagnostics Skill',
+          description: 'A skill with runtime-only diagnostics',
+          gatekeeperDiagnostics: {
+            valid: false,
+            enforceable: false,
+            message: 'Malformed gatekeeper policy',
+          },
+        } as any,
+        'Do things skillfully.',
+        metadataService,
+      );
+
+      const serialized = skill.serialize();
+      const frontmatterMatch = serialized.match(/^---\n([\s\S]*?)\n---/);
+      expect(frontmatterMatch).toBeTruthy();
+      const frontmatter = yaml.load(frontmatterMatch![1]) as any;
+      expect(frontmatter.gatekeeperDiagnostics).toBeUndefined();
     });
   });
 });

--- a/tests/unit/elements/gatekeeper-policy-roundtrip.test.ts
+++ b/tests/unit/elements/gatekeeper-policy-roundtrip.test.ts
@@ -197,8 +197,9 @@ describe('Gatekeeper policy round-trip (Issue #524)', () => {
       expect(getGatekeeperDiagnostics(metadata)).toEqual({
         valid: false,
         enforceable: false,
-        message: expect.stringContaining('gatekeeper'),
+        message: expect.stringContaining('Fix:'),
       });
+      expect(getGatekeeperDiagnostics(metadata)?.message).toContain('Use YAML arrays of strings');
     });
 
     it('should clear diagnostics when the policy is later valid', () => {

--- a/tests/unit/elements/gatekeeper-policy-roundtrip.test.ts
+++ b/tests/unit/elements/gatekeeper-policy-roundtrip.test.ts
@@ -250,7 +250,7 @@ describe('Gatekeeper policy round-trip (Issue #524)', () => {
       );
 
       const serialized = skill.serialize();
-      const frontmatterMatch = serialized.match(/^---\n([\s\S]*?)\n---/);
+      const frontmatterMatch = /^---\n([\s\S]*?)\n---/.exec(serialized);
       expect(frontmatterMatch).toBeTruthy();
       const frontmatter = yaml.load(frontmatterMatch![1]) as any;
       expect(frontmatter.gatekeeperDiagnostics).toBeUndefined();

--- a/tests/unit/handlers/strategies/SkillActivationStrategy.test.ts
+++ b/tests/unit/handlers/strategies/SkillActivationStrategy.test.ts
@@ -66,6 +66,37 @@ describe('SkillActivationStrategy', () => {
       expect(result.content[0].text).toContain('simple-skill');
     });
 
+    it('should include a warning when the skill gatekeeper policy is malformed', async () => {
+      const mockSkill = {
+        metadata: {
+          name: 'warning-skill',
+          description: 'Warns about malformed policy',
+          gatekeeperDiagnostics: {
+            valid: false,
+            enforceable: false,
+            message: 'externalRestrictions must be nested under gatekeeper',
+          },
+        },
+        instructions: 'Follow these instructions',
+        activate: jest.fn().mockResolvedValue(undefined),
+        deactivate: jest.fn(),
+        getStatus: jest.fn(),
+      };
+
+      mockSkillManager.activateSkill.mockResolvedValue({
+        success: true,
+        message: 'Activated',
+        skill: mockSkill,
+      });
+
+      const result = await strategy.activate('warning-skill');
+
+      expect(result.content[0].text).toContain('Gatekeeper Policy Warning');
+      expect(result.content[0].text).toContain('externalRestrictions must be nested under gatekeeper');
+      expect(result.content[0].text).toContain('still activate');
+      expect(result.content[0].text).toContain('not being enforced');
+    });
+
     it('should return error when skill not found', async () => {
       mockSkillManager.activateSkill.mockResolvedValue({
         success: false,

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -364,6 +364,79 @@ describe('Web console cleanup regressions', () => {
     cleanup();
   });
 
+  it('shows invalid gatekeeper warnings in the permissions dashboard without hiding the source', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="session-indicator"></div>
+      <div id="tab-logs"><div class="log-controls"></div></div>
+      <div id="console-tabs"><button class="console-tab" data-tab="permissions">Permissions</button></div>
+      <div id="permissions-dashboard-root"></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn((url: string) => {
+      if (url === '/api/sessions') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ sessions: [] }),
+        });
+      }
+
+      if (url === '/api/permissions/status') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            activeElementCount: 1,
+            hasAllowlist: false,
+            denyPatterns: [],
+            allowPatterns: [],
+            confirmPatterns: [],
+            denyRules: [],
+            allowRules: [],
+            confirmRules: [],
+            invalidPolicyElementCount: 1,
+            advisory: '1 active element has malformed gatekeeper policy. The element remains active, but that policy is not enforceable until fixed.',
+            elements: [
+              {
+                type: 'skill',
+                element_name: 'broken-guardian',
+                description: 'Still useful, but with bad policy',
+                allowPatterns: [],
+                allowRules: [],
+                confirmPatterns: [],
+                confirmRules: [],
+                denyPatterns: [],
+                denyRules: [],
+                invalidGatekeeperPolicy: true,
+                invalidGatekeeperMessage: 'externalRestrictions must be nested under gatekeeper',
+              },
+            ],
+            recentDecisions: [],
+            permissionPromptActive: false,
+          }),
+        });
+      }
+
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+    win.DollhouseConsoleConfig = {
+      sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
+      sessionFilterInjectionMaxRetries: 5,
+    };
+
+    win.eval(sessionsSource);
+    win.eval(permissionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    win.DollhouseConsole.permissions.init();
+    await wait(SESSION_FILTER_INJECTION_WAIT_MS);
+
+    expect(win.document.getElementById('perm-all-invalid-policy-summary')?.textContent).toContain('malformed gatekeeper policy');
+    expect(win.document.getElementById('perm-source-list')?.textContent).toContain('broken-guardian');
+    expect(win.document.getElementById('perm-source-list')?.textContent).toContain('policy invalid');
+
+    cleanup();
+  });
+
   it('ignores malformed persisted policy session entries in the picker', async () => {
     const { window: win, cleanup } = createDom(`
       <div id="session-indicator"></div>

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -294,6 +294,49 @@ describe('permissionRoutes', () => {
       ]);
     });
 
+    it('should surface invalid gatekeeper policy state without hiding the active element', async () => {
+      const handler = {
+        handleRead: jest.fn().mockResolvedValue([{
+          success: true,
+          data: {
+            activeElementCount: 1,
+            hasAllowlist: false,
+            combinedDenyPatterns: [],
+            combinedAllowPatterns: [],
+            combinedConfirmPatterns: [],
+            combinedDenyOperations: [],
+            combinedAllowOperations: [],
+            combinedConfirmOperations: [],
+            elements: [
+              {
+                name: 'broken-guardian',
+                type: 'skill',
+                invalidGatekeeperPolicy: true,
+                invalidGatekeeperMessage: 'gatekeeper.externalRestrictions.description is required',
+              },
+            ],
+            invalidPolicyElementCount: 1,
+            permissionPromptActive: false,
+            advisory: '1 active element has malformed gatekeeper policy. The element remains active, but that policy is not enforceable until fixed.',
+          },
+        }]),
+      } as any;
+      const app = createApp(handler);
+
+      const res = await request(app).get('/api/permissions/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.invalidPolicyElementCount).toBe(1);
+      expect(res.body.advisory).toContain('malformed gatekeeper policy');
+      expect(res.body.elements).toEqual([
+        expect.objectContaining({
+          name: 'broken-guardian',
+          invalidGatekeeperPolicy: true,
+          invalidGatekeeperMessage: 'gatekeeper.externalRestrictions.description is required',
+        }),
+      ]);
+    });
+
     it('should expose known persisted policy sessions for the session picker', async () => {
       const handler = {
         handleRead: jest.fn().mockResolvedValue([{


### PR DESCRIPTION
## Summary
- allow elements with malformed gatekeeper policy to activate while marking their policy as non-enforceable
- surface invalid policy warnings in activation responses and the permissions dashboard/reporting payloads
- keep gatekeeper diagnostics runtime-only and add focused regression coverage for persistence, routes, activation, and UI rendering

Closes #1998

## Validation
- `npm install`
- `npx tsc -p packages/safety/tsconfig.json`
- `npx tsc -p tsconfig.json --noEmit`
- `npx jest --config tests/jest.config.cjs --runInBand --modulePathIgnorePatterns=.worktrees --runTestsByPath tests/unit/elements/gatekeeper-policy-roundtrip.test.ts tests/unit/handlers/strategies/SkillActivationStrategy.test.ts tests/unit/web/permissionRoutes.test.ts tests/unit/web/console-ui-regressions.test.ts`
- `npx jest --config tests/jest.config.cjs --runInBand --modulePathIgnorePatterns=.worktrees --runTestsByPath tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts --testNamePattern="get_effective_cli_policies"`
