### PR TITLE
Fix Claude Code PreToolUse hook shape

### DIFF
--- a/scripts/pretooluse-dollhouse.sh
+++ b/scripts/pretooluse-dollhouse.sh
@@ -29,6 +29,33 @@ debug() {
   return 0
 }
 
+normalize_response() {
+  local response="$1"
+
+  case "$HOOK_PLATFORM" in
+    claude_code)
+      echo "$response" | jq -c '
+        if (.hookSpecificOutput.permissionDecision? | type) == "string" then
+          .
+        elif (.decision? | type) == "string" and (.decision | IN("allow", "deny", "ask")) then
+          {
+            hookSpecificOutput: {
+              hookEventName: "PreToolUse",
+              permissionDecision: .decision,
+              permissionDecisionReason: (.reason // .message // "")
+            }
+          }
+        else
+          empty
+        end
+      ' 2>/dev/null
+      ;;
+    *)
+      echo "$response"
+      ;;
+  esac
+}
+
 # Discover the port from the port file
 if [[ -f "$PORT_FILE" ]]; then
   PORT=$(cat "$PORT_FILE" 2>/dev/null)
@@ -92,7 +119,12 @@ while [[ $ATTEMPT -le $MAX_RETRIES ]]; do
 
   if [[ $CURL_EXIT -eq 0 ]] && [[ -n "$RESPONSE" ]]; then
     debug "Response (attempt $((ATTEMPT+1))): $RESPONSE"
-    echo "$RESPONSE"
+    NORMALIZED_RESPONSE=$(normalize_response "$RESPONSE")
+    if [[ -n "$NORMALIZED_RESPONSE" ]]; then
+      echo "$NORMALIZED_RESPONSE"
+    else
+      debug "Malformed response for platform $HOOK_PLATFORM — fail open"
+    fi
     exit 0
   fi
 

--- a/scripts/pretooluse-dollhouse.sh
+++ b/scripts/pretooluse-dollhouse.sh
@@ -54,6 +54,8 @@ normalize_response() {
       echo "$response"
       ;;
   esac
+
+  return 0
 }
 
 # Discover the port from the port file

--- a/scripts/pretooluse-dollhouse.sh
+++ b/scripts/pretooluse-dollhouse.sh
@@ -121,6 +121,10 @@ while [[ $ATTEMPT -le $MAX_RETRIES ]]; do
 
   if [[ $CURL_EXIT -eq 0 ]] && [[ -n "$RESPONSE" ]]; then
     debug "Response (attempt $((ATTEMPT+1))): $RESPONSE"
+    if ! echo "$RESPONSE" | jq -e . >/dev/null 2>&1; then
+      debug "Non-JSON response for platform $HOOK_PLATFORM — fail open"
+      exit 0
+    fi
     NORMALIZED_RESPONSE=$(normalize_response "$RESPONSE")
     if [[ -n "$NORMALIZED_RESPONSE" ]]; then
       echo "$NORMALIZED_RESPONSE"

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -44,6 +44,7 @@ interface PermissionDecisionTracker {
 
 const CLAUDE_COMPATIBLE_HOOK_PLATFORMS = new Set(['claude_code', 'vscode']);
 const NORMALIZABLE_PERMISSION_DECISIONS = new Set(['allow', 'deny', 'ask']);
+type NormalizablePermissionDecision = 'allow' | 'deny' | 'ask';
 
 /** Extract a string field from a record, trying multiple keys in order */
 function extractString(obj: Record<string, unknown>, keys: string[], fallback: string): string {
@@ -101,7 +102,12 @@ function normalizePermissionResponseForPlatform(
 
   const decision = extractDecision(result);
   if (NORMALIZABLE_PERMISSION_DECISIONS.has(decision)) {
-    return formatPermissionResponse(decision, platform, input, extractReason(result));
+    return formatPermissionResponse(
+      decision as NormalizablePermissionDecision,
+      platform,
+      input,
+      extractReason(result),
+    );
   }
 
   return formatPermissionResponse('allow', platform, input);

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -42,6 +42,9 @@ interface PermissionDecisionTracker {
   getRecentDecisions(): PermissionDecision[];
 }
 
+const CLAUDE_COMPATIBLE_HOOK_PLATFORMS = new Set(['claude_code', 'vscode']);
+const NORMALIZABLE_PERMISSION_DECISIONS = new Set(['allow', 'deny', 'ask']);
+
 /** Extract a string field from a record, trying multiple keys in order */
 function extractString(obj: Record<string, unknown>, keys: string[], fallback: string): string {
   for (const key of keys) {
@@ -75,8 +78,8 @@ function extractReason(result: Record<string, unknown>): string {
   return extractString(result, ['reason', 'message'], '');
 }
 
-function shouldNormalizeClaudeHook(platform: string): boolean {
-  return platform === 'claude_code' || platform === 'vscode';
+function shouldNormalizeClaudeHook(platform: string | undefined): boolean {
+  return platform !== undefined && CLAUDE_COMPATIBLE_HOOK_PLATFORMS.has(platform);
 }
 
 function normalizePermissionResponseForPlatform(
@@ -97,7 +100,7 @@ function normalizePermissionResponseForPlatform(
   }
 
   const decision = extractDecision(result);
-  if (decision === 'allow' || decision === 'deny' || decision === 'ask') {
+  if (NORMALIZABLE_PERMISSION_DECISIONS.has(decision)) {
     return formatPermissionResponse(decision, platform, input, extractReason(result));
   }
 

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -75,6 +75,35 @@ function extractReason(result: Record<string, unknown>): string {
   return extractString(result, ['reason', 'message'], '');
 }
 
+function shouldNormalizeClaudeHook(platform: string): boolean {
+  return platform === 'claude_code' || platform === 'vscode';
+}
+
+function normalizePermissionResponseForPlatform(
+  platform: string,
+  input: Record<string, unknown>,
+  result: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!shouldNormalizeClaudeHook(platform)) {
+    return result;
+  }
+
+  const nested = result.hookSpecificOutput;
+  if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+    const nestedDecision = (nested as Record<string, unknown>).permissionDecision;
+    if (typeof nestedDecision === 'string') {
+      return result;
+    }
+  }
+
+  const decision = extractDecision(result);
+  if (decision === 'allow' || decision === 'deny' || decision === 'ask') {
+    return formatPermissionResponse(decision, platform, input, extractReason(result));
+  }
+
+  return formatPermissionResponse('allow', platform, input);
+}
+
 function createPermissionDecisionTracker(bufferSize = DECISION_BUFFER_SIZE): PermissionDecisionTracker {
   const recentDecisions: PermissionDecision[] = [];
   let decisionCounter = 0;
@@ -220,13 +249,18 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
         return;
       }
 
-      const decision = extractDecision(opResult.data as Record<string, unknown>);
+      const responseData = normalizePermissionResponseForPlatform(
+        platform,
+        input || {},
+        opResult.data as Record<string, unknown>,
+      );
+      const decision = extractDecision(responseData);
       logger.debug(`[WebUI/Gateway] evaluate_permission: ${tool_name} → ${decision} (${elapsedMs}ms)`);
 
       // Track decision for live dashboard feed
-      decisionTracker.trackDecision(session_id, tool_name, input || {}, opResult.data as Record<string, unknown>);
+      decisionTracker.trackDecision(session_id, tool_name, input || {}, responseData);
 
-      res.json(opResult.data);
+      res.json(responseData);
     } catch (err) {
       const elapsedMs = Date.now() - startMs;
       logger.error(`[WebUI/Gateway] evaluate_permission error (${elapsedMs}ms):`, err);

--- a/tests/unit/di/permissionServerIntegration.test.ts
+++ b/tests/unit/di/permissionServerIntegration.test.ts
@@ -75,7 +75,13 @@ describe('Permission Server Integration', () => {
               ? `Tool "${parsed.tool_name}" denied by policy`
               : undefined;
             res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ decision, ...(reason && { reason }) }));
+            res.end(JSON.stringify({
+              hookSpecificOutput: {
+                hookEventName: 'PreToolUse',
+                permissionDecision: decision,
+                ...(reason && { permissionDecisionReason: reason }),
+              },
+            }));
           });
         } else {
           res.writeHead(404);
@@ -91,7 +97,7 @@ describe('Permission Server Integration', () => {
         input: {},
         platform: 'claude_code',
       });
-      expect(allowResponse.decision).toBe('allow');
+      expect(allowResponse.hookSpecificOutput.permissionDecision).toBe('allow');
 
       // Test dangerous tool
       const denyResponse = await httpPost(testPort, {
@@ -99,8 +105,8 @@ describe('Permission Server Integration', () => {
         input: { command: 'rm -rf /' },
         platform: 'claude_code',
       });
-      expect(denyResponse.decision).toBe('deny');
-      expect(denyResponse.reason).toContain('denied');
+      expect(denyResponse.hookSpecificOutput.permissionDecision).toBe('deny');
+      expect(denyResponse.hookSpecificOutput.permissionDecisionReason).toContain('denied');
     });
   });
 
@@ -233,6 +239,104 @@ describe('Permission Server Integration', () => {
         expect(response.hookSpecificOutput.permissionDecision).toBe('allow');
       }
     });
+
+    itBash('hook script should translate legacy flat Claude responses', async () => {
+      const testPort = 49361;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            decision: 'deny',
+            reason: 'Blocked by policy',
+          }));
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      await new Promise<void>(resolve => mockServer.listen(testPort, '127.0.0.1', resolve));
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { stdout } = await runHookScript({
+        tool_name: 'Bash',
+        tool_input: { command: 'git push --force' },
+      });
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+
+      expect(JSON.parse(stdout.trim())).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: 'Blocked by policy',
+        },
+      });
+    });
+
+    itBash('hook script should pass through already-wrapped Claude responses unchanged', async () => {
+      const testPort = 49362;
+      const wrappedResponse = {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'ask',
+          permissionDecisionReason: 'Needs approval',
+        },
+      };
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(wrappedResponse));
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      await new Promise<void>(resolve => mockServer.listen(testPort, '127.0.0.1', resolve));
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { stdout } = await runHookScript({
+        tool_name: 'Edit',
+        tool_input: { file_path: 'src/index.ts' },
+      });
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+
+      expect(JSON.parse(stdout.trim())).toEqual(wrappedResponse);
+    });
+
+    itBash('hook script should fail open silently on malformed Claude responses', async () => {
+      const testPort = 49363;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ nope: true }));
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      await new Promise<void>(resolve => mockServer.listen(testPort, '127.0.0.1', resolve));
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout } = await runHookScript({
+        tool_name: 'Read',
+        tool_input: { file_path: './test-fixture.txt' },
+      });
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+
+      expect(code).toBe(0);
+      expect(stdout.trim()).toBe('');
+    });
   });
 
   describe('error recovery', () => {
@@ -299,5 +403,24 @@ function httpPost(port: number, body: Record<string, unknown>): Promise<any> {
     req.on('timeout', () => { req.destroy(); reject(new Error('timeout')); });
     req.write(data);
     req.end();
+  });
+}
+
+function runHookScript(payload: Record<string, unknown>): Promise<{ code: number; stdout: string }> {
+  return new Promise(async (resolve) => {
+    const { spawn } = await import('node:child_process');
+    const hookProc = spawn('bash', [HOOK_SCRIPT], {
+      env: {
+        HOME: os.homedir(),
+        PATH: '/usr/local/bin:/usr/bin:/bin',
+        DOLLHOUSE_SESSION_ID: 'session-hook-test',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let out = '';
+    hookProc.stdout.on('data', (data: Buffer) => { out += data.toString(); });
+    hookProc.on('close', (c: number) => resolve({ code: c, stdout: out }));
+    hookProc.stdin.write(JSON.stringify(payload));
+    hookProc.stdin.end();
   });
 }

--- a/tests/unit/di/permissionServerIntegration.test.ts
+++ b/tests/unit/di/permissionServerIntegration.test.ts
@@ -17,6 +17,7 @@ const RUN_DIR = path.join(os.homedir(), '.dollhouse', 'run');
 const PORT_FILE = path.join(RUN_DIR, 'permission-server.port');
 // Hook script lives in the repo at scripts/ — works on both dev machines and CI
 const HOOK_SCRIPT = path.join(process.cwd(), 'scripts', 'pretooluse-dollhouse.sh');
+const SAFE_TEST_PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
 
 describe('Permission Server Integration', () => {
 
@@ -163,7 +164,7 @@ describe('Permission Server Integration', () => {
       // Ensure port file doesn't exist
       fs.unlink(PORT_FILE).catch(() => {}).then(() => {
         execFile('bash', [HOOK_SCRIPT], {
-          env: { HOME: os.homedir(), PATH: '/usr/local/bin:/usr/bin:/bin' },
+          env: { HOME: os.homedir(), PATH: SAFE_TEST_PATH },
         }, (error, stdout, _stderr) => {
           // Exit code 0 = fail open (allow)
           expect(error).toBeNull();
@@ -208,7 +209,7 @@ describe('Permission Server Integration', () => {
         const hookProc = spawn('bash', [HOOK_SCRIPT], {
           env: {
             HOME: os.homedir(),
-            PATH: '/usr/local/bin:/usr/bin:/bin',
+            PATH: SAFE_TEST_PATH,
             DOLLHOUSE_SESSION_ID: 'session-hook-test',
           },
           stdio: ['pipe', 'pipe', 'pipe'],
@@ -411,7 +412,7 @@ function runHookScript(payload: Record<string, unknown>): Promise<{ code: number
     const hookProc = spawn('bash', [HOOK_SCRIPT], {
       env: {
         HOME: os.homedir(),
-        PATH: '/usr/local/bin:/usr/bin:/bin',
+        PATH: SAFE_TEST_PATH,
         DOLLHOUSE_SESSION_ID: 'session-hook-test',
       },
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/tests/unit/di/permissionServerIntegration.test.ts
+++ b/tests/unit/di/permissionServerIntegration.test.ts
@@ -410,7 +410,7 @@ function httpPost(port: number, body: Record<string, unknown>): Promise<any> {
 
 function runHookScript(payload: Record<string, unknown>): Promise<{ code: number; stdout: string }> {
   return new Promise((resolve) => {
-    const hookProc = spawn('bash', [HOOK_SCRIPT], {
+    const hookProc = spawn(BASH_BINARY, [HOOK_SCRIPT], {
       env: {
         HOME: os.homedir(),
         PATH: SAFE_TEST_PATH,

--- a/tests/unit/di/permissionServerIntegration.test.ts
+++ b/tests/unit/di/permissionServerIntegration.test.ts
@@ -11,7 +11,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import * as http from 'node:http';
-import { execFile } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 
 const RUN_DIR = path.join(os.homedir(), '.dollhouse', 'run');
 const PORT_FILE = path.join(RUN_DIR, 'permission-server.port');
@@ -407,8 +407,7 @@ function httpPost(port: number, body: Record<string, unknown>): Promise<any> {
 }
 
 function runHookScript(payload: Record<string, unknown>): Promise<{ code: number; stdout: string }> {
-  return new Promise(async (resolve) => {
-    const { spawn } = await import('node:child_process');
+  return new Promise((resolve) => {
     const hookProc = spawn('bash', [HOOK_SCRIPT], {
       env: {
         HOME: os.homedir(),

--- a/tests/unit/di/permissionServerIntegration.test.ts
+++ b/tests/unit/di/permissionServerIntegration.test.ts
@@ -18,6 +18,7 @@ const PORT_FILE = path.join(RUN_DIR, 'permission-server.port');
 // Hook script lives in the repo at scripts/ — works on both dev machines and CI
 const HOOK_SCRIPT = path.join(process.cwd(), 'scripts', 'pretooluse-dollhouse.sh');
 const SAFE_TEST_PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+const BASH_BINARY = '/bin/bash';
 
 describe('Permission Server Integration', () => {
 
@@ -163,7 +164,7 @@ describe('Permission Server Integration', () => {
     itBash('hook script should fail open when port file is missing', (done) => {
       // Ensure port file doesn't exist
       fs.unlink(PORT_FILE).catch(() => {}).then(() => {
-        execFile('bash', [HOOK_SCRIPT], {
+        execFile(BASH_BINARY, [HOOK_SCRIPT], {
           env: { HOME: os.homedir(), PATH: SAFE_TEST_PATH },
         }, (error, stdout, _stderr) => {
           // Exit code 0 = fail open (allow)
@@ -206,7 +207,7 @@ describe('Permission Server Integration', () => {
       // Run hook script
       const { spawn } = await import('node:child_process');
       const { code, stdout } = await new Promise<{ code: number; stdout: string }>((resolve) => {
-        const hookProc = spawn('bash', [HOOK_SCRIPT], {
+        const hookProc = spawn(BASH_BINARY, [HOOK_SCRIPT], {
           env: {
             HOME: os.homedir(),
             PATH: SAFE_TEST_PATH,

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -12,7 +12,15 @@ import { registerPermissionRoutes } from '../../../src/web/routes/permissionRout
 function createMockHandler(readResult?: unknown) {
   return {
     handleRead: jest.fn().mockResolvedValue(
-      readResult ?? [{ success: true, data: { decision: 'allow' } }]
+      readResult ?? [{
+        success: true,
+        data: {
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
+            permissionDecision: 'allow',
+          },
+        },
+      }]
     ),
   } as any;
 }
@@ -36,7 +44,12 @@ describe('permissionRoutes', () => {
         .send({ tool_name: 'Bash', input: { command: 'npm test' }, platform: 'claude_code' });
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual({ decision: 'allow' });
+      expect(res.body).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+        },
+      });
       expect(handler.handleRead).toHaveBeenCalledWith({
         operation: 'evaluate_permission',
         params: {
@@ -143,7 +156,13 @@ describe('permissionRoutes', () => {
     it('should return deny response from handler', async () => {
       const handler = createMockHandler([{
         success: true,
-        data: { decision: 'deny', reason: 'Blocked by policy' },
+        data: {
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
+            permissionDecision: 'deny',
+            permissionDecisionReason: 'Blocked by policy',
+          },
+        },
       }]);
       const app = createApp(handler);
 
@@ -151,7 +170,33 @@ describe('permissionRoutes', () => {
         .post('/api/evaluate_permission')
         .send({ tool_name: 'Bash', input: { command: 'git push --force' } });
 
-      expect(res.body).toEqual({ decision: 'deny', reason: 'Blocked by policy' });
+      expect(res.body).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: 'Blocked by policy',
+        },
+      });
+    });
+
+    it('should wrap legacy flat Claude responses into hookSpecificOutput', async () => {
+      const handler = createMockHandler([{
+        success: true,
+        data: { decision: 'deny', reason: 'Blocked by policy' },
+      }]);
+      const app = createApp(handler);
+
+      const res = await request(app)
+        .post('/api/evaluate_permission')
+        .send({ tool_name: 'Bash', input: { command: 'git push --force' }, platform: 'claude_code' });
+
+      expect(res.body).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: 'Blocked by policy',
+        },
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- normalize Claude Code hook responses in the shared pretooluse bridge so legacy flat responses no longer trigger validation spam
- wrap stale flat Claude and VS Code permission route results into the current hookSpecificOutput shape before returning them
- add regression coverage for route normalization and hook-script translation, pass-through, and malformed-response fail-open behavior

Closes #2006

## Validation
- 
- 
up to date, audited 1026 packages in 744ms

171 packages are looking for funding
  run `npm fund` for details

7 vulnerabilities (1 moderate, 6 high)

To address issues that do not require attention, run:
  npm audit fix

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
- 
- [jest.config] --experimental-vm-modules not detected; using CJS fallback transform
