### PR TITLE
Fix permissions audit modal scrolling

### DIFF
--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -355,9 +355,10 @@
 }
 
 .perm-feed--modal {
-  height: calc(100vh - 11rem);
+  height: 100%;
   max-height: none;
   min-height: 0;
+  overflow: auto;
 }
 
 .perm-feed-empty {
@@ -398,6 +399,16 @@
   .perm-selected-grid {
     grid-template-columns: 1fr;
   }
+
+  .perm-audit-summary-row {
+    grid-template-columns: 1fr;
+    gap: 0.45rem;
+  }
+
+  .perm-audit-detail-row {
+    grid-template-columns: 1fr;
+    gap: 0.25rem;
+  }
 }
 
 .perm-feed-tool {
@@ -418,6 +429,133 @@
 
 .perm-audit-modal-dialog {
   width: min(82rem, 100%);
+}
+
+.perm-audit-modal .modal-body {
+  display: flex;
+  min-height: 0;
+  padding: 0;
+}
+
+.perm-audit-modal .modal-meta {
+  row-gap: 0.35rem;
+}
+
+.perm-audit-modal .perm-feed--modal {
+  padding: 0.875rem 1rem 1rem;
+}
+
+.perm-audit-entry {
+  border: 1px solid var(--ink-100, #e2e8f0);
+  border-radius: 0.75rem;
+  background: var(--paper-strong, #fff);
+  margin-bottom: 0.75rem;
+  overflow: hidden;
+}
+
+.perm-audit-entry:last-child {
+  margin-bottom: 0;
+}
+
+.perm-audit-entry[open] {
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--ink-900, #0f172a) 10%, transparent);
+}
+
+.perm-audit-summary-row {
+  display: grid;
+  grid-template-columns: minmax(6rem, auto) auto minmax(9rem, auto) minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.875rem 1rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.perm-audit-summary-row::-webkit-details-marker {
+  display: none;
+}
+
+.perm-audit-summary-row:hover {
+  background: var(--ink-50, #f8fafc);
+}
+
+.perm-audit-time-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.perm-audit-time {
+  color: var(--ink-800, #1e293b);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.perm-audit-date {
+  color: var(--ink-500, #64748b);
+  font-size: 0.72rem;
+}
+
+.perm-audit-tool {
+  color: var(--ink-800, #1e293b);
+  font-weight: 700;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.perm-audit-context {
+  color: var(--ink-600, #475569);
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.perm-audit-entry-body {
+  border-top: 1px solid var(--ink-100, #e2e8f0);
+  padding: 0.95rem 1rem 1rem;
+  background: color-mix(in srgb, var(--paper-base, #f8fafc) 82%, white);
+}
+
+.perm-audit-reason-block {
+  margin-bottom: 0.85rem;
+}
+
+.perm-audit-reason-text {
+  margin: 0.3rem 0 0;
+  color: var(--ink-700, #334155);
+  line-height: 1.55;
+}
+
+.perm-audit-detail-list {
+  display: grid;
+  gap: 0.625rem;
+  margin: 0;
+}
+
+.perm-audit-detail-row {
+  display: grid;
+  grid-template-columns: minmax(8rem, 11rem) minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.perm-audit-meta-label {
+  color: var(--ink-500, #64748b);
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.perm-audit-meta-value {
+  margin: 0;
+  color: var(--ink-800, #1e293b);
+  overflow-wrap: anywhere;
+}
+
+.perm-audit-detail-value--mono {
+  font-family: var(--font-mono, 'IBM Plex Mono', monospace);
+  font-size: 0.82rem;
 }
 
 /* ── Source Elements ───────────────────────────────────────── */
@@ -550,7 +688,10 @@
 [data-theme="dark"] .perm-selected-title,
 [data-theme="dark"] .perm-feed-tool,
 [data-theme="dark"] .perm-pattern-text,
-[data-theme="dark"] .perm-source-name {
+[data-theme="dark"] .perm-source-name,
+[data-theme="dark"] .perm-audit-time,
+[data-theme="dark"] .perm-audit-tool,
+[data-theme="dark"] .perm-audit-meta-value {
   color: var(--ink-200, #e2e8f0);
 }
 
@@ -558,6 +699,20 @@
 [data-theme="dark"] .perm-pattern-list,
 [data-theme="dark"] .perm-feed {
   background: color-mix(in srgb, var(--paper) 36%, var(--surface-1));
+}
+
+[data-theme="dark"] .perm-audit-entry {
+  background: color-mix(in srgb, var(--paper) 22%, var(--surface-1));
+  border-color: color-mix(in srgb, var(--line) 88%, transparent);
+}
+
+[data-theme="dark"] .perm-audit-summary-row:hover {
+  background: color-mix(in srgb, var(--surface-2) 72%, var(--paper-strong));
+}
+
+[data-theme="dark"] .perm-audit-entry-body {
+  background: color-mix(in srgb, var(--surface-1) 82%, var(--paper-strong));
+  border-color: color-mix(in srgb, var(--line) 92%, transparent);
 }
 
 [data-theme="dark"] .perm-source-item,
@@ -569,6 +724,16 @@
 [data-theme="dark"] .perm-source-item:hover,
 [data-theme="dark"] .perm-feed-row:hover {
   background: color-mix(in srgb, var(--surface-2) 72%, var(--paper-strong));
+}
+
+[data-theme="dark"] .perm-audit-context,
+[data-theme="dark"] .perm-audit-reason-text {
+  color: var(--ink-300, #cbd5e1);
+}
+
+[data-theme="dark"] .perm-audit-date,
+[data-theme="dark"] .perm-audit-meta-label {
+  color: var(--ink-500, #7b93a7);
 }
 
 [data-theme="dark"] .perm-source-type {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -324,27 +324,132 @@
     if (latestId === lastDecisionId) return; // no change
     lastDecisionId = latestId;
 
-    const html = decisions.map(d => {
-      const time = new Date(d.timestamp).toLocaleTimeString();
-      const toolDisplay = d.tool_name === 'Bash'
-        ? `Bash: ${esc(truncate(d.command || '', 60))}`
-        : esc(d.tool_name);
-
-      return `
-        <div class="perm-feed-row">
-          <span class="perm-feed-time">${time}</span>
-          <span class="perm-feed-decision perm-feed-decision--${d.decision}">${d.decision.toUpperCase()}</span>
-          <span class="perm-feed-tool" title="${esc(d.command || d.tool_name)}">${toolDisplay}</span>
-          <span class="perm-feed-reason" title="${esc(d.reason || '')}">${esc(d.reason || '')}</span>
-        </div>
-      `;
-    }).join('');
+    const html = decisions.map(renderCompactDecisionRow).join('');
 
     feed.innerHTML = html;
-    if (modalFeed) modalFeed.innerHTML = html;
+    if (modalFeed) modalFeed.innerHTML = renderAuditModal(decisions);
     if (modalCount) {
       modalCount.textContent = `${decisions.length} captured ${decisions.length === 1 ? 'entry' : 'entries'}`;
     }
+  }
+
+  function renderCompactDecisionRow(decision) {
+    const toolDisplay = decision.tool_name === 'Bash'
+      ? `Bash: ${esc(truncate(decision.command || '', 60))}`
+      : esc(decision.tool_name);
+
+    return `
+      <div class="perm-feed-row">
+        <span class="perm-feed-time">${esc(formatShortTime(decision.timestamp))}</span>
+        <span class="perm-feed-decision perm-feed-decision--${decision.decision}">${esc(getDecisionLabel(decision.decision))}</span>
+        <span class="perm-feed-tool" title="${esc(decision.command || decision.tool_name)}">${toolDisplay}</span>
+        <span class="perm-feed-reason" title="${esc(decision.reason || '')}">${esc(decision.reason || '')}</span>
+      </div>
+    `;
+  }
+
+  function renderAuditModal(decisions) {
+    if (!decisions || decisions.length === 0) {
+      return '<div class="perm-feed-empty">No permission decisions yet. Waiting for tool calls...</div>';
+    }
+
+    return decisions.map(renderAuditDecisionEntry).join('');
+  }
+
+  function renderAuditDecisionEntry(decision) {
+    const compactContext = getCompactContext(decision);
+    const detailRows = Array.isArray(decision.details) ? decision.details : [];
+    const reasonBlock = decision.reason
+      ? `
+        <div class="perm-audit-reason-block">
+          <div class="perm-audit-meta-label">Reason</div>
+          <p class="perm-audit-reason-text">${esc(decision.reason)}</p>
+        </div>
+      `
+      : '';
+    const detailList = detailRows.length > 0
+      ? `
+        <dl class="perm-audit-detail-list">
+          ${detailRows.map(detail => `
+            <div class="perm-audit-detail-row">
+              <dt class="perm-audit-meta-label">${esc(detail.label)}</dt>
+              <dd class="perm-audit-meta-value${detail.monospace ? ' perm-audit-detail-value--mono' : ''}">${esc(detail.value)}</dd>
+            </div>
+          `).join('')}
+          <div class="perm-audit-detail-row">
+            <dt class="perm-audit-meta-label">Exact Time</dt>
+            <dd class="perm-audit-meta-value perm-audit-detail-value--mono">${esc(formatExactTimestamp(decision.timestamp))}</dd>
+          </div>
+        </dl>
+      `
+      : `
+        <dl class="perm-audit-detail-list">
+          <div class="perm-audit-detail-row">
+            <dt class="perm-audit-meta-label">Exact Time</dt>
+            <dd class="perm-audit-meta-value perm-audit-detail-value--mono">${esc(formatExactTimestamp(decision.timestamp))}</dd>
+          </div>
+        </dl>
+      `;
+
+    return `
+      <details class="perm-audit-entry">
+        <summary class="perm-audit-summary-row">
+          <span class="perm-audit-time-group">
+            <span class="perm-audit-time">${esc(formatShortTime(decision.timestamp))}</span>
+            <span class="perm-audit-date">${esc(formatShortDate(decision.timestamp))}</span>
+          </span>
+          <span class="perm-feed-decision perm-feed-decision--${decision.decision}">${esc(getDecisionLabel(decision.decision))}</span>
+          <span class="perm-audit-tool">${esc(decision.tool_name)}</span>
+          <span class="perm-audit-context">${esc(compactContext)}</span>
+        </summary>
+        <div class="perm-audit-entry-body">
+          ${reasonBlock}
+          ${detailList}
+        </div>
+      </details>
+    `;
+  }
+
+  function formatShortTime(timestamp) {
+    return new Date(timestamp).toLocaleTimeString([], {
+      hour: 'numeric',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  }
+
+  function formatShortDate(timestamp) {
+    return new Date(timestamp).toLocaleDateString([], {
+      month: 'short',
+      day: 'numeric',
+    });
+  }
+
+  function formatExactTimestamp(timestamp) {
+    const date = new Date(timestamp);
+    return date.toLocaleString([], {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      second: '2-digit',
+      timeZoneName: 'short',
+    });
+  }
+
+  function getDecisionLabel(decision) {
+    return String(decision || '').toUpperCase();
+  }
+
+  function getCompactContext(decision) {
+    if (decision.targetLabel && decision.target) {
+      return `${decision.targetLabel}: ${truncate(decision.target, 96)}`;
+    }
+    if (decision.command) {
+      return truncate(decision.command, 96);
+    }
+    return decision.reason || 'No extra context captured';
   }
 
   function renderPolicySourceItem(el, extraClass = '') {

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -25,6 +25,16 @@ interface PermissionDecision {
   command?: string;
   decision: string;
   reason?: string;
+  platform?: string;
+  target?: string;
+  targetLabel?: string;
+  details?: PermissionDecisionDetail[];
+}
+
+interface PermissionDecisionDetail {
+  label: string;
+  value: string;
+  monospace?: boolean;
 }
 
 interface KnownPolicySession {
@@ -38,7 +48,13 @@ const PERMISSION_ROUTE_RATE_LIMIT_WINDOW_MS = 60_000;
 const DECISION_BUFFER_SIZE = 200;
 
 interface PermissionDecisionTracker {
-  trackDecision(sessionId: string | undefined, toolName: string, input: Record<string, unknown>, result: Record<string, unknown>): void;
+  trackDecision(
+    sessionId: string | undefined,
+    toolName: string,
+    input: Record<string, unknown>,
+    result: Record<string, unknown>,
+    platform: string,
+  ): void;
   getRecentDecisions(): PermissionDecision[];
 }
 
@@ -113,12 +129,73 @@ function normalizePermissionResponseForPlatform(
   return formatPermissionResponse('allow', platform, input);
 }
 
+function buildDecisionDetails(
+  toolName: string,
+  input: Record<string, unknown>,
+  result: Record<string, unknown>,
+  platform: string,
+): { target?: string; targetLabel?: string; details: PermissionDecisionDetail[] } {
+  const details: PermissionDecisionDetail[] = [];
+
+  if (platform) {
+    details.push({ label: 'Platform', value: platform, monospace: true });
+  }
+
+  if (toolName === 'Bash' && typeof input.command === 'string' && input.command !== '') {
+    details.push({ label: 'Command', value: input.command, monospace: true });
+  }
+
+  const targetDescriptors: Array<{ key: string; label: string; monospace?: boolean }> = [
+    { key: 'file_path', label: 'File', monospace: true },
+    { key: 'path', label: 'Path', monospace: true },
+    { key: 'url', label: 'URL' },
+    { key: 'pattern', label: 'Pattern', monospace: true },
+    { key: 'query', label: 'Query' },
+    { key: 'element_name', label: 'Element', monospace: true },
+    { key: 'request_id', label: 'Request', monospace: true },
+  ];
+
+  let target: string | undefined;
+  let targetLabel: string | undefined;
+
+  for (const descriptor of targetDescriptors) {
+    const value = input[descriptor.key];
+    if (typeof value !== 'string' || value === '') {
+      continue;
+    }
+
+    target = value;
+    targetLabel = descriptor.label;
+    details.push({ label: descriptor.label, value, monospace: descriptor.monospace });
+    break;
+  }
+
+  const matchedPattern = extractString(result, ['matched_pattern', 'matchedPattern'], '');
+  if (matchedPattern !== '') {
+    details.push({ label: 'Matched Pattern', value: matchedPattern, monospace: true });
+  }
+
+  const policySource = extractString(result, ['policy_source', 'policySource'], '');
+  if (policySource !== '') {
+    details.push({ label: 'Policy Source', value: policySource, monospace: true });
+  }
+
+  return { target, targetLabel, details };
+}
+
 function createPermissionDecisionTracker(bufferSize = DECISION_BUFFER_SIZE): PermissionDecisionTracker {
   const recentDecisions: PermissionDecision[] = [];
   let decisionCounter = 0;
 
   return {
-    trackDecision(sessionId: string | undefined, toolName: string, input: Record<string, unknown>, result: Record<string, unknown>): void {
+    trackDecision(
+      sessionId: string | undefined,
+      toolName: string,
+      input: Record<string, unknown>,
+      result: Record<string, unknown>,
+      platform: string,
+    ): void {
+      const detailState = buildDecisionDetails(toolName, input, result, platform);
       const entry: PermissionDecision = {
         id: `d-${++decisionCounter}`,
         timestamp: new Date().toISOString(),
@@ -127,6 +204,10 @@ function createPermissionDecisionTracker(bufferSize = DECISION_BUFFER_SIZE): Per
         command: toolName === 'Bash' && typeof input?.command === 'string' ? input.command : undefined,
         decision: extractDecision(result),
         reason: extractReason(result),
+        platform,
+        target: detailState.target,
+        targetLabel: detailState.targetLabel,
+        details: detailState.details,
       };
       recentDecisions.unshift(entry);
       if (recentDecisions.length > bufferSize) {
@@ -258,16 +339,18 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
         return;
       }
 
+      const rawResult = opResult.data as Record<string, unknown>;
       const responseData = normalizePermissionResponseForPlatform(
         platform,
         input || {},
-        opResult.data as Record<string, unknown>,
+        rawResult,
       );
+      const trackedResult = { ...rawResult, ...responseData };
       const decision = extractDecision(responseData);
       logger.debug(`[WebUI/Gateway] evaluate_permission: ${tool_name} → ${decision} (${elapsedMs}ms)`);
 
       // Track decision for live dashboard feed
-      decisionTracker.trackDecision(session_id, tool_name, input || {}, responseData);
+      decisionTracker.trackDecision(session_id, tool_name, input || {}, trackedResult, platform);
 
       res.json(responseData);
     } catch (err) {

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -529,11 +529,11 @@ describe('Web console cleanup regressions', () => {
                 decision: 'ask',
                 reason: 'Needs confirmation before editing a protected file.',
                 platform: 'cursor',
-                target: '/tmp/important.txt',
+                target: '/opt/dollhouse/important.txt',
                 targetLabel: 'File',
                 details: [
                   { label: 'Platform', value: 'cursor', monospace: true },
-                  { label: 'File', value: '/tmp/important.txt', monospace: true },
+                  { label: 'File', value: '/opt/dollhouse/important.txt', monospace: true },
                   { label: 'Matched Pattern', value: 'Edit:*', monospace: true },
                 ],
               },
@@ -568,7 +568,7 @@ describe('Web console cleanup regressions', () => {
     expect(modal?.hasAttribute('open')).toBe(true);
     expect(win.document.getElementById('perm-audit-modal-title')?.textContent).toContain('All Sessions Audit View');
     expect(modalFeed?.textContent).toContain('Needs confirmation before editing a protected file.');
-    expect(modalFeed?.textContent).toContain('/tmp/important.txt');
+    expect(modalFeed?.textContent).toContain('/opt/dollhouse/important.txt');
     expect(modalFeed?.textContent).toContain('Matched Pattern');
     expect(modalFeed?.textContent).toContain('Exact Time');
     expect(modalFeed?.querySelector('.perm-audit-entry')).not.toBeNull();

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -492,6 +492,99 @@ describe('Web console cleanup regressions', () => {
     cleanup();
   });
 
+  it('renders an expanded audit modal with scrollable decision context details', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="session-indicator"></div>
+      <div id="tab-logs"><div class="log-controls"></div></div>
+      <div id="console-tabs"><button class="console-tab" data-tab="permissions">Permissions</button></div>
+      <div id="permissions-dashboard-root"></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn((url: string) => {
+      if (url === '/api/sessions') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ sessions: [] }),
+        });
+      }
+
+      if (url === '/api/permissions/status') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            activeElementCount: 1,
+            hasAllowlist: false,
+            denyPatterns: [],
+            allowPatterns: [],
+            confirmPatterns: [],
+            denyRules: [],
+            allowRules: [],
+            confirmRules: [],
+            elements: [],
+            recentDecisions: [
+              {
+                id: 'd-1',
+                timestamp: '2026-04-15T20:10:11.000Z',
+                tool_name: 'Edit',
+                decision: 'ask',
+                reason: 'Needs confirmation before editing a protected file.',
+                platform: 'cursor',
+                target: '/tmp/important.txt',
+                targetLabel: 'File',
+                details: [
+                  { label: 'Platform', value: 'cursor', monospace: true },
+                  { label: 'File', value: '/tmp/important.txt', monospace: true },
+                  { label: 'Matched Pattern', value: 'Edit:*', monospace: true },
+                ],
+              },
+            ],
+            permissionPromptActive: false,
+          }),
+        });
+      }
+
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+    win.DollhouseConsoleConfig = {
+      sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
+      sessionFilterInjectionMaxRetries: 5,
+    };
+
+    win.eval(sessionsSource);
+    win.eval(permissionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    win.DollhouseConsole.permissions.init();
+    await wait(SESSION_FILTER_INJECTION_WAIT_MS);
+
+    const openButton = win.document.getElementById('perm-feed-expand-btn') as HTMLButtonElement | null;
+    expect(openButton).not.toBeNull();
+    openButton?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    const modal = win.document.getElementById('perm-audit-modal');
+    const modalFeed = win.document.getElementById('perm-audit-modal-feed');
+    expect(modal?.hasAttribute('open')).toBe(true);
+    expect(win.document.getElementById('perm-audit-modal-title')?.textContent).toContain('All Sessions Audit View');
+    expect(modalFeed?.textContent).toContain('Needs confirmation before editing a protected file.');
+    expect(modalFeed?.textContent).toContain('/tmp/important.txt');
+    expect(modalFeed?.textContent).toContain('Matched Pattern');
+    expect(modalFeed?.textContent).toContain('Exact Time');
+    expect(modalFeed?.querySelector('.perm-audit-entry')).not.toBeNull();
+
+    const details = modalFeed?.querySelector('details') as HTMLDetailsElement | null;
+    expect(details).not.toBeNull();
+    details?.setAttribute('open', '');
+
+    const closeButton = win.document.getElementById('perm-audit-modal-close') as HTMLButtonElement | null;
+    closeButton?.click();
+    await wait(DEFAULT_WAIT_MS);
+    expect(modal?.hasAttribute('open')).toBe(false);
+
+    cleanup();
+  });
+
   it('shows a visible logs banner when the SSE stream disconnects', async () => {
     const { window: win, cleanup } = createDom(`
       <div id="tab-logs"></div>

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -597,7 +597,7 @@ describe('permissionRoutes', () => {
         .post('/api/evaluate_permission')
         .send({
           tool_name: 'Edit',
-          input: { file_path: '/tmp/example.txt' },
+          input: { file_path: '/opt/dollhouse/example.txt' },
           platform: 'cursor',
         });
 
@@ -607,12 +607,12 @@ describe('permissionRoutes', () => {
         tool_name: 'Edit',
         decision: 'ask',
         platform: 'cursor',
-        target: '/tmp/example.txt',
+        target: '/opt/dollhouse/example.txt',
         targetLabel: 'File',
       }));
       expect(status.body.recentDecisions[0].details).toEqual(expect.arrayContaining([
         { label: 'Platform', value: 'cursor', monospace: true },
-        { label: 'File', value: '/tmp/example.txt', monospace: true },
+        { label: 'File', value: '/opt/dollhouse/example.txt', monospace: true },
         { label: 'Matched Pattern', value: 'Edit:*', monospace: true },
       ]));
     });

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -565,5 +565,56 @@ describe('permissionRoutes', () => {
         }),
       ]);
     });
+
+    it('should include useful audit detail fields for tracked decisions', async () => {
+      const handler = {
+        handleRead: jest
+          .fn()
+          .mockResolvedValueOnce([{
+            success: true,
+            data: {
+              decision: 'ask',
+              reason: 'Needs confirmation',
+              matched_pattern: 'Edit:*',
+            },
+          }])
+          .mockResolvedValueOnce([{
+            success: true,
+            data: {
+              activeElementCount: 0,
+              hasAllowlist: false,
+              combinedDenyPatterns: [],
+              combinedAllowPatterns: [],
+              combinedConfirmPatterns: [],
+              elements: [],
+              permissionPromptActive: false,
+            },
+          }]),
+      } as any;
+      const app = createApp(handler);
+
+      await request(app)
+        .post('/api/evaluate_permission')
+        .send({
+          tool_name: 'Edit',
+          input: { file_path: '/tmp/example.txt' },
+          platform: 'cursor',
+        });
+
+      const status = await request(app).get('/api/permissions/status');
+
+      expect(status.body.recentDecisions[0]).toEqual(expect.objectContaining({
+        tool_name: 'Edit',
+        decision: 'ask',
+        platform: 'cursor',
+        target: '/tmp/example.txt',
+        targetLabel: 'File',
+      }));
+      expect(status.body.recentDecisions[0].details).toEqual(expect.arrayContaining([
+        { label: 'Platform', value: 'cursor', monospace: true },
+        { label: 'File', value: '/tmp/example.txt', monospace: true },
+        { label: 'Matched Pattern', value: 'Edit:*', monospace: true },
+      ]));
+    });
   });
 });


### PR DESCRIPTION
## Summary
- fix the permissions audit modal so the dialog body owns scrolling cleanly instead of fighting the viewport
- enrich tracked permission decisions with platform, target, matched pattern, and policy-source details for audit review
- render the expanded audit view as accordion entries with exact timestamps and structured context

## Testing
- `node --check src/web/public/permissions.js`
- `npx jest --config tests/jest.config.cjs --runInBand --modulePathIgnorePatterns=.worktrees --runTestsByPath tests/unit/web/permissionRoutes.test.ts tests/unit/web/console-ui-regressions.test.ts`

## Notes
- `npx tsc -p tsconfig.json --noEmit` still hits the existing `smol-toml` baseline issue in `src/web/routes/setupRoutes.ts`, unrelated to this PR.