### PR TITLE
Add deadlock relief recovery flow

### DIFF
--- a/docs/security/deadlock-relief-flow.md
+++ b/docs/security/deadlock-relief-flow.md
@@ -1,0 +1,172 @@
+# Deadlock Relief Flow
+
+This document describes the new `release_deadlock` recovery path for sessions that have been locked down too aggressively by active element policies.
+
+## Purpose
+
+The goal is to provide a safe, human-confirmed escape hatch when:
+
+- an active element denies `confirm_operation`
+- the session can no longer approve normal recovery steps
+- the user needs to deactivate everything and recover control of the session
+
+## High-Level Behavior
+
+- The user or model calls `release_deadlock`.
+- Dollhouse creates a one-time verification challenge.
+- The verification code is shown only to the human via the existing OS-level warning dialog.
+- The caller must invoke `release_deadlock` again with `challenge_id` and `code`.
+- On success, Dollhouse:
+  - records a recovery snapshot file with the pre-reset session state
+  - deactivates all active personas, skills, agents, memories, and ensembles for the current session
+  - clears the current session's persisted activation state
+  - returns a summary of what was active, what was deactivated, likely deadlock causes, and any failures
+
+## Mermaid Flow
+
+```mermaid
+flowchart TD
+    A["Session becomes restrictive"] --> B{"Can normal recovery still work?"}
+    B -- "Yes" --> C["Use normal deactivate / edit flow"]
+    B -- "No: confirm_operation is sandboxed or recovery is blocked" --> D["Call release_deadlock"]
+
+    D --> E["Issue one-time challenge_id"]
+    E --> F["Show verification code in OS warning dialog"]
+    F --> G["Human reads code from screen"]
+    G --> H["Call release_deadlock with challenge_id + code"]
+
+    H --> I{"Challenge valid and code matches?"}
+    I -- "No" --> J["Return verification failure"]
+    J --> K["User retries release_deadlock to get a new code"]
+    K --> D
+
+    I -- "Yes" --> L["Collect all active elements in current session"]
+    L --> M["Deactivate active personas"]
+    M --> N["Deactivate active skills"]
+    N --> O["Deactivate active agents"]
+    O --> P["Deactivate active memories"]
+    P --> Q["Deactivate active ensembles"]
+    Q --> R["Write recovery snapshot file"]
+    R --> S["Clear current session activation persistence"]
+    S --> T["Export updated policies if available"]
+    T --> U["Return deadlock relief summary"]
+    U --> V["User reviews snapshot and selectively reactivates elements"]
+```
+
+## Detailed Decision Notes
+
+### 1. Why this does not use `confirm_operation`
+
+The whole point of this flow is that `confirm_operation` may already be blocked by an active element's gatekeeper policy. So the reset path must stay reachable even in that state.
+
+To make that work:
+
+- `release_deadlock` is treated as a gatekeeper-essential recovery operation
+- it is exempted from normal element-policy gating loops
+- it still requires a real human verification step before any reset happens
+
+### 2. Why the human code is out-of-band
+
+The recovery code is shown through the existing OS-level dialog so the model never receives the code directly in the normal tool response.
+
+That keeps the flow aligned with the existing danger-zone verification posture:
+
+- human present at machine
+- visible warning
+- one-time code
+- limited validity window
+
+### 3. Why `verify_challenge` does not complete this reset
+
+Deadlock relief challenges are reserved for `release_deadlock` itself.
+
+If someone tries to pass that code into `verify_challenge`, Dollhouse rejects it and tells them to complete the reset through the dedicated `release_deadlock` flow. This prevents accidental consumption of the code without actually performing the recovery.
+
+### 4. What gets reset
+
+Successful deadlock relief currently targets all active session-scoped element types that can affect behavior:
+
+- personas
+- skills
+- agents
+- memories
+- ensembles
+
+Templates are not part of the active session reset because they are not part of the activation persistence / active policy surface in the same way.
+
+### 5. What gets preserved for recovery
+
+Before the reset completes, Dollhouse writes a recovery snapshot file that includes:
+
+- the session id
+- all active elements before reset
+- the elements successfully deactivated
+- any deactivation failures
+- the likely deadlock cause
+  - sandboxing element if one denied `confirm_operation`
+  - advisory elements that requested extra scrutiny
+
+This gives the user a concrete checklist for rebuilding the session intentionally instead of losing track of what had been active.
+
+## Recovery Contract
+
+### Initial call
+
+```json
+{ "operation": "release_deadlock" }
+```
+
+Expected result shape:
+
+```json
+{
+  "pending": true,
+  "challenge_id": "...",
+  "message": "Deadlock relief requires human confirmation..."
+}
+```
+
+### Completion call
+
+```json
+{
+  "operation": "release_deadlock",
+  "params": {
+    "challenge_id": "...",
+    "code": "ABC123"
+  }
+}
+```
+
+Expected result shape:
+
+```json
+{
+  "released": true,
+  "challenge_id": "...",
+  "activeBeforeReset": [
+    { "element_name": "Locked Persona", "type": "persona" }
+  ],
+  "deactivated": [
+    { "element_name": "Locked Persona", "type": "persona" }
+  ],
+  "failed": [],
+  "likelyDeadlockCause": {
+    "sandboxingElement": { "element_name": "Locked Persona", "type": "persona" },
+    "advisoryElements": []
+  },
+  "persistedStateCleared": true,
+  "snapshotFile": "/Users/.../.dollhouse/state/deadlock-relief/deadlock-relief-session-....json",
+  "message": "Deadlock relief completed..."
+}
+```
+
+## What to sanity-check
+
+When reviewing this flow, the main questions are:
+
+1. Is the human verification step strong enough for this kind of reset?
+2. Are we resetting the right set of active element types?
+3. Is clearing current-session activation persistence the right scope?
+4. Should any additional audit metadata be returned or logged?
+5. Is the separation between `release_deadlock` and `verify_challenge` the right UX boundary?

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -558,6 +558,104 @@ export class ElementCRUDHandler {
     }));
   }
 
+  async releaseDeadlock(): Promise<{
+    sessionId?: string;
+    deactivated: Array<{ type: string; name: string }>;
+    failed: Array<{ type: string; name: string; error: string }>;
+    persistedStateCleared: boolean;
+  }> {
+    const activeElements = await this.collectActiveElementsForDeadlockRelief();
+    const deactivated: Array<{ type: string; name: string }> = [];
+    const failed: Array<{ type: string; name: string; error: string }> = [];
+
+    for (const element of activeElements) {
+      const strategy = this.strategies.get(element.type);
+      if (!strategy) {
+        failed.push({
+          type: element.type,
+          name: element.name,
+          error: `No activation strategy registered for type '${element.type}'`,
+        });
+        continue;
+      }
+
+      try {
+        await strategy.deactivate(element.name);
+        deactivated.push(element);
+      } catch (error) {
+        failed.push({
+          type: element.type,
+          name: element.name,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    const persistedStateCleared = Boolean(this.activationStore?.isEnabled());
+    this.activationStore?.clearAll();
+    this.policyExportService?.exportPolicies().catch(() => {});
+
+    SecurityMonitor.logSecurityEvent({
+      type: 'ELEMENT_DEACTIVATED',
+      severity: failed.length > 0 ? 'MEDIUM' : 'LOW',
+      source: 'ElementCRUDHandler.releaseDeadlock',
+      details: `Deadlock relief deactivated ${deactivated.length} element(s)${failed.length > 0 ? ` with ${failed.length} failure(s)` : ''}`,
+      additionalData: {
+        sessionId: this.activationStore?.getSessionId(),
+        deactivated,
+        failed,
+        persistedStateCleared,
+      },
+    });
+
+    return {
+      ...(this.activationStore?.getSessionId()
+        ? { sessionId: this.activationStore.getSessionId() }
+        : {}),
+      deactivated,
+      failed,
+      persistedStateCleared,
+    };
+  }
+
+  private async collectActiveElementsForDeadlockRelief(): Promise<Array<{ type: string; name: string }>> {
+    const activeElements: Array<{ type: string; name: string }> = [];
+
+    const activePersonas = this.personaManager.getActivePersonas();
+    activeElements.push(...activePersonas.map((persona) => ({
+      type: ElementType.PERSONA,
+      name: persona.metadata.name,
+    })));
+
+    const activeSkills = await this.skillManager.getActiveSkills();
+    activeElements.push(...activeSkills.map((skill) => ({
+      type: ElementType.SKILL,
+      name: skill.metadata.name,
+    })));
+
+    const activeAgents = await this.agentManager.getActiveAgents();
+    activeElements.push(...activeAgents.map((agent) => ({
+      type: ElementType.AGENT,
+      name: agent.metadata.name,
+    })));
+
+    const activeMemories = await this.memoryManager.getActiveMemories();
+    activeElements.push(...activeMemories.map((memory) => ({
+      type: ElementType.MEMORY,
+      name: memory.metadata.name,
+    })));
+
+    const activeEnsembles = await this.ensembleManager.getActiveEnsembles();
+    activeElements.push(...activeEnsembles.map((ensemble) => ({
+      type: ElementType.ENSEMBLE,
+      name: ensemble.metadata.name,
+    })));
+
+    return activeElements.filter((element, index, all) =>
+      all.findIndex((candidate) => candidate.type === element.type && candidate.name === element.name) === index,
+    );
+  }
+
   private async mergePersistedPolicyState(
     state: PersistedActivationStateSnapshot,
     addElement: (element: { type: string; name: string; metadata: Record<string, unknown> }, sessionIds?: string[]) => void,

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -18,6 +18,8 @@
  */
 
 import { ElementType, PortfolioManager } from '../portfolio/PortfolioManager.js';
+import os from 'os';
+import path from 'path';
 import { SkillManager } from '../elements/skills/index.js';
 import { TemplateManager } from '../elements/templates/TemplateManager.js';
 import { TemplateRenderer } from '../utils/TemplateRenderer.js';
@@ -56,7 +58,11 @@ import type { BackupService } from '../services/BackupService.js';
 import type { PolicyExportService } from '../services/PolicyExportService.js';
 import type { BaseElementManager } from '../elements/base/BaseElementManager.js';
 import { formatValidationFailedError } from './element-crud/responseFormatter.js';
-import { getGatekeeperDiagnostics } from './mcp-aql/policies/ElementPolicies.js';
+import {
+  findConfirmAdvisoryElements,
+  findConfirmDenyingElement,
+  getGatekeeperDiagnostics,
+} from './mcp-aql/policies/ElementPolicies.js';
 
 export class ElementCRUDHandler {
   private readonly strategies: Map<string, ElementActivationStrategy>;
@@ -560,11 +566,20 @@ export class ElementCRUDHandler {
 
   async releaseDeadlock(): Promise<{
     sessionId?: string;
+    activeBeforeReset: Array<{ type: string; name: string }>;
     deactivated: Array<{ type: string; name: string }>;
     failed: Array<{ type: string; name: string; error: string }>;
     persistedStateCleared: boolean;
+    likelyDeadlockCause: {
+      sandboxingElement?: { type: string; name: string };
+      advisoryElements: Array<{ type: string; name: string }>;
+    };
+    snapshotFile?: string;
   }> {
     const activeElements = await this.collectActiveElementsForDeadlockRelief();
+    const activePolicyElements = await this.getActiveElementsForPolicy();
+    const sandboxingElement = findConfirmDenyingElement(activePolicyElements);
+    const advisoryElements = findConfirmAdvisoryElements(activePolicyElements);
     const deactivated: Array<{ type: string; name: string }> = [];
     const failed: Array<{ type: string; name: string; error: string }> = [];
 
@@ -592,6 +607,18 @@ export class ElementCRUDHandler {
     }
 
     const persistedStateCleared = Boolean(this.activationStore?.isEnabled());
+    const snapshotFile = await this.writeDeadlockReliefSnapshot({
+      sessionId: this.activationStore?.getSessionId(),
+      activeBeforeReset: activeElements,
+      deactivated,
+      failed,
+      likelyDeadlockCause: {
+        ...(sandboxingElement ? { sandboxingElement } : {}),
+        advisoryElements,
+      },
+      persistedStateCleared,
+    });
+
     this.activationStore?.clearAll();
     this.policyExportService?.exportPolicies().catch(() => {});
 
@@ -602,9 +629,15 @@ export class ElementCRUDHandler {
       details: `Deadlock relief deactivated ${deactivated.length} element(s)${failed.length > 0 ? ` with ${failed.length} failure(s)` : ''}`,
       additionalData: {
         sessionId: this.activationStore?.getSessionId(),
+        activeBeforeReset: activeElements,
         deactivated,
         failed,
         persistedStateCleared,
+        likelyDeadlockCause: {
+          ...(sandboxingElement ? { sandboxingElement } : {}),
+          advisoryElements,
+        },
+        snapshotFile,
       },
     });
 
@@ -612,9 +645,15 @@ export class ElementCRUDHandler {
       ...(this.activationStore?.getSessionId()
         ? { sessionId: this.activationStore.getSessionId() }
         : {}),
+      activeBeforeReset: activeElements,
       deactivated,
       failed,
       persistedStateCleared,
+      likelyDeadlockCause: {
+        ...(sandboxingElement ? { sandboxingElement } : {}),
+        advisoryElements,
+      },
+      ...(snapshotFile ? { snapshotFile } : {}),
     };
   }
 
@@ -654,6 +693,43 @@ export class ElementCRUDHandler {
     return activeElements.filter((element, index, all) =>
       all.findIndex((candidate) => candidate.type === element.type && candidate.name === element.name) === index,
     );
+  }
+
+  private async writeDeadlockReliefSnapshot(snapshot: {
+    sessionId?: string;
+    activeBeforeReset: Array<{ type: string; name: string }>;
+    deactivated: Array<{ type: string; name: string }>;
+    failed: Array<{ type: string; name: string; error: string }>;
+    likelyDeadlockCause: {
+      sandboxingElement?: { type: string; name: string };
+      advisoryElements: Array<{ type: string; name: string }>;
+    };
+    persistedStateCleared: boolean;
+  }): Promise<string | undefined> {
+    const snapshotDir = path.join(os.homedir(), '.dollhouse', 'state', 'deadlock-relief');
+    const safeSessionId = (snapshot.sessionId ?? 'session')
+      .replaceAll(/[^a-zA-Z0-9_-]/g, '-');
+    const timestamp = new Date().toISOString().replaceAll(/[:.]/g, '-');
+    const snapshotFile = path.join(snapshotDir, `deadlock-relief-${safeSessionId}-${timestamp}.json`);
+
+    try {
+      await this.fileOperations.createDirectory(snapshotDir);
+      await this.fileOperations.writeFile(
+        snapshotFile,
+        JSON.stringify({
+          createdAt: new Date().toISOString(),
+          ...snapshot,
+        }, null, 2),
+        { source: 'ElementCRUDHandler.releaseDeadlock' },
+      );
+      return snapshotFile;
+    } catch (error) {
+      logger.warn('Failed to write deadlock relief snapshot', {
+        snapshotFile,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
   }
 
   private async mergePersistedPolicyState(

--- a/src/handlers/ElementCRUDHandler.ts
+++ b/src/handlers/ElementCRUDHandler.ts
@@ -18,8 +18,8 @@
  */
 
 import { ElementType, PortfolioManager } from '../portfolio/PortfolioManager.js';
-import os from 'os';
-import path from 'path';
+import os from 'node:os';
+import path from 'node:path';
 import { SkillManager } from '../elements/skills/index.js';
 import { TemplateManager } from '../elements/templates/TemplateManager.js';
 import { TemplateRenderer } from '../utils/TemplateRenderer.js';
@@ -622,11 +622,13 @@ export class ElementCRUDHandler {
     this.activationStore?.clearAll();
     this.policyExportService?.exportPolicies().catch(() => {});
 
+    const failureSummary = failed.length > 0 ? ` with ${failed.length} failure(s)` : '';
+
     SecurityMonitor.logSecurityEvent({
       type: 'ELEMENT_DEACTIVATED',
       severity: failed.length > 0 ? 'MEDIUM' : 'LOW',
       source: 'ElementCRUDHandler.releaseDeadlock',
-      details: `Deadlock relief deactivated ${deactivated.length} element(s)${failed.length > 0 ? ` with ${failed.length} failure(s)` : ''}`,
+      details: `Deadlock relief deactivated ${deactivated.length} element(s)${failureSummary}`,
       additionalData: {
         sessionId: this.activationStore?.getSessionId(),
         activeBeforeReset: activeElements,
@@ -690,9 +692,15 @@ export class ElementCRUDHandler {
       name: ensemble.metadata.name,
     })));
 
-    return activeElements.filter((element, index, all) =>
-      all.findIndex((candidate) => candidate.type === element.type && candidate.name === element.name) === index,
-    );
+    const seen = new Set<string>();
+    return activeElements.filter((element) => {
+      const key = `${element.type}:${element.name}`;
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
   }
 
   private async writeDeadlockReliefSnapshot(snapshot: {
@@ -708,7 +716,8 @@ export class ElementCRUDHandler {
   }): Promise<string | undefined> {
     const snapshotDir = path.join(os.homedir(), '.dollhouse', 'state', 'deadlock-relief');
     const safeSessionId = (snapshot.sessionId ?? 'session')
-      .replaceAll(/[^a-zA-Z0-9_-]/g, '-');
+      .replaceAll(/[^a-zA-Z0-9_-]/g, '-')
+      .slice(0, 64);
     const timestamp = new Date().toISOString().replaceAll(/[:.]/g, '-');
     const snapshotFile = path.join(snapshotDir, `deadlock-relief-${safeSessionId}-${timestamp}.json`);
 

--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -294,6 +294,11 @@ class VerificationError extends Error {
   }
 }
 
+const DEADLOCK_RELIEF_REASON = 'Deadlock relief requested';
+const DEADLOCK_RELIEF_TIMEOUT_MS = 5 * 60 * 1000;
+const DEADLOCK_RELIEF_DIALOG_REASON =
+  'Deadlock relief requested.\n\nThis will deactivate all active elements for the current session and clear persisted activation state.';
+
 /**
  * Global rate limiter for verification attempts.
  * Tracks failed attempts within a sliding window to prevent brute-force attacks.
@@ -2382,6 +2387,117 @@ export class MCPAQLHandler {
     }
   }
 
+  private challengeIsForDeadlockRelief(challenge: { reason: string } | undefined): boolean {
+    return typeof challenge?.reason === 'string' && challenge.reason.startsWith(DEADLOCK_RELIEF_REASON);
+  }
+
+  private issueDeadlockReliefChallenge(): {
+    pending: true;
+    challenge_id: string;
+    message: string;
+    warning: string;
+  } {
+    const store = this.handlers.verificationStore;
+    if (!store) {
+      throw new Error('Verification system not available. Ensure the server is properly configured.');
+    }
+
+    const challengeId = randomUUID();
+    const code = generateDisplayCode();
+    store.set(challengeId, {
+      code,
+      expiresAt: Date.now() + DEADLOCK_RELIEF_TIMEOUT_MS,
+      reason: DEADLOCK_RELIEF_REASON,
+    });
+
+    this.handlers.verificationNotifier?.showCode(code, DEADLOCK_RELIEF_DIALOG_REASON);
+
+    SecurityMonitor.logSecurityEvent({
+      type: 'DANGER_ZONE_TRIGGERED',
+      severity: 'MEDIUM',
+      source: 'MCPAQLHandler.issueDeadlockReliefChallenge',
+      details: `Deadlock relief challenge issued for session ${this.gatekeeper.sessionId}`,
+      additionalData: {
+        challengeId,
+        sessionId: this.gatekeeper.sessionId,
+      },
+    });
+
+    return {
+      pending: true,
+      challenge_id: challengeId,
+      message: 'Deadlock relief requires human confirmation. A verification code has been displayed to the user.',
+      warning: 'Completing this flow will deactivate all active elements for the current session and clear persisted activation state.',
+    };
+  }
+
+  private async completeDeadlockRelief(challengeId: string, code: string): Promise<{
+    released: true;
+    challenge_id: string;
+    sessionId?: string;
+    deactivated: Array<{ type: string; name: string }>;
+    failed: Array<{ type: string; name: string; error: string }>;
+    persistedStateCleared: boolean;
+    message: string;
+  }> {
+    const store = this.handlers.verificationStore;
+    if (!store) {
+      throw new VerificationError(
+        GatekeeperErrorCode.VERIFICATION_FAILED,
+        'Verification system not available. Ensure the server is properly configured.',
+      );
+    }
+
+    validateChallengeIdFormat(challengeId);
+
+    const challenge = store.get(challengeId);
+    if (!challenge) {
+      throw new VerificationError(
+        GatekeeperErrorCode.VERIFICATION_TIMEOUT,
+        'Deadlock relief challenge not found. It may have expired or already been used. Retry release_deadlock to receive a new code.',
+      );
+    }
+
+    if (!this.challengeIsForDeadlockRelief(challenge)) {
+      throw new VerificationError(
+        GatekeeperErrorCode.VERIFICATION_FAILED,
+        'This challenge is not for deadlock relief. Use the matching verification flow for the requested operation.',
+      );
+    }
+
+    const valid = store.verify(challengeId, code);
+    if (!valid) {
+      throw new VerificationError(
+        GatekeeperErrorCode.VERIFICATION_FAILED,
+        'Verification failed: incorrect code. The code has been consumed (one-time use). Retry release_deadlock to receive a new code.',
+      );
+    }
+
+    const reset = await this.handlers.elementCRUD.releaseDeadlock();
+
+    SecurityMonitor.logSecurityEvent({
+      type: 'VERIFICATION_SUCCEEDED',
+      severity: 'MEDIUM',
+      source: 'MCPAQLHandler.completeDeadlockRelief',
+      details: `Deadlock relief completed for session ${this.gatekeeper.sessionId}`,
+      additionalData: {
+        challengeId,
+        sessionId: this.gatekeeper.sessionId,
+        deactivatedCount: reset.deactivated.length,
+        failedCount: reset.failed.length,
+      },
+    });
+
+    return {
+      released: true,
+      challenge_id: challengeId,
+      ...reset,
+      message: reset.failed.length > 0
+        ? `Deadlock relief completed with ${reset.failed.length} deactivation failure(s). Review the failed list and re-check active elements.`
+        : 'Deadlock relief completed. All active elements for this session were deactivated and persisted activation state was cleared.',
+    };
+  }
+
   /**
    * Dispatch Gatekeeper operations for confirmation management.
    *
@@ -2586,6 +2702,13 @@ export class MCPAQLHandler {
           );
         }
 
+        if (this.challengeIsForDeadlockRelief(challengePreCheck)) {
+          throw new VerificationError(
+            GatekeeperErrorCode.VERIFICATION_FAILED,
+            'This verification code is reserved for deadlock relief. Use release_deadlock with challenge_id and code to complete the reset.'
+          );
+        }
+
         // Verify the code (one-time use — store deletes challenge after this call)
         const valid = store.verify(challengeId, code);
         if (!valid) {
@@ -2655,6 +2778,27 @@ export class MCPAQLHandler {
           verified: true,
           message: 'Verification successful. You may now retry the operation.',
         };
+      }
+
+      case 'releaseDeadlock': {
+        const challengeIdValue = typeof params.challenge_id === 'string'
+          ? params.challenge_id.trim()
+          : '';
+        const codeValue = typeof params.code === 'string'
+          ? params.code.trim()
+          : '';
+
+        if ((challengeIdValue && !codeValue) || (!challengeIdValue && codeValue)) {
+          throw new Error(
+            'release_deadlock requires both challenge_id and code together, or neither for the initial challenge request.'
+          );
+        }
+
+        if (!challengeIdValue && !codeValue) {
+          return this.issueDeadlockReliefChallenge();
+        }
+
+        return this.completeDeadlockRelief(challengeIdValue, codeValue);
       }
 
       case 'beetlejuice': {

--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -2435,9 +2435,15 @@ export class MCPAQLHandler {
     released: true;
     challenge_id: string;
     sessionId?: string;
+    activeBeforeReset: Array<{ type: string; name: string }>;
     deactivated: Array<{ type: string; name: string }>;
     failed: Array<{ type: string; name: string; error: string }>;
     persistedStateCleared: boolean;
+    likelyDeadlockCause: {
+      sandboxingElement?: { type: string; name: string };
+      advisoryElements: Array<{ type: string; name: string }>;
+    };
+    snapshotFile?: string;
     message: string;
   }> {
     const store = this.handlers.verificationStore;
@@ -2493,8 +2499,8 @@ export class MCPAQLHandler {
       challenge_id: challengeId,
       ...reset,
       message: reset.failed.length > 0
-        ? `Deadlock relief completed with ${reset.failed.length} deactivation failure(s). Review the failed list and re-check active elements.`
-        : 'Deadlock relief completed. All active elements for this session were deactivated and persisted activation state was cleared.',
+        ? `Deadlock relief completed with ${reset.failed.length} deactivation failure(s). Review the failed list, likely deadlock cause, and recovery snapshot before reactivating elements.`
+        : `Deadlock relief completed. All active elements for this session were deactivated and persisted activation state was cleared${reset.snapshotFile ? `; a recovery snapshot was saved to ${reset.snapshotFile}` : ''}.`,
     };
   }
 

--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -2494,13 +2494,18 @@ export class MCPAQLHandler {
       },
     });
 
+    const snapshotSuffix = reset.snapshotFile
+      ? ` A recovery snapshot was saved to ${reset.snapshotFile}.`
+      : '';
+    const message = reset.failed.length > 0
+      ? `Deadlock relief completed with ${reset.failed.length} deactivation failure(s). Review the failed list, likely deadlock cause, and recovery snapshot before reactivating elements.`
+      : `Deadlock relief completed. All active elements for this session were deactivated and persisted activation state was cleared.${snapshotSuffix}`;
+
     return {
       released: true,
       challenge_id: challengeId,
       ...reset,
-      message: reset.failed.length > 0
-        ? `Deadlock relief completed with ${reset.failed.length} deactivation failure(s). Review the failed list, likely deadlock cause, and recovery snapshot before reactivating elements.`
-        : `Deadlock relief completed. All active elements for this session were deactivated and persisted activation state was cleared${reset.snapshotFile ? `; a recovery snapshot was saved to ${reset.snapshotFile}` : ''}.`,
+      message,
     };
   }
 

--- a/src/handlers/mcp-aql/OperationRouter.ts
+++ b/src/handlers/mcp-aql/OperationRouter.ts
@@ -156,6 +156,11 @@ export const OPERATION_ROUTES: Record<string, OperationRoute> = {
     handler: 'Gatekeeper.verify',
     description: 'Submit verification code to unblock a danger zone operation',
   },
+  release_deadlock: {
+    endpoint: 'CREATE',
+    handler: 'Gatekeeper.releaseDeadlock',
+    description: 'Use out-of-band verification to deactivate all active elements and clear current-session activation state',
+  },
   // Issue #503: Beetlejuice safe-trigger for danger zone verification testing
   beetlejuice_beetlejuice_beetlejuice: {
     endpoint: 'CREATE',

--- a/src/handlers/mcp-aql/OperationSchema.ts
+++ b/src/handlers/mcp-aql/OperationSchema.ts
@@ -1423,7 +1423,7 @@ export const GATEKEEPER_SCHEMAS: OperationSchemaMap = {
       challenge_id: { type: 'string', description: 'Challenge ID from the first release_deadlock call' },
       code: { type: 'string', description: 'Verification code displayed to the user for deadlock relief' },
     },
-    returns: { name: 'DeadlockReliefResult', kind: 'object', description: 'Two-step flow. First call returns { pending, challenge_id, message }. Second call with challenge_id + code returns { released, deactivated, failed, persistedStateCleared, message }.' },
+    returns: { name: 'DeadlockReliefResult', kind: 'object', description: 'Two-step flow. First call returns { pending, challenge_id, message }. Second call with challenge_id + code returns { released, activeBeforeReset, deactivated, failed, likelyDeadlockCause, persistedStateCleared, snapshotFile?, message }.' },
     examples: [
       '{ operation: "release_deadlock" }',
       '{ operation: "release_deadlock", params: { challenge_id: "550e8400-e29b-41d4-a716-446655440000", code: "ABC123" } }',

--- a/src/handlers/mcp-aql/OperationSchema.ts
+++ b/src/handlers/mcp-aql/OperationSchema.ts
@@ -1413,6 +1413,22 @@ export const GATEKEEPER_SCHEMAS: OperationSchemaMap = {
       // Response: { verified: true, challenge_id: "...", agentName: "my-agent", message: "Agent unblocked" }
     ],
   },
+  release_deadlock: {
+    endpoint: 'CREATE',
+    handler: 'mcpAqlHandler',
+    method: 'dispatchGatekeeper',
+    category: 'Security & Permissions',
+    description: 'Recover from a restrictive permission deadlock by showing a human-only verification code, then deactivating all active elements and clearing current-session activation state',
+    params: {
+      challenge_id: { type: 'string', description: 'Challenge ID from the first release_deadlock call' },
+      code: { type: 'string', description: 'Verification code displayed to the user for deadlock relief' },
+    },
+    returns: { name: 'DeadlockReliefResult', kind: 'object', description: 'Two-step flow. First call returns { pending, challenge_id, message }. Second call with challenge_id + code returns { released, deactivated, failed, persistedStateCleared, message }.' },
+    examples: [
+      '{ operation: "release_deadlock" }',
+      '{ operation: "release_deadlock", params: { challenge_id: "550e8400-e29b-41d4-a716-446655440000", code: "ABC123" } }',
+    ],
+  },
   beetlejuice_beetlejuice_beetlejuice: {
     endpoint: 'CREATE',
     handler: 'mcpAqlHandler',

--- a/src/handlers/mcp-aql/policies/AgentToolPolicyTranslator.ts
+++ b/src/handlers/mcp-aql/policies/AgentToolPolicyTranslator.ts
@@ -42,6 +42,7 @@ const EXEMPT_OPERATIONS = new Set([
   // Safety system — agent must interact with Gatekeeper/verification
   'confirm_operation',
   'verify_challenge',
+  'release_deadlock',
   'permission_prompt', // Issue #625: CLI-level permission delegation
   'approve_cli_permission', // Issue #625 Phase 3: CLI approval workflow
   'get_pending_cli_approvals', // Issue #625 Phase 3: CLI approval visibility

--- a/src/handlers/mcp-aql/policies/ElementPolicies.ts
+++ b/src/handlers/mcp-aql/policies/ElementPolicies.ts
@@ -635,6 +635,7 @@ function checkToolPrefix(
  */
 const UNGATABLE_OPERATIONS = new Set([
   'verify_challenge',
+  'release_deadlock',
   'approve_cli_permission',
   'permission_prompt',
 ]);

--- a/src/handlers/mcp-aql/policies/OperationPolicies.ts
+++ b/src/handlers/mcp-aql/policies/OperationPolicies.ts
@@ -87,6 +87,11 @@ export const OPERATION_POLICY_OVERRIDES: Record<string, OperationPolicy> = {
     defaultLevel: PermissionLevel.AUTO_APPROVE,
     rationale: 'Verification flow — must be auto-approved to avoid requiring confirmation to verify',
   },
+  release_deadlock: {
+    defaultLevel: PermissionLevel.AUTO_APPROVE,
+    rationale: 'Deadlock relief flow — requires out-of-band verification and must remain reachable even when confirmations are blocked',
+    canBeElevated: false,
+  },
   beetlejuice_beetlejuice_beetlejuice: {
     defaultLevel: PermissionLevel.AUTO_APPROVE,
     rationale: 'Test fixture for danger zone verification — must be auto-approved to avoid requiring confirmation to test',

--- a/src/handlers/mcp-aql/policies/ToolClassification.ts
+++ b/src/handlers/mcp-aql/policies/ToolClassification.ts
@@ -57,6 +57,7 @@ export interface CliToolPolicyResult {
 const GATEKEEPER_ESSENTIAL_OPERATIONS = new Set([
   'confirm_operation',
   'verify_challenge',
+  'release_deadlock',
   'permission_prompt',
   'introspect',
   'get_active_elements',

--- a/src/server/tools/MCPAQLTools.ts
+++ b/src/server/tools/MCPAQLTools.ts
@@ -281,6 +281,7 @@ Auth & verification:
 { operation: "setup_github_auth" }
 { operation: "configure_oauth", params: { client_id: "your-client-id" } }
 { operation: "verify_challenge", params: { code: "ABC123" } }
+{ operation: "release_deadlock" }
 { operation: "beetlejuice_beetlejuice_beetlejuice" }
 
 Batch operations: Use the operations array to execute multiple operations sequentially in a single request.

--- a/tests/integration/mcp-aql/permission-flow-matrix.test.ts
+++ b/tests/integration/mcp-aql/permission-flow-matrix.test.ts
@@ -133,6 +133,7 @@ describe('Permission Flow Full Matrix (Issue #1669)', () => {
 
     it('should include verification flow operations', () => {
       expect(autoApproved).toContain('verify_challenge');
+      expect(autoApproved).toContain('release_deadlock');
       expect(autoApproved).toContain('beetlejuice_beetlejuice_beetlejuice');
     });
 

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -452,7 +452,7 @@ describe('ElementCRUDHandler (DI)', () => {
       expect(result.likelyDeadlockCause).toEqual({
         advisoryElements: [],
       });
-      expect(result.snapshotFile).toContain('/.dollhouse/state/deadlock-relief/');
+      expect(result.snapshotFile).toMatch(/[\\/]\.dollhouse[\\/]state[\\/]deadlock-relief[\\/]/);
       expect(personaHandler.deactivatePersona).toHaveBeenCalledWith('Locked Persona');
       expect(skillManager.deactivateSkill).toHaveBeenCalledWith('locked-skill');
       expect(agentManager.deactivateAgent).toHaveBeenCalledWith('locked-agent');

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -34,6 +34,8 @@ describe('ElementCRUDHandler (DI)', () => {
       create: jest.fn(),
       delete: jest.fn(),
       find: jest.fn(),
+      getActiveSkills: jest.fn().mockResolvedValue([]),
+      deactivateSkill: jest.fn().mockResolvedValue({ success: true, message: 'deactivated' }),
     } as unknown as jest.Mocked<SkillManager>;
 
     templateManager = {
@@ -47,20 +49,27 @@ describe('ElementCRUDHandler (DI)', () => {
     agentManager = {
       create: jest.fn(),
       getActiveAgents: jest.fn().mockResolvedValue([]),
+      deactivateAgent: jest.fn().mockResolvedValue({ success: true, message: 'deactivated' }),
       list: jest.fn().mockResolvedValue([]),
     } as unknown as jest.Mocked<AgentManager>;
 
     memoryManager = {
       save: jest.fn(),
+      getActiveMemories: jest.fn().mockResolvedValue([]),
+      deactivateMemory: jest.fn().mockResolvedValue({ success: true, message: 'deactivated' }),
     } as unknown as jest.Mocked<MemoryManager>;
 
     ensembleManager = {
       list: jest.fn(),
+      getActiveEnsembles: jest.fn().mockResolvedValue([]),
+      deactivateEnsemble: jest.fn().mockResolvedValue({ success: true, message: 'deactivated' }),
     } as unknown as jest.Mocked<EnsembleManager>;
 
     personaHandler = {
       getActivePersona: jest.fn(),
       getActivePersonas: jest.fn().mockReturnValue([]),
+      deactivatePersona: jest.fn().mockReturnValue({ success: true, message: 'deactivated' }),
+      findPersona: jest.fn(),
       list: jest.fn().mockReturnValue([]),
     } as unknown as jest.Mocked<PersonaHandler>;
 
@@ -376,6 +385,69 @@ describe('ElementCRUDHandler (DI)', () => {
           sessionIds: ['session-other'],
         }),
       ]);
+    });
+  });
+
+  describe('releaseDeadlock', () => {
+    it('should deactivate all active elements and clear persisted session state', async () => {
+      const activationStore = {
+        isEnabled: jest.fn().mockReturnValue(true),
+        getSessionId: jest.fn().mockReturnValue('session-lock'),
+        clearAll: jest.fn(),
+      } as unknown as jest.Mocked<ActivationStore>;
+
+      personaHandler.getActivePersonas.mockReturnValue([
+        { metadata: { name: 'Locked Persona' } } as any,
+      ]);
+      personaHandler.findPersona.mockReturnValue({ metadata: { name: 'Locked Persona' } } as any);
+      skillManager.getActiveSkills.mockResolvedValue([
+        { metadata: { name: 'locked-skill' } } as any,
+      ]);
+      agentManager.getActiveAgents.mockResolvedValue([
+        { metadata: { name: 'locked-agent' } } as any,
+      ]);
+      memoryManager.getActiveMemories.mockResolvedValue([
+        { metadata: { name: 'locked-memory' } } as any,
+      ]);
+      ensembleManager.getActiveEnsembles.mockResolvedValue([
+        { metadata: { name: 'locked-ensemble' } } as any,
+      ]);
+
+      const handlerWithPersistence = new ElementCRUDHandler(
+        skillManager,
+        templateManager,
+        templateRenderer,
+        agentManager,
+        memoryManager,
+        ensembleManager,
+        personaHandler,
+        portfolioManager,
+        initService,
+        indicatorService,
+        fileOperations,
+        undefined as any,
+        undefined as any,
+        activationStore,
+      );
+
+      const result = await handlerWithPersistence.releaseDeadlock();
+
+      expect(result.sessionId).toBe('session-lock');
+      expect(result.failed).toEqual([]);
+      expect(result.persistedStateCleared).toBe(true);
+      expect(result.deactivated).toEqual(expect.arrayContaining([
+        { type: ElementType.PERSONA, name: 'Locked Persona' },
+        { type: ElementType.SKILL, name: 'locked-skill' },
+        { type: ElementType.AGENT, name: 'locked-agent' },
+        { type: ElementType.MEMORY, name: 'locked-memory' },
+        { type: ElementType.ENSEMBLE, name: 'locked-ensemble' },
+      ]));
+      expect(personaHandler.deactivatePersona).toHaveBeenCalledWith('Locked Persona');
+      expect(skillManager.deactivateSkill).toHaveBeenCalledWith('locked-skill');
+      expect(agentManager.deactivateAgent).toHaveBeenCalledWith('locked-agent');
+      expect(memoryManager.deactivateMemory).toHaveBeenCalledWith('locked-memory');
+      expect(ensembleManager.deactivateEnsemble).toHaveBeenCalledWith('locked-ensemble');
+      expect(activationStore.clearAll).toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/handlers/ElementCRUDHandler.test.ts
+++ b/tests/unit/handlers/ElementCRUDHandler.test.ts
@@ -435,6 +435,13 @@ describe('ElementCRUDHandler (DI)', () => {
       expect(result.sessionId).toBe('session-lock');
       expect(result.failed).toEqual([]);
       expect(result.persistedStateCleared).toBe(true);
+      expect(result.activeBeforeReset).toEqual(expect.arrayContaining([
+        { type: ElementType.PERSONA, name: 'Locked Persona' },
+        { type: ElementType.SKILL, name: 'locked-skill' },
+        { type: ElementType.AGENT, name: 'locked-agent' },
+        { type: ElementType.MEMORY, name: 'locked-memory' },
+        { type: ElementType.ENSEMBLE, name: 'locked-ensemble' },
+      ]));
       expect(result.deactivated).toEqual(expect.arrayContaining([
         { type: ElementType.PERSONA, name: 'Locked Persona' },
         { type: ElementType.SKILL, name: 'locked-skill' },
@@ -442,12 +449,18 @@ describe('ElementCRUDHandler (DI)', () => {
         { type: ElementType.MEMORY, name: 'locked-memory' },
         { type: ElementType.ENSEMBLE, name: 'locked-ensemble' },
       ]));
+      expect(result.likelyDeadlockCause).toEqual({
+        advisoryElements: [],
+      });
+      expect(result.snapshotFile).toContain('/.dollhouse/state/deadlock-relief/');
       expect(personaHandler.deactivatePersona).toHaveBeenCalledWith('Locked Persona');
       expect(skillManager.deactivateSkill).toHaveBeenCalledWith('locked-skill');
       expect(agentManager.deactivateAgent).toHaveBeenCalledWith('locked-agent');
       expect(memoryManager.deactivateMemory).toHaveBeenCalledWith('locked-memory');
       expect(ensembleManager.deactivateEnsemble).toHaveBeenCalledWith('locked-ensemble');
       expect(activationStore.clearAll).toHaveBeenCalled();
+      expect(fileOperations.createDirectory).toHaveBeenCalled();
+      expect(fileOperations.writeFile).toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/handlers/mcp-aql/Gatekeeper.test.ts
+++ b/tests/unit/handlers/mcp-aql/Gatekeeper.test.ts
@@ -820,6 +820,7 @@ describe('Gatekeeper', () => {
     it('should allow explicit overrides to differ from endpoint default', () => {
       // verify_challenge is on CREATE (default CONFIRM_SESSION) but overridden to AUTO_APPROVE
       expect(getDefaultPermissionLevel('verify_challenge')).toBe(PermissionLevel.AUTO_APPROVE);
+      expect(getDefaultPermissionLevel('release_deadlock')).toBe(PermissionLevel.AUTO_APPROVE);
       // confirm_operation is on EXECUTE (default CONFIRM_SINGLE_USE) but overridden to AUTO_APPROVE
       expect(getDefaultPermissionLevel('confirm_operation')).toBe(PermissionLevel.AUTO_APPROVE);
       // get_execution_state is on EXECUTE but overridden to AUTO_APPROVE

--- a/tests/unit/handlers/mcp-aql/IntrospectionResolver.test.ts
+++ b/tests/unit/handlers/mcp-aql/IntrospectionResolver.test.ts
@@ -839,13 +839,13 @@ describe('IntrospectionResolver', () => {
       });
     });
 
-    describe('all 14 migrated operations have schema metadata via introspect', () => {
+    describe('all 15 migrated operations have schema metadata via introspect', () => {
       const migratedOps = [
         'addEntry', 'clear',
         'execute_agent', 'get_execution_state', 'record_execution_step',
         'complete_execution', 'continue_execution', 'abort_execution',
         'get_gathered_data', 'prepare_handoff', 'resume_from_handoff',
-        'confirm_operation', 'verify_challenge', 'beetlejuice_beetlejuice_beetlejuice',
+        'confirm_operation', 'verify_challenge', 'release_deadlock', 'beetlejuice_beetlejuice_beetlejuice',
         'query_logs',
       ];
 

--- a/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
+++ b/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
@@ -2387,9 +2387,15 @@ describe('MCPAQLHandler', () => {
         ...mockRegistry.elementCRUD,
         releaseDeadlock: jest.fn().mockResolvedValue({
           sessionId: 'test-session',
+          activeBeforeReset: [{ type: 'persona', name: 'locked-persona' }],
           deactivated: [{ type: 'persona', name: 'locked-persona' }],
           failed: [],
+          likelyDeadlockCause: {
+            sandboxingElement: { type: 'persona', name: 'locked-persona' },
+            advisoryElements: [],
+          },
           persistedStateCleared: true,
+          snapshotFile: '/tmp/deadlock-relief-test.json',
         }),
       };
 
@@ -2409,7 +2415,13 @@ describe('MCPAQLHandler', () => {
         expect(result.data).toEqual(expect.objectContaining({
           released: true,
           persistedStateCleared: true,
+          activeBeforeReset: [{ type: 'persona', element_name: 'locked-persona' }],
           deactivated: [{ type: 'persona', element_name: 'locked-persona' }],
+          likelyDeadlockCause: {
+            sandboxingElement: { type: 'persona', element_name: 'locked-persona' },
+            advisoryElements: [],
+          },
+          snapshotFile: '/tmp/deadlock-relief-test.json',
         }));
       }
       expect(verificationStore.verify).toHaveBeenCalledWith(VALID_CHALLENGE_ID, 'RELIEF1');

--- a/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
+++ b/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
@@ -2395,7 +2395,7 @@ describe('MCPAQLHandler', () => {
             advisoryElements: [],
           },
           persistedStateCleared: true,
-          snapshotFile: '/tmp/deadlock-relief-test.json',
+          snapshotFile: '/opt/dollhouse/test-data/deadlock-relief-test.json',
         }),
       };
 
@@ -2421,7 +2421,7 @@ describe('MCPAQLHandler', () => {
             sandboxingElement: { type: 'persona', element_name: 'locked-persona' },
             advisoryElements: [],
           },
-          snapshotFile: '/tmp/deadlock-relief-test.json',
+          snapshotFile: '/opt/dollhouse/test-data/deadlock-relief-test.json',
         }));
       }
       expect(verificationStore.verify).toHaveBeenCalledWith(VALID_CHALLENGE_ID, 'RELIEF1');

--- a/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
+++ b/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
@@ -59,6 +59,12 @@ describe('MCPAQLHandler', () => {
         deleteElement: jest.fn().mockResolvedValue({ deleted: true }),
         activateElement: jest.fn().mockResolvedValue({ activated: true }),
         deactivateElement: jest.fn().mockResolvedValue({ deactivated: true }),
+        releaseDeadlock: jest.fn().mockResolvedValue({
+          sessionId: 'test-session',
+          deactivated: [],
+          failed: [],
+          persistedStateCleared: true,
+        }),
         getActiveElements: jest.fn().mockResolvedValue([]),
         getActiveElementsForPolicy: jest.fn().mockResolvedValue([]),
         getPolicyElementsForReport: jest.fn().mockResolvedValue([]),
@@ -2042,6 +2048,25 @@ describe('MCPAQLHandler', () => {
       }
     });
 
+    it('should reject deadlock relief challenges via verify_challenge', async () => {
+      mockVerificationStore.get.mockReturnValue({
+        code: 'RELIEF1',
+        expiresAt: Date.now() + 300000,
+        reason: 'Deadlock relief requested',
+      });
+
+      const result = await verifyHandler.handleCreate({
+        operation: 'verify_challenge',
+        params: { challenge_id: VALID_CHALLENGE_ID, code: 'RELIEF1' },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain('reserved for deadlock relief');
+      }
+      expect(mockVerificationStore.verify).not.toHaveBeenCalled();
+    });
+
     // --- UUID v4 format validation ---
 
     it('should reject challenge_id with invalid UUID format', async () => {
@@ -2301,6 +2326,175 @@ describe('MCPAQLHandler', () => {
       if (!result.success) {
         expect(result.error).toContain('one-time use');
         expect(result.error).toContain('Retry the blocked operation');
+      }
+    });
+  });
+
+  describe('release_deadlock operation', () => {
+    const VALID_CHALLENGE_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+    it('should issue a challenge on the first call', async () => {
+      const verificationStore = {
+        set: jest.fn(),
+        get: jest.fn(),
+        verify: jest.fn(),
+        clear: jest.fn(),
+        size: jest.fn().mockReturnValue(0),
+        cleanup: jest.fn(),
+        destroy: jest.fn(),
+      };
+      const verificationNotifier = {
+        showCode: jest.fn(),
+        isAvailable: jest.fn().mockReturnValue(true),
+      };
+
+      const releaseHandler = new MCPAQLHandler({
+        ...mockRegistry,
+        verificationStore,
+        verificationNotifier,
+      } as unknown as HandlerRegistry);
+
+      const result = await releaseHandler.handleCreate({
+        operation: 'release_deadlock',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(expect.objectContaining({
+          pending: true,
+          challenge_id: expect.any(String),
+        }));
+      }
+      expect(verificationStore.set).toHaveBeenCalled();
+      expect(verificationNotifier.showCode).toHaveBeenCalled();
+    });
+
+    it('should complete deadlock relief after successful verification', async () => {
+      const verificationStore = {
+        set: jest.fn(),
+        get: jest.fn().mockReturnValue({
+          code: 'RELIEF1',
+          expiresAt: Date.now() + 300000,
+          reason: 'Deadlock relief requested',
+        }),
+        verify: jest.fn().mockReturnValue(true),
+        clear: jest.fn(),
+        size: jest.fn().mockReturnValue(1),
+        cleanup: jest.fn(),
+        destroy: jest.fn(),
+      };
+      const elementCRUD = {
+        ...mockRegistry.elementCRUD,
+        releaseDeadlock: jest.fn().mockResolvedValue({
+          sessionId: 'test-session',
+          deactivated: [{ type: 'persona', name: 'locked-persona' }],
+          failed: [],
+          persistedStateCleared: true,
+        }),
+      };
+
+      const releaseHandler = new MCPAQLHandler({
+        ...mockRegistry,
+        elementCRUD,
+        verificationStore,
+      } as unknown as HandlerRegistry);
+
+      const result = await releaseHandler.handleCreate({
+        operation: 'release_deadlock',
+        params: { challenge_id: VALID_CHALLENGE_ID, code: 'RELIEF1' },
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(expect.objectContaining({
+          released: true,
+          persistedStateCleared: true,
+          deactivated: [{ type: 'persona', element_name: 'locked-persona' }],
+        }));
+      }
+      expect(verificationStore.verify).toHaveBeenCalledWith(VALID_CHALLENGE_ID, 'RELIEF1');
+      expect(elementCRUD.releaseDeadlock).toHaveBeenCalled();
+    });
+
+    it('should remain available even when confirm_operation is sandboxed by an active element', async () => {
+      const verificationStore = {
+        set: jest.fn(),
+        get: jest.fn(),
+        verify: jest.fn(),
+        clear: jest.fn(),
+        size: jest.fn().mockReturnValue(0),
+        cleanup: jest.fn(),
+        destroy: jest.fn(),
+      };
+      const verificationNotifier = {
+        showCode: jest.fn(),
+        isAvailable: jest.fn().mockReturnValue(true),
+      };
+      const restrictiveRegistry = {
+        ...mockRegistry,
+        gatekeeper: new Gatekeeper(undefined, { enableAuditLogging: false }),
+        verificationStore,
+        verificationNotifier,
+        elementCRUD: {
+          ...mockRegistry.elementCRUD,
+          getActiveElementsForPolicy: jest.fn().mockResolvedValue([
+            {
+              type: 'persona',
+              name: 'sandbox-persona',
+              metadata: {
+                gatekeeper: {
+                  deny: ['confirm_operation'],
+                },
+              },
+            },
+          ]),
+        },
+      } as unknown as HandlerRegistry;
+
+      const restrictiveHandler = new MCPAQLHandler(restrictiveRegistry);
+
+      const confirmResult = await restrictiveHandler.handleExecute({
+        operation: 'confirm_operation',
+        params: { operation: 'edit_element' },
+      });
+      expect(confirmResult.success).toBe(false);
+
+      const releaseResult = await restrictiveHandler.handleCreate({
+        operation: 'release_deadlock',
+      });
+
+      expect(releaseResult.success).toBe(true);
+      if (releaseResult.success) {
+        expect(releaseResult.data).toEqual(expect.objectContaining({
+          pending: true,
+          challenge_id: expect.any(String),
+        }));
+      }
+      expect(verificationStore.set).toHaveBeenCalled();
+    });
+
+    it('should require challenge_id and code together on completion', async () => {
+      const releaseHandler = new MCPAQLHandler({
+        ...mockRegistry,
+        verificationStore: {
+          set: jest.fn(),
+          get: jest.fn(),
+          verify: jest.fn(),
+          clear: jest.fn(),
+          size: jest.fn(),
+          cleanup: jest.fn(),
+          destroy: jest.fn(),
+        },
+      } as unknown as HandlerRegistry);
+
+      const result = await releaseHandler.handleCreate({
+        operation: 'release_deadlock',
+        params: { challenge_id: VALID_CHALLENGE_ID },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain('requires both challenge_id and code together');
       }
     });
   });

--- a/tests/unit/handlers/mcp-aql/OperationRouter.test.ts
+++ b/tests/unit/handlers/mcp-aql/OperationRouter.test.ts
@@ -22,6 +22,7 @@ describe('OperationRouter', () => {
         'import_element',
         'addEntry',
         'verify_challenge',
+        'release_deadlock',
         'beetlejuice_beetlejuice_beetlejuice',
         'install_collection_content',
         'submit_collection_content',
@@ -166,6 +167,7 @@ describe('OperationRouter', () => {
       expect(createOps.length).toBeGreaterThan(0);
       expect(createOps).toContain('create_element');
       expect(createOps).toContain('record_execution_step');
+      expect(createOps).toContain('release_deadlock');
     });
   });
 

--- a/tests/unit/handlers/mcp-aql/OperationSchema.test.ts
+++ b/tests/unit/handlers/mcp-aql/OperationSchema.test.ts
@@ -619,10 +619,11 @@ describe('OperationSchema', () => {
     });
 
     describe('GATEKEEPER_SCHEMAS', () => {
-      it('should define 8 gatekeeper operations', () => {
-        expect(Object.keys(GATEKEEPER_SCHEMAS)).toHaveLength(8);
+      it('should define 9 gatekeeper operations', () => {
+        expect(Object.keys(GATEKEEPER_SCHEMAS)).toHaveLength(9);
         expect(GATEKEEPER_SCHEMAS.confirm_operation).toBeDefined();
         expect(GATEKEEPER_SCHEMAS.verify_challenge).toBeDefined();
+        expect(GATEKEEPER_SCHEMAS.release_deadlock).toBeDefined();
         expect(GATEKEEPER_SCHEMAS.beetlejuice_beetlejuice_beetlejuice).toBeDefined();
         expect(GATEKEEPER_SCHEMAS.permission_prompt).toBeDefined();
         expect(GATEKEEPER_SCHEMAS.get_effective_cli_policies).toBeDefined();
@@ -633,6 +634,7 @@ describe('OperationSchema', () => {
       it('should have correct endpoints', () => {
         expect(GATEKEEPER_SCHEMAS.confirm_operation.endpoint).toBe('EXECUTE');
         expect(GATEKEEPER_SCHEMAS.verify_challenge.endpoint).toBe('CREATE');
+        expect(GATEKEEPER_SCHEMAS.release_deadlock.endpoint).toBe('CREATE');
         expect(GATEKEEPER_SCHEMAS.beetlejuice_beetlejuice_beetlejuice.endpoint).toBe('CREATE');
         // Issue #647: permission_prompt is a read-only policy evaluation
         expect(GATEKEEPER_SCHEMAS.permission_prompt.endpoint).toBe('READ');
@@ -646,6 +648,11 @@ describe('OperationSchema', () => {
       it('should define required params for verify_challenge', () => {
         expect(GATEKEEPER_SCHEMAS.verify_challenge.params?.challenge_id?.required).toBe(true);
         expect(GATEKEEPER_SCHEMAS.verify_challenge.params?.code?.required).toBe(true);
+      });
+
+      it('should allow a challenge request or completion payload for release_deadlock', () => {
+        expect(GATEKEEPER_SCHEMAS.release_deadlock.params?.challenge_id?.required).toBeUndefined();
+        expect(GATEKEEPER_SCHEMAS.release_deadlock.params?.code?.required).toBeUndefined();
       });
 
       it('should have optional agent_name for beetlejuice', () => {

--- a/tests/unit/handlers/mcp-aql/policies/ToolClassification.test.ts
+++ b/tests/unit/handlers/mcp-aql/policies/ToolClassification.test.ts
@@ -150,6 +150,7 @@ describe('ToolClassification', () => {
         // These operations must never be blocked — they are the gatekeeper flow itself
         expect(classifyTool('mcp__DollhouseMCP__mcp_aql_create', { operation: 'confirm_operation' }).behavior).toBe('allow');
         expect(classifyTool('mcp__DollhouseMCP__mcp_aql_execute', { operation: 'verify_challenge' }).behavior).toBe('allow');
+        expect(classifyTool('mcp__DollhouseMCP__mcp_aql_create', { operation: 'release_deadlock' }).behavior).toBe('allow');
         expect(classifyTool('mcp__DollhouseMCP__mcp_aql_execute', { operation: 'permission_prompt' }).behavior).toBe('allow');
         expect(classifyTool('mcp__DollhouseMCP__mcp_aql_read', { operation: 'introspect' }).behavior).toBe('allow');
         expect(classifyTool('mcp__DollhouseMCP__mcp_aql_read', { operation: 'get_active_elements' }).behavior).toBe('allow');

--- a/tests/unit/security/AgentToolPolicyTranslator.test.ts
+++ b/tests/unit/security/AgentToolPolicyTranslator.test.ts
@@ -125,6 +125,7 @@ describe('AgentToolPolicyTranslator', () => {
         expect(policy).toBeDefined();
         expect(policy!.deny).not.toContain('confirm_operation');
         expect(policy!.deny).not.toContain('verify_challenge');
+        expect(policy!.deny).not.toContain('release_deadlock');
       });
 
       it('should never deny lifecycle operations even when EXECUTE is explicitly denied', () => {


### PR DESCRIPTION
## Summary
- add a two-step `release_deadlock` recovery operation for restrictive permission sessions
- reuse the existing verification popup flow so a human at the machine must approve the reset
- deactivate all active elements and clear current-session activation persistence on successful relief

Closes #2026

## What changed
- added `release_deadlock` to the MCP-AQL router, schema, and gatekeeper policy exemptions
- added `ElementCRUDHandler.releaseDeadlock()` to deactivate active personas, skills, agents, memories, and ensembles in one pass
- made `verify_challenge` refuse to consume deadlock-relief codes, so the reset has to complete through the dedicated operation
- updated policy/tool classification helpers so this recovery path stays reachable even when `confirm_operation` is sandboxed
- added focused unit coverage for the new flow and recovery semantics

## Validation
- `npx tsc -p tsconfig.json --noEmit`
- `npx jest --config tests/jest.config.cjs --runInBand --modulePathIgnorePatterns=.worktrees --runTestsByPath tests/unit/handlers/ElementCRUDHandler.test.ts tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts tests/unit/handlers/mcp-aql/OperationRouter.test.ts tests/unit/handlers/mcp-aql/OperationSchema.test.ts tests/unit/handlers/mcp-aql/Gatekeeper.test.ts tests/unit/handlers/mcp-aql/policies/ToolClassification.test.ts tests/unit/security/AgentToolPolicyTranslator.test.ts tests/unit/handlers/mcp-aql/IntrospectionResolver.test.ts tests/integration/mcp-aql/permission-flow-matrix.test.ts`
