### PR TITLE
Make web console leadership version-aware

### DIFF
--- a/docs/architecture/ADR-002-CONSOLE-VERSION-AWARE-LEADERSHIP.md
+++ b/docs/architecture/ADR-002-CONSOLE-VERSION-AWARE-LEADERSHIP.md
@@ -1,0 +1,72 @@
+# ADR-002: Version-Aware Web Console Leadership
+
+**Status:** Accepted
+**Date:** 2026-04-16
+**Authors:** DollhouseMCP Team
+
+## Context
+
+The authenticated web console can be open in multiple browser tabs while multiple `mcp-server` processes are also running on the same machine. Before this change, leadership was primarily based on liveness and lock ownership. That allowed an older process to remain leader even after a newer process started.
+
+That mismatch created two concrete problems:
+
+1. An older leader could keep serving stale UI assets and session metadata after a newer server was available.
+2. Browser tabs connected to that older leader could miss controls, rendering paths, or session fields introduced by the newer server.
+
+The console needed a deterministic rule for choosing which process should lead, plus a browser-side recovery path so already-open tabs would reconnect to the newest compatible leader.
+
+## Decision
+
+We make web console leadership **version-aware and compatibility-aware**.
+
+### Leader selection
+
+- Each leader lock and session heartbeat now includes:
+  - `serverVersion`
+  - `consoleProtocolVersion`
+- A candidate may replace the current leader only when:
+  - both processes are compatible at the console protocol level, and
+  - the candidate's package version is strictly newer
+- Equal versions do not trigger takeover, which avoids leadership flapping.
+- Leaders without version/protocol metadata are treated as legacy and therefore older than any authenticated-console leader that includes the new fields.
+
+### Browser recovery
+
+- The HTML shell is served with `no-cache, no-store, must-revalidate`.
+- Local CSS, JS, and image assets are stamped with `?v=<asset version>`.
+- The sessions client compares the loaded console version to the active MCP leader version returned by `/api/sessions`.
+- When the leader is newer, the tab schedules a short debounced forced reload to a cache-busted URL so it reconnects to the newest compatible leader and fetches fresh assets.
+
+## Consequences
+
+### Benefits
+
+1. Open browser tabs converge toward the newest compatible server automatically.
+2. Older leaders naturally lose authority when a newer compatible process starts.
+3. Asset cache invalidation is tied to the server version, reducing stale frontend state.
+4. Legacy leaders remain detectable and replaceable without requiring a separate migration path.
+
+### Trade-offs
+
+1. Leadership is no longer purely "first live process wins"; version metadata becomes part of the election contract.
+2. Browser tabs may reload during upgrades, which is a small UX interruption but preferable to serving incompatible UI.
+3. Future breaking console changes must increment `consoleProtocolVersion` so incompatible leaders are never elected over one another.
+
+## Compatibility Matrix
+
+| Existing leader | Candidate | Result |
+|----------------|-----------|--------|
+| Same protocol, older version | Same protocol, newer version | Candidate takes leadership |
+| Same protocol, same version | Same protocol, same version | Existing leader stays |
+| Older/legacy metadata | Current authenticated-console process | Current process takes leadership |
+| Different protocol version | Any newer package version | Existing leader stays; no forced takeover |
+
+## Related Documents
+
+- [Architecture Overview](./overview.md)
+- [ADR-001: CRUDE Protocol for MCP-AQL Endpoints](./ADR-001-CRUDE-PROTOCOL.md)
+
+## References
+
+- Issue #2025: Prefer newest compatible web console leader
+- PR #2028: Version-aware console leadership and cache-busted reloads

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -19,6 +19,7 @@ For a high-level overview, see the [Architecture Overview](overview.md).
 
 ### Specialized Topics
 - [Version Storage](version-storage-approach.md) - How we handle element versions
+- [ADR-002: Version-Aware Web Console Leadership](ADR-002-CONSOLE-VERSION-AWARE-LEADERSHIP.md) - Why the newest compatible console leader wins and how stale tabs recover
 
 ## For Contributors
 If you're implementing new features, start with the relevant deep dive, then refer to the [Development Guide](../developer-guide/workflow.md).

--- a/src/web/console/IngestRoutes.ts
+++ b/src/web/console/IngestRoutes.ts
@@ -24,6 +24,11 @@ import { UnicodeValidator } from '../../security/validators/unicodeValidator.js'
 import { SessionNamePool } from './SessionNames.js';
 import { logger } from '../../utils/logger.js';
 import { env } from '../../config/env.js';
+import { PACKAGE_VERSION } from '../../generated/version.js';
+import {
+  CONSOLE_PROTOCOL_VERSION,
+  LEGACY_CONSOLE_PROTOCOL_VERSION,
+} from './LeaderElection.js';
 
 /** Maximum payload size for ingestion requests */
 const MAX_PAYLOAD_SIZE = '1mb';
@@ -68,6 +73,10 @@ export interface SessionInfo {
   authenticated: boolean;
   /** Session kind — 'mcp' for MCP stdio sessions, 'console' for the web console itself (#1805). */
   kind: 'mcp' | 'console';
+  /** DollhouseMCP package version reported by the session. */
+  serverVersion: string;
+  /** Console/session contract version used for compatibility-aware takeover. */
+  consoleProtocolVersion: number;
 }
 
 /**
@@ -94,6 +103,8 @@ export interface SessionEventPayload {
   event: 'started' | 'stopped' | 'heartbeat';
   pid: number;
   startedAt: string;
+  serverVersion?: string;
+  consoleProtocolVersion?: number;
 }
 
 /**
@@ -123,6 +134,20 @@ export interface IngestRoutesResult {
 /** Normalize a string via UnicodeValidator (DMCP-SEC-004) */
 function normalizeInput(s: string): string {
   return UnicodeValidator.normalize(s).normalizedContent;
+}
+
+function normalizeServerVersion(version?: string): string {
+  if (typeof version === 'string' && version.trim().length > 0) {
+    return version.trim();
+  }
+  return 'unknown';
+}
+
+function normalizeConsoleProtocolVersion(version?: number): number {
+  if (typeof version === 'number' && Number.isInteger(version) && version >= 0) {
+    return version;
+  }
+  return LEGACY_CONSOLE_PROTOCOL_VERSION;
 }
 
 /**
@@ -166,7 +191,13 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
   }
 
   /** Create a new session entry for an orphan. Returns null on failure. */
-  function autoRegister(sessionId: string, pid?: number, authenticated = false): SessionInfo | null {
+  function autoRegister(
+    sessionId: string,
+    pid?: number,
+    authenticated = false,
+    serverVersion?: string,
+    consoleProtocolVersion?: number,
+  ): SessionInfo | null {
     try {
       const displayName = namePool.assign(sessionId);
       const color = namePool.getColor(sessionId) ?? '#3b82f6';
@@ -176,6 +207,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
         pid: pid || 0,
         startedAt: now, lastHeartbeat: now,
         status: 'active', isLeader: false, authenticated, kind: 'mcp',
+        serverVersion: normalizeServerVersion(serverVersion),
+        consoleProtocolVersion: normalizeConsoleProtocolVersion(consoleProtocolVersion),
       };
       sessions.set(sessionId, info);
       logger.info('[IngestRoutes] Auto-registered orphaned session', {
@@ -195,7 +228,13 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
    * Auto-register or update an orphaned session from ingestion data.
    * Returns the session (existing or newly created), or null if killed/pending.
    */
-  function ensureSession(sessionId: string, pid?: number, authenticated = false): SessionInfo | null {
+  function ensureSession(
+    sessionId: string,
+    pid?: number,
+    authenticated = false,
+    serverVersion?: string,
+    consoleProtocolVersion?: number,
+  ): SessionInfo | null {
     if (killedSessions.has(sessionId)) return null;
     if (pendingKills.has(sessionId)) {
       finalizePendingKill(sessionId, pid);
@@ -203,7 +242,9 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     }
 
     const existing = sessions.get(sessionId);
-    if (!existing) return autoRegister(sessionId, pid, authenticated);
+    if (!existing) {
+      return autoRegister(sessionId, pid, authenticated, serverVersion, consoleProtocolVersion);
+    }
 
     if (existing.status === 'ended') {
       existing.status = 'active';
@@ -217,6 +258,12 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       logger.info('[IngestRoutes] Recovered PID for orphaned session', {
         displayName: existing.displayName, sessionId, pid,
       });
+    }
+    if (serverVersion) {
+      existing.serverVersion = normalizeServerVersion(serverVersion);
+    }
+    if (consoleProtocolVersion !== undefined) {
+      existing.consoleProtocolVersion = normalizeConsoleProtocolVersion(consoleProtocolVersion);
     }
     return existing;
   }
@@ -323,6 +370,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
           sessionId: payload.sessionId, displayName, color,
           pid: payload.pid, startedAt: payload.startedAt || now, lastHeartbeat: now,
           status: 'active', isLeader: false, authenticated: isAuthenticated, kind: 'mcp',
+          serverVersion: normalizeServerVersion(payload.serverVersion),
+          consoleProtocolVersion: normalizeConsoleProtocolVersion(payload.consoleProtocolVersion),
         });
         logger.info('[IngestRoutes] Session registered', {
           displayName, sessionId: payload.sessionId, pid: payload.pid, color,
@@ -347,7 +396,13 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       }
       case 'heartbeat': {
         // Auto-register or update — heartbeat includes PID for recovery (#1870)
-        ensureSession(payload.sessionId, payload.pid);
+        ensureSession(
+          payload.sessionId,
+          payload.pid,
+          false,
+          payload.serverVersion,
+          payload.consoleProtocolVersion,
+        );
         break;
       }
     }
@@ -384,6 +439,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
                 ...ls,
                 authenticated: false,
                 kind: ls.kind || 'mcp',
+                serverVersion: normalizeServerVersion(ls.serverVersion),
+                consoleProtocolVersion: normalizeConsoleProtocolVersion(ls.consoleProtocolVersion),
               });
             }
           }
@@ -445,14 +502,12 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
 
     // SIGTERM the process. Even if it fails (ESRCH = already dead, EPERM = not ours),
     // mark the session as permanently killed so it never reappears (#1870).
-    let killed = false;
     try {
       process.kill(session.pid, 'SIGTERM');
-      killed = true;
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       if (code === 'ESRCH') {
-        killed = true; // process already dead — treat as successful kill
+        // Process already dead — treat as successful kill.
       } else {
         logger.error('[IngestRoutes] Failed to kill session', {
           displayName: session.displayName, sessionId, pid: session.pid, error: (err as Error).message,
@@ -523,6 +578,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       isLeader: true,
       authenticated: true,
       kind: 'mcp',
+      serverVersion: PACKAGE_VERSION,
+      consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
     });
     logger.info('[IngestRoutes] Leader session registered', { displayName, sessionId, pid, color });
   }
@@ -547,6 +604,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       isLeader: false,
       authenticated: true,
       kind: 'console',
+      serverVersion: PACKAGE_VERSION,
+      consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
     });
     logger.info('[IngestRoutes] Console session registered', { sessionId: consoleId, pid: process.pid });
   }

--- a/src/web/console/LeaderElection.ts
+++ b/src/web/console/LeaderElection.ts
@@ -23,7 +23,9 @@ import { join } from 'node:path';
 import { mkdir, readFile, writeFile, rename, unlink } from 'node:fs/promises';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { env } from '../../config/env.js';
+import { PACKAGE_VERSION } from '../../generated/version.js';
 import { logger } from '../../utils/logger.js';
+import { compareVersions } from '../../utils/version.js';
 
 /** Directory for runtime state files */
 const RUN_DIR = join(homedir(), '.dollhouse', 'run');
@@ -65,6 +67,18 @@ const HEARTBEAT_STALE_MS = 30_000;
 export const LOCK_VERSION = 1;
 
 /**
+ * Version of the leader-election/session metadata contract used by the
+ * authenticated web console. Older leaders will not have this field.
+ */
+export const CONSOLE_PROTOCOL_VERSION = 1;
+
+/** Missing protocol metadata means the leader predates version-aware election. */
+export const LEGACY_CONSOLE_PROTOCOL_VERSION = 0;
+
+/** Old lock files do not carry package version metadata. Treat them as oldest. */
+export const LEGACY_SERVER_VERSION = '0.0.0';
+
+/**
  * Information stored in the leader lock file.
  */
 export interface ConsoleLeaderInfo {
@@ -74,6 +88,8 @@ export interface ConsoleLeaderInfo {
   sessionId: string;
   startedAt: string;
   heartbeat: string;
+  serverVersion?: string;
+  consoleProtocolVersion?: number;
 }
 
 /**
@@ -83,6 +99,15 @@ export interface ElectionResult {
   role: 'leader' | 'follower';
   /** Leader info — for followers, this is the existing leader's info */
   leaderInfo: ConsoleLeaderInfo;
+}
+
+export interface LeaderPreferenceDecision {
+  shouldReplace: boolean;
+  reason: 'newer-compatible-version' | 'same-version' | 'older-version' | 'incompatible-protocol';
+  candidateVersion: string;
+  existingVersion: string;
+  candidateProtocolVersion: number;
+  existingProtocolVersion: number;
 }
 
 /**
@@ -97,6 +122,106 @@ export function isProcessAlive(pid: number): boolean {
     // EPERM = process exists but owned by another user — still alive
     return err?.code === 'EPERM';
   }
+}
+
+/**
+ * Normalize the server version present in the leader lock.
+ * Missing metadata means "legacy leader" for election purposes.
+ */
+export function getLeaderServerVersion(info: ConsoleLeaderInfo): string {
+  if (typeof info.serverVersion === 'string' && info.serverVersion.trim().length > 0) {
+    return info.serverVersion.trim();
+  }
+  return LEGACY_SERVER_VERSION;
+}
+
+/**
+ * Normalize the console protocol version present in the leader lock.
+ * Missing metadata means a leader from before version-aware election.
+ */
+export function getLeaderConsoleProtocolVersion(info: ConsoleLeaderInfo): number {
+  const raw = info.consoleProtocolVersion;
+  if (typeof raw === 'number' && Number.isInteger(raw) && raw >= 0) {
+    return raw;
+  }
+  return LEGACY_CONSOLE_PROTOCOL_VERSION;
+}
+
+/**
+ * Create this process's leader metadata in one place so all leadership paths
+ * publish the same version and protocol information.
+ */
+export function createLeaderInfo(sessionId: string, port: number): ConsoleLeaderInfo {
+  const now = new Date().toISOString();
+  return {
+    version: LOCK_VERSION,
+    pid: process.pid,
+    port,
+    sessionId: UnicodeValidator.normalize(sessionId).normalizedContent,
+    startedAt: now,
+    heartbeat: now,
+    serverVersion: PACKAGE_VERSION,
+    consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+  };
+}
+
+/**
+ * Decide whether this process should replace the current live leader based on
+ * compatibility first, then package version.
+ */
+export function evaluateLeaderPreference(
+  candidate: ConsoleLeaderInfo,
+  existing: ConsoleLeaderInfo,
+): LeaderPreferenceDecision {
+  const candidateVersion = getLeaderServerVersion(candidate);
+  const existingVersion = getLeaderServerVersion(existing);
+  const candidateProtocolVersion = getLeaderConsoleProtocolVersion(candidate);
+  const existingProtocolVersion = getLeaderConsoleProtocolVersion(existing);
+
+  const compatible =
+    existingProtocolVersion === candidateProtocolVersion ||
+    existingProtocolVersion === LEGACY_CONSOLE_PROTOCOL_VERSION;
+
+  if (!compatible) {
+    return {
+      shouldReplace: false,
+      reason: 'incompatible-protocol',
+      candidateVersion,
+      existingVersion,
+      candidateProtocolVersion,
+      existingProtocolVersion,
+    };
+  }
+
+  const versionComparison = compareVersions(candidateVersion, existingVersion);
+  if (versionComparison > 0) {
+    return {
+      shouldReplace: true,
+      reason: 'newer-compatible-version',
+      candidateVersion,
+      existingVersion,
+      candidateProtocolVersion,
+      existingProtocolVersion,
+    };
+  }
+  if (versionComparison === 0) {
+    return {
+      shouldReplace: false,
+      reason: 'same-version',
+      candidateVersion,
+      existingVersion,
+      candidateProtocolVersion,
+      existingProtocolVersion,
+    };
+  }
+  return {
+    shouldReplace: false,
+    reason: 'older-version',
+    candidateVersion,
+    existingVersion,
+    candidateProtocolVersion,
+    existingProtocolVersion,
+  };
 }
 
 /**
@@ -221,19 +346,46 @@ export async function deleteLeaderLock(): Promise<void> {
  * @returns Election result with role and leader info
  */
 export async function electLeader(sessionId: string, port: number): Promise<ElectionResult> {
-  sessionId = UnicodeValidator.normalize(sessionId).normalizedContent;
+  const myInfo = createLeaderInfo(sessionId, port);
+  sessionId = myInfo.sessionId;
   const existingLock = await readLeaderLock();
 
   if (existingLock && !isLockStale(existingLock)) {
-    logger.info('[LeaderElection] Existing leader found — becoming follower', {
-      leaderSession: existingLock.sessionId, leaderPid: existingLock.pid,
-      leaderPort: existingLock.port, mySession: sessionId, myPid: process.pid,
-    });
-    return { role: 'follower', leaderInfo: existingLock };
+    const preference = evaluateLeaderPreference(myInfo, existingLock);
+    if (preference.shouldReplace) {
+      logger.info('[LeaderElection] Replacing leader with newer compatible version', {
+        staleSession: existingLock.sessionId,
+        stalePid: existingLock.pid,
+        stalePort: existingLock.port,
+        staleVersion: preference.existingVersion,
+        staleProtocolVersion: preference.existingProtocolVersion,
+        mySession: sessionId,
+        myPid: process.pid,
+        myVersion: preference.candidateVersion,
+        myProtocolVersion: preference.candidateProtocolVersion,
+      });
+      await deleteLeaderLock();
+    } else {
+      logger.info('[LeaderElection] Existing leader found — becoming follower', {
+        leaderSession: existingLock.sessionId,
+        leaderPid: existingLock.pid,
+        leaderPort: existingLock.port,
+        leaderVersion: preference.existingVersion,
+        leaderProtocolVersion: preference.existingProtocolVersion,
+        mySession: sessionId,
+        myPid: process.pid,
+        myVersion: preference.candidateVersion,
+        myProtocolVersion: preference.candidateProtocolVersion,
+        reason: preference.reason,
+      });
+      return { role: 'follower', leaderInfo: existingLock };
+    }
   }
 
-  // No valid leader — try to claim
-  if (existingLock) {
+  if (existingLock && !isLockStale(existingLock)) {
+    // Leader was intentionally replaced above. Continue to the claim path.
+  } else if (existingLock) {
+    // No valid leader — try to claim
     const alive = isProcessAlive(existingLock.pid);
     const heartbeatAge = Date.now() - new Date(existingLock.heartbeat).getTime();
     logger.info('[LeaderElection] Stale leader lock — taking over', {
@@ -242,16 +394,6 @@ export async function electLeader(sessionId: string, port: number): Promise<Elec
     });
     await deleteLeaderLock();
   }
-
-  const now = new Date().toISOString();
-  const myInfo: ConsoleLeaderInfo = {
-    version: LOCK_VERSION,
-    pid: process.pid,
-    port,
-    sessionId,
-    startedAt: now,
-    heartbeat: now,
-  };
 
   const claimed = await claimLeadership(myInfo);
   if (claimed) {
@@ -270,7 +412,7 @@ export async function electLeader(sessionId: string, port: number): Promise<Elec
 
   // Extremely unlikely: lock disappeared between our claim and re-read. Retry once.
   logger.warn('[LeaderElection] Lock vanished after failed claim. Retrying.');
-  const retryInfo: ConsoleLeaderInfo = { ...myInfo, heartbeat: new Date().toISOString() };
+  const retryInfo: ConsoleLeaderInfo = { ...createLeaderInfo(sessionId, port) };
   const retryClaimed = await claimLeadership(retryInfo);
   if (retryClaimed) {
     return { role: 'leader', leaderInfo: retryInfo };
@@ -304,16 +446,7 @@ export async function isLeaderWebConsoleReachable(leaderInfo: ConsoleLeaderInfo)
 export async function forceClaimLeadership(sessionId: string, port: number): Promise<ElectionResult> {
   logger.info('[LeaderElection] Forcing leadership takeover — existing leader has no web console');
   await deleteLeaderLock();
-
-  const now = new Date().toISOString();
-  const myInfo: ConsoleLeaderInfo = {
-    version: LOCK_VERSION,
-    pid: process.pid,
-    port,
-    sessionId: UnicodeValidator.normalize(sessionId).normalizedContent,
-    startedAt: now,
-    heartbeat: now,
-  };
+  const myInfo = createLeaderInfo(sessionId, port);
 
   const claimed = await claimLeadership(myInfo);
   if (claimed) {

--- a/src/web/console/LeaderElection.ts
+++ b/src/web/console/LeaderElection.ts
@@ -286,7 +286,13 @@ export async function readLeaderLock(): Promise<ConsoleLeaderInfo | null> {
       return null;
     }
     return data;
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      logger.debug('[LeaderElection] Ignoring unreadable or invalid leader lock', {
+        lockFile: LOCK_FILE,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
     return null;
   }
 }

--- a/src/web/console/LeaderForwardingSink.ts
+++ b/src/web/console/LeaderForwardingSink.ts
@@ -18,8 +18,10 @@
 import type { ILogSink, UnifiedLogEntry } from '../../logging/types.js';
 import type { MetricSnapshot } from '../../metrics/types.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
+import { PACKAGE_VERSION } from '../../generated/version.js';
 import { logger } from '../../utils/logger.js';
 import { env } from '../../config/env.js';
+import { CONSOLE_PROTOCOL_VERSION } from './LeaderElection.js';
 
 /** Maximum entries to buffer when leader is unreachable */
 const MAX_BUFFER_SIZE = 10_000;
@@ -253,6 +255,8 @@ export class SessionHeartbeat {
           event,
           pid: this.pid,
           startedAt: new Date().toISOString(),
+          serverVersion: PACKAGE_VERSION,
+          consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
         }),
         signal: controller.signal,
       });

--- a/src/web/console/PromotionManager.ts
+++ b/src/web/console/PromotionManager.ts
@@ -15,9 +15,8 @@ import {
   deleteLeaderLock,
   claimLeadership,
   readLeaderLock,
-  LOCK_VERSION,
+  createLeaderInfo,
   type ElectionResult,
-  type ConsoleLeaderInfo,
 } from './LeaderElection.js';
 import type { LeaderForwardingLogSink, SessionHeartbeat } from './LeaderForwardingSink.js';
 import type { UnifiedConsoleOptions } from './UnifiedConsole.js';
@@ -74,15 +73,7 @@ export class PromotionManager {
       await forwardingSink.close();
       await deleteLeaderLock();
 
-      const now = new Date().toISOString();
-      const myInfo: ConsoleLeaderInfo = {
-        version: LOCK_VERSION,
-        pid: process.pid,
-        port: this.consolePort,
-        sessionId: this.options.sessionId,
-        startedAt: now,
-        heartbeat: now,
-      };
+      const myInfo = createLeaderInfo(this.options.sessionId, this.consolePort);
 
       const claimed = await claimLeadership(myInfo);
       const durationMs = Date.now() - startMs;

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -1978,12 +1978,70 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
 
     const TAB_KEY = 'dollhousemcp-active-tab';
     const SETUP_SEEN_KEY = 'dollhousemcp-setup-seen';
+    const FORCED_RELOAD_KEY = 'dollhousemcp-last-forced-reload';
     // Server version injected at request time — used to show Setup tab once per version
     // so upgraders automatically see it on each new release (not just first-ever visit).
     // Validate format (semver-like) before trusting the value; malformed falls back to
     // 'unknown' which safely triggers setup on every load rather than silently skipping.
     const _rawVersion = document.querySelector('meta[name="dollhouse-server-version"]')?.content || '';
     const currentServerVersion = /^\d+\.\d+\.\d+/.test(_rawVersion) ? _rawVersion : 'unknown';
+    const _rawAssetVersion = document.querySelector('meta[name="dollhouse-console-asset-version"]')?.content || '';
+    const currentAssetVersion = /^\d+\.\d+\.\d+/.test(_rawAssetVersion) ? _rawAssetVersion : currentServerVersion;
+    let forcedReloadInFlight = false;
+
+    function normalizeReloadVersion(version) {
+      return typeof version === 'string' && /^\d+\.\d+\.\d+/.test(version)
+        ? version
+        : (currentAssetVersion || currentServerVersion || 'unknown');
+    }
+
+    function shouldThrottleForcedReload(targetVersion) {
+      try {
+        const raw = sessionStorage.getItem(FORCED_RELOAD_KEY);
+        if (!raw) return false;
+        const parsed = JSON.parse(raw);
+        return parsed
+          && parsed.version === targetVersion
+          && typeof parsed.at === 'number'
+          && Date.now() - parsed.at < 60_000;
+      } catch {
+        return false;
+      }
+    }
+
+    function rememberForcedReload(targetVersion, reason) {
+      try {
+        sessionStorage.setItem(FORCED_RELOAD_KEY, JSON.stringify({
+          version: targetVersion,
+          reason: reason || 'manual',
+          at: Date.now(),
+        }));
+      } catch {
+        // Ignore storage failures — reload still proceeds.
+      }
+    }
+
+    function buildCacheBustedConsoleUrl(targetVersion, reason) {
+      const url = new URL(globalThis.location.href);
+      url.searchParams.set('dollhouse_bust', targetVersion + '-' + Date.now());
+      url.searchParams.set('dollhouse_asset_version', targetVersion);
+      if (reason) {
+        url.searchParams.set('dollhouse_reload_reason', reason);
+      }
+      return url.toString();
+    }
+
+    function forceConsoleReload(reason, targetVersion) {
+      const normalizedTargetVersion = normalizeReloadVersion(targetVersion);
+      if (forcedReloadInFlight || shouldThrottleForcedReload(normalizedTargetVersion)) {
+        return false;
+      }
+      forcedReloadInFlight = true;
+      rememberForcedReload(normalizedTargetVersion, reason);
+      const reloadUrl = buildCacheBustedConsoleUrl(normalizedTargetVersion, reason);
+      globalThis.location.replace(reloadUrl);
+      return true;
+    }
 
     // Determine which tab to show on load:
     // 1. URL hash (deep link)
@@ -2022,6 +2080,9 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
     // Expose for other scripts (logs.js, metrics.js, permissions.js)
     globalThis.DollhouseConsole = globalThis.DollhouseConsole || {};
     globalThis.DollhouseConsole.getUrlParams = () => getTabAndParams().params;
+    globalThis.DollhouseConsole.currentServerVersion = currentServerVersion;
+    globalThis.DollhouseConsole.currentAssetVersion = currentAssetVersion;
+    globalThis.DollhouseConsole.forceReload = forceConsoleReload;
 
     /**
      * Apply URL params to the portfolio tab.
@@ -2175,7 +2236,7 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
       toast.innerHTML = 'Console session token changed\u2009\u2014\u2009'
         + '<button style="background:#fff;color:#b91c1c;border:none;padding:6px 16px;'
         + 'border-radius:4px;cursor:pointer;font-weight:600;font-size:14px"'
-        + ' onclick="location.reload()">Reload</button>';
+        + ' onclick="window.DollhouseConsole.forceReload(\'session-expired\')">Reload</button>';
       document.body.appendChild(toast);
     });
 

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -14,14 +14,16 @@
   <meta name="dollhouse-console-token" content="{{CONSOLE_TOKEN}}">
   <!-- Server version — injected at request time for version-aware UI behaviour (e.g. setup-seen per version). -->
   <meta name="dollhouse-server-version" content="{{DOLLHOUSE_VERSION}}">
-  <link rel="stylesheet" href="fonts.css">
-  <link rel="stylesheet" href="styles.css">
-  <link rel="stylesheet" href="logs.css">
-  <link rel="stylesheet" href="metrics.css">
-  <link rel="stylesheet" href="permissions.css">
-  <link rel="stylesheet" href="sessions.css">
-  <link rel="stylesheet" href="setup.css">
-  <link rel="stylesheet" href="security.css">
+  <!-- Asset version — injected at request time for cache-busting local CSS/JS/img files. -->
+  <meta name="dollhouse-console-asset-version" content="{{DOLLHOUSE_ASSET_VERSION}}">
+  <link rel="stylesheet" href="fonts.css?v={{DOLLHOUSE_ASSET_VERSION}}">
+  <link rel="stylesheet" href="styles.css?v={{DOLLHOUSE_ASSET_VERSION}}">
+  <link rel="stylesheet" href="logs.css?v={{DOLLHOUSE_ASSET_VERSION}}">
+  <link rel="stylesheet" href="metrics.css?v={{DOLLHOUSE_ASSET_VERSION}}">
+  <link rel="stylesheet" href="permissions.css?v={{DOLLHOUSE_ASSET_VERSION}}">
+  <link rel="stylesheet" href="sessions.css?v={{DOLLHOUSE_ASSET_VERSION}}">
+  <link rel="stylesheet" href="setup.css?v={{DOLLHOUSE_ASSET_VERSION}}">
+  <link rel="stylesheet" href="security.css?v={{DOLLHOUSE_ASSET_VERSION}}">
   <!-- uPlot for metrics time-series charts -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uplot@1.6.30/dist/uPlot.min.css" integrity="sha384-IfV0B7MIOYuO95kO9G5ySKPz/85zqFNOAs8iy4tkK5zd9izhJAB8b7lHrwYqqmYE" crossorigin="anonymous">
 </head>
@@ -31,7 +33,7 @@
 
   <header class="site-header">
     <div class="header-brand">
-      <img src="dollhouse-logo.png" alt="DollhouseMCP" class="header-logo" width="32" height="32">
+      <img src="dollhouse-logo.png?v={{DOLLHOUSE_ASSET_VERSION}}" alt="DollhouseMCP" class="header-logo" width="32" height="32">
       <div class="header-brand-text">
         <h1 class="site-title">DollhouseMCP</h1>
         <p class="site-tagline">Management Console</p>
@@ -598,13 +600,13 @@ npm install @dollhousemcp/mcp-server</code></pre>
   <script src="https://cdn.jsdelivr.net/npm/uplot@1.6.30/dist/uPlot.iife.min.js" integrity="sha384-1NEYi76CBpge3gahk4+X4M4JzdOV3WYq84RnByqYdAd5SdvJBTNCPFh/nsoHfN6i" crossorigin="anonymous"></script>
   <!-- Console auth helper must load first — it reads the token meta tag and
        exposes window.DollhouseAuth for all subsequent scripts (#1780). -->
-  <script src="consoleAuth.js"></script>
-  <script src="setup.js"></script>
-  <script src="app.js"></script>
-  <script src="logs.js"></script>
-  <script src="metrics.js"></script>
-  <script src="permissions.js"></script>
-  <script src="sessions.js"></script>
-  <script src="security.js"></script>
+  <script src="consoleAuth.js?v={{DOLLHOUSE_ASSET_VERSION}}"></script>
+  <script src="setup.js?v={{DOLLHOUSE_ASSET_VERSION}}"></script>
+  <script src="app.js?v={{DOLLHOUSE_ASSET_VERSION}}"></script>
+  <script src="logs.js?v={{DOLLHOUSE_ASSET_VERSION}}"></script>
+  <script src="metrics.js?v={{DOLLHOUSE_ASSET_VERSION}}"></script>
+  <script src="permissions.js?v={{DOLLHOUSE_ASSET_VERSION}}"></script>
+  <script src="sessions.js?v={{DOLLHOUSE_ASSET_VERSION}}"></script>
+  <script src="security.js?v={{DOLLHOUSE_ASSET_VERSION}}"></script>
 </body>
 </html>

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -30,28 +30,71 @@
   var lastSessionKey = ''; // tracks session list identity to avoid unnecessary rebuilds
   var lastReloadTargetVersion = '';
 
+  function parseSemver(version) {
+    if (typeof version !== 'string') return null;
+    var trimmed = version.trim();
+    var match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(trimmed);
+    if (!match) return null;
+    return {
+      normalized: trimmed,
+      major: parseInt(match[1], 10) || 0,
+      minor: parseInt(match[2], 10) || 0,
+      patch: parseInt(match[3], 10) || 0,
+      prerelease: match[4] ? match[4].split('.') : [],
+    };
+  }
+
   function normalizeSemver(version) {
-    return typeof version === 'string' && /^\d+\.\d+\.\d+/.test(version)
-      ? version
-      : '';
+    var parsed = parseSemver(version);
+    return parsed ? parsed.normalized : '';
+  }
+
+  function comparePrereleaseParts(partsA, partsB) {
+    var maxLength = Math.max(partsA.length, partsB.length);
+    if (!maxLength) return 0;
+    for (var i = 0; i < maxLength; i++) {
+      var a = partsA[i];
+      var b = partsB[i];
+      if (a === undefined) return -1;
+      if (b === undefined) return 1;
+
+      var aIsNumeric = /^\d+$/.test(a);
+      var bIsNumeric = /^\d+$/.test(b);
+      if (aIsNumeric && bIsNumeric) {
+        var aNumber = parseInt(a, 10);
+        var bNumber = parseInt(b, 10);
+        if (aNumber < bNumber) return -1;
+        if (aNumber > bNumber) return 1;
+        continue;
+      }
+
+      if (aIsNumeric) return -1;
+      if (bIsNumeric) return 1;
+
+      var lexical = a.localeCompare(b);
+      if (lexical !== 0) return lexical;
+    }
+    return 0;
   }
 
   function compareSemver(versionA, versionB) {
-    var a = normalizeSemver(versionA);
-    var b = normalizeSemver(versionB);
+    var a = parseSemver(versionA);
+    var b = parseSemver(versionB);
     if (!a && !b) return 0;
     if (!a) return -1;
     if (!b) return 1;
-    var aParts = a.replace(/^v/, '').split('-')[0].split('.');
-    var bParts = b.replace(/^v/, '').split('-')[0].split('.');
-    var maxLength = Math.max(aParts.length, bParts.length);
-    for (var i = 0; i < maxLength; i++) {
-      var aPart = parseInt(aParts[i] || '0', 10) || 0;
-      var bPart = parseInt(bParts[i] || '0', 10) || 0;
+    var versionKeys = ['major', 'minor', 'patch'];
+    for (var i = 0; i < versionKeys.length; i++) {
+      var key = versionKeys[i];
+      var aPart = a[key];
+      var bPart = b[key];
       if (aPart < bPart) return -1;
       if (aPart > bPart) return 1;
     }
-    return 0;
+
+    if (!a.prerelease.length && b.prerelease.length) return 1;
+    if (a.prerelease.length && !b.prerelease.length) return -1;
+    return comparePrereleaseParts(a.prerelease, b.prerelease);
   }
 
   function getCurrentConsoleVersion() {

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -28,6 +28,56 @@
   var filterSessionId = '';
   var dropdownBuilt = false;
   var lastSessionKey = ''; // tracks session list identity to avoid unnecessary rebuilds
+  var lastReloadTargetVersion = '';
+
+  function normalizeSemver(version) {
+    return typeof version === 'string' && /^\d+\.\d+\.\d+/.test(version)
+      ? version
+      : '';
+  }
+
+  function compareSemver(versionA, versionB) {
+    var a = normalizeSemver(versionA);
+    var b = normalizeSemver(versionB);
+    if (!a && !b) return 0;
+    if (!a) return -1;
+    if (!b) return 1;
+    var aParts = a.replace(/^v/, '').split('-')[0].split('.');
+    var bParts = b.replace(/^v/, '').split('-')[0].split('.');
+    var maxLength = Math.max(aParts.length, bParts.length);
+    for (var i = 0; i < maxLength; i++) {
+      var aPart = parseInt(aParts[i] || '0', 10) || 0;
+      var bPart = parseInt(bParts[i] || '0', 10) || 0;
+      if (aPart < bPart) return -1;
+      if (aPart > bPart) return 1;
+    }
+    return 0;
+  }
+
+  function getCurrentConsoleVersion() {
+    var dc = window.DollhouseConsole;
+    if (dc && typeof dc.currentServerVersion === 'string') {
+      return normalizeSemver(dc.currentServerVersion);
+    }
+    var meta = document.querySelector('meta[name="dollhouse-server-version"]');
+    return normalizeSemver(meta ? meta.getAttribute('content') || '' : '');
+  }
+
+  function maybeForceReloadForNewLeader(list) {
+    var dc = window.DollhouseConsole;
+    if (!dc || typeof dc.forceReload !== 'function' || !Array.isArray(list)) return;
+    var currentVersion = getCurrentConsoleVersion();
+    var leader = list.find(function(session) {
+      return session && session.status === 'active' && session.isLeader && session.kind === 'mcp';
+    });
+    if (!leader) return;
+    var leaderVersion = normalizeSemver(leader.serverVersion);
+    if (!leaderVersion) return;
+    if (compareSemver(leaderVersion, currentVersion) <= 0) return;
+    if (lastReloadTargetVersion === leaderVersion) return;
+    lastReloadTargetVersion = leaderVersion;
+    dc.forceReload('leader-upgraded', leaderVersion);
+  }
 
   function formatUptime(startedAt) {
     if (!startedAt) return '';
@@ -535,6 +585,7 @@
     }).then(function(data) {
       if (data && data.sessions) {
         sessions = data.sessions;
+        maybeForceReloadForNewLeader(sessions);
         updateSessionIndicator();
         updateSessionFilterOptions();
         clearSessionsError();

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -23,12 +23,14 @@
   var SESSION_POLL_INTERVAL = getConfiguredNumber('sessionPollIntervalMs', 5000);
   var SESSION_FILTER_INJECTION_RETRY_INTERVAL = getConfiguredNumber('sessionFilterInjectionRetryIntervalMs', 500);
   var SESSION_FILTER_INJECTION_MAX_RETRIES = getConfiguredNumber('sessionFilterInjectionMaxRetries', 20);
+  var LEADER_RELOAD_DEBOUNCE_MS = getConfiguredNumber('leaderReloadDebounceMs', 150);
   var sessions = [];
   var policySessions = [];
   var filterSessionId = '';
   var dropdownBuilt = false;
   var lastSessionKey = ''; // tracks session list identity to avoid unnecessary rebuilds
   var lastReloadTargetVersion = '';
+  var pendingLeaderReloadTimer = null;
 
   function parseSemver(version) {
     if (typeof version !== 'string') return null;
@@ -106,6 +108,15 @@
     return normalizeSemver(meta ? meta.getAttribute('content') || '' : '');
   }
 
+  /**
+   * Schedule a cache-busted reload when the session poller observes that a
+   * newer MCP leader is serving the console than the version loaded in this tab.
+   * A small debounce lets rapid leadership churn settle so the browser reloads
+   * directly into the newest compatible leader rather than bouncing through
+   * intermediate versions.
+   *
+   * @param {Array<Record<string, unknown>>} list
+   */
   function maybeForceReloadForNewLeader(list) {
     var dc = window.DollhouseConsole;
     if (!dc || typeof dc.forceReload !== 'function' || !Array.isArray(list)) return;
@@ -118,8 +129,14 @@
     if (!leaderVersion) return;
     if (compareSemver(leaderVersion, currentVersion) <= 0) return;
     if (lastReloadTargetVersion === leaderVersion) return;
+    if (pendingLeaderReloadTimer) {
+      clearTimeout(pendingLeaderReloadTimer);
+    }
     lastReloadTargetVersion = leaderVersion;
-    dc.forceReload('leader-upgraded', leaderVersion);
+    pendingLeaderReloadTimer = setTimeout(function() {
+      pendingLeaderReloadTimer = null;
+      dc.forceReload('leader-upgraded', leaderVersion);
+    }, LEADER_RELOAD_DEBOUNCE_MS);
   }
 
   function formatUptime(startedAt) {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -51,6 +51,8 @@ const PUBLIC_PATH_PREFIXES = [
 const TOKEN_META_PLACEHOLDER = '{{CONSOLE_TOKEN}}';
 /** Placeholder in index.html that is replaced with the running server version. */
 const VERSION_META_PLACEHOLDER = '{{DOLLHOUSE_VERSION}}';
+/** Placeholder in index.html that is replaced with the asset cache-busting version. */
+const ASSET_VERSION_META_PLACEHOLDER = '{{DOLLHOUSE_ASSET_VERSION}}';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 /**
@@ -373,7 +375,9 @@ export async function startWebServer(options: WebServerOptions): Promise<WebServ
     index: false,
     // In debug mode, disable caching on all static assets (JS, CSS) so
     // UI changes are picked up on normal reload without Cmd+Shift+R.
-    ...(isDebug ? { etag: false, lastModified: false, maxAge: 0 } : {}),
+    ...(isDebug
+      ? { etag: false, lastModified: false, maxAge: 0 }
+      : { maxAge: '1y', immutable: true }),
   }));
 
   // SPA fallback with console token injection (#1780).
@@ -404,7 +408,8 @@ export async function startWebServer(options: WebServerOptions): Promise<WebServ
       .replaceAll('>', '&gt;');
     cachedIndexHtml = template
       .replaceAll(TOKEN_META_PLACEHOLDER, escapedToken)
-      .replaceAll(VERSION_META_PLACEHOLDER, PACKAGE_VERSION);
+      .replaceAll(VERSION_META_PLACEHOLDER, PACKAGE_VERSION)
+      .replaceAll(ASSET_VERSION_META_PLACEHOLDER, PACKAGE_VERSION);
     cachedTokenValue = tokenValue;
     return cachedIndexHtml;
   };
@@ -422,12 +427,10 @@ export async function startWebServer(options: WebServerOptions): Promise<WebServ
     try {
       const html = await renderIndexHtml();
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
-      // In debug mode, prevent browser caching so UI changes are picked up
-      // immediately. In production, allow short caching for performance.
-      const isDebug = Boolean(process.env.DOLLHOUSE_DEBUG || process.env.ENABLE_DEBUG);
-      res.setHeader('Cache-Control', isDebug
-        ? 'no-cache, no-store, must-revalidate'
-        : 'private, max-age=60');
+      // The shell should always revalidate so a forced reload can pick up
+      // a new leader/version immediately. Asset files themselves carry a
+      // version query and can be cached aggressively.
+      res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
       res.send(html);
     } catch (err) {
       logger.error(`[WebUI] Failed to render index.html: ${(err as Error).message}`);
@@ -438,7 +441,6 @@ export async function startWebServer(options: WebServerOptions): Promise<WebServ
   // Global error handler — catch Express errors and route to logger instead of terminal.
   // Without this, Express dumps stack traces to stderr (visible in --web terminal).
   // All errors still appear in the management console's Logs tab via MemoryLogSink.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   app.use((err: Error, _req: import('express').Request, res: import('express').Response, _next: import('express').NextFunction) => {
     const status = (err as any).status || (err as any).statusCode || 500;
     logger.warn(`[WebUI] ${err.name}: ${err.message}`);

--- a/tests/integration/console-lifecycle.test.ts
+++ b/tests/integration/console-lifecycle.test.ts
@@ -10,7 +10,7 @@
  * recovery, and follower re-election.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import * as net from 'node:net';
 import { mkdtemp, writeFile, readFile, rm, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';

--- a/tests/unit/web/cacheBustingSources.test.ts
+++ b/tests/unit/web/cacheBustingSources.test.ts
@@ -28,6 +28,6 @@ describe('cache busting source wiring', () => {
     expect(appJs).toContain('dollhousemcp-last-forced-reload');
     expect(appJs).toContain('buildCacheBustedConsoleUrl');
     expect(appJs).toContain('globalThis.DollhouseConsole.forceReload = forceConsoleReload');
-    expect(appJs).toContain("window.DollhouseConsole.forceReload(\\'session-expired\\')");
+    expect(appJs).toContain(String.raw`window.DollhouseConsole.forceReload(\'session-expired\')`);
   });
 });

--- a/tests/unit/web/cacheBustingSources.test.ts
+++ b/tests/unit/web/cacheBustingSources.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Source-level checks for cache-busting and forced reload wiring.
+ *
+ * These assertions stay small and deterministic: they verify that the
+ * server-rendered HTML stamps local asset URLs with a version placeholder
+ * and that app.js exposes a forced reload helper for stale tabs.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const PUBLIC_DIR = join(process.cwd(), 'src', 'web', 'public');
+
+describe('cache busting source wiring', () => {
+  it('index.html stamps local assets with the asset-version placeholder', () => {
+    const html = readFileSync(join(PUBLIC_DIR, 'index.html'), 'utf-8');
+    expect(html).toContain('name="dollhouse-console-asset-version"');
+    expect(html).toContain('{{DOLLHOUSE_ASSET_VERSION}}');
+    expect(html).toContain('styles.css?v={{DOLLHOUSE_ASSET_VERSION}}');
+    expect(html).toContain('app.js?v={{DOLLHOUSE_ASSET_VERSION}}');
+    expect(html).toContain('sessions.js?v={{DOLLHOUSE_ASSET_VERSION}}');
+    expect(html).toContain('dollhouse-logo.png?v={{DOLLHOUSE_ASSET_VERSION}}');
+  });
+
+  it('app.js exposes a cache-busted forced reload helper', () => {
+    const appJs = readFileSync(join(PUBLIC_DIR, 'app.js'), 'utf-8');
+    expect(appJs).toContain('dollhousemcp-last-forced-reload');
+    expect(appJs).toContain('buildCacheBustedConsoleUrl');
+    expect(appJs).toContain('globalThis.DollhouseConsole.forceReload = forceConsoleReload');
+    expect(appJs).toContain("window.DollhouseConsole.forceReload(\\'session-expired\\')");
+  });
+});

--- a/tests/unit/web/console/LeaderElection.test.ts
+++ b/tests/unit/web/console/LeaderElection.test.ts
@@ -132,6 +132,69 @@ describe('LeaderElection', () => {
     });
   });
 
+  describe('createLeaderInfo', () => {
+    it('stamps the current server version and console protocol version', () => {
+      const info = LeaderElection.createLeaderInfo('session-123', 41715);
+      expect(info.serverVersion).toMatch(/^\d+\.\d+\.\d+/);
+      expect(info.consoleProtocolVersion).toBe(LeaderElection.CONSOLE_PROTOCOL_VERSION);
+      expect(info.sessionId).toBe('session-123');
+      expect(info.port).toBe(41715);
+    });
+  });
+
+  describe('evaluateLeaderPreference', () => {
+    function makeInfo(overrides: Partial<import('../../../../src/web/console/LeaderElection.js').ConsoleLeaderInfo> = {}) {
+      return {
+        version: 1,
+        pid: process.pid,
+        port: 41715,
+        sessionId: 'test-session',
+        startedAt: new Date().toISOString(),
+        heartbeat: new Date().toISOString(),
+        serverVersion: '2.0.18',
+        consoleProtocolVersion: LeaderElection.CONSOLE_PROTOCOL_VERSION,
+        ...overrides,
+      };
+    }
+
+    it('prefers a newer compatible candidate', () => {
+      const decision = LeaderElection.evaluateLeaderPreference(
+        makeInfo({ sessionId: 'newer', serverVersion: '2.0.19' }),
+        makeInfo({ sessionId: 'older', serverVersion: '2.0.18' }),
+      );
+      expect(decision.shouldReplace).toBe(true);
+      expect(decision.reason).toBe('newer-compatible-version');
+    });
+
+    it('does not replace on equal version', () => {
+      const decision = LeaderElection.evaluateLeaderPreference(
+        makeInfo({ sessionId: 'same-a', serverVersion: '2.0.18' }),
+        makeInfo({ sessionId: 'same-b', serverVersion: '2.0.18' }),
+      );
+      expect(decision.shouldReplace).toBe(false);
+      expect(decision.reason).toBe('same-version');
+    });
+
+    it('treats missing version metadata as a legacy leader and prefers the newer candidate', () => {
+      const decision = LeaderElection.evaluateLeaderPreference(
+        makeInfo({ sessionId: 'newer', serverVersion: '2.0.18' }),
+        makeInfo({ sessionId: 'legacy', serverVersion: undefined, consoleProtocolVersion: undefined }),
+      );
+      expect(decision.shouldReplace).toBe(true);
+      expect(decision.existingVersion).toBe(LeaderElection.LEGACY_SERVER_VERSION);
+      expect(decision.existingProtocolVersion).toBe(LeaderElection.LEGACY_CONSOLE_PROTOCOL_VERSION);
+    });
+
+    it('does not replace an incompatible leader even if the candidate version is newer', () => {
+      const decision = LeaderElection.evaluateLeaderPreference(
+        makeInfo({ sessionId: 'newer', serverVersion: '9.0.0', consoleProtocolVersion: 2 }),
+        makeInfo({ sessionId: 'incompatible', serverVersion: '1.0.0', consoleProtocolVersion: 1 }),
+      );
+      expect(decision.shouldReplace).toBe(false);
+      expect(decision.reason).toBe('incompatible-protocol');
+    });
+  });
+
   describe('startHeartbeat', () => {
     it('should return a stop function', () => {
       const info = {

--- a/tests/unit/web/console/LeaderElection.test.ts
+++ b/tests/unit/web/console/LeaderElection.test.ts
@@ -17,6 +17,22 @@ beforeAll(async () => {
   LeaderElection = await import('../../../../src/web/console/LeaderElection.js');
 });
 
+function makeLeaderInfo(
+  overrides: Partial<import('../../../../src/web/console/LeaderElection.js').ConsoleLeaderInfo> = {},
+): import('../../../../src/web/console/LeaderElection.js').ConsoleLeaderInfo {
+  return {
+    version: 1,
+    pid: process.pid,
+    port: 41715,
+    sessionId: 'test-session',
+    startedAt: new Date().toISOString(),
+    heartbeat: new Date().toISOString(),
+    serverVersion: '2.0.18',
+    consoleProtocolVersion: LeaderElection.CONSOLE_PROTOCOL_VERSION,
+    ...overrides,
+  };
+}
+
 describe('LeaderElection', () => {
   describe('isProcessAlive', () => {
     it('should return true for the current process', () => {
@@ -143,24 +159,10 @@ describe('LeaderElection', () => {
   });
 
   describe('evaluateLeaderPreference', () => {
-    function makeInfo(overrides: Partial<import('../../../../src/web/console/LeaderElection.js').ConsoleLeaderInfo> = {}) {
-      return {
-        version: 1,
-        pid: process.pid,
-        port: 41715,
-        sessionId: 'test-session',
-        startedAt: new Date().toISOString(),
-        heartbeat: new Date().toISOString(),
-        serverVersion: '2.0.18',
-        consoleProtocolVersion: LeaderElection.CONSOLE_PROTOCOL_VERSION,
-        ...overrides,
-      };
-    }
-
     it('prefers a newer compatible candidate', () => {
       const decision = LeaderElection.evaluateLeaderPreference(
-        makeInfo({ sessionId: 'newer', serverVersion: '2.0.19' }),
-        makeInfo({ sessionId: 'older', serverVersion: '2.0.18' }),
+        makeLeaderInfo({ sessionId: 'newer', serverVersion: '2.0.19' }),
+        makeLeaderInfo({ sessionId: 'older', serverVersion: '2.0.18' }),
       );
       expect(decision.shouldReplace).toBe(true);
       expect(decision.reason).toBe('newer-compatible-version');
@@ -168,8 +170,8 @@ describe('LeaderElection', () => {
 
     it('does not replace on equal version', () => {
       const decision = LeaderElection.evaluateLeaderPreference(
-        makeInfo({ sessionId: 'same-a', serverVersion: '2.0.18' }),
-        makeInfo({ sessionId: 'same-b', serverVersion: '2.0.18' }),
+        makeLeaderInfo({ sessionId: 'same-a', serverVersion: '2.0.18' }),
+        makeLeaderInfo({ sessionId: 'same-b', serverVersion: '2.0.18' }),
       );
       expect(decision.shouldReplace).toBe(false);
       expect(decision.reason).toBe('same-version');
@@ -177,8 +179,8 @@ describe('LeaderElection', () => {
 
     it('treats missing version metadata as a legacy leader and prefers the newer candidate', () => {
       const decision = LeaderElection.evaluateLeaderPreference(
-        makeInfo({ sessionId: 'newer', serverVersion: '2.0.18' }),
-        makeInfo({ sessionId: 'legacy', serverVersion: undefined, consoleProtocolVersion: undefined }),
+        makeLeaderInfo({ sessionId: 'newer', serverVersion: '2.0.18' }),
+        makeLeaderInfo({ sessionId: 'legacy', serverVersion: undefined, consoleProtocolVersion: undefined }),
       );
       expect(decision.shouldReplace).toBe(true);
       expect(decision.existingVersion).toBe(LeaderElection.LEGACY_SERVER_VERSION);
@@ -187,8 +189,8 @@ describe('LeaderElection', () => {
 
     it('does not replace an incompatible leader even if the candidate version is newer', () => {
       const decision = LeaderElection.evaluateLeaderPreference(
-        makeInfo({ sessionId: 'newer', serverVersion: '9.0.0', consoleProtocolVersion: 2 }),
-        makeInfo({ sessionId: 'incompatible', serverVersion: '1.0.0', consoleProtocolVersion: 1 }),
+        makeLeaderInfo({ sessionId: 'newer', serverVersion: '9.0.0', consoleProtocolVersion: 2 }),
+        makeLeaderInfo({ sessionId: 'incompatible', serverVersion: '1.0.0', consoleProtocolVersion: 1 }),
       );
       expect(decision.shouldReplace).toBe(false);
       expect(decision.reason).toBe('incompatible-protocol');

--- a/tests/unit/web/console/console-failure-modes.test.ts
+++ b/tests/unit/web/console/console-failure-modes.test.ts
@@ -13,6 +13,14 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import * as net from 'node:net';
 
+function parseRequestBody(body: RequestInit['body'] | undefined): Record<string, unknown> {
+  if (typeof body !== 'string') {
+    return {};
+  }
+
+  return JSON.parse(body) as Record<string, unknown>;
+}
+
 // ─── LeaderElection: stale lock detection ────────────────────────────────────
 
 describe('Console Failure Modes', () => {
@@ -474,7 +482,7 @@ describe('Console Failure Modes', () => {
         await heartbeat.stop();
 
         const firstCall = fetchSpy.mock.calls[0];
-        const body = JSON.parse(String((firstCall?.[1] as RequestInit | undefined)?.body ?? '{}'));
+        const body = parseRequestBody((firstCall?.[1] as RequestInit | undefined)?.body);
         expect(body.serverVersion).toBe(PACKAGE_VERSION);
         expect(body.consoleProtocolVersion).toBe(CONSOLE_PROTOCOL_VERSION);
       } finally {

--- a/tests/unit/web/console/console-failure-modes.test.ts
+++ b/tests/unit/web/console/console-failure-modes.test.ts
@@ -448,5 +448,38 @@ describe('Console Failure Modes', () => {
       await heartbeat.stop(); // second stop should be safe
       expect(true).toBe(true);
     });
+
+    it('sends server version metadata with session events', async () => {
+      const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+      } as Response);
+
+      try {
+        const { SessionHeartbeat } = await import(
+          '../../../../src/web/console/LeaderForwardingSink.js'
+        );
+        const { PACKAGE_VERSION } = await import('../../../../src/generated/version.js');
+        const { CONSOLE_PROTOCOL_VERSION } = await import(
+          '../../../../src/web/console/LeaderElection.js'
+        );
+
+        const heartbeat = new SessionHeartbeat(
+          'http://127.0.0.1:41715',
+          'test-session',
+          process.pid,
+          null,
+        );
+
+        await heartbeat.start();
+        await heartbeat.stop();
+
+        const firstCall = fetchSpy.mock.calls[0];
+        const body = JSON.parse(String((firstCall?.[1] as RequestInit | undefined)?.body ?? '{}'));
+        expect(body.serverVersion).toBe(PACKAGE_VERSION);
+        expect(body.consoleProtocolVersion).toBe(CONSOLE_PROTOCOL_VERSION);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
   });
 });

--- a/tests/unit/web/console/sessionRegistry.test.ts
+++ b/tests/unit/web/console/sessionRegistry.test.ts
@@ -13,6 +13,8 @@ import {
   type IngestRoutesResult,
   type SessionInfo,
 } from '../../../../src/web/console/IngestRoutes.js';
+import { PACKAGE_VERSION } from '../../../../src/generated/version.js';
+import { CONSOLE_PROTOCOL_VERSION } from '../../../../src/web/console/LeaderElection.js';
 
 function buildApp(ingestResult: IngestRoutesResult) {
   const app = express();
@@ -39,6 +41,8 @@ describe('Session registry (#1805)', () => {
       expect(sessions[0].kind).toBe('mcp');
       expect(sessions[0].isLeader).toBe(true);
       expect(sessions[0].status).toBe('active');
+      expect(sessions[0].serverVersion).toBe(PACKAGE_VERSION);
+      expect(sessions[0].consoleProtocolVersion).toBe(CONSOLE_PROTOCOL_VERSION);
     });
 
     it('assigns a puppet display name', () => {
@@ -142,11 +146,37 @@ describe('Session registry (#1805)', () => {
       expect(leader).toBeDefined();
       expect(leader.authenticated).toBe(true);
       expect(leader.kind).toBe('mcp');
+      expect(leader.serverVersion).toBe(PACKAGE_VERSION);
+      expect(leader.consoleProtocolVersion).toBe(CONSOLE_PROTOCOL_VERSION);
 
       const consoleSess = res.body.sessions.find((s: SessionInfo) => s.kind === 'console');
       expect(consoleSess).toBeDefined();
       expect(consoleSess.authenticated).toBe(true);
       expect(consoleSess.displayName).toBe('Web Console');
+      expect(consoleSess.serverVersion).toBe(PACKAGE_VERSION);
+      expect(consoleSess.consoleProtocolVersion).toBe(CONSOLE_PROTOCOL_VERSION);
+    });
+
+    it('records follower version metadata from session heartbeat payloads', async () => {
+      const app = buildApp(ingestResult);
+
+      await request(app)
+        .post('/api/ingest/session')
+        .send({
+          sessionId: 'follower-001',
+          event: 'started',
+          pid: 12345,
+          startedAt: new Date().toISOString(),
+          serverVersion: '2.0.99',
+          consoleProtocolVersion: 1,
+        });
+
+      const res = await request(app).get('/api/sessions');
+      expect(res.status).toBe(200);
+      const follower = res.body.sessions.find((s: SessionInfo) => s.sessionId === 'follower-001');
+      expect(follower).toBeDefined();
+      expect(follower.serverVersion).toBe('2.0.99');
+      expect(follower.consoleProtocolVersion).toBe(1);
     });
   });
 
@@ -194,6 +224,8 @@ describe('Session registry (#1805)', () => {
         isLeader: true,
         authenticated: true,
         kind: 'mcp',
+        serverVersion: PACKAGE_VERSION,
+        consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
       }));
       expect(session.displayName).toBeTruthy();
       expect(session.color).toMatch(/^#[0-9a-fA-F]{6}$/);
@@ -211,6 +243,8 @@ describe('Session registry (#1805)', () => {
         isLeader: false,
         authenticated: true,
         kind: 'console',
+        serverVersion: PACKAGE_VERSION,
+        consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
       }));
       expect(session.sessionId).toMatch(/^console-\d+$/);
       expect(session.color).toBe('#6366f1');

--- a/tests/unit/web/sessionsReload.test.ts
+++ b/tests/unit/web/sessionsReload.test.ts
@@ -127,4 +127,30 @@ describe('sessions.js forced reload path', () => {
       env.cleanup();
     }
   });
+
+  it('treats a stable release as newer than a prerelease of the same version', async () => {
+    const env = await createBrowserEnv({
+      currentVersion: '2.0.18-beta.1',
+      sessions: [{
+        sessionId: 'leader-1',
+        displayName: 'Kermit',
+        color: '#00aa00',
+        pid: 1234,
+        startedAt: new Date().toISOString(),
+        lastHeartbeat: new Date().toISOString(),
+        status: 'active',
+        isLeader: true,
+        authenticated: true,
+        kind: 'mcp',
+        serverVersion: '2.0.18',
+        consoleProtocolVersion: 1,
+      }],
+    });
+
+    try {
+      expect(env.reloadSpy).toHaveBeenCalledWith('leader-upgraded', '2.0.18');
+    } finally {
+      env.cleanup();
+    }
+  });
 });

--- a/tests/unit/web/sessionsReload.test.ts
+++ b/tests/unit/web/sessionsReload.test.ts
@@ -26,9 +26,17 @@ async function tick(): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, 0));
 }
 
+async function waitForReload(waitMs = 10): Promise<void> {
+  await tick();
+  await tick();
+  await new Promise(resolve => setTimeout(resolve, waitMs));
+}
+
 async function createBrowserEnv(options: {
   currentVersion: string;
   sessions: Array<Record<string, unknown>>;
+  leaderReloadDebounceMs?: number;
+  waitAfterInitMs?: number;
 }) {
   const source = await loadSource();
   const dom = new JSDOM(
@@ -49,26 +57,33 @@ async function createBrowserEnv(options: {
     ok: true,
     json: async () => ({ sessions: options.sessions }),
   });
+  const intervalCallbacks: Array<() => void> = [];
 
   (dom.window as any).DollhouseAuth = { apiFetch };
   (dom.window as any).DollhouseConsole = {
     currentServerVersion: options.currentVersion,
     forceReload: reloadSpy,
   };
-  (dom.window as any).DollhouseConsoleConfig = { sessionPollIntervalMs: 300000 };
-  (dom.window as any).setInterval = jest.fn(() => 1);
+  (dom.window as any).DollhouseConsoleConfig = {
+    sessionPollIntervalMs: 300000,
+    leaderReloadDebounceMs: options.leaderReloadDebounceMs ?? 1,
+  };
+  (dom.window as any).setInterval = jest.fn((fn: () => void) => {
+    intervalCallbacks.push(fn);
+    return intervalCallbacks.length;
+  });
   (dom.window as any).clearInterval = jest.fn();
   (dom.window as any).confirm = jest.fn(() => true);
   (dom.window as any).alert = jest.fn();
 
   dom.window.eval(source);
   dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
-  await tick();
-  await tick();
+  await waitForReload(options.waitAfterInitMs ?? ((options.leaderReloadDebounceMs ?? 1) + 10));
 
   return {
     window: dom.window,
     apiFetch,
+    intervalCallbacks,
     reloadSpy,
     cleanup: () => dom.window.close(),
   };
@@ -149,6 +164,58 @@ describe('sessions.js forced reload path', () => {
 
     try {
       expect(env.reloadSpy).toHaveBeenCalledWith('leader-upgraded', '2.0.18');
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  it('reloads to the newest observed leader version when upgrades arrive in quick succession', async () => {
+    const env = await createBrowserEnv({
+      currentVersion: '2.0.18',
+      leaderReloadDebounceMs: 50,
+      waitAfterInitMs: 5,
+      sessions: [{
+        sessionId: 'leader-1',
+        displayName: 'Kermit',
+        color: '#00aa00',
+        pid: 1234,
+        startedAt: new Date().toISOString(),
+        lastHeartbeat: new Date().toISOString(),
+        status: 'active',
+        isLeader: true,
+        authenticated: true,
+        kind: 'mcp',
+        serverVersion: '2.0.19',
+        consoleProtocolVersion: 1,
+      }],
+    });
+
+    try {
+      env.reloadSpy.mockClear();
+      const newerSessions = [{
+        sessionId: 'leader-1',
+        displayName: 'Kermit',
+        color: '#00aa00',
+        pid: 1234,
+        startedAt: new Date().toISOString(),
+        lastHeartbeat: new Date().toISOString(),
+        status: 'active',
+        isLeader: true,
+        authenticated: true,
+        kind: 'mcp',
+        serverVersion: '2.0.20',
+        consoleProtocolVersion: 1,
+      }];
+
+      env.apiFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ sessions: newerSessions }),
+      });
+      env.intervalCallbacks[0]();
+      await waitForReload(60);
+
+      expect(env.reloadSpy).toHaveBeenCalledTimes(1);
+      expect(env.reloadSpy).toHaveBeenCalledWith('leader-upgraded', '2.0.20');
     } finally {
       env.cleanup();
     }

--- a/tests/unit/web/sessionsReload.test.ts
+++ b/tests/unit/web/sessionsReload.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for sessions.js forced reload behavior.
+ *
+ * Verifies that the session poller triggers a cache-busted reload when it
+ * detects a newer leader version than the one currently loaded in the tab.
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+import { JSDOM } from 'jsdom';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+let sessionsSource: string;
+
+async function loadSource(): Promise<string> {
+  if (!sessionsSource) {
+    sessionsSource = await readFile(
+      join(process.cwd(), 'src/web/public/sessions.js'),
+      'utf8',
+    );
+  }
+  return sessionsSource;
+}
+
+async function tick(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function createBrowserEnv(options: {
+  currentVersion: string;
+  sessions: Array<Record<string, unknown>>;
+}) {
+  const source = await loadSource();
+  const dom = new JSDOM(
+    `<!DOCTYPE html><html><head>
+      <meta name="dollhouse-server-version" content="${options.currentVersion}">
+    </head><body>
+      <div id="session-indicator"></div>
+    </body></html>`,
+    {
+      url: 'http://dollhouse.localhost:41715',
+      runScripts: 'dangerously',
+      pretendToBeVisual: true,
+    },
+  );
+
+  const reloadSpy = jest.fn();
+  const apiFetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ sessions: options.sessions }),
+  });
+
+  (dom.window as any).DollhouseAuth = { apiFetch };
+  (dom.window as any).DollhouseConsole = {
+    currentServerVersion: options.currentVersion,
+    forceReload: reloadSpy,
+  };
+  (dom.window as any).DollhouseConsoleConfig = { sessionPollIntervalMs: 300000 };
+  (dom.window as any).setInterval = jest.fn(() => 1);
+  (dom.window as any).clearInterval = jest.fn();
+  (dom.window as any).confirm = jest.fn(() => true);
+  (dom.window as any).alert = jest.fn();
+
+  dom.window.eval(source);
+  dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+  await tick();
+  await tick();
+
+  return {
+    window: dom.window,
+    apiFetch,
+    reloadSpy,
+    cleanup: () => dom.window.close(),
+  };
+}
+
+describe('sessions.js forced reload path', () => {
+  it('forces a reload when the leader version is newer than the loaded console', async () => {
+    const env = await createBrowserEnv({
+      currentVersion: '2.0.18',
+      sessions: [{
+        sessionId: 'leader-1',
+        displayName: 'Kermit',
+        color: '#00aa00',
+        pid: 1234,
+        startedAt: new Date().toISOString(),
+        lastHeartbeat: new Date().toISOString(),
+        status: 'active',
+        isLeader: true,
+        authenticated: true,
+        kind: 'mcp',
+        serverVersion: '2.0.19',
+        consoleProtocolVersion: 1,
+      }],
+    });
+
+    try {
+      expect(env.apiFetch).toHaveBeenCalledWith('/api/sessions');
+      expect(env.reloadSpy).toHaveBeenCalledWith('leader-upgraded', '2.0.19');
+    } finally {
+      env.cleanup();
+    }
+  });
+
+  it('does not reload when the leader version matches the loaded console', async () => {
+    const env = await createBrowserEnv({
+      currentVersion: '2.0.18',
+      sessions: [{
+        sessionId: 'leader-1',
+        displayName: 'Kermit',
+        color: '#00aa00',
+        pid: 1234,
+        startedAt: new Date().toISOString(),
+        lastHeartbeat: new Date().toISOString(),
+        status: 'active',
+        isLeader: true,
+        authenticated: true,
+        kind: 'mcp',
+        serverVersion: '2.0.18',
+        consoleProtocolVersion: 1,
+      }],
+    });
+
+    try {
+      expect(env.reloadSpy).not.toHaveBeenCalled();
+    } finally {
+      env.cleanup();
+    }
+  });
+});

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -437,16 +437,16 @@ describe('Setup Tab — HTML Content Integrity', () => {
     });
 
     it('has setup.css linked', () => {
-      expect(html).toContain('href="setup.css"');
+      expect(html).toContain('href="setup.css?v={{DOLLHOUSE_ASSET_VERSION}}"');
     });
 
     it('has setup.js loaded', () => {
-      expect(html).toContain('src="setup.js"');
+      expect(html).toContain('src="setup.js?v={{DOLLHOUSE_ASSET_VERSION}}"');
     });
 
     it('loads setup.js before app.js', () => {
-      const setupIdx = html.indexOf('src="setup.js"');
-      const appIdx = html.indexOf('src="app.js"');
+      const setupIdx = html.indexOf('src="setup.js?v={{DOLLHOUSE_ASSET_VERSION}}"');
+      const appIdx = html.indexOf('src="app.js?v={{DOLLHOUSE_ASSET_VERSION}}"');
       expect(setupIdx).toBeLessThan(appIdx);
     });
   });

--- a/tests/unit/web/tokenInjection.test.ts
+++ b/tests/unit/web/tokenInjection.test.ts
@@ -19,11 +19,14 @@ const INDEX_TEMPLATE = `<!DOCTYPE html>
 <html>
 <head>
   <meta name="dollhouse-console-token" content="{{CONSOLE_TOKEN}}">
+  <meta name="dollhouse-console-asset-version" content="{{DOLLHOUSE_ASSET_VERSION}}">
+  <link rel="stylesheet" href="styles.css?v={{DOLLHOUSE_ASSET_VERSION}}">
 </head>
-<body><h1>DollhouseMCP Console</h1></body>
+<body><h1>DollhouseMCP Console</h1><script src="app.js?v={{DOLLHOUSE_ASSET_VERSION}}"></script></body>
 </html>`;
 
 const TOKEN_META_PLACEHOLDER = '{{CONSOLE_TOKEN}}';
+const ASSET_VERSION_PLACEHOLDER = '{{DOLLHOUSE_ASSET_VERSION}}';
 
 /** A valid 64-hex-char token. */
 const TEST_TOKEN = 'a'.repeat(64);
@@ -37,6 +40,7 @@ const ROTATED_TOKEN = 'b'.repeat(64);
 async function buildTestApp(options: {
   publicDir: string;
   getToken: () => string;
+  getAssetVersion?: () => string;
 }) {
   const app = express();
 
@@ -48,6 +52,7 @@ async function buildTestApp(options: {
 
   app.get('/{*path}', async (_req, res) => {
     const currentToken = options.getToken();
+    const currentAssetVersion = options.getAssetVersion ? options.getAssetVersion() : '2.0.18';
     if (cachedHtml !== null && cachedToken === currentToken) {
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
       res.send(cachedHtml);
@@ -62,6 +67,7 @@ async function buildTestApp(options: {
       .replaceAll('<', '&lt;')
       .replaceAll('>', '&gt;');
     cachedHtml = template.replaceAll(TOKEN_META_PLACEHOLDER, escaped);
+    cachedHtml = cachedHtml.replaceAll(ASSET_VERSION_PLACEHOLDER, currentAssetVersion);
     cachedToken = currentToken;
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     res.send(cachedHtml);
@@ -88,6 +94,7 @@ describe('token injection into index.html (#1804)', () => {
     const app = await buildTestApp({
       publicDir: testDir,
       getToken: () => TEST_TOKEN,
+      getAssetVersion: () => '2.0.18',
     });
 
     const res = await request(app).get('/');
@@ -95,12 +102,17 @@ describe('token injection into index.html (#1804)', () => {
     expect(res.headers['content-type']).toContain('text/html');
     expect(res.text).toContain(`content="${TEST_TOKEN}"`);
     expect(res.text).not.toContain('{{CONSOLE_TOKEN}}');
+    expect(res.text).toContain('content="2.0.18"');
+    expect(res.text).toContain('styles.css?v=2.0.18');
+    expect(res.text).toContain('app.js?v=2.0.18');
+    expect(res.text).not.toContain('{{DOLLHOUSE_ASSET_VERSION}}');
   });
 
   it('serves empty token when no token is available', async () => {
     const app = await buildTestApp({
       publicDir: testDir,
       getToken: () => '',
+      getAssetVersion: () => '2.0.18',
     });
 
     const res = await request(app).get('/');
@@ -113,6 +125,7 @@ describe('token injection into index.html (#1804)', () => {
     const app = await buildTestApp({
       publicDir: testDir,
       getToken: () => TEST_TOKEN,
+      getAssetVersion: () => '2.0.18',
     });
 
     const res = await request(app).get('/styles.css');
@@ -125,6 +138,7 @@ describe('token injection into index.html (#1804)', () => {
     const app = await buildTestApp({
       publicDir: testDir,
       getToken: () => TEST_TOKEN,
+      getAssetVersion: () => '2.0.18',
     });
 
     const res = await request(app).get('/app.js');
@@ -137,6 +151,7 @@ describe('token injection into index.html (#1804)', () => {
     const app = await buildTestApp({
       publicDir: testDir,
       getToken: () => currentToken,
+      getAssetVersion: () => '2.0.18',
     });
 
     // First request caches with TEST_TOKEN
@@ -156,6 +171,7 @@ describe('token injection into index.html (#1804)', () => {
     const app = await buildTestApp({
       publicDir: testDir,
       getToken: () => 'a"b<c&d',
+      getAssetVersion: () => '2.0.18',
     });
 
     const res = await request(app).get('/');
@@ -167,6 +183,7 @@ describe('token injection into index.html (#1804)', () => {
     const app = await buildTestApp({
       publicDir: testDir,
       getToken: () => TEST_TOKEN,
+      getAssetVersion: () => '2.0.18',
     });
 
     const res = await request(app).get('/some/deep/path');


### PR DESCRIPTION
## Summary

Makes the authenticated web console prefer the newest compatible DollhouseMCP session as leader, and adds cache-busting plus forced reload behavior so open browser tabs move onto the new console code instead of staying on stale assets.

Closes #2025.

## What changed

- add `serverVersion` and `consoleProtocolVersion` to console leader/session metadata
- prefer a newer compatible session over an older live leader during election
- propagate version metadata through follower heartbeats, session registry, and `/api/sessions`
- version-stamp local console CSS/JS/image assets in `index.html`
- serve the HTML shell with `no-cache/no-store` while allowing versioned assets to cache aggressively
- add a client-side forced reload path with cache-busting query params
- trigger forced reload when the browser sees a newer leader version than the one currently loaded

## Why

Older leaders were trying to render controls and state produced by newer sessions. That meant the console could silently miss new UI behavior even when the newest code was already running elsewhere on the machine.

This change makes leadership converge toward the newest compatible console process and ensures already-open browser tabs refresh onto the new asset set instead of holding onto stale JS/CSS.

## Verification

- `npm test -- --runInBand tests/unit/web/console/LeaderElection.test.ts tests/unit/web/console/sessionRegistry.test.ts tests/unit/web/console/console-failure-modes.test.ts`
- `npm run test:integration -- --runInBand tests/integration/console-lifecycle.test.ts`
- `npm test -- --runInBand tests/unit/web/tokenInjection.test.ts tests/unit/web/sessionsReload.test.ts tests/unit/web/cacheBustingSources.test.ts`
- `npx eslint src/web/console/IngestRoutes.ts src/web/console/LeaderElection.ts src/web/console/LeaderForwardingSink.ts src/web/console/PromotionManager.ts src/web/server.ts src/web/public/app.js src/web/public/sessions.js tests/integration/console-lifecycle.test.ts tests/unit/web/console/LeaderElection.test.ts tests/unit/web/console/console-failure-modes.test.ts tests/unit/web/console/sessionRegistry.test.ts tests/unit/web/tokenInjection.test.ts tests/unit/web/sessionsReload.test.ts tests/unit/web/cacheBustingSources.test.ts`
