### PR TITLE
Hotfix console leader bind fallback and session registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.20] - 2026-04-16
+
+Point release for console leader bind authority and follower registration recovery.
+
 ## [2.0.19] - 2026-04-16
 
 Point release for deadlock relief recovery and version-aware web console leadership.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dollhousemcp",
   "display_name": "DollhouseMCP",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "description": "Open-source AI customization through modular Dollhouse elements — personas, skills, templates, agents, memories, and ensembles.",
   "long_description": "DollhouseMCP is an MCP server that lets you customize your AI with modular Dollhouse elements. Create personas that shape behavior and permissions, skills that add capabilities, templates for consistent outputs, agents for autonomous multi-step goals, memories for persistent context, and ensembles that bundle elements together. Includes MCP-AQL query language with 5 semantic CRUDE endpoints, Gatekeeper permission system, community collection, and a built-in portfolio browser.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.19",
+      "version": "2.0.20",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.19",
+      "version": "2.0.20",
       "transport": {
         "type": "stdio"
       }

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.19';
-export const BUILD_TIMESTAMP = '2026-04-16T13:23:58.417Z';
+export const PACKAGE_VERSION = '2.0.20';
+export const BUILD_TIMESTAMP = '2026-04-16T14:20:04.017Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';

--- a/src/web/console/StaleProcessRecovery.ts
+++ b/src/web/console/StaleProcessRecovery.ts
@@ -21,6 +21,10 @@ const KILL_POLL_COUNT = 10;
 const SIGKILL_WAIT_MS = 500;
 /** Wait between lock file reads for TOCTOU mitigation (ms) */
 const LOCK_RECHECK_DELAY_MS = 500;
+/** Number of lock-file checks before deciding the port holder is not a fresh leader. */
+const LOCK_RECHECK_ATTEMPTS = 2;
+/** PID used by the OS init/launchd process; direct children are effectively orphaned. */
+const ROOT_PARENT_PID = 1;
 
 let _logger: typeof import('../../utils/logger.js').logger | null = null;
 async function getLogger() {
@@ -210,7 +214,7 @@ export async function killStaleProcessDetailed(pid: number, port: number): Promi
   }
 
   let parentCommand: string | undefined;
-  if (processInfo.parentPid > 1 && isPidAlive(processInfo.parentPid)) {
+  if (processInfo.parentPid > ROOT_PARENT_PID && isPidAlive(processInfo.parentPid)) {
     parentCommand = (await getProcessCommand(processInfo.parentPid)) ?? undefined;
     if (parentCommand && isRecognizedMcpHostParent(parentCommand)) {
       await logger.warn(`[WebUI] Port ${port} held by active client-backed DollhouseMCP process (pid ${pid}) — not killing`, {
@@ -306,7 +310,7 @@ export async function recoverStalePort(port: number): Promise<boolean> {
   // written its lock file. Read the lock, pause, re-read. If the second read
   // now matches the port holder, it's a fresh leader — don't kill.
   const { readLeaderLock } = await import('./LeaderElection.js');
-  for (let check = 0; check < 2; check++) {
+  for (let check = 0; check < LOCK_RECHECK_ATTEMPTS; check++) {
     try {
       const lock = await readLeaderLock();
       if (lock?.pid === stalePid && lock?.port === port && lock.pid !== process.pid) {
@@ -316,7 +320,7 @@ export async function recoverStalePort(port: number): Promise<boolean> {
     } catch {
       // Can't read lock file — continue to next check or kill
     }
-    if (check === 0) {
+    if (check < LOCK_RECHECK_ATTEMPTS - 1) {
       await new Promise(r => setTimeout(r, LOCK_RECHECK_DELAY_MS));
     }
   }

--- a/src/web/console/StaleProcessRecovery.ts
+++ b/src/web/console/StaleProcessRecovery.ts
@@ -9,6 +9,8 @@
  * the full Express server and its dependency chain.
  */
 
+import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
+
 // Use lazy import for logger to avoid pulling in the full env.ts/config chain
 // at module load time. This keeps the module independently testable.
 /** Timeout for lsof/fuser/ps system calls (ms) */
@@ -25,6 +27,8 @@ const LOCK_RECHECK_DELAY_MS = 500;
 const LOCK_RECHECK_ATTEMPTS = 2;
 /** PID used by the OS init/launchd process; direct children are effectively orphaned. */
 const ROOT_PARENT_PID = 1;
+/** Number of `ps` columns requested by inspectProcess: user, pid, ppid, command. */
+const PROCESS_INSPECTION_FIELD_COUNT = 4;
 
 let _logger: typeof import('../../utils/logger.js').logger | null = null;
 async function getLogger() {
@@ -84,15 +88,65 @@ export interface KillStaleProcessOutcome {
 }
 
 export function isRecognizedMcpHostParent(command: string): boolean {
-  return MCP_HOST_PARENT_PATTERNS.some((pattern) => pattern.test(command));
+  const normalizedCommand = UnicodeValidator.normalize(command).normalizedContent;
+  return MCP_HOST_PARENT_PATTERNS.some((pattern) => pattern.test(normalizedCommand));
 }
 
 function isDollhouseProcessCommand(cmdLine: string): boolean {
-  const isDollhouseBin = /(?:^|\/)dollhousemcp(?:\s|$)/.test(cmdLine) ||
-    cmdLine.includes('.bin/dollhousemcp');
-  const isMcpServerBin = cmdLine.includes('.bin/mcp-server') ||
-    /(?:dollhousemcp|mcp-server)[/\\]dist[/\\]index\.js/.test(cmdLine);
+  const normalizedCommand = UnicodeValidator.normalize(cmdLine).normalizedContent;
+  const isDollhouseBin = /(?:^|\/)dollhousemcp(?:\s|$)/.test(normalizedCommand) ||
+    normalizedCommand.includes('.bin/dollhousemcp');
+  const isMcpServerBin = normalizedCommand.includes('.bin/mcp-server') ||
+    /(?:dollhousemcp|mcp-server)[/\\]dist[/\\]index\.js/.test(normalizedCommand);
   return isDollhouseBin || isMcpServerBin;
+}
+
+function parsePidToken(value: string): number | null {
+  if (!value) return null;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code < 48 || code > 57) {
+      return null;
+    }
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < ROOT_PARENT_PID) {
+    return null;
+  }
+  return parsed;
+}
+
+function isWhitespaceChar(value: string): boolean {
+  return value === ' ' || value === '\t' || value === '\n' || value === '\r' || value === '\f' || value === '\v';
+}
+
+function splitProcessInspectionFields(line: string): string[] | null {
+  const fields: string[] = [];
+  let index = 0;
+  const normalizedLine = UnicodeValidator.normalize(line).normalizedContent.trim();
+
+  while (index < normalizedLine.length && fields.length < PROCESS_INSPECTION_FIELD_COUNT - 1) {
+    while (index < normalizedLine.length && isWhitespaceChar(normalizedLine[index])) {
+      index++;
+    }
+    if (index >= normalizedLine.length) break;
+
+    const fieldStart = index;
+    while (index < normalizedLine.length && !isWhitespaceChar(normalizedLine[index])) {
+      index++;
+    }
+    fields.push(normalizedLine.slice(fieldStart, index));
+  }
+
+  while (index < normalizedLine.length && isWhitespaceChar(normalizedLine[index])) {
+    index++;
+  }
+  if (index < normalizedLine.length) {
+    fields.push(normalizedLine.slice(index));
+  }
+
+  return fields.length === PROCESS_INSPECTION_FIELD_COUNT ? fields : null;
 }
 
 async function inspectProcess(pid: number): Promise<ProcessInspection | null> {
@@ -106,14 +160,18 @@ async function inspectProcess(pid: number): Promise<ProcessInspection | null> {
       ['-p', String(pid), '-o', 'user=,pid=,ppid=,command='],
       { timeout: COMMAND_TIMEOUT_MS },
     );
-    const line = stdout.trim();
-    const match = line.match(/^(\S+)\s+(\d+)\s+(\d+)\s+(.+)$/);
-    if (!match) return null;
+    const fields = splitProcessInspectionFields(stdout);
+    if (!fields) return null;
+    const [user, pidToken, parentPidToken, command] = fields;
+    const parsedPid = parsePidToken(pidToken);
+    const parsedParentPid = parsePidToken(parentPidToken);
+    if (parsedPid === null || parsedParentPid === null) return null;
+
     return {
-      user: match[1],
-      pid: Number(match[2]),
-      parentPid: Number(match[3]),
-      command: match[4],
+      user: UnicodeValidator.normalize(user).normalizedContent,
+      pid: parsedPid,
+      parentPid: parsedParentPid,
+      command: UnicodeValidator.normalize(command).normalizedContent,
     };
   } catch {
     return null;
@@ -127,7 +185,8 @@ async function getProcessCommand(pid: number): Promise<string | null> {
 
   try {
     const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'command='], { timeout: COMMAND_TIMEOUT_MS });
-    return stdout.trim() || null;
+    const normalized = UnicodeValidator.normalize(stdout).normalizedContent.trim();
+    return normalized || null;
   } catch {
     return null;
   }
@@ -164,7 +223,10 @@ export async function findPidOnPort(port: number): Promise<number | null> {
       const { stdout, stderr } = await execFileAsync(cmd.bin, cmd.args, { timeout: COMMAND_TIMEOUT_MS });
       // fuser outputs to stderr on some systems
       const output = (stdout || stderr || '').trim();
-      const pids = output.split(/\s+/).map(Number).filter(n => !Number.isNaN(n) && n > 0);
+      const pids = output
+        .split(/\s+/)
+        .map((token) => parsePidToken(token))
+        .filter((pid): pid is number => pid !== null);
       const otherPid = pids.find(p => p !== process.pid);
       if (otherPid) return otherPid;
     } catch {

--- a/src/web/console/StaleProcessRecovery.ts
+++ b/src/web/console/StaleProcessRecovery.ts
@@ -31,10 +31,112 @@ async function getLogger() {
   return _logger;
 }
 const logger = {
-  warn: async (...args: unknown[]) => { const l = await getLogger(); l ? l.warn(args[0] as string, args[1]) : console.error('[WARN]', ...args); },
-  info: async (...args: unknown[]) => { const l = await getLogger(); l ? l.info(args[0] as string, args[1]) : console.error('[INFO]', ...args); },
-  debug: async (...args: unknown[]) => { const l = await getLogger(); l ? l.debug(args[0] as string, args[1]) : void 0; },
+  warn: async (...args: unknown[]) => {
+    const l = await getLogger();
+    if (l) l.warn(args[0] as string, args[1]);
+    else console.error('[WARN]', ...args);
+  },
+  info: async (...args: unknown[]) => {
+    const l = await getLogger();
+    if (l) l.info(args[0] as string, args[1]);
+    else console.error('[INFO]', ...args);
+  },
+  debug: async (...args: unknown[]) => {
+    const l = await getLogger();
+    if (l) l.debug(args[0] as string, args[1]);
+  },
 };
+
+const MCP_HOST_PARENT_PATTERNS = [
+  /Claude\.app\/Contents\/Helpers\/disclaimer/i,
+  /Codex\.app\/Contents\/Resources\/codex app-server/i,
+  /Cursor\.app\//i,
+  /Windsurf\.app\//i,
+];
+
+interface ProcessInspection {
+  user: string;
+  pid: number;
+  parentPid: number;
+  command: string;
+}
+
+export interface KillStaleProcessOutcome {
+  killed: boolean;
+  reason:
+    | 'inspect_failed'
+    | 'different_user'
+    | 'not_dollhouse_process'
+    | 'active_host_parent'
+    | 'terminated'
+    | 'already_dead'
+    | 'still_alive'
+    | 'signal_failed';
+  pid: number;
+  parentPid?: number;
+  command?: string;
+  parentCommand?: string;
+  detail?: string;
+}
+
+export function isRecognizedMcpHostParent(command: string): boolean {
+  return MCP_HOST_PARENT_PATTERNS.some((pattern) => pattern.test(command));
+}
+
+function isDollhouseProcessCommand(cmdLine: string): boolean {
+  const isDollhouseBin = /(?:^|\/)dollhousemcp(?:\s|$)/.test(cmdLine) ||
+    cmdLine.includes('.bin/dollhousemcp');
+  const isMcpServerBin = cmdLine.includes('.bin/mcp-server') ||
+    /(?:dollhousemcp|mcp-server)[/\\]dist[/\\]index\.js/.test(cmdLine);
+  return isDollhouseBin || isMcpServerBin;
+}
+
+async function inspectProcess(pid: number): Promise<ProcessInspection | null> {
+  const { execFile: execFileCb } = await import('node:child_process');
+  const { promisify } = await import('node:util');
+  const execFileAsync = promisify(execFileCb);
+
+  try {
+    const { stdout } = await execFileAsync(
+      'ps',
+      ['-p', String(pid), '-o', 'user=,pid=,ppid=,command='],
+      { timeout: COMMAND_TIMEOUT_MS },
+    );
+    const line = stdout.trim();
+    const match = line.match(/^(\S+)\s+(\d+)\s+(\d+)\s+(.+)$/);
+    if (!match) return null;
+    return {
+      user: match[1],
+      pid: Number(match[2]),
+      parentPid: Number(match[3]),
+      command: match[4],
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function getProcessCommand(pid: number): Promise<string | null> {
+  const { execFile: execFileCb } = await import('node:child_process');
+  const { promisify } = await import('node:util');
+  const execFileAsync = promisify(execFileCb);
+
+  try {
+    const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'command='], { timeout: COMMAND_TIMEOUT_MS });
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Find the PID of the process listening on a given port.
@@ -77,60 +179,115 @@ export async function findPidOnPort(port: number): Promise<number | null> {
  * before escalating to SIGKILL. Total worst case: ~4s.
  */
 export async function killStaleProcess(pid: number, port: number): Promise<boolean> {
-  const { execFile: execFileCb } = await import('node:child_process');
-  const { promisify } = await import('node:util');
-  const execFileAsync = promisify(execFileCb);
+  const outcome = await killStaleProcessDetailed(pid, port);
+  return outcome.killed;
+}
 
-  // Security verification flow — three checks must pass before we kill:
-  // 1. Process must be owned by the current OS user (prevents cross-user kills)
-  // 2. Command line must match a DollhouseMCP binary path (prevents killing other services)
-  // 3. If both fail or ps can't run, we refuse — safe default is to not kill
-  let cmdLine = '';
-  try {
-    const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'user=,command='], { timeout: COMMAND_TIMEOUT_MS });
-
-    // Check 1: User ownership — only kill our own processes
-    const currentUser = (await import('node:os')).userInfo().username;
-    if (!stdout.trim().startsWith(currentUser)) {
-      await logger.warn(`[WebUI] Port ${port} held by different user (pid ${pid}) — not killing`);
-      return false;
-    }
-
-    // Check 2: Binary identity — must be .bin/mcp-server, .bin/dollhousemcp,
-    // /bin/dollhousemcp (global install), or dist/index.js (direct node execution).
-    // NOT just 'mcp-server' anywhere in the path — that would match Jest workers
-    // running from within the mcp-server project directory.
-    cmdLine = stdout.trim();
-    const isDollhouseBin = /(?:^|\/)dollhousemcp(?:\s|$)/.test(cmdLine) ||
-      cmdLine.includes('.bin/dollhousemcp');
-    const isMcpServerBin = cmdLine.includes('.bin/mcp-server') ||
-      /(?:dollhousemcp|mcp-server)[/\\]dist[/\\]index\.js/.test(cmdLine);
-    if (!isDollhouseBin && !isMcpServerBin) {
-      await logger.warn(`[WebUI] Port ${port} held by non-DollhouseMCP process (pid ${pid}) — not killing`, { cmdLine });
-      return false;
-    }
-    await logger.debug(`[WebUI] Verified stale process ${pid} is DollhouseMCP`, { cmdLine });
-  } catch (err) {
-    // Check 3: If we can't verify, don't kill — safe default
-    await logger.debug(`[WebUI] Cannot verify process ${pid} — skipping kill`, {
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return false;
+export async function killStaleProcessDetailed(pid: number, port: number): Promise<KillStaleProcessOutcome> {
+  const processInfo = await inspectProcess(pid);
+  if (!processInfo) {
+    await logger.debug(`[WebUI] Cannot verify process ${pid} — skipping kill`);
+    return { killed: false, reason: 'inspect_failed', pid };
   }
+
+  const currentUser = (await import('node:os')).userInfo().username;
+  if (processInfo.user !== currentUser) {
+    await logger.warn(`[WebUI] Port ${port} held by different user (pid ${pid}) — not killing`);
+    return { killed: false, reason: 'different_user', pid, parentPid: processInfo.parentPid, command: processInfo.command };
+  }
+
+  if (!isDollhouseProcessCommand(processInfo.command)) {
+    await logger.warn(`[WebUI] Port ${port} held by non-DollhouseMCP process (pid ${pid}) — not killing`, {
+      cmdLine: processInfo.command,
+    });
+    return {
+      killed: false,
+      reason: 'not_dollhouse_process',
+      pid,
+      parentPid: processInfo.parentPid,
+      command: processInfo.command,
+    };
+  }
+
+  let parentCommand: string | undefined;
+  if (processInfo.parentPid > 1 && isPidAlive(processInfo.parentPid)) {
+    parentCommand = (await getProcessCommand(processInfo.parentPid)) ?? undefined;
+    if (parentCommand && isRecognizedMcpHostParent(parentCommand)) {
+      await logger.warn(`[WebUI] Port ${port} held by active client-backed DollhouseMCP process (pid ${pid}) — not killing`, {
+        cmdLine: processInfo.command,
+        parentPid: processInfo.parentPid,
+        parentCommand,
+      });
+      return {
+        killed: false,
+        reason: 'active_host_parent',
+        pid,
+        parentPid: processInfo.parentPid,
+        command: processInfo.command,
+        parentCommand,
+      };
+    }
+  }
+
+  await logger.debug(`[WebUI] Verified stale process ${pid} is DollhouseMCP`, { cmdLine: processInfo.command, parentPid: processInfo.parentPid, parentCommand });
 
   try {
     process.kill(pid, 'SIGTERM');
-    logger.warn(`[WebUI] Sent SIGTERM to stale process ${pid} on port ${port}`, { cmdLine });
+    logger.warn(`[WebUI] Sent SIGTERM to stale process ${pid} on port ${port}`, { cmdLine: processInfo.command, parentPid: processInfo.parentPid, parentCommand });
     for (let i = 0; i < KILL_POLL_COUNT; i++) {
       await new Promise(r => setTimeout(r, SIGTERM_POLL_MS));
-      try { process.kill(pid, 0); } catch { return true; }
+      if (!isPidAlive(pid)) {
+        return {
+          killed: true,
+          reason: 'terminated',
+          pid,
+          parentPid: processInfo.parentPid,
+          command: processInfo.command,
+          parentCommand,
+        };
+      }
     }
     process.kill(pid, 'SIGKILL');
     logger.warn(`[WebUI] Sent SIGKILL to stale process ${pid} on port ${port}`);
     await new Promise(r => setTimeout(r, SIGKILL_WAIT_MS));
-    return true;
-  } catch {
-    return true; // process already dead
+    if (!isPidAlive(pid)) {
+      return {
+        killed: true,
+        reason: 'terminated',
+        pid,
+        parentPid: processInfo.parentPid,
+        command: processInfo.command,
+        parentCommand,
+      };
+    }
+    return {
+      killed: false,
+      reason: 'still_alive',
+      pid,
+      parentPid: processInfo.parentPid,
+      command: processInfo.command,
+      parentCommand,
+    };
+  } catch (err) {
+    if (!isPidAlive(pid)) {
+      return {
+        killed: true,
+        reason: 'already_dead',
+        pid,
+        parentPid: processInfo.parentPid,
+        command: processInfo.command,
+        parentCommand,
+      };
+    }
+    return {
+      killed: false,
+      reason: 'signal_failed',
+      pid,
+      parentPid: processInfo.parentPid,
+      command: processInfo.command,
+      parentCommand,
+      detail: err instanceof Error ? err.message : String(err),
+    };
   }
 }
 
@@ -164,10 +321,17 @@ export async function recoverStalePort(port: number): Promise<boolean> {
     }
   }
 
-  const killed = await killStaleProcess(stalePid, port);
-  if (killed) {
+  const outcome = await killStaleProcessDetailed(stalePid, port);
+  if (outcome.killed) {
     logger.info(`[WebUI] Stale process ${stalePid} removed from port ${port}`);
     await new Promise(r => setTimeout(r, SIGKILL_WAIT_MS)); // brief pause for port release
+  } else {
+    await logger.debug(`[WebUI] Stale-port recovery skipped for pid ${stalePid}`, {
+      reason: outcome.reason,
+      parentPid: outcome.parentPid,
+      parentCommand: outcome.parentCommand,
+      detail: outcome.detail,
+    });
   }
-  return killed;
+  return outcome.killed;
 }

--- a/src/web/console/StaleProcessRecovery.ts
+++ b/src/web/console/StaleProcessRecovery.ts
@@ -104,8 +104,8 @@ function isDollhouseProcessCommand(cmdLine: string): boolean {
 function parsePidToken(value: string): number | null {
   if (!value) return null;
   for (let i = 0; i < value.length; i++) {
-    const code = value.charCodeAt(i);
-    if (code < 48 || code > 57) {
+    const codePoint = value.codePointAt(i);
+    if (codePoint === undefined || codePoint < 48 || codePoint > 57) {
       return null;
     }
   }
@@ -119,6 +119,85 @@ function parsePidToken(value: string): number | null {
 
 function isWhitespaceChar(value: string): boolean {
   return value === ' ' || value === '\t' || value === '\n' || value === '\r' || value === '\f' || value === '\v';
+}
+
+function buildKillOutcome(
+  killed: boolean,
+  reason: KillStaleProcessOutcome['reason'],
+  processInfo: ProcessInspection,
+  parentCommand?: string,
+  detail?: string,
+): KillStaleProcessOutcome {
+  return {
+    killed,
+    reason,
+    pid: processInfo.pid,
+    parentPid: processInfo.parentPid,
+    command: processInfo.command,
+    parentCommand,
+    ...(detail ? { detail } : {}),
+  };
+}
+
+async function getKillGuardFailure(
+  processInfo: ProcessInspection,
+  port: number,
+): Promise<KillStaleProcessOutcome | null> {
+  const currentUser = (await import('node:os')).userInfo().username;
+  if (processInfo.user !== currentUser) {
+    await logger.warn(`[WebUI] Port ${port} held by different user (pid ${processInfo.pid}) — not killing`);
+    return buildKillOutcome(false, 'different_user', processInfo);
+  }
+
+  if (!isDollhouseProcessCommand(processInfo.command)) {
+    await logger.warn(`[WebUI] Port ${port} held by non-DollhouseMCP process (pid ${processInfo.pid}) — not killing`, {
+      cmdLine: processInfo.command,
+    });
+    return buildKillOutcome(false, 'not_dollhouse_process', processInfo);
+  }
+
+  if (processInfo.parentPid <= ROOT_PARENT_PID || !isPidAlive(processInfo.parentPid)) {
+    return null;
+  }
+
+  const parentCommand = (await getProcessCommand(processInfo.parentPid)) ?? undefined;
+  if (parentCommand && isRecognizedMcpHostParent(parentCommand)) {
+    await logger.warn(`[WebUI] Port ${port} held by active client-backed DollhouseMCP process (pid ${processInfo.pid}) — not killing`, {
+      cmdLine: processInfo.command,
+      parentPid: processInfo.parentPid,
+      parentCommand,
+    });
+    return buildKillOutcome(false, 'active_host_parent', processInfo, parentCommand);
+  }
+
+  return null;
+}
+
+async function terminateProcess(
+  processInfo: ProcessInspection,
+  port: number,
+  parentCommand?: string,
+): Promise<KillStaleProcessOutcome> {
+  process.kill(processInfo.pid, 'SIGTERM');
+  logger.warn(`[WebUI] Sent SIGTERM to stale process ${processInfo.pid} on port ${port}`, {
+    cmdLine: processInfo.command,
+    parentPid: processInfo.parentPid,
+    parentCommand,
+  });
+
+  for (let i = 0; i < KILL_POLL_COUNT; i++) {
+    await new Promise(r => setTimeout(r, SIGTERM_POLL_MS));
+    if (!isPidAlive(processInfo.pid)) {
+      return buildKillOutcome(true, 'terminated', processInfo, parentCommand);
+    }
+  }
+
+  process.kill(processInfo.pid, 'SIGKILL');
+  logger.warn(`[WebUI] Sent SIGKILL to stale process ${processInfo.pid} on port ${port}`);
+  await new Promise(r => setTimeout(r, SIGKILL_WAIT_MS));
+  return isPidAlive(processInfo.pid)
+    ? buildKillOutcome(false, 'still_alive', processInfo, parentCommand)
+    : buildKillOutcome(true, 'terminated', processInfo, parentCommand);
 }
 
 function splitProcessInspectionFields(line: string): string[] | null {
@@ -256,104 +335,23 @@ export async function killStaleProcessDetailed(pid: number, port: number): Promi
     return { killed: false, reason: 'inspect_failed', pid };
   }
 
-  const currentUser = (await import('node:os')).userInfo().username;
-  if (processInfo.user !== currentUser) {
-    await logger.warn(`[WebUI] Port ${port} held by different user (pid ${pid}) — not killing`);
-    return { killed: false, reason: 'different_user', pid, parentPid: processInfo.parentPid, command: processInfo.command };
+  const guardFailure = await getKillGuardFailure(processInfo, port);
+  if (guardFailure) {
+    return guardFailure;
   }
-
-  if (!isDollhouseProcessCommand(processInfo.command)) {
-    await logger.warn(`[WebUI] Port ${port} held by non-DollhouseMCP process (pid ${pid}) — not killing`, {
-      cmdLine: processInfo.command,
-    });
-    return {
-      killed: false,
-      reason: 'not_dollhouse_process',
-      pid,
-      parentPid: processInfo.parentPid,
-      command: processInfo.command,
-    };
-  }
-
-  let parentCommand: string | undefined;
-  if (processInfo.parentPid > ROOT_PARENT_PID && isPidAlive(processInfo.parentPid)) {
-    parentCommand = (await getProcessCommand(processInfo.parentPid)) ?? undefined;
-    if (parentCommand && isRecognizedMcpHostParent(parentCommand)) {
-      await logger.warn(`[WebUI] Port ${port} held by active client-backed DollhouseMCP process (pid ${pid}) — not killing`, {
-        cmdLine: processInfo.command,
-        parentPid: processInfo.parentPid,
-        parentCommand,
-      });
-      return {
-        killed: false,
-        reason: 'active_host_parent',
-        pid,
-        parentPid: processInfo.parentPid,
-        command: processInfo.command,
-        parentCommand,
-      };
-    }
-  }
+  const parentCommand = processInfo.parentPid > ROOT_PARENT_PID
+    ? (await getProcessCommand(processInfo.parentPid)) ?? undefined
+    : undefined;
 
   await logger.debug(`[WebUI] Verified stale process ${pid} is DollhouseMCP`, { cmdLine: processInfo.command, parentPid: processInfo.parentPid, parentCommand });
 
   try {
-    process.kill(pid, 'SIGTERM');
-    logger.warn(`[WebUI] Sent SIGTERM to stale process ${pid} on port ${port}`, { cmdLine: processInfo.command, parentPid: processInfo.parentPid, parentCommand });
-    for (let i = 0; i < KILL_POLL_COUNT; i++) {
-      await new Promise(r => setTimeout(r, SIGTERM_POLL_MS));
-      if (!isPidAlive(pid)) {
-        return {
-          killed: true,
-          reason: 'terminated',
-          pid,
-          parentPid: processInfo.parentPid,
-          command: processInfo.command,
-          parentCommand,
-        };
-      }
-    }
-    process.kill(pid, 'SIGKILL');
-    logger.warn(`[WebUI] Sent SIGKILL to stale process ${pid} on port ${port}`);
-    await new Promise(r => setTimeout(r, SIGKILL_WAIT_MS));
-    if (!isPidAlive(pid)) {
-      return {
-        killed: true,
-        reason: 'terminated',
-        pid,
-        parentPid: processInfo.parentPid,
-        command: processInfo.command,
-        parentCommand,
-      };
-    }
-    return {
-      killed: false,
-      reason: 'still_alive',
-      pid,
-      parentPid: processInfo.parentPid,
-      command: processInfo.command,
-      parentCommand,
-    };
+    return await terminateProcess(processInfo, port, parentCommand);
   } catch (err) {
     if (!isPidAlive(pid)) {
-      return {
-        killed: true,
-        reason: 'already_dead',
-        pid,
-        parentPid: processInfo.parentPid,
-        command: processInfo.command,
-        parentCommand,
-      };
+      return buildKillOutcome(true, 'already_dead', processInfo, parentCommand);
     }
-    return {
-      killed: false,
-      reason: 'signal_failed',
-      pid,
-      parentPid: processInfo.parentPid,
-      command: processInfo.command,
-      parentCommand,
-      detail: err instanceof Error ? err.message : String(err),
-    };
+    return buildKillOutcome(false, 'signal_failed', processInfo, parentCommand, err instanceof Error ? err.message : String(err));
   }
 }
 

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -171,6 +171,61 @@ interface DiscoveryDependencies {
   readLeaderLockImpl?: typeof readLeaderLock;
 }
 
+function buildDiscoveryHeaders(authToken: string | null): Record<string, string> {
+  return authToken ? { Authorization: `Bearer ${authToken}` } : {};
+}
+
+function buildLeaderInfoFromSession(port: number, ownerPid: number, leaderSession: SessionApiRecord): ConsoleLeaderInfo {
+  return {
+    version: LOCK_VERSION,
+    pid: ownerPid,
+    port,
+    sessionId: UnicodeValidator.normalize(leaderSession.sessionId).normalizedContent,
+    startedAt: leaderSession.startedAt ?? currentTimestamp(),
+    heartbeat: leaderSession.lastHeartbeat ?? currentTimestamp(),
+    serverVersion: leaderSession.serverVersion ?? LEGACY_SERVER_VERSION,
+    consoleProtocolVersion: leaderSession.consoleProtocolVersion ?? CONSOLE_PROTOCOL_VERSION,
+  };
+}
+
+function buildSyntheticLeaderInfo(port: number, ownerPid: number): ConsoleLeaderInfo {
+  const now = currentTimestamp();
+  return {
+    version: LOCK_VERSION,
+    pid: ownerPid,
+    port,
+    sessionId: `${SYNTHETIC_PORT_OWNER_SESSION_PREFIX}${ownerPid}`,
+    startedAt: now,
+    heartbeat: now,
+    serverVersion: LEGACY_SERVER_VERSION,
+    consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+  };
+}
+
+async function discoverLeaderViaSessionsApi(
+  port: number,
+  ownerPid: number,
+  authToken: string | null,
+  fetchImpl: typeof fetch,
+): Promise<ConsoleLeaderInfo | null> {
+  const response = await fetchImpl(`http://127.0.0.1:${port}/api/sessions`, {
+    headers: buildDiscoveryHeaders(authToken),
+  });
+  if (!response.ok) {
+    return null;
+  }
+
+  const payload = await response.json() as { sessions?: SessionApiRecord[] };
+  const sessions = Array.isArray(payload.sessions) ? payload.sessions : [];
+  const leaderSession = sessions.find((session) =>
+    session.pid === ownerPid &&
+    session.isLeader === true &&
+    session.kind === 'mcp' &&
+    session.status !== 'stopped'
+  );
+  return leaderSession ? buildLeaderInfoFromSession(port, ownerPid, leaderSession) : null;
+}
+
 export async function discoverLeaderServingPort(
   port: number,
   authToken: string | null,
@@ -183,37 +238,9 @@ export async function discoverLeaderServingPort(
 
   if (ownerPid !== null) {
     try {
-      const headers: Record<string, string> = {};
-      if (authToken) {
-        headers.Authorization = `Bearer ${authToken}`;
-      }
-      const response = await fetchImpl(`http://127.0.0.1:${port}/api/sessions`, { headers });
-      if (response.ok) {
-        const payload = await response.json() as { sessions?: SessionApiRecord[] };
-        const sessions = Array.isArray(payload.sessions) ? payload.sessions : [];
-        const leaderSession = sessions.find((session) =>
-          session.pid === ownerPid &&
-          session.isLeader === true &&
-          session.kind === 'mcp' &&
-          session.status !== 'stopped'
-        );
-        if (leaderSession) {
-          const normalizedSessionId = UnicodeValidator.normalize(leaderSession.sessionId).normalizedContent;
-          return {
-            ownerPid,
-            source: 'api',
-            leaderInfo: {
-              version: LOCK_VERSION,
-              pid: ownerPid,
-              port,
-              sessionId: normalizedSessionId,
-              startedAt: leaderSession.startedAt ?? currentTimestamp(),
-              heartbeat: leaderSession.lastHeartbeat ?? currentTimestamp(),
-              serverVersion: leaderSession.serverVersion ?? LEGACY_SERVER_VERSION,
-              consoleProtocolVersion: leaderSession.consoleProtocolVersion ?? CONSOLE_PROTOCOL_VERSION,
-            },
-          };
-        }
+      const leaderInfo = await discoverLeaderViaSessionsApi(port, ownerPid, authToken, fetchImpl);
+      if (leaderInfo) {
+        return { ownerPid, source: 'api', leaderInfo };
       }
     } catch (err) {
       logger.debug('[UnifiedConsole] Failed to query active leader sessions', {
@@ -225,7 +252,7 @@ export async function discoverLeaderServingPort(
   }
 
   const lock = await readLeaderLockImpl();
-  if (lock && lock.port === port && (ownerPid === null || lock.pid === ownerPid)) {
+  if (lock?.port === port && (ownerPid === null || lock.pid === ownerPid)) {
     return {
       ownerPid: ownerPid ?? lock.pid,
       source: 'lock',
@@ -237,20 +264,10 @@ export async function discoverLeaderServingPort(
   }
 
   if (ownerPid !== null) {
-    const now = currentTimestamp();
     return {
       ownerPid,
       source: 'synthetic',
-      leaderInfo: {
-        version: LOCK_VERSION,
-        pid: ownerPid,
-        port,
-        sessionId: `${SYNTHETIC_PORT_OWNER_SESSION_PREFIX}${ownerPid}`,
-        startedAt: now,
-        heartbeat: now,
-        serverVersion: LEGACY_SERVER_VERSION,
-        consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
-      },
+      leaderInfo: buildSyntheticLeaderInfo(port, ownerPid),
     };
   }
 
@@ -279,17 +296,15 @@ export async function recoverLeaderBindFailure(
   let lockCleanupAttempted = false;
   let lockCleanupPerformed = false;
   const currentLock = await readLeaderLockImpl();
-  const provisionalLockMatches = Boolean(
-    currentLock &&
-    currentLock.pid === provisionalLeader.pid &&
+  const provisionalLockMatches = (
+    currentLock?.pid === provisionalLeader.pid &&
     currentLock.port === provisionalLeader.port &&
-    currentLock.sessionId === provisionalLeader.sessionId,
+    currentLock.sessionId === provisionalLeader.sessionId
   );
-  const fallbackPointsToProvisionalLeader = Boolean(
-    fallback.leaderInfo &&
-    fallback.leaderInfo.pid === provisionalLeader.pid &&
+  const fallbackPointsToProvisionalLeader = (
+    fallback.leaderInfo?.pid === provisionalLeader.pid &&
     fallback.leaderInfo.port === provisionalLeader.port &&
-    fallback.leaderInfo.sessionId === provisionalLeader.sessionId,
+    fallback.leaderInfo.sessionId === provisionalLeader.sessionId
   );
 
   if (provisionalLockMatches) {
@@ -493,15 +508,15 @@ async function startAsFollower(
   options: UnifiedConsoleOptions,
   election: ElectionResult,
   consolePort: number = DEFAULT_CONSOLE_PORT,
-  initialAuthToken?: string | null,
+  initialAuthToken: string | null = null,
 ): Promise<UnifiedConsoleResult> {
   const leaderUrl = `http://127.0.0.1:${election.leaderInfo.port}`;
 
   // Read the console auth token (#1780) written by the leader. May be null
   // if the file doesn't exist yet — the sinks handle that gracefully and
   // simply omit the Bearer header, which is fine when auth is not enforced.
-  let authToken = initialAuthToken ?? null;
-  if (authToken === null || authToken === undefined) {
+  let authToken = initialAuthToken;
+  if (authToken === null) {
     const { getPrimaryTokenFromFile } = await import('./consoleToken.js');
     authToken = await getPrimaryTokenFromFile(env.DOLLHOUSE_CONSOLE_TOKEN_FILE);
   }

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -25,7 +25,13 @@ import {
   startHeartbeat,
   registerLeaderCleanup,
   detectLegacyLeader,
+  readLeaderLock,
+  deleteLeaderLock,
+  LOCK_VERSION,
+  CONSOLE_PROTOCOL_VERSION,
+  LEGACY_SERVER_VERSION,
   type ElectionResult,
+  type ConsoleLeaderInfo,
 } from './LeaderElection.js';
 import { createIngestRoutes } from './IngestRoutes.js';
 import {
@@ -34,6 +40,7 @@ import {
 } from './LeaderForwardingSink.js';
 import { PromotionManager } from './PromotionManager.js';
 import { ConsoleTokenStore } from './consoleToken.js';
+import { findPidOnPort } from './StaleProcessRecovery.js';
 import { env } from '../../config/env.js';
 
 /**
@@ -128,6 +135,133 @@ export async function warnIfLegacyConsolePresent(
   }
 }
 
+interface SessionApiRecord {
+  sessionId: string;
+  pid: number;
+  startedAt?: string;
+  lastHeartbeat?: string;
+  status?: string;
+  isLeader?: boolean;
+  kind?: string;
+  serverVersion?: string;
+  consoleProtocolVersion?: number;
+}
+
+export interface PortLeaderDiscovery {
+  leaderInfo: ConsoleLeaderInfo | null;
+  ownerPid: number | null;
+  source: 'api' | 'lock' | 'synthetic' | 'none';
+}
+
+interface DiscoveryDependencies {
+  fetchImpl?: typeof fetch;
+  findPidOnPortImpl?: typeof findPidOnPort;
+  readLeaderLockImpl?: typeof readLeaderLock;
+}
+
+export async function discoverLeaderServingPort(
+  port: number,
+  authToken: string | null,
+  deps: DiscoveryDependencies = {},
+): Promise<PortLeaderDiscovery> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const findPidOnPortImpl = deps.findPidOnPortImpl ?? findPidOnPort;
+  const readLeaderLockImpl = deps.readLeaderLockImpl ?? readLeaderLock;
+  const ownerPid = await findPidOnPortImpl(port);
+
+  if (ownerPid !== null) {
+    try {
+      const headers: Record<string, string> = {};
+      if (authToken) {
+        headers.Authorization = `Bearer ${authToken}`;
+      }
+      const response = await fetchImpl(`http://127.0.0.1:${port}/api/sessions`, { headers });
+      if (response.ok) {
+        const payload = await response.json() as { sessions?: SessionApiRecord[] };
+        const sessions = Array.isArray(payload.sessions) ? payload.sessions : [];
+        const leaderSession = sessions.find((session) =>
+          session.pid === ownerPid &&
+          session.isLeader === true &&
+          session.kind === 'mcp' &&
+          session.status !== 'stopped'
+        );
+        if (leaderSession) {
+          return {
+            ownerPid,
+            source: 'api',
+            leaderInfo: {
+              version: LOCK_VERSION,
+              pid: ownerPid,
+              port,
+              sessionId: leaderSession.sessionId,
+              startedAt: leaderSession.startedAt ?? new Date().toISOString(),
+              heartbeat: leaderSession.lastHeartbeat ?? new Date().toISOString(),
+              serverVersion: leaderSession.serverVersion ?? LEGACY_SERVER_VERSION,
+              consoleProtocolVersion: leaderSession.consoleProtocolVersion ?? CONSOLE_PROTOCOL_VERSION,
+            },
+          };
+        }
+      }
+    } catch (err) {
+      logger.debug('[UnifiedConsole] Failed to query active leader sessions', {
+        port,
+        ownerPid,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const lock = await readLeaderLockImpl();
+  if (lock && lock.port === port && (ownerPid === null || lock.pid === ownerPid)) {
+    return { leaderInfo: lock, ownerPid: ownerPid ?? lock.pid, source: 'lock' };
+  }
+
+  if (ownerPid !== null) {
+    const now = new Date().toISOString();
+    return {
+      ownerPid,
+      source: 'synthetic',
+      leaderInfo: {
+        version: LOCK_VERSION,
+        pid: ownerPid,
+        port,
+        sessionId: `port-owner-${ownerPid}`,
+        startedAt: now,
+        heartbeat: now,
+        serverVersion: LEGACY_SERVER_VERSION,
+        consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+      },
+    };
+  }
+
+  return { leaderInfo: null, ownerPid: null, source: 'none' };
+}
+
+interface BindFailureRecoveryDependencies extends DiscoveryDependencies {
+  deleteLeaderLockImpl?: typeof deleteLeaderLock;
+}
+
+export async function recoverLeaderBindFailure(
+  provisionalLeader: ConsoleLeaderInfo,
+  port: number,
+  authToken: string | null,
+  deps: BindFailureRecoveryDependencies = {},
+): Promise<PortLeaderDiscovery> {
+  const readLeaderLockImpl = deps.readLeaderLockImpl ?? readLeaderLock;
+  const deleteLeaderLockImpl = deps.deleteLeaderLockImpl ?? deleteLeaderLock;
+  const currentLock = await readLeaderLockImpl();
+  if (
+    currentLock &&
+    currentLock.pid === provisionalLeader.pid &&
+    currentLock.port === provisionalLeader.port &&
+    currentLock.sessionId === provisionalLeader.sessionId
+  ) {
+    await deleteLeaderLockImpl();
+  }
+
+  return discoverLeaderServingPort(port, authToken, deps);
+}
+
 /**
  * Start the unified web console.
  *
@@ -204,12 +338,6 @@ async function startAsLeader(
     storeMetricsSnapshot: (snapshot) => options.metricsSink?.onSnapshot(snapshot),
   });
 
-  // Register the leader as a session
-  ingestResult.registerLeaderSession(options.sessionId, process.pid);
-
-  // Register the web console itself so the session indicator is never empty (#1805)
-  ingestResult.registerConsoleSession();
-
   // Start the web server with ingest routes mounted before the SPA fallback.
   // If the port is occupied by a stale process, retry with exponential backoff.
   const serverOpts = {
@@ -226,8 +354,32 @@ async function startAsLeader(
   const webResult = await startWebServer(serverOpts);
 
   if (webResult.bindResult && !webResult.bindResult.success) {
-    logger.error(`[UnifiedConsole] Leader failed to bind port ${consolePort} — console unavailable`);
+    const fallback = await recoverLeaderBindFailure(election.leaderInfo, consolePort, primaryToken.token);
+    if (fallback.leaderInfo) {
+      logger.warn('[UnifiedConsole] Leader role aborted: bind failed, falling back to follower', {
+        port: consolePort,
+        provisionalLeaderPid: election.leaderInfo.pid,
+        ownerPid: fallback.ownerPid,
+        source: fallback.source,
+      });
+      const followerElection: ElectionResult = { role: 'follower', leaderInfo: fallback.leaderInfo };
+      return startAsFollower(options, followerElection, consolePort, primaryToken.token);
+    }
+
+    logger.error('[UnifiedConsole] Leader failed to bind and no active leader could be identified', {
+      port: consolePort,
+      provisionalLeaderPid: election.leaderInfo.pid,
+      bindError: webResult.bindResult.error,
+      bindDetail: webResult.bindResult.detail,
+    });
+    throw new Error(`Leader failed to bind port ${consolePort} and no active leader was discoverable`);
   }
+
+  // Register the leader only after the HTTP listener is actually serving the port.
+  ingestResult.registerLeaderSession(options.sessionId, process.pid);
+
+  // Register the web console itself so the session indicator is never empty (#1805)
+  ingestResult.registerConsoleSession();
 
   // Wire SSE broadcasts for this leader's own events
   options.wireSSEBroadcasts(webResult, options.metricsSink);
@@ -275,14 +427,18 @@ async function startAsFollower(
   options: UnifiedConsoleOptions,
   election: ElectionResult,
   consolePort: number = DEFAULT_CONSOLE_PORT,
+  initialAuthToken?: string | null,
 ): Promise<UnifiedConsoleResult> {
   const leaderUrl = `http://127.0.0.1:${election.leaderInfo.port}`;
 
   // Read the console auth token (#1780) written by the leader. May be null
   // if the file doesn't exist yet — the sinks handle that gracefully and
   // simply omit the Bearer header, which is fine when auth is not enforced.
-  const { getPrimaryTokenFromFile } = await import('./consoleToken.js');
-  const authToken = await getPrimaryTokenFromFile(env.DOLLHOUSE_CONSOLE_TOKEN_FILE);
+  let authToken = initialAuthToken ?? null;
+  if (authToken === null || authToken === undefined) {
+    const { getPrimaryTokenFromFile } = await import('./consoleToken.js');
+    authToken = await getPrimaryTokenFromFile(env.DOLLHOUSE_CONSOLE_TOKEN_FILE);
+  }
   if (authToken) {
     logger.debug('[UnifiedConsole] Follower loaded console auth token');
   } else {

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -17,6 +17,7 @@ import type { UnifiedLogEntry } from '../../logging/types.js';
 import type { MetricSnapshot } from '../../metrics/types.js';
 import type { MemoryLogSink } from '../../logging/sinks/MemoryLogSink.js';
 import type { MemoryMetricsSink } from '../../metrics/sinks/MemoryMetricsSink.js';
+import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { logger } from '../../utils/logger.js';
 import {
   electLeader,
@@ -51,6 +52,12 @@ import { env } from '../../config/env.js';
  *   3. 41715 (hardcoded default in env.ts)
  */
 const DEFAULT_CONSOLE_PORT = env.DOLLHOUSE_WEB_CONSOLE_PORT;
+const LEGACY_CONSOLE_FALLBACK_PORT = 3939;
+const SYNTHETIC_PORT_OWNER_SESSION_PREFIX = 'port-owner-';
+
+function currentTimestamp(): string {
+  return new Date().toISOString();
+}
 
 /**
  * Options for starting the unified console.
@@ -120,7 +127,7 @@ export async function warnIfLegacyConsolePresent(
         `(pid=${legacy.pid}, port=${legacy.port}). Both consoles will run ` +
         `independently on different ports with different security posture. ` +
         `The authenticated console (this process) uses port ${currentPort}; ` +
-        `the legacy console uses port ${legacy.port ?? 3939}. ` +
+        `the legacy console uses port ${legacy.port ?? LEGACY_CONSOLE_FALLBACK_PORT}. ` +
         `For consistent security, update the legacy installation to a ` +
         `version with the authenticated console.`,
       );
@@ -151,6 +158,11 @@ export interface PortLeaderDiscovery {
   leaderInfo: ConsoleLeaderInfo | null;
   ownerPid: number | null;
   source: 'api' | 'lock' | 'synthetic' | 'none';
+}
+
+export interface BindFailureRecoveryResult extends PortLeaderDiscovery {
+  lockCleanupAttempted: boolean;
+  lockCleanupPerformed: boolean;
 }
 
 interface DiscoveryDependencies {
@@ -186,6 +198,7 @@ export async function discoverLeaderServingPort(
           session.status !== 'stopped'
         );
         if (leaderSession) {
+          const normalizedSessionId = UnicodeValidator.normalize(leaderSession.sessionId).normalizedContent;
           return {
             ownerPid,
             source: 'api',
@@ -193,9 +206,9 @@ export async function discoverLeaderServingPort(
               version: LOCK_VERSION,
               pid: ownerPid,
               port,
-              sessionId: leaderSession.sessionId,
-              startedAt: leaderSession.startedAt ?? new Date().toISOString(),
-              heartbeat: leaderSession.lastHeartbeat ?? new Date().toISOString(),
+              sessionId: normalizedSessionId,
+              startedAt: leaderSession.startedAt ?? currentTimestamp(),
+              heartbeat: leaderSession.lastHeartbeat ?? currentTimestamp(),
               serverVersion: leaderSession.serverVersion ?? LEGACY_SERVER_VERSION,
               consoleProtocolVersion: leaderSession.consoleProtocolVersion ?? CONSOLE_PROTOCOL_VERSION,
             },
@@ -213,11 +226,18 @@ export async function discoverLeaderServingPort(
 
   const lock = await readLeaderLockImpl();
   if (lock && lock.port === port && (ownerPid === null || lock.pid === ownerPid)) {
-    return { leaderInfo: lock, ownerPid: ownerPid ?? lock.pid, source: 'lock' };
+    return {
+      ownerPid: ownerPid ?? lock.pid,
+      source: 'lock',
+      leaderInfo: {
+        ...lock,
+        sessionId: UnicodeValidator.normalize(lock.sessionId).normalizedContent,
+      },
+    };
   }
 
   if (ownerPid !== null) {
-    const now = new Date().toISOString();
+    const now = currentTimestamp();
     return {
       ownerPid,
       source: 'synthetic',
@@ -225,7 +245,7 @@ export async function discoverLeaderServingPort(
         version: LOCK_VERSION,
         pid: ownerPid,
         port,
-        sessionId: `port-owner-${ownerPid}`,
+        sessionId: `${SYNTHETIC_PORT_OWNER_SESSION_PREFIX}${ownerPid}`,
         startedAt: now,
         heartbeat: now,
         serverVersion: LEGACY_SERVER_VERSION,
@@ -246,20 +266,61 @@ export async function recoverLeaderBindFailure(
   port: number,
   authToken: string | null,
   deps: BindFailureRecoveryDependencies = {},
-): Promise<PortLeaderDiscovery> {
+): Promise<BindFailureRecoveryResult> {
   const readLeaderLockImpl = deps.readLeaderLockImpl ?? readLeaderLock;
   const deleteLeaderLockImpl = deps.deleteLeaderLockImpl ?? deleteLeaderLock;
+  logger.info('[UnifiedConsole] Leader bind recovery initiated', {
+    provisionalSessionId: provisionalLeader.sessionId,
+    provisionalPid: provisionalLeader.pid,
+    port,
+  });
+
+  let fallback = await discoverLeaderServingPort(port, authToken, deps);
+  let lockCleanupAttempted = false;
+  let lockCleanupPerformed = false;
   const currentLock = await readLeaderLockImpl();
-  if (
+  const provisionalLockMatches = Boolean(
     currentLock &&
     currentLock.pid === provisionalLeader.pid &&
     currentLock.port === provisionalLeader.port &&
-    currentLock.sessionId === provisionalLeader.sessionId
-  ) {
+    currentLock.sessionId === provisionalLeader.sessionId,
+  );
+  const fallbackPointsToProvisionalLeader = Boolean(
+    fallback.leaderInfo &&
+    fallback.leaderInfo.pid === provisionalLeader.pid &&
+    fallback.leaderInfo.port === provisionalLeader.port &&
+    fallback.leaderInfo.sessionId === provisionalLeader.sessionId,
+  );
+
+  if (provisionalLockMatches) {
+    lockCleanupAttempted = true;
     await deleteLeaderLockImpl();
+    lockCleanupPerformed = true;
+    logger.info('[UnifiedConsole] Removed provisional leader lock after bind failure', {
+      provisionalSessionId: provisionalLeader.sessionId,
+      provisionalPid: provisionalLeader.pid,
+      port,
+    });
+    if (fallbackPointsToProvisionalLeader) {
+      fallback = await discoverLeaderServingPort(port, authToken, deps);
+    }
   }
 
-  return discoverLeaderServingPort(port, authToken, deps);
+  logger.info('[UnifiedConsole] Leader bind recovery completed', {
+    provisionalSessionId: provisionalLeader.sessionId,
+    provisionalPid: provisionalLeader.pid,
+    port,
+    discoverySource: fallback.source,
+    ownerPid: fallback.ownerPid,
+    lockCleanupAttempted,
+    lockCleanupPerformed,
+  });
+
+  return {
+    ...fallback,
+    lockCleanupAttempted,
+    lockCleanupPerformed,
+  };
 }
 
 /**
@@ -358,9 +419,14 @@ async function startAsLeader(
     if (fallback.leaderInfo) {
       logger.warn('[UnifiedConsole] Leader role aborted: bind failed, falling back to follower', {
         port: consolePort,
+        bindError: webResult.bindResult.error,
+        bindDetail: webResult.bindResult.detail,
         provisionalLeaderPid: election.leaderInfo.pid,
+        provisionalLeaderSessionId: election.leaderInfo.sessionId,
         ownerPid: fallback.ownerPid,
         source: fallback.source,
+        lockCleanupAttempted: fallback.lockCleanupAttempted,
+        lockCleanupPerformed: fallback.lockCleanupPerformed,
       });
       const followerElection: ElectionResult = { role: 'follower', leaderInfo: fallback.leaderInfo };
       return startAsFollower(options, followerElection, consolePort, primaryToken.token);

--- a/tests/unit/web/console/UnifiedConsole.test.ts
+++ b/tests/unit/web/console/UnifiedConsole.test.ts
@@ -210,6 +210,29 @@ describe('discoverLeaderServingPort', () => {
     });
   });
 
+  it('normalizes the discovered leader session ID from /api/sessions', async () => {
+    const result = await discoverLeaderServingPort(41715, null, {
+      fetchImpl: jest.fn<typeof fetch>().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          sessions: [
+            {
+              sessionId: 'real\u200Bleader',
+              pid: 4567,
+              isLeader: true,
+              kind: 'mcp',
+              status: 'active',
+            },
+          ],
+        }),
+      } as Response),
+      findPidOnPortImpl: async () => 4567,
+      readLeaderLockImpl: async () => null,
+    });
+
+    expect(result.leaderInfo?.sessionId).toBe('realleader');
+  });
+
   it('falls back to a synthetic leader when the port owner is known but sessions are unavailable', async () => {
     const result = await discoverLeaderServingPort(41715, null, {
       fetchImpl: jest.fn<typeof fetch>().mockRejectedValue(new Error('connect ECONNRESET')),
@@ -265,6 +288,8 @@ describe('recoverLeaderBindFailure', () => {
 
     expect(deleteLeaderLockImpl).toHaveBeenCalledTimes(1);
     expect(result.source).toBe('api');
+    expect(result.lockCleanupAttempted).toBe(true);
+    expect(result.lockCleanupPerformed).toBe(true);
     expect(result.leaderInfo).toMatchObject({
       sessionId: 'ollie',
       pid: 57117,

--- a/tests/unit/web/console/UnifiedConsole.test.ts
+++ b/tests/unit/web/console/UnifiedConsole.test.ts
@@ -17,8 +17,12 @@
  */
 
 import { describe, it, expect, jest } from '@jest/globals';
-import { warnIfLegacyConsolePresent } from '../../../../src/web/console/UnifiedConsole.js';
-import type { LegacyLeaderInfo } from '../../../../src/web/console/LeaderElection.js';
+import {
+  warnIfLegacyConsolePresent,
+  discoverLeaderServingPort,
+  recoverLeaderBindFailure,
+} from '../../../../src/web/console/UnifiedConsole.js';
+import type { LegacyLeaderInfo, ConsoleLeaderInfo } from '../../../../src/web/console/LeaderElection.js';
 
 /**
  * Fake fixture path used in mock `LegacyLeaderInfo` return values.
@@ -155,5 +159,116 @@ describe('warnIfLegacyConsolePresent', () => {
     const warnMessage = (logStub.warn as jest.Mock).mock.calls[0][0] as string;
     expect(warnMessage).toContain('port 8080');
     expect(warnMessage).not.toMatch(/port 41715/);
+  });
+});
+
+describe('discoverLeaderServingPort', () => {
+  it('prefers the active leader session returned by /api/sessions for the port owner', async () => {
+    const fetchStub = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        sessions: [
+          {
+            sessionId: 'older-follower',
+            pid: 1234,
+            isLeader: false,
+            kind: 'mcp',
+            status: 'active',
+          },
+          {
+            sessionId: 'real-leader',
+            pid: 4567,
+            isLeader: true,
+            kind: 'mcp',
+            status: 'active',
+            startedAt: '2026-04-16T13:55:00.000Z',
+            lastHeartbeat: '2026-04-16T13:55:10.000Z',
+            serverVersion: '2.0.19',
+            consoleProtocolVersion: 1,
+          },
+        ],
+      }),
+    } as Response);
+
+    const result = await discoverLeaderServingPort(41715, 'token-123', {
+      fetchImpl: fetchStub,
+      findPidOnPortImpl: async () => 4567,
+      readLeaderLockImpl: async () => null,
+    });
+
+    expect(fetchStub).toHaveBeenCalledWith('http://127.0.0.1:41715/api/sessions', {
+      headers: { Authorization: 'Bearer token-123' },
+    });
+    expect(result.source).toBe('api');
+    expect(result.ownerPid).toBe(4567);
+    expect(result.leaderInfo).toMatchObject({
+      sessionId: 'real-leader',
+      pid: 4567,
+      port: 41715,
+      serverVersion: '2.0.19',
+      consoleProtocolVersion: 1,
+    });
+  });
+
+  it('falls back to a synthetic leader when the port owner is known but sessions are unavailable', async () => {
+    const result = await discoverLeaderServingPort(41715, null, {
+      fetchImpl: jest.fn<typeof fetch>().mockRejectedValue(new Error('connect ECONNRESET')),
+      findPidOnPortImpl: async () => 81234,
+      readLeaderLockImpl: async () => null,
+    });
+
+    expect(result.source).toBe('synthetic');
+    expect(result.ownerPid).toBe(81234);
+    expect(result.leaderInfo).toMatchObject({
+      sessionId: 'port-owner-81234',
+      pid: 81234,
+      port: 41715,
+    });
+  });
+});
+
+describe('recoverLeaderBindFailure', () => {
+  it('removes the provisional self-lock before following the real leader on the bound port', async () => {
+    const provisionalLeader: ConsoleLeaderInfo = {
+      version: 1,
+      pid: 99123,
+      port: 41715,
+      sessionId: 'burattino',
+      startedAt: '2026-04-16T13:55:09.000Z',
+      heartbeat: '2026-04-16T13:55:09.000Z',
+      serverVersion: '2.0.19',
+      consoleProtocolVersion: 1,
+    };
+    const deleteLeaderLockImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').deleteLeaderLock>().mockResolvedValue();
+
+    const result = await recoverLeaderBindFailure(provisionalLeader, 41715, 'token-123', {
+      deleteLeaderLockImpl,
+      readLeaderLockImpl: async () => provisionalLeader,
+      findPidOnPortImpl: async () => 57117,
+      fetchImpl: jest.fn<typeof fetch>().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          sessions: [
+            {
+              sessionId: 'ollie',
+              pid: 57117,
+              isLeader: true,
+              kind: 'mcp',
+              status: 'active',
+              serverVersion: '2.0.18',
+              consoleProtocolVersion: 1,
+            },
+          ],
+        }),
+      } as Response),
+    });
+
+    expect(deleteLeaderLockImpl).toHaveBeenCalledTimes(1);
+    expect(result.source).toBe('api');
+    expect(result.leaderInfo).toMatchObject({
+      sessionId: 'ollie',
+      pid: 57117,
+      port: 41715,
+    });
   });
 });

--- a/tests/unit/web/console/stale-process-recovery.test.ts
+++ b/tests/unit/web/console/stale-process-recovery.test.ts
@@ -307,6 +307,10 @@ describe('Stale Process Recovery (#1850)', () => {
       expect(Recovery.isRecognizedMcpHostParent('/Applications/Codex.app/Contents/Resources/codex app-server')).toBe(true);
     });
 
+    it('normalizes hidden Unicode characters before matching host parents', () => {
+      expect(Recovery.isRecognizedMcpHostParent('/Applications/Co\u200Bdex.app/Contents/Resources/codex app-server')).toBe(true);
+    });
+
     it('does not treat launchd or plain shells as active MCP hosts', () => {
       expect(Recovery.isRecognizedMcpHostParent('/sbin/launchd')).toBe(false);
       expect(Recovery.isRecognizedMcpHostParent('/bin/zsh -lc npm exec @dollhousemcp/mcp-server')).toBe(false);

--- a/tests/unit/web/console/stale-process-recovery.test.ts
+++ b/tests/unit/web/console/stale-process-recovery.test.ts
@@ -54,7 +54,7 @@ function isDollhouseProcess(cmdLine: string): boolean {
   const isDollhouseBin = /(?:^|\/)dollhousemcp(?:\s|$)/.test(cmdLine) ||
     cmdLine.includes('.bin/dollhousemcp');
   const isMcpServerBin = cmdLine.includes('.bin/mcp-server') ||
-    cmdLine.includes('dist/index.js');
+    /(?:dollhousemcp|mcp-server)[/\\]dist[/\\]index\.js/.test(cmdLine);
   return isDollhouseBin || isMcpServerBin;
 }
 
@@ -301,13 +301,27 @@ describe('Stale Process Recovery (#1850)', () => {
     });
   });
 
+  describe('recognized MCP host parents', () => {
+    it('treats Claude Desktop and Codex app-server parents as active MCP hosts', () => {
+      expect(Recovery.isRecognizedMcpHostParent('/Applications/Claude.app/Contents/Helpers/disclaimer npx @dollhousemcp/mcp-server@latest')).toBe(true);
+      expect(Recovery.isRecognizedMcpHostParent('/Applications/Codex.app/Contents/Resources/codex app-server')).toBe(true);
+    });
+
+    it('does not treat launchd or plain shells as active MCP hosts', () => {
+      expect(Recovery.isRecognizedMcpHostParent('/sbin/launchd')).toBe(false);
+      expect(Recovery.isRecognizedMcpHostParent('/bin/zsh -lc npm exec @dollhousemcp/mcp-server')).toBe(false);
+    });
+  });
+
   // ── Exports ───────────────────────────────────────────────────────────
 
   describe('module exports', () => {
     it('all recovery functions are exported and callable', () => {
       expect(typeof Recovery.findPidOnPort).toBe('function');
       expect(typeof Recovery.killStaleProcess).toBe('function');
+      expect(typeof Recovery.killStaleProcessDetailed).toBe('function');
       expect(typeof Recovery.recoverStalePort).toBe('function');
+      expect(typeof Recovery.isRecognizedMcpHostParent).toBe('function');
     });
   });
 });


### PR DESCRIPTION
## Summary
- make console leadership provisional until the HTTP listener actually binds
- fall back to follower mode and register with the real port owner when bind fails
- harden stale-port recovery so we do not evict live Claude/Codex-hosted MCP servers, and bump release metadata to `2.0.20`

## Testing
- `npx eslint src/web/console/UnifiedConsole.ts src/web/console/StaleProcessRecovery.ts tests/unit/web/console/UnifiedConsole.test.ts tests/unit/web/console/stale-process-recovery.test.ts`
- `npm test -- --runInBand tests/unit/web/console/UnifiedConsole.test.ts tests/unit/web/console/stale-process-recovery.test.ts tests/unit/web/console/console-failure-modes.test.ts tests/unit/web/console/LeaderElection.test.ts tests/unit/web/console/sessionRegistry.test.ts`
- `npm run test:integration -- --runInBand tests/integration/console-lifecycle.test.ts`
