### PR TITLE
Sanitize OAuth and PAT logging for Sonar

### DIFF
--- a/oauth-helper.mjs
+++ b/oauth-helper.mjs
@@ -130,7 +130,7 @@ async function storeToken(token) {
     await TokenManager.storeGitHubToken(token);
     await log('Token stored successfully using TokenManager');
     return true;
-  } catch (error) {
+  } catch {
     await log('Failed to store token using TokenManager');
     
     // Fallback: Write to a temporary file for the MCP server to pick up
@@ -192,7 +192,7 @@ async function writePidFile() {
     await fs.mkdir(pidDir, { recursive: true, mode: 0o700 });
     await fs.writeFile(pidFile, process.pid.toString(), { mode: 0o600 });
     await log(`PID file written: ${pidFile}`);
-  } catch (error) {
+  } catch {
     await log('Failed to write PID file');
   }
 }
@@ -355,7 +355,7 @@ async function main() {
 }
 
 // Run the main function
-main().catch(async (error) => {
+main().catch(async () => {
   await log('Fatal error');
   console.error('Fatal error in OAuth helper');
   await cleanupPidFile();

--- a/oauth-helper.mjs
+++ b/oauth-helper.mjs
@@ -110,7 +110,7 @@ async function pollGitHub(deviceCode, clientId) {
     const data = await response.json();
     return data;
   } catch (error) {
-    await log(`Network error polling GitHub: ${error.message}`);
+    await log('Network error polling GitHub');
     throw error;
   }
 }
@@ -131,7 +131,7 @@ async function storeToken(token) {
     await log('Token stored successfully using TokenManager');
     return true;
   } catch (error) {
-    await log(`Failed to store token using TokenManager: ${error.message}`);
+    await log('Failed to store token using TokenManager');
     
     // Fallback: Write to a temporary file for the MCP server to pick up
     try {
@@ -154,10 +154,10 @@ async function storeToken(token) {
       // Verify file permissions
       await fs.chmod(tempTokenFile, 0o600);
       
-      await log(`Token written to fallback file with secure permissions`);
+      await log('Token written to fallback file with secure permissions');
       return true;
     } catch (fallbackError) {
-      await log(`Fallback storage also failed: ${fallbackError.message}`);
+      await log('Fallback storage also failed');
       throw fallbackError;
     }
   }
@@ -193,13 +193,13 @@ async function writePidFile() {
     await fs.writeFile(pidFile, process.pid.toString(), { mode: 0o600 });
     await log(`PID file written: ${pidFile}`);
   } catch (error) {
-    await log(`Failed to write PID file: ${error.message}`);
+    await log('Failed to write PID file');
   }
 }
 
 async function main() {
   await log(`[START] OAuth helper started - PID: ${process.pid}`);
-  await log(`[CONFIG] Device code: ${deviceCode.substring(0, 2)}****`); // More aggressive truncation
+  await log('[CONFIG] Device code received');
   await log(`[CONFIG] Poll interval: ${pollInterval}s, Expires in: ${expiresIn}s`);
   await log(`[CONFIG] Node version: ${process.version}`);
   await log(`[CONFIG] Platform: ${process.platform}`);
@@ -278,9 +278,9 @@ async function main() {
             process.exit(1);
             
           default:
-            await log(`OAUTH_HELPER_276: Unknown error from GitHub: ${response.error}`);
-            await log(`[ERROR] Error description: ${response.error_description}`);
-            console.error(`OAUTH_UNKNOWN_RESPONSE: Unknown error '${response.error}' at line 276`);
+            await log('OAUTH_HELPER_276: Unknown error from GitHub during device flow polling');
+            await log('[ERROR] GitHub returned an unrecognized OAuth polling response');
+            console.error('OAUTH_UNKNOWN_RESPONSE: Unknown GitHub OAuth response at line 276');
         }
       } else if (response.access_token) {
         // Success! We got the token
@@ -309,7 +309,7 @@ async function main() {
         consecutiveErrors = 0;
       }
     } catch (error) {
-      await log(`[ERROR] Polling error: ${error.message}`);
+      await log('[ERROR] Polling error');
       
       // Classify error types
       const isNetworkError = error.message && (
@@ -333,8 +333,8 @@ async function main() {
         }
       } else {
         // Non-network error, likely fatal
-        await log(`OAUTH_HELPER_330: Non-recoverable error: ${error.message}`);
-        console.error(`OAUTH_FATAL_ERROR: Non-recoverable error at line 330 - ${error.message}`);
+        await log('OAUTH_HELPER_330: Non-recoverable error');
+        console.error('OAUTH_FATAL_ERROR: Non-recoverable error at line 330');
         clearInterval(heartbeatInterval);
         await cleanupPidFile();
         process.exit(1);
@@ -356,8 +356,8 @@ async function main() {
 
 // Run the main function
 main().catch(async (error) => {
-  await log(`Fatal error: ${error.message}`);
-  console.error('Fatal error in OAuth helper:', error);
+  await log('Fatal error');
+  console.error('Fatal error in OAuth helper');
   await cleanupPidFile();
   process.exit(1);
 });

--- a/scripts/utils/github-auth.js
+++ b/scripts/utils/github-auth.js
@@ -106,7 +106,7 @@ export async function validateToken(token) {
       },
       isTestMode: isTestMode()
     };
-  } catch (error) {
+  } catch {
     return {
       valid: false,
       error: 'Unable to validate GitHub authentication'

--- a/scripts/utils/github-auth.js
+++ b/scripts/utils/github-auth.js
@@ -14,6 +14,11 @@ import fs from 'fs/promises';
 import path from 'path';
 import { homedir } from 'os';
 
+const CONFIGURED_STORAGE_MESSAGE = '✅ Using OAuth token from configured storage';
+const GITHUB_AUTH_FAILED_ERROR = 'GitHub authentication failed';
+const GITHUB_AUTH_UNAVAILABLE_ERROR = 'Unable to validate GitHub authentication';
+const INVALID_TOKEN_DETAILS = '   GitHub rejected the token or authentication could not be verified';
+
 /**
  * Check if running in test mode (PAT available)
  */
@@ -44,7 +49,7 @@ export async function getAuthToken() {
       const token = await fs.readFile(tokenPath, 'utf-8');
       const trimmed = token.trim();
       if (trimmed && (trimmed.startsWith('gho_') || trimmed.startsWith('ghp_') || trimmed.startsWith('github_pat_'))) {
-        console.log('✅ Using OAuth token from configured storage');
+        console.log(CONFIGURED_STORAGE_MESSAGE);
         return trimmed;
       }
     } catch (error) {
@@ -77,7 +82,7 @@ export async function validateToken(token) {
     if (!response.ok) {
       return { 
         valid: false, 
-        error: 'GitHub authentication failed'
+        error: GITHUB_AUTH_FAILED_ERROR
       };
     }
     
@@ -109,7 +114,7 @@ export async function validateToken(token) {
   } catch {
     return {
       valid: false,
-      error: 'Unable to validate GitHub authentication'
+      error: GITHUB_AUTH_UNAVAILABLE_ERROR
     };
   }
 }
@@ -149,7 +154,7 @@ export async function showAuthStatus() {
   
   if (!validation.valid) {
     console.log('❌ Invalid token');
-    console.log('   GitHub rejected the token or authentication could not be verified');
+    console.log(INVALID_TOKEN_DETAILS);
     return false;
   }
   

--- a/scripts/utils/github-auth.js
+++ b/scripts/utils/github-auth.js
@@ -44,7 +44,7 @@ export async function getAuthToken() {
       const token = await fs.readFile(tokenPath, 'utf-8');
       const trimmed = token.trim();
       if (trimmed && (trimmed.startsWith('gho_') || trimmed.startsWith('ghp_') || trimmed.startsWith('github_pat_'))) {
-        console.log('✅ Using OAuth token from:', tokenPath);
+        console.log('✅ Using OAuth token from configured storage');
         return trimmed;
       }
     } catch (error) {
@@ -77,7 +77,7 @@ export async function validateToken(token) {
     if (!response.ok) {
       return { 
         valid: false, 
-        error: `GitHub API returned ${response.status}: ${response.statusText}` 
+        error: 'GitHub authentication failed'
       };
     }
     
@@ -109,7 +109,7 @@ export async function validateToken(token) {
   } catch (error) {
     return {
       valid: false,
-      error: `Failed to validate token: ${error.message}`
+      error: 'Unable to validate GitHub authentication'
     };
   }
 }
@@ -148,20 +148,20 @@ export async function showAuthStatus() {
   const validation = await validateToken(token);
   
   if (!validation.valid) {
-    console.log('❌ Invalid token:', validation.error);
+    console.log('❌ Invalid token');
+    console.log('   GitHub rejected the token or authentication could not be verified');
     return false;
   }
   
-  console.log('✅ Authenticated as:', validation.user);
-  console.log('   Name:', validation.name || 'Not set');
+  console.log('✅ Authentication verified');
   console.log('   Mode:', validation.isTestMode ? '🧪 TEST (PAT)' : '🔐 PRODUCTION (OAuth)');
   
   if (validation.scopes.length > 0) {
-    console.log('   Scopes:', validation.scopes.join(', '));
+    console.log('   Scopes: available');
   }
   
-  console.log('   Rate Limit:', `${validation.rateLimit.remaining}/${validation.rateLimit.limit}`);
-  console.log('   Reset:', validation.rateLimit.reset.toLocaleTimeString());
+  console.log('   Rate Limit: available');
+  console.log('   Reset: available');
   
   // Warn if using PAT in what looks like production
   if (validation.isTestMode && !process.env.CI && !process.env.TEST) {

--- a/scripts/validate-pat-setup.js
+++ b/scripts/validate-pat-setup.js
@@ -119,14 +119,11 @@ async function checkEnvironmentVariable() {
   if (!isValidFormat) {
     printStatus('warning', 'Token format may be incorrect');
     console.log('   Expected format: ghp_xxxx (classic) or github_pat_xxxx (fine-grained)');
-    console.log('   Your token starts with:', token.substring(0, 8) + '...');
+    console.log('   Token prefix: hidden for safety');
   } else {
     printStatus('success', 'TEST_GITHUB_TOKEN is set and has correct format');
-    const tokenType = token.startsWith('ghp_') ? 'Classic PAT' : 
-                     token.startsWith('github_pat_') ? 'Fine-grained PAT' : 
-                     'OAuth token';
-    console.log(`   Token type: ${tokenType}`);
-    console.log(`   Token prefix: ${token.substring(0, 12)}...`);
+    console.log('   Token type: recognized GitHub token format');
+    console.log('   Token prefix: hidden for safety');
   }
   
   console.log('');
@@ -148,15 +145,12 @@ async function checkTokenValidity(token) {
     
     if (!validation.valid) {
       printStatus('error', 'Token is invalid or expired');
-      console.log(`   Error: ${validation.error}`);
+      console.log('   GitHub rejected the token or could not validate it');
       return { valid: false };
     }
     
     printStatus('success', 'Token is valid and active');
-    console.log(`   Authenticated as: ${validation.user}`);
-    if (validation.name) {
-      console.log(`   Display name: ${validation.name}`);
-    }
+    console.log('   GitHub user identity verified');
     
     // Check rate limits
     if (validation.rateLimit) {
@@ -164,11 +158,11 @@ async function checkTokenValidity(token) {
       const percentage = Math.round((remaining / limit) * 100);
       
       if (remaining < 100) {
-        printStatus('warning', `Low rate limit remaining: ${remaining}/${limit} (${percentage}%)`);
-        console.log(`   Resets at: ${reset.toLocaleString()}`);
+        printStatus('warning', 'Low GitHub rate limit remaining');
+        console.log('   Reset time available');
       } else {
-        printStatus('success', `Rate limit: ${remaining}/${limit} (${percentage}%)`);
-        console.log(`   Resets at: ${reset.toLocaleString()}`);
+        printStatus('success', 'GitHub rate limit information available');
+        console.log('   Reset time available');
       }
     }
     
@@ -176,7 +170,7 @@ async function checkTokenValidity(token) {
     return { valid: true, validation };
   } catch (error) {
     printStatus('error', 'Failed to validate token');
-    console.log(`   Error: ${error.message}`);
+    console.log('   Validation failed while contacting GitHub');
     console.log('   This could indicate network issues or an invalid token');
     console.log('');
     return { valid: false };
@@ -193,7 +187,7 @@ async function checkScopes(validation) {
   }
   
   const availableScopes = validation.scopes;
-  console.log(`Available scopes: ${availableScopes.join(', ') || 'None reported'}`);
+  console.log(`Available scopes: ${availableScopes.length > 0 ? 'reported by GitHub' : 'none reported'}`);
   console.log('');
   
   const missingRequired = [];
@@ -266,7 +260,7 @@ async function checkModeDetection() {
     console.log('   Neither PAT nor OAuth token available');
   } else {
     printStatus('error', 'Inconsistent authentication state');
-    console.log(`   Test mode: ${testMode}, Token available: ${!!token}`);
+    console.log('   Authentication mode and token availability do not agree');
   }
   
   console.log('');
@@ -374,7 +368,7 @@ async function main() {
   } catch (error) {
     console.log('');
     printStatus('error', 'Validation failed with unexpected error');
-    console.log(`Error: ${error.message}`);
+    console.log('Error details were suppressed for safety');
     console.log('');
     console.log('This might indicate:');
     console.log('  • Network connectivity issues');

--- a/scripts/validate-pat-setup.js
+++ b/scripts/validate-pat-setup.js
@@ -24,6 +24,12 @@ import {
 import fs from 'fs/promises';
 
 // Required scopes for full DollhouseMCP functionality
+const TOKEN_REJECTED_MESSAGE = 'GitHub rejected the token or could not validate it';
+const RATE_LIMIT_LOW_MESSAGE = 'Low GitHub rate limit remaining';
+const RATE_LIMIT_AVAILABLE_MESSAGE = 'GitHub rate limit information available';
+const RESET_TIME_AVAILABLE_MESSAGE = 'Reset time available';
+const ERROR_DETAILS_SUPPRESSED_MESSAGE = 'Error details were suppressed for safety';
+
 const REQUIRED_SCOPES = [
   { scope: 'repo', description: 'Full repository access (read/write)' },
   { scope: 'read:user', description: 'Read user profile information' },
@@ -145,7 +151,7 @@ async function checkTokenValidity(token) {
     
     if (!validation.valid) {
       printStatus('error', 'Token is invalid or expired');
-      console.log('   GitHub rejected the token or could not validate it');
+      console.log(`   ${TOKEN_REJECTED_MESSAGE}`);
       return { valid: false };
     }
     
@@ -157,11 +163,11 @@ async function checkTokenValidity(token) {
       const { remaining } = validation.rateLimit;
       
       if (remaining < 100) {
-        printStatus('warning', 'Low GitHub rate limit remaining');
-        console.log('   Reset time available');
+        printStatus('warning', RATE_LIMIT_LOW_MESSAGE);
+        console.log(`   ${RESET_TIME_AVAILABLE_MESSAGE}`);
       } else {
-        printStatus('success', 'GitHub rate limit information available');
-        console.log('   Reset time available');
+        printStatus('success', RATE_LIMIT_AVAILABLE_MESSAGE);
+        console.log(`   ${RESET_TIME_AVAILABLE_MESSAGE}`);
       }
     }
     
@@ -367,7 +373,7 @@ async function main() {
   } catch {
     console.log('');
     printStatus('error', 'Validation failed with unexpected error');
-    console.log('Error details were suppressed for safety');
+    console.log(ERROR_DETAILS_SUPPRESSED_MESSAGE);
     console.log('');
     console.log('This might indicate:');
     console.log('  • Network connectivity issues');

--- a/scripts/validate-pat-setup.js
+++ b/scripts/validate-pat-setup.js
@@ -154,8 +154,7 @@ async function checkTokenValidity(token) {
     
     // Check rate limits
     if (validation.rateLimit) {
-      const { remaining, limit, reset } = validation.rateLimit;
-      const percentage = Math.round((remaining / limit) * 100);
+      const { remaining } = validation.rateLimit;
       
       if (remaining < 100) {
         printStatus('warning', 'Low GitHub rate limit remaining');
@@ -168,7 +167,7 @@ async function checkTokenValidity(token) {
     
     console.log('');
     return { valid: true, validation };
-  } catch (error) {
+  } catch {
     printStatus('error', 'Failed to validate token');
     console.log('   Validation failed while contacting GitHub');
     console.log('   This could indicate network issues or an invalid token');
@@ -365,7 +364,7 @@ async function main() {
     // Exit with appropriate code
     process.exit(isFullyConfigured ? 0 : 1);
     
-  } catch (error) {
+  } catch {
     console.log('');
     printStatus('error', 'Validation failed with unexpected error');
     console.log('Error details were suppressed for safety');

--- a/tests/qa/oauth-pat-test.mjs
+++ b/tests/qa/oauth-pat-test.mjs
@@ -67,7 +67,7 @@ async function testPATAuthentication() {
     } else {
       failed++;
     }
-  } catch (error) {
+  } catch {
     console.log('Test 3 - Token Retrieval: ❌ Error');
     failed++;
   }
@@ -134,7 +134,7 @@ async function testScopeValidation() {
       }
     }
     
-  } catch (error) {
+  } catch {
     console.log('❌ Error validating token');
     failed++;
   }
@@ -203,7 +203,7 @@ async function testErrorHandling() {
     } else {
       failed++;
     }
-  } catch (error) {
+  } catch {
     console.log(`Test 1 - Invalid Token: ✅ Correctly threw error`);
     console.log('         Error details suppressed for safety');
     passed++;
@@ -219,7 +219,7 @@ async function testErrorHandling() {
     } else {
       failed++;
     }
-  } catch (error) {
+  } catch {
     console.log(`Test 2 - Empty Token: ✅ Correctly threw error`);
     console.log('         Error details suppressed for safety');
     passed++;
@@ -235,7 +235,7 @@ async function testErrorHandling() {
     } else {
       failed++;
     }
-  } catch (error) {
+  } catch {
     console.log(`Test 3 - Null Token: ✅ Correctly handled error`);
     console.log('         Error details suppressed for safety');
     passed++;
@@ -252,7 +252,7 @@ async function testErrorHandling() {
     } else {
       failed++;
     }
-  } catch (error) {
+  } catch {
     console.log(`Test 4 - Fake Token: ✅ Correctly threw error`);
     console.log('         Error details suppressed for safety');
     passed++;
@@ -319,7 +319,7 @@ async function testAuthHeaders() {
       console.log('         Authorization header format was incorrect');
     }
     
-  } catch (error) {
+  } catch {
     console.log('❌ Error getting auth headers');
     failed++;
   }
@@ -346,7 +346,7 @@ async function testRealGitHubAPI() {
     const response = await fetch('https://api.github.com/user', { headers });
     
     if (response.ok) {
-      const user = await response.json();
+      await response.json();
       console.log(`✅ GitHub API Integration successful`);
       console.log('   User profile endpoint returned successfully');
       
@@ -362,7 +362,7 @@ async function testRealGitHubAPI() {
       console.log('❌ GitHub API request failed');
       return false;
     }
-  } catch (error) {
+  } catch {
     console.log('❌ Error testing GitHub API');
     return false;
   }

--- a/tests/qa/oauth-pat-test.mjs
+++ b/tests/qa/oauth-pat-test.mjs
@@ -25,6 +25,10 @@ import { homedir } from 'os';
 
 // Required scopes for full functionality
 const REQUIRED_SCOPES = ['repo', 'read:user', 'user:email', 'read:org'];
+const TOKEN_TYPE_RECOGNIZED_MESSAGE = '         Token type recognized';
+const VALIDATION_FAILURE_REPORTED_MESSAGE = '         Validation failure was reported';
+const ERROR_DETAILS_SUPPRESSED_MESSAGE = '         Error details suppressed for safety';
+const RATE_LIMIT_ENDPOINT_SUCCESS_MESSAGE = '   Rate limit endpoint returned successfully';
 
 async function testPATAuthentication() {
   console.log('🔑 Testing PAT Authentication...\n');
@@ -60,7 +64,7 @@ async function testPATAuthentication() {
     console.log(`Test 3 - Token Retrieval: ${hasToken ? '✅ Success' : '⚠️  No Token'}`);
     if (hasToken && hasPAT) {
       passed++;
-      console.log('         Token type recognized');
+      console.log(TOKEN_TYPE_RECOGNIZED_MESSAGE);
     } else if (!hasToken && !hasPAT) {
       passed++;
       console.log('         No PAT set, no token retrieved (expected)');
@@ -168,7 +172,7 @@ async function testOAuthFallback() {
     console.log(`Test 2 - OAuth Token Search: ${token ? '✅ Found OAuth token' : '⚠️  No OAuth token'}`);
     
     if (token) {
-      console.log('         Token type recognized');
+      console.log(TOKEN_TYPE_RECOGNIZED_MESSAGE);
       passed++;
     } else {
       console.log('         No OAuth token found (expected if not set up)');
@@ -199,13 +203,13 @@ async function testErrorHandling() {
     console.log(`Test 1 - Invalid Token: ${!validation.valid ? '✅ Correctly rejected' : '❌ Incorrectly accepted'}`);
     if (!validation.valid) {
       passed++;
-      console.log('         Validation failure was reported');
+      console.log(VALIDATION_FAILURE_REPORTED_MESSAGE);
     } else {
       failed++;
     }
   } catch {
     console.log(`Test 1 - Invalid Token: ✅ Correctly threw error`);
-    console.log('         Error details suppressed for safety');
+    console.log(ERROR_DETAILS_SUPPRESSED_MESSAGE);
     passed++;
   }
   
@@ -215,13 +219,13 @@ async function testErrorHandling() {
     console.log(`Test 2 - Empty Token: ${!validation.valid ? '✅ Correctly rejected' : '❌ Incorrectly accepted'}`);
     if (!validation.valid) {
       passed++;
-      console.log('         Validation failure was reported');
+      console.log(VALIDATION_FAILURE_REPORTED_MESSAGE);
     } else {
       failed++;
     }
   } catch {
     console.log(`Test 2 - Empty Token: ✅ Correctly threw error`);
-    console.log('         Error details suppressed for safety');
+    console.log(ERROR_DETAILS_SUPPRESSED_MESSAGE);
     passed++;
   }
   
@@ -231,13 +235,13 @@ async function testErrorHandling() {
     console.log(`Test 3 - Null Token: ${!validation.valid ? '✅ Correctly rejected' : '❌ Incorrectly accepted'}`);
     if (!validation.valid) {
       passed++;
-      console.log('         Validation failure was reported');
+      console.log(VALIDATION_FAILURE_REPORTED_MESSAGE);
     } else {
       failed++;
     }
   } catch {
     console.log(`Test 3 - Null Token: ✅ Correctly handled error`);
-    console.log('         Error details suppressed for safety');
+    console.log(ERROR_DETAILS_SUPPRESSED_MESSAGE);
     passed++;
   }
   
@@ -248,13 +252,13 @@ async function testErrorHandling() {
     console.log(`Test 4 - Fake Token: ${!validation.valid ? '✅ Correctly rejected' : '❌ Incorrectly accepted'}`);
     if (!validation.valid) {
       passed++;
-      console.log('         Validation failure was reported');
+      console.log(VALIDATION_FAILURE_REPORTED_MESSAGE);
     } else {
       failed++;
     }
   } catch {
     console.log(`Test 4 - Fake Token: ✅ Correctly threw error`);
-    console.log('         Error details suppressed for safety');
+    console.log(ERROR_DETAILS_SUPPRESSED_MESSAGE);
     passed++;
   }
   
@@ -354,7 +358,7 @@ async function testRealGitHubAPI() {
       const rateLimitResponse = await fetch('https://api.github.com/rate_limit', { headers });
       if (rateLimitResponse.ok) {
         await rateLimitResponse.json();
-        console.log('   Rate limit endpoint returned successfully');
+        console.log(RATE_LIMIT_ENDPOINT_SUCCESS_MESSAGE);
       }
       
       return true;

--- a/tests/qa/oauth-pat-test.mjs
+++ b/tests/qa/oauth-pat-test.mjs
@@ -37,7 +37,7 @@ async function testPATAuthentication() {
   console.log(`Test 1 - PAT Available: ${hasPAT ? '✅ Yes' : '⚠️  No'}`);
   if (hasPAT) {
     passed++;
-    console.log(`         Token prefix: ${process.env.TEST_GITHUB_TOKEN.substring(0, 8)}...`);
+    console.log('         Token is present');
   } else {
     console.log('         Set TEST_GITHUB_TOKEN to test PAT functionality');
     failed++;
@@ -46,7 +46,7 @@ async function testPATAuthentication() {
   // Test 2: Test mode detection
   const testModeResult = isTestMode();
   console.log(`Test 2 - Test Mode: ${testModeResult === hasPAT ? '✅ Correct' : '❌ Incorrect'}`);
-  console.log(`         Expected: ${hasPAT}, Got: ${testModeResult}`);
+  console.log(`         Detection matched environment: ${testModeResult === hasPAT ? 'yes' : 'no'}`);
   if (testModeResult === hasPAT) {
     passed++;
   } else {
@@ -60,9 +60,7 @@ async function testPATAuthentication() {
     console.log(`Test 3 - Token Retrieval: ${hasToken ? '✅ Success' : '⚠️  No Token'}`);
     if (hasToken && hasPAT) {
       passed++;
-      console.log(`         Token type: ${token.startsWith('ghp_') ? 'PAT (classic)' : 
-        token.startsWith('github_pat_') ? 'PAT (fine-grained)' : 
-        token.startsWith('gho_') ? 'OAuth' : 'Unknown'}`);
+      console.log('         Token type recognized');
     } else if (!hasToken && !hasPAT) {
       passed++;
       console.log('         No PAT set, no token retrieved (expected)');
@@ -70,7 +68,7 @@ async function testPATAuthentication() {
       failed++;
     }
   } catch (error) {
-    console.log(`Test 3 - Token Retrieval: ❌ Error - ${error.message}`);
+    console.log('Test 3 - Token Retrieval: ❌ Error');
     failed++;
   }
   
@@ -96,12 +94,13 @@ async function testScopeValidation() {
     const validation = await validateToken(token);
     
     if (!validation.valid) {
-      console.log(`❌ Token validation failed: ${validation.error}`);
+      console.log('❌ Token validation failed');
+      console.log('   GitHub rejected the token or validation could not be completed');
       return false;
     }
     
-    console.log(`✅ Token is valid for user: ${validation.user}`);
-    console.log(`   Available scopes: ${validation.scopes.join(', ') || 'None reported'}`);
+    console.log('✅ Token is valid');
+    console.log('   Scope information received');
     
     // Check each required scope
     const missingScopes = [];
@@ -118,7 +117,7 @@ async function testScopeValidation() {
     }
     
     if (missingScopes.length > 0) {
-      console.log(`\n⚠️  Missing scopes: ${missingScopes.join(', ')}`);
+      console.log(`\n⚠️  Missing scopes: ${missingScopes.length}`);
       console.log('   Some features may not work correctly');
       console.log('   Consider creating a new PAT with required scopes');
     }
@@ -126,9 +125,9 @@ async function testScopeValidation() {
     // Test rate limit information
     if (validation.rateLimit) {
       console.log(`\n📊 Rate Limit Status:`);
-      console.log(`   Limit: ${validation.rateLimit.limit}`);
-      console.log(`   Remaining: ${validation.rateLimit.remaining}`);
-      console.log(`   Reset: ${validation.rateLimit.reset.toLocaleString()}`);
+      console.log('   Limit: available');
+      console.log('   Remaining: available');
+      console.log('   Reset: available');
       
       if (validation.rateLimit.remaining < 100) {
         console.log('   ⚠️  Low rate limit remaining');
@@ -136,7 +135,7 @@ async function testScopeValidation() {
     }
     
   } catch (error) {
-    console.log(`❌ Error validating token: ${error.message}`);
+    console.log('❌ Error validating token');
     failed++;
   }
   
@@ -169,7 +168,7 @@ async function testOAuthFallback() {
     console.log(`Test 2 - OAuth Token Search: ${token ? '✅ Found OAuth token' : '⚠️  No OAuth token'}`);
     
     if (token) {
-      console.log(`         Token type: ${token.startsWith('gho_') ? 'OAuth' : 'Other'}`);
+      console.log('         Token type recognized');
       passed++;
     } else {
       console.log('         No OAuth token found (expected if not set up)');
@@ -200,13 +199,13 @@ async function testErrorHandling() {
     console.log(`Test 1 - Invalid Token: ${!validation.valid ? '✅ Correctly rejected' : '❌ Incorrectly accepted'}`);
     if (!validation.valid) {
       passed++;
-      console.log(`         Error: ${validation.error}`);
+      console.log('         Validation failure was reported');
     } else {
       failed++;
     }
   } catch (error) {
     console.log(`Test 1 - Invalid Token: ✅ Correctly threw error`);
-    console.log(`         Error: ${error.message}`);
+    console.log('         Error details suppressed for safety');
     passed++;
   }
   
@@ -216,13 +215,13 @@ async function testErrorHandling() {
     console.log(`Test 2 - Empty Token: ${!validation.valid ? '✅ Correctly rejected' : '❌ Incorrectly accepted'}`);
     if (!validation.valid) {
       passed++;
-      console.log(`         Error: ${validation.error}`);
+      console.log('         Validation failure was reported');
     } else {
       failed++;
     }
   } catch (error) {
     console.log(`Test 2 - Empty Token: ✅ Correctly threw error`);
-    console.log(`         Error: ${error.message}`);
+    console.log('         Error details suppressed for safety');
     passed++;
   }
   
@@ -232,13 +231,13 @@ async function testErrorHandling() {
     console.log(`Test 3 - Null Token: ${!validation.valid ? '✅ Correctly rejected' : '❌ Incorrectly accepted'}`);
     if (!validation.valid) {
       passed++;
-      console.log(`         Error: ${validation.error}`);
+      console.log('         Validation failure was reported');
     } else {
       failed++;
     }
   } catch (error) {
     console.log(`Test 3 - Null Token: ✅ Correctly handled error`);
-    console.log(`         Error: ${error.message}`);
+    console.log('         Error details suppressed for safety');
     passed++;
   }
   
@@ -249,13 +248,13 @@ async function testErrorHandling() {
     console.log(`Test 4 - Fake Token: ${!validation.valid ? '✅ Correctly rejected' : '❌ Incorrectly accepted'}`);
     if (!validation.valid) {
       passed++;
-      console.log(`         Error: ${validation.error}`);
+      console.log('         Validation failure was reported');
     } else {
       failed++;
     }
   } catch (error) {
     console.log(`Test 4 - Fake Token: ✅ Correctly threw error`);
-    console.log(`         Error: ${error.message}`);
+    console.log('         Error details suppressed for safety');
     passed++;
   }
   
@@ -285,7 +284,7 @@ async function testAuthHeaders() {
     console.log(`Test 1 - Authorization Header: ${hasAuth ? '✅ Present' : '❌ Missing'}`);
     if (hasAuth) {
       passed++;
-      console.log(`         Value: ${headers.Authorization.substring(0, 20)}...`);
+      console.log('         Authorization header value withheld');
     } else {
       failed++;
     }
@@ -295,7 +294,7 @@ async function testAuthHeaders() {
     console.log(`Test 2 - Accept Header: ${hasAccept ? '✅ Present' : '❌ Missing'}`);
     if (hasAccept) {
       passed++;
-      console.log(`         Value: ${headers.Accept}`);
+      console.log('         Accept header verified');
     } else {
       failed++;
     }
@@ -305,7 +304,7 @@ async function testAuthHeaders() {
     console.log(`Test 3 - User-Agent Header: ${hasUserAgent ? '✅ Present' : '❌ Missing'}`);
     if (hasUserAgent) {
       passed++;
-      console.log(`         Value: ${headers['User-Agent']}`);
+      console.log('         User-Agent header verified');
     } else {
       failed++;
     }
@@ -317,11 +316,11 @@ async function testAuthHeaders() {
       passed++;
     } else {
       failed++;
-      console.log(`         Expected 'token ...', got: ${headers.Authorization}`);
+      console.log('         Authorization header format was incorrect');
     }
     
   } catch (error) {
-    console.log(`❌ Error getting auth headers: ${error.message}`);
+    console.log('❌ Error getting auth headers');
     failed++;
   }
   
@@ -349,24 +348,22 @@ async function testRealGitHubAPI() {
     if (response.ok) {
       const user = await response.json();
       console.log(`✅ GitHub API Integration successful`);
-      console.log(`   Authenticated as: ${user.login}`);
-      console.log(`   Name: ${user.name || 'Not set'}`);
-      console.log(`   Public repos: ${user.public_repos}`);
+      console.log('   User profile endpoint returned successfully');
       
       // Test rate limit endpoint
       const rateLimitResponse = await fetch('https://api.github.com/rate_limit', { headers });
       if (rateLimitResponse.ok) {
-        const rateLimit = await rateLimitResponse.json();
-        console.log(`   Rate limit: ${rateLimit.rate.remaining}/${rateLimit.rate.limit}`);
+        await rateLimitResponse.json();
+        console.log('   Rate limit endpoint returned successfully');
       }
       
       return true;
     } else {
-      console.log(`❌ GitHub API request failed: ${response.status} ${response.statusText}`);
+      console.log('❌ GitHub API request failed');
       return false;
     }
   } catch (error) {
-    console.log(`❌ Error testing GitHub API: ${error.message}`);
+    console.log('❌ Error testing GitHub API');
     return false;
   }
 }
@@ -436,6 +433,6 @@ console.log('');
 
 // Run the tests
 runAllPATTests().catch(error => {
-  console.error('Fatal error running PAT tests:', error);
+  console.error('Fatal error running PAT tests');
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- sanitize OAuth helper logging so GitHub/token/error-derived strings are not echoed to logs
- sanitize PAT setup and QA script output to avoid printing token prefixes, auth header values, and raw GitHub response details
- keep the scripts actionable while removing the user-controlled output patterns flagged by SonarCloud

## Verification
- `node --check oauth-helper.mjs`
- `node --check scripts/utils/github-auth.js`
- `node --check scripts/validate-pat-setup.js`
- `node --check tests/qa/oauth-pat-test.mjs`
- `npx eslint --no-ignore --no-warn-ignored oauth-helper.mjs scripts/utils/github-auth.js scripts/validate-pat-setup.js tests/qa/oauth-pat-test.mjs`