### PR TITLE
Replace legacy console leaders on bind recovery

### DIFF
--- a/src/web/console/StaleProcessRecovery.ts
+++ b/src/web/console/StaleProcessRecovery.ts
@@ -87,6 +87,10 @@ export interface KillStaleProcessOutcome {
   detail?: string;
 }
 
+export interface KillStaleProcessOptions {
+  allowActiveHostParent?: boolean;
+}
+
 export function isRecognizedMcpHostParent(command: string): boolean {
   const normalizedCommand = UnicodeValidator.normalize(command).normalizedContent;
   return MCP_HOST_PARENT_PATTERNS.some((pattern) => pattern.test(normalizedCommand));
@@ -142,6 +146,7 @@ function buildKillOutcome(
 async function getKillGuardFailure(
   processInfo: ProcessInspection,
   port: number,
+  options: KillStaleProcessOptions = {},
 ): Promise<KillStaleProcessOutcome | null> {
   const currentUser = (await import('node:os')).userInfo().username;
   if (processInfo.user !== currentUser) {
@@ -161,7 +166,7 @@ async function getKillGuardFailure(
   }
 
   const parentCommand = (await getProcessCommand(processInfo.parentPid)) ?? undefined;
-  if (parentCommand && isRecognizedMcpHostParent(parentCommand)) {
+  if (!options.allowActiveHostParent && parentCommand && isRecognizedMcpHostParent(parentCommand)) {
     await logger.warn(`[WebUI] Port ${port} held by active client-backed DollhouseMCP process (pid ${processInfo.pid}) — not killing`, {
       cmdLine: processInfo.command,
       parentPid: processInfo.parentPid,
@@ -328,14 +333,18 @@ export async function killStaleProcess(pid: number, port: number): Promise<boole
   return outcome.killed;
 }
 
-export async function killStaleProcessDetailed(pid: number, port: number): Promise<KillStaleProcessOutcome> {
+export async function killStaleProcessDetailed(
+  pid: number,
+  port: number,
+  options: KillStaleProcessOptions = {},
+): Promise<KillStaleProcessOutcome> {
   const processInfo = await inspectProcess(pid);
   if (!processInfo) {
     await logger.debug(`[WebUI] Cannot verify process ${pid} — skipping kill`);
     return { killed: false, reason: 'inspect_failed', pid };
   }
 
-  const guardFailure = await getKillGuardFailure(processInfo, port);
+  const guardFailure = await getKillGuardFailure(processInfo, port, options);
   if (guardFailure) {
     return guardFailure;
   }

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -28,11 +28,15 @@ import {
   detectLegacyLeader,
   readLeaderLock,
   deleteLeaderLock,
+  claimLeadership,
+  createLeaderInfo,
   LOCK_VERSION,
   CONSOLE_PROTOCOL_VERSION,
   LEGACY_SERVER_VERSION,
+  evaluateLeaderPreference,
   type ElectionResult,
   type ConsoleLeaderInfo,
+  type LeaderPreferenceDecision,
 } from './LeaderElection.js';
 import { createIngestRoutes } from './IngestRoutes.js';
 import {
@@ -41,7 +45,7 @@ import {
 } from './LeaderForwardingSink.js';
 import { PromotionManager } from './PromotionManager.js';
 import { ConsoleTokenStore } from './consoleToken.js';
-import { findPidOnPort } from './StaleProcessRecovery.js';
+import { findPidOnPort, killStaleProcessDetailed } from './StaleProcessRecovery.js';
 import { env } from '../../config/env.js';
 
 /**
@@ -163,6 +167,12 @@ export interface PortLeaderDiscovery {
 export interface BindFailureRecoveryResult extends PortLeaderDiscovery {
   lockCleanupAttempted: boolean;
   lockCleanupPerformed: boolean;
+}
+
+export interface PortOwnerReplacementDecision {
+  shouldEvict: boolean;
+  ownerPid: number | null;
+  preference: LeaderPreferenceDecision | null;
 }
 
 interface DiscoveryDependencies {
@@ -338,6 +348,26 @@ export async function recoverLeaderBindFailure(
   };
 }
 
+export function evaluatePortOwnerReplacement(
+  candidateLeader: ConsoleLeaderInfo,
+  fallback: PortLeaderDiscovery,
+): PortOwnerReplacementDecision {
+  if (!fallback.leaderInfo || fallback.ownerPid === null || fallback.ownerPid === candidateLeader.pid) {
+    return {
+      shouldEvict: false,
+      ownerPid: fallback.ownerPid,
+      preference: null,
+    };
+  }
+
+  const preference = evaluateLeaderPreference(candidateLeader, fallback.leaderInfo);
+  return {
+    shouldEvict: preference.shouldReplace,
+    ownerPid: fallback.ownerPid,
+    preference,
+  };
+}
+
 /**
  * Start the unified web console.
  *
@@ -427,10 +457,59 @@ async function startAsLeader(
   };
   // bindAndListen now handles EADDRINUSE by finding and killing the stale
   // process on the port, then retrying. No external retry loop needed.
-  const webResult = await startWebServer(serverOpts);
+  let webResult = await startWebServer(serverOpts);
 
   if (webResult.bindResult && !webResult.bindResult.success) {
     const fallback = await recoverLeaderBindFailure(election.leaderInfo, consolePort, primaryToken.token);
+    const replacement = evaluatePortOwnerReplacement(election.leaderInfo, fallback);
+
+    if (replacement.shouldEvict && replacement.ownerPid !== null) {
+      logger.warn('[UnifiedConsole] Attempting forced takeover from older or incompatible active leader', {
+        port: consolePort,
+        ownerPid: replacement.ownerPid,
+        source: fallback.source,
+        candidateSessionId: election.leaderInfo.sessionId,
+        candidateVersion: replacement.preference?.candidateVersion,
+        existingSessionId: fallback.leaderInfo?.sessionId,
+        existingVersion: replacement.preference?.existingVersion,
+        reason: replacement.preference?.reason,
+      });
+
+      const forcedKill = await killStaleProcessDetailed(replacement.ownerPid, consolePort, {
+        allowActiveHostParent: true,
+      });
+      if (forcedKill.killed) {
+        webResult = await startWebServer(serverOpts);
+        if (!webResult.bindResult || webResult.bindResult.success) {
+          const reboundLeaderInfo = createLeaderInfo(options.sessionId, consolePort);
+          const claimed = await claimLeadership(reboundLeaderInfo);
+          if (!claimed) {
+            logger.warn('[UnifiedConsole] Rebound leader bound port but could not immediately re-claim lock', {
+              sessionId: reboundLeaderInfo.sessionId,
+              pid: reboundLeaderInfo.pid,
+              port: reboundLeaderInfo.port,
+            });
+          }
+          election = { role: 'leader', leaderInfo: reboundLeaderInfo };
+        } else {
+          logger.warn('[UnifiedConsole] Forced takeover killed old leader but bind retry still failed', {
+            port: consolePort,
+            bindError: webResult.bindResult.error,
+            bindDetail: webResult.bindResult.detail,
+            ownerPid: replacement.ownerPid,
+          });
+        }
+      } else {
+        logger.warn('[UnifiedConsole] Forced takeover skipped or failed after identifying replaceable leader', {
+          port: consolePort,
+          ownerPid: replacement.ownerPid,
+          reason: forcedKill.reason,
+          detail: forcedKill.detail,
+        });
+      }
+    }
+
+    if (webResult.bindResult && !webResult.bindResult.success) {
     if (fallback.leaderInfo) {
       logger.warn('[UnifiedConsole] Leader role aborted: bind failed, falling back to follower', {
         port: consolePort,
@@ -447,13 +526,14 @@ async function startAsLeader(
       return startAsFollower(options, followerElection, consolePort, primaryToken.token);
     }
 
-    logger.error('[UnifiedConsole] Leader failed to bind and no active leader could be identified', {
-      port: consolePort,
-      provisionalLeaderPid: election.leaderInfo.pid,
-      bindError: webResult.bindResult.error,
-      bindDetail: webResult.bindResult.detail,
-    });
-    throw new Error(`Leader failed to bind port ${consolePort} and no active leader was discoverable`);
+      logger.error('[UnifiedConsole] Leader failed to bind and no active leader could be identified', {
+        port: consolePort,
+        provisionalLeaderPid: election.leaderInfo.pid,
+        bindError: webResult.bindResult.error,
+        bindDetail: webResult.bindResult.detail,
+      });
+      throw new Error(`Leader failed to bind port ${consolePort} and no active leader was discoverable`);
+    }
   }
 
   // Register the leader only after the HTTP listener is actually serving the port.

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -17,6 +17,7 @@ import type { UnifiedLogEntry } from '../../logging/types.js';
 import type { MetricSnapshot } from '../../metrics/types.js';
 import type { MemoryLogSink } from '../../logging/sinks/MemoryLogSink.js';
 import type { MemoryMetricsSink } from '../../metrics/sinks/MemoryMetricsSink.js';
+import type { WebServerOptions, WebServerResult } from '../server.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { logger } from '../../utils/logger.js';
 import {
@@ -45,7 +46,11 @@ import {
 } from './LeaderForwardingSink.js';
 import { PromotionManager } from './PromotionManager.js';
 import { ConsoleTokenStore } from './consoleToken.js';
-import { findPidOnPort, killStaleProcessDetailed } from './StaleProcessRecovery.js';
+import {
+  findPidOnPort,
+  killStaleProcessDetailed,
+  type KillStaleProcessOutcome,
+} from './StaleProcessRecovery.js';
 import { env } from '../../config/env.js';
 
 /**
@@ -173,6 +178,16 @@ export interface PortOwnerReplacementDecision {
   shouldEvict: boolean;
   ownerPid: number | null;
   preference: LeaderPreferenceDecision | null;
+}
+
+interface ForceTakeoverAttemptResult {
+  webResult: WebServerResult;
+  election: ElectionResult;
+  fallback: PortLeaderDiscovery;
+  replacement: PortOwnerReplacementDecision;
+  forcedKill: KillStaleProcessOutcome | null;
+  takeoverAttempted: boolean;
+  reboundLockClaimed: boolean;
 }
 
 interface DiscoveryDependencies {
@@ -368,6 +383,162 @@ export function evaluatePortOwnerReplacement(
   };
 }
 
+function buildBindFailureLogContext(
+  consolePort: number,
+  provisionalLeader: ConsoleLeaderInfo,
+  bindResult: WebServerResult['bindResult'],
+  fallback: PortLeaderDiscovery,
+  replacement?: PortOwnerReplacementDecision,
+  forcedKill?: KillStaleProcessOutcome | null,
+) {
+  return {
+    port: consolePort,
+    bindError: bindResult?.error,
+    bindDetail: bindResult?.detail,
+    provisionalLeaderPid: provisionalLeader.pid,
+    provisionalLeaderSessionId: provisionalLeader.sessionId,
+    provisionalLeaderVersion: provisionalLeader.serverVersion ?? LEGACY_SERVER_VERSION,
+    provisionalLeaderProtocolVersion: provisionalLeader.consoleProtocolVersion ?? CONSOLE_PROTOCOL_VERSION,
+    fallbackOwnerPid: fallback.ownerPid,
+    fallbackSource: fallback.source,
+    fallbackLeaderPid: fallback.leaderInfo?.pid,
+    fallbackLeaderSessionId: fallback.leaderInfo?.sessionId,
+    fallbackLeaderVersion: fallback.leaderInfo?.serverVersion ?? LEGACY_SERVER_VERSION,
+    fallbackLeaderProtocolVersion: fallback.leaderInfo?.consoleProtocolVersion ?? CONSOLE_PROTOCOL_VERSION,
+    replacementShouldEvict: replacement?.shouldEvict ?? false,
+    replacementReason: replacement?.preference?.reason,
+    forcedKillReason: forcedKill?.reason,
+    forcedKillPid: forcedKill?.pid,
+    forcedKillDetail: forcedKill?.detail,
+  };
+}
+
+async function attemptForceTakeover(
+  options: UnifiedConsoleOptions,
+  currentElection: ElectionResult,
+  consolePort: number,
+  primaryToken: string,
+  serverOpts: WebServerOptions,
+  startWebServerImpl: (options: WebServerOptions) => Promise<WebServerResult>,
+): Promise<ForceTakeoverAttemptResult> {
+  const initialFallback = await recoverLeaderBindFailure(currentElection.leaderInfo, consolePort, primaryToken);
+  const initialReplacement = evaluatePortOwnerReplacement(currentElection.leaderInfo, initialFallback);
+
+  if (!initialReplacement.shouldEvict || initialReplacement.ownerPid === null) {
+    return {
+      webResult: { bindResult: { success: false, error: 'EADDRINUSE', detail: `Port ${consolePort} already in use` } },
+      election: currentElection,
+      fallback: initialFallback,
+      replacement: initialReplacement,
+      forcedKill: null,
+      takeoverAttempted: false,
+      reboundLockClaimed: false,
+    };
+  }
+
+  const latestFallback = await discoverLeaderServingPort(consolePort, primaryToken);
+  const latestReplacement = evaluatePortOwnerReplacement(currentElection.leaderInfo, latestFallback);
+  if (!latestReplacement.shouldEvict || latestReplacement.ownerPid === null) {
+    logger.warn('[UnifiedConsole] Forced takeover target changed before eviction; skipping forced kill', {
+      ...buildBindFailureLogContext(
+        consolePort,
+        currentElection.leaderInfo,
+        { success: false, error: 'EADDRINUSE', detail: `Port ${consolePort} already in use` },
+        latestFallback,
+        latestReplacement,
+      ),
+      previousOwnerPid: initialReplacement.ownerPid,
+    });
+    return {
+      webResult: { bindResult: { success: false, error: 'EADDRINUSE', detail: `Port ${consolePort} already in use` } },
+      election: currentElection,
+      fallback: latestFallback,
+      replacement: latestReplacement,
+      forcedKill: null,
+      takeoverAttempted: false,
+      reboundLockClaimed: false,
+    };
+  }
+
+  logger.warn('[UnifiedConsole] Attempting forced takeover from older or incompatible active leader', {
+    ...buildBindFailureLogContext(
+      consolePort,
+      currentElection.leaderInfo,
+      { success: false, error: 'EADDRINUSE', detail: `Port ${consolePort} already in use` },
+      latestFallback,
+      latestReplacement,
+    ),
+  });
+
+  const forcedKill = await killStaleProcessDetailed(latestReplacement.ownerPid, consolePort, {
+    allowActiveHostParent: true,
+  });
+  if (!forcedKill.killed) {
+    logger.warn('[UnifiedConsole] Forced takeover skipped or failed after identifying replaceable leader', {
+      ...buildBindFailureLogContext(
+        consolePort,
+        currentElection.leaderInfo,
+        { success: false, error: 'EADDRINUSE', detail: `Port ${consolePort} already in use` },
+        latestFallback,
+        latestReplacement,
+        forcedKill,
+      ),
+    });
+    return {
+      webResult: { bindResult: { success: false, error: 'EADDRINUSE', detail: `Port ${consolePort} already in use` } },
+      election: currentElection,
+      fallback: latestFallback,
+      replacement: latestReplacement,
+      forcedKill,
+      takeoverAttempted: true,
+      reboundLockClaimed: false,
+    };
+  }
+
+  const reboundWebResult = await startWebServerImpl(serverOpts);
+  let reboundElection = currentElection;
+  let reboundLockClaimed = false;
+
+  if (!reboundWebResult.bindResult || reboundWebResult.bindResult.success) {
+    const reboundLeaderInfo = createLeaderInfo(options.sessionId, consolePort);
+    reboundLockClaimed = await claimLeadership(reboundLeaderInfo);
+    if (!reboundLockClaimed) {
+      logger.warn('[UnifiedConsole] Rebound leader bound port but could not immediately re-claim lock', {
+        ...buildBindFailureLogContext(
+          consolePort,
+          reboundLeaderInfo,
+          reboundWebResult.bindResult,
+          latestFallback,
+          latestReplacement,
+          forcedKill,
+        ),
+      });
+    }
+    reboundElection = { role: 'leader', leaderInfo: reboundLeaderInfo };
+  } else {
+    logger.warn('[UnifiedConsole] Forced takeover killed old leader but bind retry still failed', {
+      ...buildBindFailureLogContext(
+        consolePort,
+        currentElection.leaderInfo,
+        reboundWebResult.bindResult,
+        latestFallback,
+        latestReplacement,
+        forcedKill,
+      ),
+    });
+  }
+
+  return {
+    webResult: reboundWebResult,
+    election: reboundElection,
+    fallback: latestFallback,
+    replacement: latestReplacement,
+    forcedKill,
+    takeoverAttempted: true,
+    reboundLockClaimed,
+  };
+}
+
 /**
  * Start the unified web console.
  *
@@ -460,77 +631,47 @@ async function startAsLeader(
   let webResult = await startWebServer(serverOpts);
 
   if (webResult.bindResult && !webResult.bindResult.success) {
-    const fallback = await recoverLeaderBindFailure(election.leaderInfo, consolePort, primaryToken.token);
-    const replacement = evaluatePortOwnerReplacement(election.leaderInfo, fallback);
-
-    if (replacement.shouldEvict && replacement.ownerPid !== null) {
-      logger.warn('[UnifiedConsole] Attempting forced takeover from older or incompatible active leader', {
-        port: consolePort,
-        ownerPid: replacement.ownerPid,
-        source: fallback.source,
-        candidateSessionId: election.leaderInfo.sessionId,
-        candidateVersion: replacement.preference?.candidateVersion,
-        existingSessionId: fallback.leaderInfo?.sessionId,
-        existingVersion: replacement.preference?.existingVersion,
-        reason: replacement.preference?.reason,
-      });
-
-      const forcedKill = await killStaleProcessDetailed(replacement.ownerPid, consolePort, {
-        allowActiveHostParent: true,
-      });
-      if (forcedKill.killed) {
-        webResult = await startWebServer(serverOpts);
-        if (!webResult.bindResult || webResult.bindResult.success) {
-          const reboundLeaderInfo = createLeaderInfo(options.sessionId, consolePort);
-          const claimed = await claimLeadership(reboundLeaderInfo);
-          if (!claimed) {
-            logger.warn('[UnifiedConsole] Rebound leader bound port but could not immediately re-claim lock', {
-              sessionId: reboundLeaderInfo.sessionId,
-              pid: reboundLeaderInfo.pid,
-              port: reboundLeaderInfo.port,
-            });
-          }
-          election = { role: 'leader', leaderInfo: reboundLeaderInfo };
-        } else {
-          logger.warn('[UnifiedConsole] Forced takeover killed old leader but bind retry still failed', {
-            port: consolePort,
-            bindError: webResult.bindResult.error,
-            bindDetail: webResult.bindResult.detail,
-            ownerPid: replacement.ownerPid,
-          });
-        }
-      } else {
-        logger.warn('[UnifiedConsole] Forced takeover skipped or failed after identifying replaceable leader', {
-          port: consolePort,
-          ownerPid: replacement.ownerPid,
-          reason: forcedKill.reason,
-          detail: forcedKill.detail,
-        });
-      }
-    }
+    const forceTakeover = await attemptForceTakeover(
+      options,
+      election,
+      consolePort,
+      primaryToken.token,
+      serverOpts,
+      startWebServer,
+    );
+    webResult = forceTakeover.webResult;
+    election = forceTakeover.election;
 
     if (webResult.bindResult && !webResult.bindResult.success) {
-    if (fallback.leaderInfo) {
+      if (forceTakeover.fallback.leaderInfo) {
       logger.warn('[UnifiedConsole] Leader role aborted: bind failed, falling back to follower', {
-        port: consolePort,
-        bindError: webResult.bindResult.error,
-        bindDetail: webResult.bindResult.detail,
-        provisionalLeaderPid: election.leaderInfo.pid,
-        provisionalLeaderSessionId: election.leaderInfo.sessionId,
-        ownerPid: fallback.ownerPid,
-        source: fallback.source,
-        lockCleanupAttempted: fallback.lockCleanupAttempted,
-        lockCleanupPerformed: fallback.lockCleanupPerformed,
+        ...buildBindFailureLogContext(
+          consolePort,
+          election.leaderInfo,
+          webResult.bindResult,
+          forceTakeover.fallback,
+          forceTakeover.replacement,
+          forceTakeover.forcedKill,
+        ),
+        takeoverAttempted: forceTakeover.takeoverAttempted,
+        reboundLockClaimed: forceTakeover.reboundLockClaimed,
+        lockCleanupAttempted: forceTakeover.fallback.source !== 'none',
       });
-      const followerElection: ElectionResult = { role: 'follower', leaderInfo: fallback.leaderInfo };
+      const followerElection: ElectionResult = { role: 'follower', leaderInfo: forceTakeover.fallback.leaderInfo };
       return startAsFollower(options, followerElection, consolePort, primaryToken.token);
-    }
+      }
 
       logger.error('[UnifiedConsole] Leader failed to bind and no active leader could be identified', {
-        port: consolePort,
-        provisionalLeaderPid: election.leaderInfo.pid,
-        bindError: webResult.bindResult.error,
-        bindDetail: webResult.bindResult.detail,
+        ...buildBindFailureLogContext(
+          consolePort,
+          election.leaderInfo,
+          webResult.bindResult,
+          forceTakeover.fallback,
+          forceTakeover.replacement,
+          forceTakeover.forcedKill,
+        ),
+        takeoverAttempted: forceTakeover.takeoverAttempted,
+        reboundLockClaimed: forceTakeover.reboundLockClaimed,
       });
       throw new Error(`Leader failed to bind port ${consolePort} and no active leader was discoverable`);
     }

--- a/tests/unit/web/console/UnifiedConsole.test.ts
+++ b/tests/unit/web/console/UnifiedConsole.test.ts
@@ -21,6 +21,7 @@ import {
   warnIfLegacyConsolePresent,
   discoverLeaderServingPort,
   recoverLeaderBindFailure,
+  evaluatePortOwnerReplacement,
 } from '../../../../src/web/console/UnifiedConsole.js';
 import type { LegacyLeaderInfo, ConsoleLeaderInfo } from '../../../../src/web/console/LeaderElection.js';
 
@@ -294,6 +295,76 @@ describe('recoverLeaderBindFailure', () => {
       sessionId: 'ollie',
       pid: 57117,
       port: 41715,
+    });
+  });
+});
+
+describe('evaluatePortOwnerReplacement', () => {
+  it('prefers evicting an older legacy leader that still owns the console port', () => {
+    const candidateLeader: ConsoleLeaderInfo = {
+      version: 1,
+      pid: 83150,
+      port: 41715,
+      sessionId: 'session-new',
+      startedAt: '2026-04-16T15:45:00.000Z',
+      heartbeat: '2026-04-16T15:45:00.000Z',
+      serverVersion: '2.0.21',
+      consoleProtocolVersion: 1,
+    };
+
+    const decision = evaluatePortOwnerReplacement(candidateLeader, {
+      ownerPid: 57117,
+      source: 'api',
+      leaderInfo: {
+        version: 1,
+        pid: 57117,
+        port: 41715,
+        sessionId: 'session-old',
+        startedAt: '2026-04-09T23:21:46.000Z',
+        heartbeat: '2026-04-16T15:45:00.000Z',
+        serverVersion: undefined,
+        consoleProtocolVersion: undefined,
+      },
+    });
+
+    expect(decision.shouldEvict).toBe(true);
+    expect(decision.ownerPid).toBe(57117);
+    expect(decision.preference).toMatchObject({
+      reason: 'newer-compatible-version',
+      existingVersion: '0.0.0',
+    });
+  });
+
+  it('does not evict a port owner when there is no preference to replace it', () => {
+    const candidateLeader: ConsoleLeaderInfo = {
+      version: 1,
+      pid: 83150,
+      port: 41715,
+      sessionId: 'session-new',
+      startedAt: '2026-04-16T15:45:00.000Z',
+      heartbeat: '2026-04-16T15:45:00.000Z',
+      serverVersion: '2.0.21',
+      consoleProtocolVersion: 1,
+    };
+
+    const decision = evaluatePortOwnerReplacement(candidateLeader, {
+      ownerPid: 57117,
+      source: 'api',
+      leaderInfo: {
+        version: 1,
+        pid: 57117,
+        port: 41715,
+        sessionId: 'session-current',
+        startedAt: '2026-04-16T15:44:00.000Z',
+        heartbeat: '2026-04-16T15:45:00.000Z',
+        serverVersion: '2.0.21',
+        consoleProtocolVersion: 1,
+      },
+    });
+
+    expect(decision.shouldEvict).toBe(false);
+    expect(decision.preference).toMatchObject({
+      reason: 'same-version',
     });
   });
 });


### PR DESCRIPTION
## Summary
- allow a newer authenticated console to evict an older incompatible Dollhouse leader that still owns the console port
- keep the active-host-parent safety guard for ordinary stale recovery, but bypass it intentionally only after bind recovery proves the discovered leader is older or legacy
- add regression coverage for the split-brain case where a live legacy leader keeps serving the old console and blocks new session registration

## Why
A live `2.0.12-rc.15` leader on port `41715` can currently survive behind the host-parent protection and force a `2.0.21` session to fall back to follower mode. That leaves the browser on the old console and the new session never appears in `/api/sessions`.

## Verification
- `npx eslint src/web/console/UnifiedConsole.ts src/web/console/StaleProcessRecovery.ts tests/unit/web/console/UnifiedConsole.test.ts`
- `npm test -- --runInBand tests/unit/web/console/UnifiedConsole.test.ts tests/unit/web/console/LeaderElection.test.ts tests/unit/web/console/stale-process-recovery.test.ts`
- `npm run test:integration -- --runInBand tests/integration/console-lifecycle.test.ts`