### PR TITLE
Stabilize post-release main checks after 2.0.24

### DIFF
--- a/tests/unit/web/console/UnifiedConsole.test.ts
+++ b/tests/unit/web/console/UnifiedConsole.test.ts
@@ -17,6 +17,7 @@
  */
 
 import { describe, it, expect, jest } from '@jest/globals';
+import { PACKAGE_VERSION } from '../../../../src/generated/version.js';
 import {
   warnIfLegacyConsolePresent,
   discoverLeaderServingPort,
@@ -42,6 +43,13 @@ import type { LegacyLeaderInfo, ConsoleLeaderInfo } from '../../../../src/web/co
  * avoids the false positive without suppressing the rule globally.
  */
 const FIXTURE_LEGACY_LOCK_PATH = '/sonar-fixture/legacy.lock';
+
+function makeNewerVersion(version: string): string {
+  const [mainVersion] = version.replace(/^v/, '').split('-');
+  const parts = mainVersion.split('.').map(part => Number.parseInt(part, 10) || 0);
+  const [major = 0, minor = 0, patch = 0] = parts;
+  return `${major}.${minor}.${patch + 1}`;
+}
 
 /** Build a minimal logger stub with jest mocks for .warn and .debug. */
 function makeLoggerStub() {
@@ -443,7 +451,7 @@ describe('resolveFollowerAuthority', () => {
   });
 
   it('follows the actual port owner when split-brain is present but replacement is not preferred', async () => {
-    const actualOwnerVersion = '999.0.0';
+    const actualOwnerVersion = makeNewerVersion(PACKAGE_VERSION);
     const electedLeader: ConsoleLeaderInfo = {
       version: 1,
       pid: 77290,

--- a/tests/unit/web/console/UnifiedConsole.test.ts
+++ b/tests/unit/web/console/UnifiedConsole.test.ts
@@ -443,6 +443,7 @@ describe('resolveFollowerAuthority', () => {
   });
 
   it('follows the actual port owner when split-brain is present but replacement is not preferred', async () => {
+    const actualOwnerVersion = '999.0.0';
     const electedLeader: ConsoleLeaderInfo = {
       version: 1,
       pid: 77290,
@@ -450,7 +451,7 @@ describe('resolveFollowerAuthority', () => {
       sessionId: 'lock-holder',
       startedAt: '2026-04-16T13:55:09.000Z',
       heartbeat: '2026-04-16T16:29:44.000Z',
-      serverVersion: '2.0.23',
+      serverVersion: actualOwnerVersion,
       consoleProtocolVersion: 1,
     };
 
@@ -469,7 +470,7 @@ describe('resolveFollowerAuthority', () => {
           sessionId: 'actual-owner',
           startedAt: '2026-04-16T16:29:44.000Z',
           heartbeat: '2026-04-16T16:29:44.000Z',
-          serverVersion: '2.0.23',
+          serverVersion: actualOwnerVersion,
           consoleProtocolVersion: 1,
         },
       }),
@@ -484,7 +485,7 @@ describe('resolveFollowerAuthority', () => {
         sessionId: 'actual-owner',
         startedAt: '2026-04-16T16:29:44.000Z',
         heartbeat: '2026-04-16T16:29:44.000Z',
-        serverVersion: '2.0.23',
+        serverVersion: actualOwnerVersion,
         consoleProtocolVersion: 1,
       },
     });


### PR DESCRIPTION
## Summary
- stabilize the split-brain follower-authority test so it does not depend on the current package version
- model the non-replacement case with a clearly newer mocked port owner
- restore the failing post-release `main` checks without changing runtime behavior

## Testing
- `npm test -- --runInBand tests/unit/web/console/UnifiedConsole.test.ts`
- `npx eslint tests/unit/web/console/UnifiedConsole.test.ts`