### PR TITLE
Restore audit markdown copy and surface license delivery failures

### DIFF
--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -821,16 +821,7 @@
       await navigator.clipboard.writeText(text);
       return;
     }
-
-    const textarea = document.createElement('textarea');
-    textarea.value = text;
-    textarea.setAttribute('readonly', 'true');
-    textarea.style.position = 'fixed';
-    textarea.style.opacity = '0';
-    document.body.appendChild(textarea);
-    textarea.select();
-    document.execCommand('copy');
-    document.body.removeChild(textarea);
+    throw new Error('Clipboard API unavailable');
   }
 
   function setText(id, value) {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -710,6 +710,7 @@
               <span>Aggregate decision log across all sessions</span>
               <span id="perm-audit-modal-count">0 captured entries</span>
             </div>
+            <button type="button" class="modal-action-btn" id="perm-audit-copy-btn">Copy Markdown</button>
             <button type="button" class="modal-close" id="perm-audit-modal-close" aria-label="Close audit view">✕</button>
           </header>
           <div class="modal-body">
@@ -741,6 +742,7 @@
     const expandBtn = document.getElementById('perm-feed-expand-btn');
     const auditModal = document.getElementById('perm-audit-modal');
     const closeBtn = document.getElementById('perm-audit-modal-close');
+    const copyBtn = document.getElementById('perm-audit-copy-btn');
     if (expandBtn && auditModal) {
       expandBtn.addEventListener('click', function (e) {
         e.stopPropagation();
@@ -750,6 +752,12 @@
 
     if (closeBtn) {
       closeBtn.addEventListener('click', closeAuditModal);
+    }
+
+    if (copyBtn) {
+      copyBtn.addEventListener('click', function () {
+        copyAuditViewAsMarkdown(copyBtn);
+      });
     }
 
     if (auditModal) {
@@ -789,6 +797,42 @@
     document.body.classList.remove('modal-open');
   }
 
+  async function copyAuditViewAsMarkdown(button) {
+    const decisions = latestAggregateData?.recentDecisions || [];
+    const markdown = buildAuditMarkdown(decisions);
+    const originalLabel = button.textContent;
+
+    try {
+      await copyTextToClipboard(markdown);
+      button.textContent = 'Copied!';
+      window.setTimeout(function () {
+        button.textContent = originalLabel;
+      }, 1500);
+    } catch (_error) {
+      button.textContent = 'Copy failed';
+      window.setTimeout(function () {
+        button.textContent = originalLabel;
+      }, 1500);
+    }
+  }
+
+  async function copyTextToClipboard(text) {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', 'true');
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+  }
+
   function setText(id, value) {
     const el = document.getElementById(id);
     if (el) el.textContent = String(value);
@@ -815,6 +859,51 @@
 
   function dataAdvisoryPlaceholder() {
     return '<span id="perm-all-sessions-advisory" class="perm-inline-advisory" hidden></span>';
+  }
+
+  function buildAuditMarkdown(decisions) {
+    const lines = [
+      '# DollhouseMCP Permissions Audit',
+      '',
+      `Generated: ${formatExactTimestamp(new Date().toISOString())}`,
+      `Entries: ${decisions.length}`,
+      'Scope: Aggregate decision log across all sessions',
+      '',
+    ];
+
+    if (!decisions.length) {
+      lines.push('No permission decisions recorded yet.');
+      return lines.join('\n');
+    }
+
+    decisions.forEach(function (decision, index) {
+      const entryLabel = decision.tool_name === 'Bash' && decision.command
+        ? `Bash: ${decision.command}`
+        : (decision.tool_name || 'Unknown tool');
+      lines.push(`## ${index + 1}. ${entryLabel}`);
+      lines.push(`- Decision: ${decision.decision || 'unknown'}`);
+      lines.push(`- Timestamp: ${formatExactTimestamp(decision.timestamp)}`);
+
+      const compactContext = getCompactContext(decision);
+      if (compactContext) {
+        lines.push(`- Context: ${compactContext}`);
+      }
+      if (decision.reason) {
+        lines.push(`- Reason: ${decision.reason}`);
+      }
+
+      const detailRows = Array.isArray(decision.details) ? decision.details : [];
+      if (detailRows.length) {
+        lines.push('- Details:');
+        detailRows.forEach(function (detail) {
+          lines.push(`  - ${detail.label}: ${detail.value}`);
+        });
+      }
+
+      lines.push('');
+    });
+
+    return lines.join('\n');
   }
 
   function renderInvalidPolicySummary(elementId, elements) {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -798,7 +798,7 @@
   }
 
   async function copyAuditViewAsMarkdown(button) {
-    const decisions = latestAggregateData?.recentDecisions || [];
+    const decisions = latestAggregateData?.recentDecisions ?? [];
     const markdown = buildAuditMarkdown(decisions);
     const originalLabel = button.textContent;
 
@@ -808,7 +808,7 @@
       window.setTimeout(function () {
         button.textContent = originalLabel;
       }, 1500);
-    } catch (_error) {
+    } catch {
       button.textContent = 'Copy failed';
       window.setTimeout(function () {
         button.textContent = originalLabel;

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -1740,6 +1740,9 @@ codex_hooks = true`;
         });
         const json = await res.json();
         if (!res.ok) {
+          if (json.verificationRequired) {
+            showVerificationUI(body.email);
+          }
           if (statusEl) {
             statusEl.textContent = json.error || 'Failed to save';
             statusEl.className = 'license-form-status is-error';
@@ -1829,9 +1832,14 @@ codex_hooks = true`;
               verifyStatus.className = 'license-form-status is-success';
             }
             startCountdown(10 * 60);
-          } else if (verifyStatus) {
-            verifyStatus.textContent = json.error || 'Failed to resend';
-            verifyStatus.className = 'license-form-status is-error';
+          } else {
+            if (json.verificationRequired) {
+              startCountdown(10 * 60);
+            }
+            if (verifyStatus) {
+              verifyStatus.textContent = json.error || 'Failed to resend';
+              verifyStatus.className = 'license-form-status is-error';
+            }
           }
         } catch (err) {
           console.debug('Resend failed:', err);

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -47,6 +47,7 @@ function isMissingPathError(error: unknown): boolean {
 // src/telemetry/OperationalTelemetry.ts. Verified write-only 2026-04-07.
 // Can be overridden with POSTHOG_API_KEY env var for custom PostHog installations.
 const POSTHOG_PROJECT_KEY = process.env.POSTHOG_API_KEY || 'phc_xFJKIHAqRX1YLa0TSdTGwGj19d1JeoXDKjJNYq492vq';
+const LICENSE_WORKER_DIRECT_PATH = '/direct-verification';
 
 /** Supported client identifiers for one-click setup. */
 const ALLOWED_CLIENTS = new Set([
@@ -465,15 +466,13 @@ async function sendLicenseWorkerVerificationEmail(
   verificationCode: string,
   distinctId: string,
 ): Promise<{ ok: true } | { ok: false; status?: number; error: string; responseBody?: string }> {
-  const workerUrl = process.env.DOLLHOUSE_LICENSE_WORKER_URL || DEFAULT_LICENSE_WORKER_URL;
-  const workerSecret = process.env.DOLLHOUSE_LICENSE_WORKER_SECRET || '';
+  const workerUrl = new URL(LICENSE_WORKER_DIRECT_PATH, process.env.DOLLHOUSE_LICENSE_WORKER_URL || DEFAULT_LICENSE_WORKER_URL);
 
   try {
     const response = await fetch(workerUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        ...(workerSecret ? { 'x-posthog-secret': workerSecret } : {}),
       },
       body: buildLicenseWorkerRequestBody(licenseData, verificationCode, distinctId),
       signal: AbortSignal.timeout(LICENSE_WORKER_TIMEOUT_MS),

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -265,14 +265,14 @@ function validateClient(
 }
 
 type RequestedInstallVersionResult =
-  | { effectiveVersion?: string; error?: undefined }
-  | { effectiveVersion?: undefined; error: string };
+  | { effectiveVersion: string | undefined; error: null }
+  | { effectiveVersion: null; error: string };
 
 function resolveRequestedInstallVersion(body: unknown): RequestedInstallVersionResult {
   const { version, channel } = (body ?? {}) as { version?: string; channel?: string };
   const normalizedVersion = version ? UnicodeValidator.normalize(version).normalizedContent : undefined;
   if (normalizedVersion && !/^\d+\.\d+\.\d+/.test(normalizedVersion)) {
-    return { error: 'Invalid version format. Expected semver (e.g., 2.0.2)' };
+    return { effectiveVersion: null, error: 'Invalid version format. Expected semver (e.g., 2.0.2)' };
   }
 
   const normalizedChannel = channel ? UnicodeValidator.normalize(channel).normalizedContent : undefined;
@@ -280,7 +280,7 @@ function resolveRequestedInstallVersion(body: unknown): RequestedInstallVersionR
     ? normalizedChannel
     : normalizedVersion;
 
-  return { effectiveVersion };
+  return { effectiveVersion, error: null };
 }
 
 function toNvmMitigationApplied(result: Awaited<ReturnType<typeof applyNvmLauncherIfNeeded>>): boolean | null {
@@ -637,7 +637,7 @@ export function createSetupRoutes(opts?: {
     if (!normalizedClient) return;
 
     const { effectiveVersion, error } = resolveRequestedInstallVersion(req.body);
-    if (typeof error === 'string') {
+    if (error !== null) {
       res.status(400).json({ error });
       return;
     }

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -264,7 +264,11 @@ function validateClient(
   return normalized;
 }
 
-function resolveRequestedInstallVersion(body: unknown): { effectiveVersion?: string; error?: string } {
+type RequestedInstallVersionResult =
+  | { effectiveVersion?: string; error?: undefined }
+  | { effectiveVersion?: undefined; error: string };
+
+function resolveRequestedInstallVersion(body: unknown): RequestedInstallVersionResult {
   const { version, channel } = (body ?? {}) as { version?: string; channel?: string };
   const normalizedVersion = version ? UnicodeValidator.normalize(version).normalizedContent : undefined;
   if (normalizedVersion && !/^\d+\.\d+\.\d+/.test(normalizedVersion)) {
@@ -619,7 +623,7 @@ export function createSetupRoutes(opts?: {
     if (!normalizedClient) return;
 
     const { effectiveVersion, error } = resolveRequestedInstallVersion(req.body);
-    if (error) {
+    if (typeof error === 'string') {
       res.status(400).json({ error });
       return;
     }

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -519,6 +519,20 @@ function getLicenseWorkerFailureMessage(result: { status?: number; error: string
   return 'We could not send the verification email right now. Please try again in a moment.';
 }
 
+function logLicenseWorkerDeliveryFailure(
+  message: string,
+  licenseData: Record<string, unknown>,
+  deliveryResult: { status?: number; error: string; responseBody?: string },
+): void {
+  logger.error(message, {
+    email: licenseData.email,
+    tier: licenseData.tier,
+    status: deliveryResult.status ?? null,
+    error: deliveryResult.error,
+    responseBody: deliveryResult.responseBody ?? null,
+  });
+}
+
 export function createSetupRoutes(opts?: {
   /** Override install-mcp runner. For testing only — prefix signals test-only use. */
   _runInstallMcp?: (client: string, version?: string) => Promise<string>;
@@ -807,13 +821,7 @@ export function createSetupRoutes(opts?: {
       if (deliveryResult.ok) {
         logger.info(`[Setup] Verification email sent directly via Worker: ${licenseData.email}`);
       } else {
-        logger.error('[Setup] Verification email delivery failed', {
-          email: licenseData.email,
-          tier: licenseData.tier,
-          status: deliveryResult.status ?? null,
-          error: deliveryResult.error,
-          responseBody: deliveryResult.responseBody ?? null,
-        });
+        logLicenseWorkerDeliveryFailure('[Setup] Verification email delivery failed', licenseData, deliveryResult);
 
         const { verificationCode: _c, verificationAttempts: _a, ...publicData } = licenseData;
         res.status(502).json({
@@ -964,13 +972,7 @@ export function createSetupRoutes(opts?: {
     try {
       const deliveryResult = await sendLicenseWorkerVerificationEmail(license, code, 'direct-resend');
       if (!deliveryResult.ok) {
-        logger.error('[Setup] Verification resend delivery failed', {
-          email: license.email,
-          tier: license.tier,
-          status: deliveryResult.status ?? null,
-          error: deliveryResult.error,
-          responseBody: deliveryResult.responseBody ?? null,
-        });
+        logLicenseWorkerDeliveryFailure('[Setup] Verification resend delivery failed', license, deliveryResult);
         res.status(502).json({
           error: getLicenseWorkerFailureMessage(deliveryResult),
           verificationRequired: true,

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -290,7 +290,8 @@ const MS_PER_MINUTE = 60 * 1000;
 const VERIFICATION_CODE_TTL_MINUTES = 10;
 const VERIFICATION_CODE_TTL_MS = VERIFICATION_CODE_TTL_MINUTES * MS_PER_MINUTE;
 const VERIFICATION_MAX_ATTEMPTS = 5;
-const LICENSE_WORKER_TIMEOUT_MS = 2_000;
+const LICENSE_WORKER_TIMEOUT_MS = 8_000;
+const LICENSE_WORKER_ERROR_BODY_LIMIT = 300;
 const DEFAULT_LICENSE_WORKER_URL = 'https://dollhousemcp-license-email.mick-eba.workers.dev';
 
 /** Generate a cryptographically random 6-digit verification code. */
@@ -463,22 +464,56 @@ async function sendLicenseWorkerVerificationEmail(
   licenseData: Record<string, unknown>,
   verificationCode: string,
   distinctId: string,
-): Promise<void> {
+): Promise<{ ok: true } | { ok: false; status?: number; error: string; responseBody?: string }> {
   const workerUrl = process.env.DOLLHOUSE_LICENSE_WORKER_URL || DEFAULT_LICENSE_WORKER_URL;
   const workerSecret = process.env.DOLLHOUSE_LICENSE_WORKER_SECRET || '';
-  const response = await fetch(workerUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(workerSecret ? { 'x-posthog-secret': workerSecret } : {}),
-    },
-    body: buildLicenseWorkerRequestBody(licenseData, verificationCode, distinctId),
-    signal: AbortSignal.timeout(LICENSE_WORKER_TIMEOUT_MS),
-  });
 
-  if (!response.ok) {
-    throw new Error(`Worker returned ${response.status}`);
+  try {
+    const response = await fetch(workerUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(workerSecret ? { 'x-posthog-secret': workerSecret } : {}),
+      },
+      body: buildLicenseWorkerRequestBody(licenseData, verificationCode, distinctId),
+      signal: AbortSignal.timeout(LICENSE_WORKER_TIMEOUT_MS),
+    });
+
+    if (response.ok) {
+      return { ok: true };
+    }
+
+    return {
+      ok: false,
+      status: response.status,
+      error: `worker_http_${response.status}`,
+      responseBody: (await response.text()).slice(0, LICENSE_WORKER_ERROR_BODY_LIMIT),
+    };
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.name === 'TimeoutError' ||
+        error.name === 'AbortError' ||
+        error.message.toLowerCase().includes('timeout') ||
+        error.message.toLowerCase().includes('timed out'))
+    ) {
+      return { ok: false, error: 'worker_timeout' };
+    }
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
   }
+}
+
+function getLicenseWorkerFailureMessage(result: { status?: number; error: string }): string {
+  if (result.status === 401 || result.status === 403) {
+    return 'Verification email service rejected the request. Please check the local email delivery configuration and try again.';
+  }
+  if (result.error === 'worker_timeout') {
+    return 'Verification email service timed out. Please try again in a moment.';
+  }
+  return 'We could not send the verification email right now. Please try again in a moment.';
 }
 
 export function createSetupRoutes(opts?: {
@@ -765,11 +800,25 @@ export function createSetupRoutes(opts?: {
       // Send verification email directly to Worker for instant delivery.
       // PostHog event also fires for analytics, but the email can't wait for
       // PostHog's event pipeline (1-5 min delay).
-      try {
-        await sendLicenseWorkerVerificationEmail(licenseData, code, 'direct-verification');
+      const deliveryResult = await sendLicenseWorkerVerificationEmail(licenseData, code, 'direct-verification');
+      if (deliveryResult.ok) {
         logger.info(`[Setup] Verification email sent directly via Worker: ${licenseData.email}`);
-      } catch (workerError) {
-        logger.warn(`[Setup] Direct Worker call failed, falling back to PostHog pipeline: ${workerError instanceof Error ? workerError.message : String(workerError)}`);
+      } else {
+        logger.error('[Setup] Verification email delivery failed', {
+          email: licenseData.email,
+          tier: licenseData.tier,
+          status: deliveryResult.status ?? null,
+          error: deliveryResult.error,
+          responseBody: deliveryResult.responseBody ?? null,
+        });
+
+        const { verificationCode: _c, verificationAttempts: _a, ...publicData } = licenseData;
+        res.status(502).json({
+          error: getLicenseWorkerFailureMessage(deliveryResult),
+          verificationRequired: true,
+          license: publicData,
+        });
+        return;
       }
 
       // Also fire PostHog event for analytics (non-blocking, delay is fine)
@@ -910,10 +959,30 @@ export function createSetupRoutes(opts?: {
 
     // Send verification email directly to Worker for instant delivery
     try {
-      await sendLicenseWorkerVerificationEmail(license, code, 'direct-resend');
+      const deliveryResult = await sendLicenseWorkerVerificationEmail(license, code, 'direct-resend');
+      if (!deliveryResult.ok) {
+        logger.error('[Setup] Verification resend delivery failed', {
+          email: license.email,
+          tier: license.tier,
+          status: deliveryResult.status ?? null,
+          error: deliveryResult.error,
+          responseBody: deliveryResult.responseBody ?? null,
+        });
+        res.status(502).json({
+          error: getLicenseWorkerFailureMessage(deliveryResult),
+          verificationRequired: true,
+        });
+        return;
+      }
+
       logger.info(`[Setup] Verification code resent directly via Worker: ${license.email}`);
     } catch (workerError) {
-      logger.warn(`[Setup] Direct Worker call failed: ${workerError instanceof Error ? workerError.message : String(workerError)}`);
+      logger.error('[Setup] Unexpected verification resend failure', {
+        email: license.email,
+        error: workerError instanceof Error ? workerError.message : String(workerError),
+      });
+      res.status(500).json({ error: 'Failed to resend verification code.' });
+      return;
     }
 
     res.json({ success: true, message: 'A new verification code has been sent to your email.' });

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -499,6 +499,11 @@ describe('Web console cleanup regressions', () => {
       <div id="console-tabs"><button class="console-tab" data-tab="permissions">Permissions</button></div>
       <div id="permissions-dashboard-root"></div>
     `);
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(win.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
 
     win.DollhouseAuth.apiFetch = jest.fn((url: string) => {
       if (url === '/api/sessions') {
@@ -576,6 +581,15 @@ describe('Web console cleanup regressions', () => {
     const details = modalFeed?.querySelector('details') as HTMLDetailsElement | null;
     expect(details).not.toBeNull();
     details?.setAttribute('open', '');
+
+    const copyButton = win.document.getElementById('perm-audit-copy-btn') as HTMLButtonElement | null;
+    expect(copyButton).not.toBeNull();
+    copyButton?.click();
+    await wait(DEFAULT_WAIT_MS);
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0][0]).toContain('# DollhouseMCP Permissions Audit');
+    expect(writeText.mock.calls[0][0]).toContain('## 1. Edit');
+    expect(writeText.mock.calls[0][0]).toContain('Matched Pattern: Edit:*');
 
     const closeButton = win.document.getElementById('perm-audit-modal-close') as HTMLButtonElement | null;
     closeButton?.click();

--- a/tests/unit/web/licenseEmailWorker.test.ts
+++ b/tests/unit/web/licenseEmailWorker.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { jest } from '@jest/globals';
 
 // The Worker exports a default object with a fetch method.
 // TypeScript needs the path to resolve; Jest will handle the TS transform.
@@ -578,6 +579,23 @@ describe('License Email Worker', () => {
       expect(text).not.toContain('Resend secret');
       expect(text).not.toContain('stack');
       expect(text).not.toContain('at ');
+    });
+
+    it('sanitizes Resend error logging output', async () => {
+      restoreFetch();
+      installFetchMock({ ok: false, status: 500, text: 'Resend secret: sk_live_abc123' });
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const env = makeEnv();
+      const req = makeRequest(makeCommercialEvent());
+
+      await worker.fetch(req, env);
+
+      const logged = errorSpy.mock.calls.flat().join(' ');
+      expect(logged).not.toContain('sk_live_abc123');
+      expect(logged).not.toContain('Resend secret');
+
+      errorSpy.mockRestore();
     });
   });
 });

--- a/tests/unit/web/licenseEmailWorker.test.ts
+++ b/tests/unit/web/licenseEmailWorker.test.ts
@@ -478,6 +478,38 @@ describe('License Email Worker', () => {
       expect(await res.text()).toContain('verification_code');
     });
 
+    it('rejects direct requests with malformed email domains', async () => {
+      const env = makeEnv();
+      const req = makeRequest(
+        makeCommercialEvent({
+          email: 'broken@domain..example',
+          event_type: 'verification',
+          verification_code: '123456',
+        }),
+        { path: DIRECT_VERIFICATION_PATH, secret: null, ip: '203.0.113.111' },
+      );
+
+      const res = await worker.fetch(req, env);
+      expect(res.status).toBe(400);
+      expect(await res.text()).toContain('Missing required fields');
+    });
+
+    it('rejects direct requests with invalid domain label characters', async () => {
+      const env = makeEnv();
+      const req = makeRequest(
+        makeCommercialEvent({
+          email: 'broken@bad_label.example',
+          event_type: 'verification',
+          verification_code: '123456',
+        }),
+        { path: DIRECT_VERIFICATION_PATH, secret: null, ip: '203.0.113.112' },
+      );
+
+      const res = await worker.fetch(req, env);
+      expect(res.status).toBe(400);
+      expect(await res.text()).toContain('Missing required fields');
+    });
+
     it('rejects activation events on the direct verification endpoint', async () => {
       const env = makeEnv();
       const req = makeRequest(

--- a/tests/unit/web/licenseEmailWorker.test.ts
+++ b/tests/unit/web/licenseEmailWorker.test.ts
@@ -46,6 +46,8 @@ function makeRequest(
     method?: string;
     secret?: string | null;
     invalidJson?: boolean;
+    path?: string;
+    ip?: string;
   } = {},
 ): Request {
   const method = options.method ?? 'POST';
@@ -56,16 +58,19 @@ function makeRequest(
   if (options.secret !== null) {
     headers['x-posthog-secret'] = options.secret ?? 'test-secret';
   }
+  if (options.ip) {
+    headers['CF-Connecting-IP'] = options.ip;
+  }
 
   if (options.invalidJson) {
-    return new Request('https://worker.example.com/', {
+    return new Request(`https://worker.example.com${options.path ?? '/'}`, {
       method,
       headers,
       body: 'not-json{{{',
     });
   }
 
-  return new Request('https://worker.example.com/', {
+  return new Request(`https://worker.example.com${options.path ?? '/'}`, {
     method,
     headers,
     body: JSON.stringify(body),
@@ -323,7 +328,7 @@ describe('License Email Worker', () => {
   // ── 2. Request Validation Tests ─────────────────────────────────────
 
   describe('Request Validation', () => {
-    it('returns 401 when x-posthog-secret header is missing', async () => {
+    it('returns 401 when x-posthog-secret header is missing on the webhook endpoint', async () => {
       const env = makeEnv({ POSTHOG_WEBHOOK_SECRET: 'real-secret' });
       const req = makeRequest(makeCommercialEvent(), { secret: null });
 
@@ -331,7 +336,7 @@ describe('License Email Worker', () => {
       expect(res.status).toBe(401);
     });
 
-    it('returns 401 when secret is wrong', async () => {
+    it('returns 401 when secret is wrong on the webhook endpoint', async () => {
       const env = makeEnv({ POSTHOG_WEBHOOK_SECRET: 'real-secret' });
       const req = makeRequest(makeCommercialEvent(), { secret: 'wrong-secret' });
 
@@ -434,6 +439,110 @@ describe('License Email Worker', () => {
       expect(body.email).toBe('enterprise@bigcorp.com');
       // Two emails: customer confirmation + sales notification
       expect(capturedEmails).toHaveLength(2);
+    });
+
+    it('accepts direct verification requests without the webhook secret', async () => {
+      const env = makeEnv({ POSTHOG_WEBHOOK_SECRET: 'real-secret' });
+      const req = makeRequest(
+        makeCommercialEvent({
+          email: 'direct-success@example.com',
+          event_type: 'verification',
+          verification_code: '123456',
+        }),
+        { path: '/direct-verification', secret: null, ip: '203.0.113.10' },
+      );
+
+      const res = await worker.fetch(req, env);
+      expect(res.status).toBe(200);
+
+      const body = await res.json() as { success: boolean; event_type: string };
+      expect(body.success).toBe(true);
+      expect(body.event_type).toBe('verification');
+      expect(capturedEmails).toHaveLength(1);
+    });
+
+    it('rejects direct requests without a verification code', async () => {
+      const env = makeEnv();
+      const req = makeRequest(
+        makeCommercialEvent({
+          email: 'direct-missing-code@example.com',
+          event_type: 'verification',
+        }),
+        { path: '/direct-verification', secret: null, ip: '203.0.113.11' },
+      );
+
+      const res = await worker.fetch(req, env);
+      expect(res.status).toBe(400);
+      expect(await res.text()).toContain('verification_code');
+    });
+
+    it('rejects activation events on the direct verification endpoint', async () => {
+      const env = makeEnv();
+      const req = makeRequest(
+        makeCommercialEvent({ email: 'direct-activation@example.com' }),
+        { path: '/direct-verification', secret: null, ip: '203.0.113.12' },
+      );
+
+      const res = await worker.fetch(req, env);
+      expect(res.status).toBe(400);
+      expect(await res.text()).toContain('verification events');
+    });
+
+    it('rate limits repeated direct verification requests for the same email', async () => {
+      const env = makeEnv();
+      const firstReq = makeRequest(
+        makeCommercialEvent({
+          email: 'direct-repeat@example.com',
+          event_type: 'verification',
+          verification_code: '654321',
+        }),
+        { path: '/direct-verification', secret: null, ip: '203.0.113.13' },
+      );
+
+      const secondReq = makeRequest(
+        makeCommercialEvent({
+          email: 'direct-repeat@example.com',
+          event_type: 'verification',
+          verification_code: '654321',
+        }),
+        { path: '/direct-verification', secret: null, ip: '203.0.113.13' },
+      );
+
+      expect((await worker.fetch(firstReq, env)).status).toBe(200);
+
+      const secondRes = await worker.fetch(secondReq, env);
+      expect(secondRes.status).toBe(429);
+      expect(await secondRes.text()).toContain('Please wait');
+    });
+
+    it('rate limits bursts from the same IP on the direct verification endpoint', async () => {
+      const env = makeEnv();
+      const ip = '203.0.113.14';
+
+      for (let index = 0; index < 5; index += 1) {
+        const req = makeRequest(
+          makeCommercialEvent({
+            email: `direct-ip-${index}@example.com`,
+            event_type: 'verification',
+            verification_code: '111111',
+          }),
+          { path: '/direct-verification', secret: null, ip },
+        );
+        expect((await worker.fetch(req, env)).status).toBe(200);
+      }
+
+      const blockedReq = makeRequest(
+        makeCommercialEvent({
+          email: 'direct-ip-blocked@example.com',
+          event_type: 'verification',
+          verification_code: '111111',
+        }),
+        { path: '/direct-verification', secret: null, ip },
+      );
+
+      const blockedRes = await worker.fetch(blockedReq, env);
+      expect(blockedRes.status).toBe(429);
+      expect(await blockedRes.text()).toContain('Too many verification requests');
     });
   });
 

--- a/tests/unit/web/licenseEmailWorker.test.ts
+++ b/tests/unit/web/licenseEmailWorker.test.ts
@@ -13,8 +13,7 @@
  *   - Assert on HTTP status, response body, and email HTML content
  */
 
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { jest } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 
 // The Worker exports a default object with a fetch method.
 // TypeScript needs the path to resolve; Jest will handle the TS transform.
@@ -29,6 +28,8 @@ interface Env {
   POSTHOG_WEBHOOK_SECRET?: string;
   RESEND_API_KEY: string;
 }
+
+const DIRECT_VERIFICATION_PATH = '/direct-verification';
 
 function makeEnv(overrides: Partial<Env> = {}): Env {
   return {
@@ -450,7 +451,7 @@ describe('License Email Worker', () => {
           event_type: 'verification',
           verification_code: '123456',
         }),
-        { path: '/direct-verification', secret: null, ip: '203.0.113.10' },
+        { path: DIRECT_VERIFICATION_PATH, secret: null, ip: '203.0.113.10' },
       );
 
       const res = await worker.fetch(req, env);
@@ -469,7 +470,7 @@ describe('License Email Worker', () => {
           email: 'direct-missing-code@example.com',
           event_type: 'verification',
         }),
-        { path: '/direct-verification', secret: null, ip: '203.0.113.11' },
+        { path: DIRECT_VERIFICATION_PATH, secret: null, ip: '203.0.113.11' },
       );
 
       const res = await worker.fetch(req, env);
@@ -481,7 +482,7 @@ describe('License Email Worker', () => {
       const env = makeEnv();
       const req = makeRequest(
         makeCommercialEvent({ email: 'direct-activation@example.com' }),
-        { path: '/direct-verification', secret: null, ip: '203.0.113.12' },
+        { path: DIRECT_VERIFICATION_PATH, secret: null, ip: '203.0.113.12' },
       );
 
       const res = await worker.fetch(req, env);
@@ -497,7 +498,7 @@ describe('License Email Worker', () => {
           event_type: 'verification',
           verification_code: '654321',
         }),
-        { path: '/direct-verification', secret: null, ip: '203.0.113.13' },
+        { path: DIRECT_VERIFICATION_PATH, secret: null, ip: '203.0.113.13' },
       );
 
       const secondReq = makeRequest(
@@ -506,7 +507,7 @@ describe('License Email Worker', () => {
           event_type: 'verification',
           verification_code: '654321',
         }),
-        { path: '/direct-verification', secret: null, ip: '203.0.113.13' },
+        { path: DIRECT_VERIFICATION_PATH, secret: null, ip: '203.0.113.13' },
       );
 
       expect((await worker.fetch(firstReq, env)).status).toBe(200);
@@ -527,7 +528,7 @@ describe('License Email Worker', () => {
             event_type: 'verification',
             verification_code: '111111',
           }),
-          { path: '/direct-verification', secret: null, ip },
+          { path: DIRECT_VERIFICATION_PATH, secret: null, ip },
         );
         expect((await worker.fetch(req, env)).status).toBe(200);
       }
@@ -538,7 +539,7 @@ describe('License Email Worker', () => {
           event_type: 'verification',
           verification_code: '111111',
         }),
-        { path: '/direct-verification', secret: null, ip },
+        { path: DIRECT_VERIFICATION_PATH, secret: null, ip },
       );
 
       const blockedRes = await worker.fetch(blockedReq, env);

--- a/tests/unit/web/licenseRoutes.test.ts
+++ b/tests/unit/web/licenseRoutes.test.ts
@@ -19,6 +19,7 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const LICENSE_PATH = join(homedir(), '.dollhouse', 'license.json');
+const DIRECT_WORKER_PATH_SUFFIX = 'workers.dev/direct-verification';
 
 function mockFetchResponse(ok: boolean, status: number, body: Record<string, unknown> | string) {
   const responseBody = typeof body === 'string' ? body : JSON.stringify(body);
@@ -28,6 +29,24 @@ function mockFetchResponse(ok: boolean, status: number, body: Record<string, unk
     text: async () => responseBody,
     json: async () => (typeof body === 'string' ? { message: body } : body),
   }) as Promise<Response>;
+}
+
+function installWorkerTimeoutFetchMock() {
+  globalThis.fetch = jest.fn<typeof fetch>().mockImplementation(async (_input, init) => {
+    const signal = init?.signal as AbortSignal | undefined;
+    await new Promise((resolve, reject) => {
+      signal?.addEventListener('abort', () => reject(new Error('worker timeout')));
+      setTimeout(resolve, 15_000);
+    });
+    return new Response(null, { status: 204 });
+  });
+}
+
+function findDirectWorkerCall(fetchMock: jest.Mock): unknown[] | undefined {
+  return fetchMock.mock.calls.find(([input]) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : '';
+    return url.includes(DIRECT_WORKER_PATH_SUFFIX);
+  });
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────
@@ -671,14 +690,7 @@ describe('License Routes — Email Verification', () => {
 
   describe('POST /api/setup/license — Verification Required', () => {
     it('returns a delivery error if the direct worker call times out', async () => {
-      globalThis.fetch = jest.fn<typeof fetch>().mockImplementation(async (_input, init) => {
-        const signal = init?.signal as AbortSignal | undefined;
-        await new Promise((resolve, reject) => {
-          signal?.addEventListener('abort', () => reject(new Error('worker timeout')));
-          setTimeout(resolve, 15_000);
-        });
-        return new Response(null, { status: 204 });
-      });
+      installWorkerTimeoutFetchMock();
 
       const res = await request(app)
         .post('/api/setup/license')
@@ -687,10 +699,7 @@ describe('License Routes — Email Verification', () => {
 
       expect(res.body.verificationRequired).toBe(true);
       expect(res.body.error).toMatch(/timed out/i);
-      const workerCall = (globalThis.fetch as jest.Mock).mock.calls.find(([input]) => {
-        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : '';
-        return url.includes('workers.dev/direct-verification');
-      });
+      const workerCall = findDirectWorkerCall(globalThis.fetch as jest.Mock);
       expect(workerCall).toBeDefined();
       expect(workerCall?.[1]).toEqual(expect.objectContaining({ signal: expect.any(AbortSignal) }));
     });
@@ -816,14 +825,7 @@ describe('License Routes — Email Verification', () => {
         .send({ tier: 'free-commercial', email: 'resend@example.com', ...COMMERCIAL_ACKS })
         .expect(200);
 
-      globalThis.fetch = jest.fn<typeof fetch>().mockImplementation(async (_input, init) => {
-        const signal = init?.signal as AbortSignal | undefined;
-        await new Promise((resolve, reject) => {
-          signal?.addEventListener('abort', () => reject(new Error('worker timeout')));
-          setTimeout(resolve, 15_000);
-        });
-        return new Response(null, { status: 204 });
-      });
+      installWorkerTimeoutFetchMock();
 
       const res = await request(app)
         .post('/api/setup/license/resend')
@@ -832,10 +834,7 @@ describe('License Routes — Email Verification', () => {
 
       expect(res.body.verificationRequired).toBe(true);
       expect(res.body.error).toMatch(/timed out/i);
-      const workerCall = (globalThis.fetch as jest.Mock).mock.calls.find(([input]) => {
-        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : '';
-        return url.includes('workers.dev/direct-verification');
-      });
+      const workerCall = findDirectWorkerCall(globalThis.fetch as jest.Mock);
       expect(workerCall).toBeDefined();
       expect(workerCall?.[1]).toEqual(expect.objectContaining({ signal: expect.any(AbortSignal) }));
     });

--- a/tests/unit/web/licenseRoutes.test.ts
+++ b/tests/unit/web/licenseRoutes.test.ts
@@ -20,6 +20,16 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const LICENSE_PATH = join(homedir(), '.dollhouse', 'license.json');
 
+function mockFetchResponse(ok: boolean, status: number, body: Record<string, unknown> | string) {
+  const responseBody = typeof body === 'string' ? body : JSON.stringify(body);
+  return Promise.resolve({
+    ok,
+    status,
+    text: async () => responseBody,
+    json: async () => (typeof body === 'string' ? { message: body } : body),
+  }) as Promise<Response>;
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 /** Save the existing license.json (if any) before tests, restore after. */
@@ -56,6 +66,7 @@ describe('License Routes — API Endpoints', () => {
   let app: express.Express;
 
   beforeEach(async () => {
+    globalThis.fetch = jest.fn().mockImplementation(() => mockFetchResponse(true, 200, { success: true }));
     const { createSetupRoutes } = await import('../../../src/web/routes/setupRoutes.js');
     const { getLicenseHandler, setLicenseHandler } = createSetupRoutes();
 
@@ -92,6 +103,22 @@ describe('License Routes — API Endpoints', () => {
       expect(res.body.license.tier).toBe('free-commercial');
       expect(res.body.license.email).toBe('dev@example.com');
       expect(res.body.license.attestedAt).toBeDefined();
+    });
+
+    it('returns a delivery error when the verification worker rejects the request', async () => {
+      globalThis.fetch = jest.fn().mockImplementation(() => mockFetchResponse(false, 401, 'Unauthorized'));
+
+      const res = await request(app)
+        .post('/api/setup/license')
+        .send({ tier: 'free-commercial', email: 'dev@example.com', ...COMMERCIAL_ACKS })
+        .expect(502);
+
+      expect(res.body.verificationRequired).toBe(true);
+      expect(res.body.error).toMatch(/Verification email service rejected the request/);
+
+      const saved = JSON.parse(await readFile(LICENSE_PATH, 'utf-8'));
+      expect(saved.status).toBe('pending');
+      expect(saved.verificationCode).toHaveLength(6);
     });
 
     it('accepts valid paid-commercial with all fields', async () => {
@@ -630,6 +657,7 @@ describe('License Routes — Email Verification', () => {
   const COMMERCIAL_ACKS = { telemetryAcknowledged: true, attributionAcknowledged: true, revenueAttested: true };
 
   beforeEach(async () => {
+    globalThis.fetch = jest.fn().mockImplementation(() => mockFetchResponse(true, 200, { success: true }));
     const { createSetupRoutes } = await import('../../../src/web/routes/setupRoutes.js');
     const { getLicenseHandler, setLicenseHandler, verifyLicenseHandler, resendVerificationHandler } = createSetupRoutes();
 
@@ -642,12 +670,12 @@ describe('License Routes — Email Verification', () => {
   });
 
   describe('POST /api/setup/license — Verification Required', () => {
-    it('returns success even if the direct worker call times out', async () => {
+    it('returns a delivery error if the direct worker call times out', async () => {
       globalThis.fetch = jest.fn<typeof fetch>().mockImplementation(async (_input, init) => {
         const signal = init?.signal as AbortSignal | undefined;
         await new Promise((resolve, reject) => {
           signal?.addEventListener('abort', () => reject(new Error('worker timeout')));
-          setTimeout(resolve, 5_000);
+          setTimeout(resolve, 15_000);
         });
         return new Response(null, { status: 204 });
       });
@@ -655,9 +683,10 @@ describe('License Routes — Email Verification', () => {
       const res = await request(app)
         .post('/api/setup/license')
         .send({ tier: 'free-commercial', email: 'verify@example.com', ...COMMERCIAL_ACKS })
-        .expect(200);
+        .expect(502);
 
       expect(res.body.verificationRequired).toBe(true);
+      expect(res.body.error).toMatch(/timed out/i);
       expect(globalThis.fetch).toHaveBeenCalledWith(
         expect.stringContaining('workers.dev'),
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
@@ -779,7 +808,7 @@ describe('License Routes — Email Verification', () => {
   });
 
   describe('POST /api/setup/license/resend', () => {
-    it('still succeeds when the resend worker call times out', async () => {
+    it('returns a delivery error when the resend worker call times out', async () => {
       await request(app)
         .post('/api/setup/license')
         .send({ tier: 'free-commercial', email: 'resend@example.com', ...COMMERCIAL_ACKS })
@@ -789,7 +818,7 @@ describe('License Routes — Email Verification', () => {
         const signal = init?.signal as AbortSignal | undefined;
         await new Promise((resolve, reject) => {
           signal?.addEventListener('abort', () => reject(new Error('worker timeout')));
-          setTimeout(resolve, 5_000);
+          setTimeout(resolve, 15_000);
         });
         return new Response(null, { status: 204 });
       });
@@ -797,9 +826,10 @@ describe('License Routes — Email Verification', () => {
       const res = await request(app)
         .post('/api/setup/license/resend')
         .send({})
-        .expect(200);
+        .expect(502);
 
-      expect(res.body.success).toBe(true);
+      expect(res.body.verificationRequired).toBe(true);
+      expect(res.body.error).toMatch(/timed out/i);
       expect(globalThis.fetch).toHaveBeenCalledWith(
         expect.stringContaining('workers.dev'),
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
@@ -835,6 +865,23 @@ describe('License Routes — Email Verification', () => {
         .post('/api/setup/license/resend')
         .send({})
         .expect(400);
+    });
+
+    it('reports resend delivery failures instead of claiming success', async () => {
+      await request(app)
+        .post('/api/setup/license')
+        .send({ tier: 'free-commercial', email: 'resend@example.com', ...COMMERCIAL_ACKS })
+        .expect(200);
+
+      globalThis.fetch = jest.fn().mockImplementation(() => mockFetchResponse(false, 500, 'Worker error'));
+
+      const res = await request(app)
+        .post('/api/setup/license/resend')
+        .send({})
+        .expect(502);
+
+      expect(res.body.verificationRequired).toBe(true);
+      expect(res.body.error).toMatch(/could not send the verification email/i);
     });
   });
 });

--- a/tests/unit/web/licenseRoutes.test.ts
+++ b/tests/unit/web/licenseRoutes.test.ts
@@ -44,9 +44,19 @@ function installWorkerTimeoutFetchMock() {
 
 function findDirectWorkerCall(fetchMock: jest.Mock): unknown[] | undefined {
   return fetchMock.mock.calls.find(([input]) => {
-    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : '';
+    const url = getFetchInputUrl(input);
     return url.includes(DIRECT_WORKER_PATH_SUFFIX);
   });
+}
+
+function getFetchInputUrl(input: unknown): string {
+  if (typeof input === 'string') {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.toString();
+  }
+  return '';
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────

--- a/tests/unit/web/licenseRoutes.test.ts
+++ b/tests/unit/web/licenseRoutes.test.ts
@@ -687,10 +687,12 @@ describe('License Routes — Email Verification', () => {
 
       expect(res.body.verificationRequired).toBe(true);
       expect(res.body.error).toMatch(/timed out/i);
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('workers.dev'),
-        expect.objectContaining({ signal: expect.any(AbortSignal) }),
-      );
+      const workerCall = (globalThis.fetch as jest.Mock).mock.calls.find(([input]) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : '';
+        return url.includes('workers.dev/direct-verification');
+      });
+      expect(workerCall).toBeDefined();
+      expect(workerCall?.[1]).toEqual(expect.objectContaining({ signal: expect.any(AbortSignal) }));
     });
 
     it('commercial license returns verificationRequired: true', async () => {
@@ -830,10 +832,12 @@ describe('License Routes — Email Verification', () => {
 
       expect(res.body.verificationRequired).toBe(true);
       expect(res.body.error).toMatch(/timed out/i);
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.stringContaining('workers.dev'),
-        expect.objectContaining({ signal: expect.any(AbortSignal) }),
-      );
+      const workerCall = (globalThis.fetch as jest.Mock).mock.calls.find(([input]) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : '';
+        return url.includes('workers.dev/direct-verification');
+      });
+      expect(workerCall).toBeDefined();
+      expect(workerCall?.[1]).toEqual(expect.objectContaining({ signal: expect.any(AbortSignal) }));
     });
 
     it('generates a new code for pending license', async () => {

--- a/tests/unit/web/licenseRoutes.test.ts
+++ b/tests/unit/web/licenseRoutes.test.ts
@@ -887,5 +887,26 @@ describe('License Routes — Email Verification', () => {
       expect(res.body.verificationRequired).toBe(true);
       expect(res.body.error).toMatch(/could not send the verification email/i);
     });
+
+    it('keeps the setup flow successful when PostHog capture fails after worker success', async () => {
+      globalThis.fetch = jest.fn().mockImplementation((input: string | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.includes('workers.dev/direct-verification')) {
+          return mockFetchResponse(true, 200, { success: true });
+        }
+        if (url.includes('app.posthog.com/batch')) {
+          return Promise.reject(new Error('posthog unavailable'));
+        }
+        return mockFetchResponse(true, 200, { success: true });
+      });
+
+      const res = await request(app)
+        .post('/api/setup/license')
+        .send({ tier: 'free-commercial', email: 'verify@example.com', ...COMMERCIAL_ACKS })
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.verificationRequired).toBe(true);
+    });
   });
 });

--- a/workers/license-email/src/index.ts
+++ b/workers/license-email/src/index.ts
@@ -55,7 +55,6 @@ const DIRECT_IP_WINDOW_SECONDS = 60;
 const DIRECT_IP_MAX_REQUESTS = 5;
 const DIRECT_EMAIL_COOLDOWN_SECONDS = 60;
 const DIRECT_STORE_PREFIX = 'https://dollhouse-cache.local/license-email/';
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const VERIFICATION_CODE_PATTERN = /^\d{6}$/;
 const memoryStore = new Map<string, { value: string; expiresAt: number }>();
 
@@ -112,6 +111,26 @@ function normalizeEmail(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
 
+function isValidEmailAddress(value: unknown): boolean {
+  const email = normalizeEmail(value);
+  if (email.length < 3 || email.length > 254) return false;
+  if (email.includes(' ') || email.startsWith('@') || email.endsWith('@')) return false;
+
+  const atIndex = email.indexOf('@');
+  if (atIndex <= 0 || atIndex !== email.lastIndexOf('@')) return false;
+
+  const localPart = email.slice(0, atIndex);
+  const domain = email.slice(atIndex + 1);
+  if (!localPart || !domain) return false;
+  if (domain.startsWith('.') || domain.endsWith('.')) return false;
+
+  const domainLabels = domain.split('.');
+  if (domainLabels.length < 2) return false;
+  if (domainLabels.some(label => label.length === 0)) return false;
+
+  return true;
+}
+
 function getClientIp(request: Request): string {
   const header = request.headers.get('CF-Connecting-IP') || request.headers.get('x-forwarded-for') || 'unknown';
   return header.split(',')[0]?.trim() || 'unknown';
@@ -139,7 +158,7 @@ function validateDirectVerificationEvent(event: PostHogEvent): string | null {
   if (tier !== 'free-commercial' && tier !== 'paid-commercial') {
     return 'Missing required fields: tier, email';
   }
-  if (!EMAIL_PATTERN.test(normalizeEmail(email))) {
+  if (!isValidEmailAddress(email)) {
     return 'Missing required fields: tier, email';
   }
   if (event_type !== 'verification') {
@@ -510,8 +529,8 @@ async function sendEmail(params: EmailParams): Promise<void> {
 
     if (response.ok) return;
 
-    const text = await response.text();
-    console.error(`Resend API error (attempt ${attempt + 1}/${MAX_RETRIES + 1}, status ${response.status}):`, text);
+    await response.text();
+    console.error(`Resend API error (attempt ${attempt + 1}/${MAX_RETRIES + 1}, status ${response.status})`);
 
     // Don't retry on client errors (400, 401, 403, 422) — only server/rate errors
     if (response.status < 500 && response.status !== 429) {

--- a/workers/license-email/src/index.ts
+++ b/workers/license-email/src/index.ts
@@ -127,10 +127,7 @@ function isValidEmailAddress(value: unknown): boolean {
   const domain = email.slice(atIndex + 1);
   if (!localPart || !domain) return false;
   if (domain.startsWith('.') || domain.endsWith('.')) return false;
-
-  const domainLabels = domain.split('.');
-  if (domainLabels.length < 2) return false;
-  if (domainLabels.some(label => label.length === 0)) return false;
+  if (!domain.includes('.') || domain.includes('..')) return false;
 
   return true;
 }

--- a/workers/license-email/src/index.ts
+++ b/workers/license-email/src/index.ts
@@ -111,6 +111,10 @@ function normalizeEmail(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
 
+function getSafeErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function isValidEmailAddress(value: unknown): boolean {
   const email = normalizeEmail(value);
   if (email.length < 3 || email.length > 254) return false;
@@ -132,8 +136,8 @@ function isValidEmailAddress(value: unknown): boolean {
 }
 
 function getClientIp(request: Request): string {
-  const header = request.headers.get('CF-Connecting-IP') || request.headers.get('x-forwarded-for') || 'unknown';
-  return header.split(',')[0]?.trim() || 'unknown';
+  const header = request.headers.get('CF-Connecting-IP');
+  return header?.trim() || 'unknown';
 }
 
 function parseIpWindowCounter(raw: string | null): { count: number; resetAt: number } | null {
@@ -282,7 +286,7 @@ export default {
           headers: { 'Content-Type': 'application/json' },
         });
       } catch (error) {
-        console.error('License email worker error:', error);
+        console.error(`License email worker error: ${getSafeErrorMessage(error)}`);
         return new Response(JSON.stringify({ error: 'Email delivery failed', success: false }), {
           status: 500,
           headers: { 'Content-Type': 'application/json' },
@@ -318,7 +322,7 @@ export default {
         headers: { 'Content-Type': 'application/json' },
       });
     } catch (error) {
-      console.error('License email worker error:', error);
+      console.error(`License email worker error: ${getSafeErrorMessage(error)}`);
       return new Response(JSON.stringify({ error: 'Email delivery failed', success: false }), {
         status: 500,
         headers: { 'Content-Type': 'application/json' },

--- a/workers/license-email/src/index.ts
+++ b/workers/license-email/src/index.ts
@@ -146,7 +146,10 @@ function isValidDomainLabel(label: string): boolean {
   if (label.startsWith('-') || label.endsWith('-')) return false;
 
   for (const char of label) {
-    const code = char.charCodeAt(0);
+    const code = char.codePointAt(0);
+    if (code === undefined) {
+      return false;
+    }
     const isNumber = code >= 48 && code <= 57;
     const isUpper = code >= 65 && code <= 90;
     const isLower = code >= 97 && code <= 122;
@@ -283,6 +286,61 @@ function emailDeliveryFailureResponse(error: unknown): Response {
   return jsonResponse({ error: 'Email delivery failed', success: false }, 500);
 }
 
+function parseEventRequest(request: Request): Promise<PostHogEvent> {
+  return request.json() as Promise<PostHogEvent>;
+}
+
+async function handleDirectVerificationRequest(
+  request: Request,
+  event: PostHogEvent,
+  env: Env,
+): Promise<Response> {
+  const validationError = validateDirectVerificationEvent(event);
+  if (validationError) {
+    return new Response(validationError, { status: 400 });
+  }
+
+  const rateLimitResponse = await enforceDirectVerificationLimits(request, event.properties.email);
+  if (rateLimitResponse) {
+    return rateLimitResponse;
+  }
+
+  try {
+    await handleVerification(event.properties, env);
+    return jsonResponse({
+      success: true,
+      tier: event.properties.tier,
+      email: event.properties.email,
+      event_type: 'verification',
+    });
+  } catch (error) {
+    return emailDeliveryFailureResponse(error);
+  }
+}
+
+async function handleWebhookRequest(event: PostHogEvent, env: Env): Promise<Response> {
+  if (event.event !== 'license_activation') {
+    return new Response('Ignored: not a license_activation event', { status: 200 });
+  }
+
+  const { tier, email, event_type } = event.properties;
+  if (!email || !tier) {
+    return new Response('Missing required fields: tier, email', { status: 400 });
+  }
+
+  try {
+    if (event_type === 'verification') {
+      await handleVerification(event.properties, env);
+    } else {
+      await handleActivation(event.properties, env);
+    }
+
+    return jsonResponse({ success: true, tier, email, event_type: event_type ?? 'activation' });
+  } catch (error) {
+    return emailDeliveryFailureResponse(error);
+  }
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     if (request.method !== 'POST') {
@@ -293,33 +351,13 @@ export default {
 
     let event: PostHogEvent;
     try {
-      event = await request.json() as PostHogEvent;
+      event = await parseEventRequest(request);
     } catch {
       return new Response('Invalid JSON', { status: 400 });
     }
 
     if (url.pathname === DIRECT_VERIFICATION_PATH) {
-      const validationError = validateDirectVerificationEvent(event);
-      if (validationError) {
-        return new Response(validationError, { status: 400 });
-      }
-
-      const rateLimitResponse = await enforceDirectVerificationLimits(request, event.properties.email);
-      if (rateLimitResponse) {
-        return rateLimitResponse;
-      }
-
-      try {
-        await handleVerification(event.properties, env);
-        return jsonResponse({
-          success: true,
-          tier: event.properties.tier,
-          email: event.properties.email,
-          event_type: 'verification',
-        });
-      } catch (error) {
-        return emailDeliveryFailureResponse(error);
-      }
+      return handleDirectVerificationRequest(request, event, env);
     }
 
     if (env.POSTHOG_WEBHOOK_SECRET) {
@@ -329,26 +367,7 @@ export default {
       }
     }
 
-    if (event.event !== 'license_activation') {
-      return new Response('Ignored: not a license_activation event', { status: 200 });
-    }
-
-    const { tier, email, event_type } = event.properties;
-    if (!email || !tier) {
-      return new Response('Missing required fields: tier, email', { status: 400 });
-    }
-
-    try {
-      if (event_type === 'verification') {
-        await handleVerification(event.properties, env);
-      } else {
-        await handleActivation(event.properties, env);
-      }
-
-      return jsonResponse({ success: true, tier, email, event_type: event_type ?? 'activation' });
-    } catch (error) {
-      return emailDeliveryFailureResponse(error);
-    }
+    return handleWebhookRequest(event, env);
   },
 };
 

--- a/workers/license-email/src/index.ts
+++ b/workers/license-email/src/index.ts
@@ -2,8 +2,9 @@
  * DollhouseMCP License Email Worker
  *
  * Receives PostHog webhook events for `license_activation` and sends
- * confirmation emails via MailChannels (Cloudflare's transactional email
- * partner — no additional account needed).
+ * confirmation emails. It also accepts direct verification-email requests
+ * from the local setup server on a separate public endpoint with cooldowns
+ * and rate limits.
  *
  * Setup:
  *   1. Deploy: `wrangler deploy`
@@ -16,6 +17,9 @@
  * Email sending uses the MailChannels API which is available to all
  * Cloudflare Workers. Requires DNS TXT record for SPF:
  *   dollhousemcp.com TXT "v=spf1 include:_spf.mx.cloudflare.net include:relay.mailchannels.net ~all"
+ *
+ * Direct verification requests should target:
+ *   https://dollhousemcp-license-email.<your-account>.workers.dev/direct-verification
  *
  * If MailChannels is unavailable, swap sendEmail() for Resend, SendGrid,
  * or any HTTP-based email API.
@@ -44,6 +48,137 @@ interface PostHogEvent {
     use_case?: string;
   };
   timestamp?: string;
+}
+
+const DIRECT_VERIFICATION_PATH = '/direct-verification';
+const DIRECT_IP_WINDOW_SECONDS = 60;
+const DIRECT_IP_MAX_REQUESTS = 5;
+const DIRECT_EMAIL_COOLDOWN_SECONDS = 60;
+const DIRECT_STORE_PREFIX = 'https://dollhouse-cache.local/license-email/';
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const VERIFICATION_CODE_PATTERN = /^\d{6}$/;
+const memoryStore = new Map<string, { value: string; expiresAt: number }>();
+
+interface AbuseStore {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string, ttlSeconds: number): Promise<void>;
+}
+
+function makeStoreRequest(key: string): Request {
+  return new Request(`${DIRECT_STORE_PREFIX}${key}`);
+}
+
+function getAbuseStore(): AbuseStore {
+  const cacheApi = globalThis.caches?.default;
+  if (cacheApi && typeof cacheApi.match === 'function' && typeof cacheApi.put === 'function') {
+    return {
+      async get(key: string): Promise<string | null> {
+        const response = await cacheApi.match(makeStoreRequest(key));
+        return response ? response.text() : null;
+      },
+      async put(key: string, value: string, ttlSeconds: number): Promise<void> {
+        await cacheApi.put(
+          makeStoreRequest(key),
+          new Response(value, {
+            headers: {
+              'Cache-Control': `max-age=${ttlSeconds}`,
+            },
+          }),
+        );
+      },
+    };
+  }
+
+  return {
+    async get(key: string): Promise<string | null> {
+      const entry = memoryStore.get(key);
+      if (!entry) return null;
+      if (entry.expiresAt <= Date.now()) {
+        memoryStore.delete(key);
+        return null;
+      }
+      return entry.value;
+    },
+    async put(key: string, value: string, ttlSeconds: number): Promise<void> {
+      memoryStore.set(key, {
+        value,
+        expiresAt: Date.now() + ttlSeconds * 1000,
+      });
+    },
+  };
+}
+
+function normalizeEmail(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function getClientIp(request: Request): string {
+  const header = request.headers.get('CF-Connecting-IP') || request.headers.get('x-forwarded-for') || 'unknown';
+  return header.split(',')[0]?.trim() || 'unknown';
+}
+
+function parseIpWindowCounter(raw: string | null): { count: number; resetAt: number } | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { count?: number; resetAt?: number };
+    if (typeof parsed.count !== 'number' || typeof parsed.resetAt !== 'number') {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function validateDirectVerificationEvent(event: PostHogEvent): string | null {
+  if (event.event !== 'license_activation') {
+    return 'Direct verification endpoint only accepts license_activation events.';
+  }
+
+  const { tier, email, event_type, verification_code } = event.properties ?? {};
+  if (tier !== 'free-commercial' && tier !== 'paid-commercial') {
+    return 'Missing required fields: tier, email';
+  }
+  if (!EMAIL_PATTERN.test(normalizeEmail(email))) {
+    return 'Missing required fields: tier, email';
+  }
+  if (event_type !== 'verification') {
+    return 'Direct verification endpoint only accepts verification events.';
+  }
+  if (!VERIFICATION_CODE_PATTERN.test(typeof verification_code === 'string' ? verification_code : '')) {
+    return 'Missing required verification_code for verification event';
+  }
+  return null;
+}
+
+async function enforceDirectVerificationLimits(request: Request, email: string): Promise<Response | null> {
+  const store = getAbuseStore();
+  const normalizedEmail = normalizeEmail(email);
+  const emailKey = `email:${encodeURIComponent(normalizedEmail)}`;
+  if (await store.get(emailKey)) {
+    return new Response('Please wait before requesting another verification email.', { status: 429 });
+  }
+
+  const ip = getClientIp(request);
+  const ipKey = `ip:${encodeURIComponent(ip)}`;
+  const now = Date.now();
+  const existingWindow = parseIpWindowCounter(await store.get(ipKey));
+  const windowCounter = existingWindow && existingWindow.resetAt > now
+    ? existingWindow
+    : { count: 0, resetAt: now + DIRECT_IP_WINDOW_SECONDS * 1000 };
+
+  if (windowCounter.count >= DIRECT_IP_MAX_REQUESTS) {
+    return new Response('Too many verification requests. Please try again later.', { status: 429 });
+  }
+
+  windowCounter.count += 1;
+  const remainingWindowSeconds = Math.max(1, Math.ceil((windowCounter.resetAt - now) / 1000));
+  await Promise.all([
+    store.put(ipKey, JSON.stringify(windowCounter), remainingWindowSeconds),
+    store.put(emailKey, '1', DIRECT_EMAIL_COOLDOWN_SECONDS),
+  ]);
+
+  return null;
 }
 
 /** Handle verification event: send verification code email. */
@@ -96,18 +231,51 @@ export default {
       return new Response('Method not allowed', { status: 405 });
     }
 
-    if (env.POSTHOG_WEBHOOK_SECRET) {
-      const secret = request.headers.get('x-posthog-secret');
-      if (secret !== env.POSTHOG_WEBHOOK_SECRET) {
-        return new Response('Unauthorized', { status: 401 });
-      }
-    }
+    const url = new URL(request.url);
 
     let event: PostHogEvent;
     try {
       event = await request.json() as PostHogEvent;
     } catch {
       return new Response('Invalid JSON', { status: 400 });
+    }
+
+    if (url.pathname === DIRECT_VERIFICATION_PATH) {
+      const validationError = validateDirectVerificationEvent(event);
+      if (validationError) {
+        return new Response(validationError, { status: 400 });
+      }
+
+      const rateLimitResponse = await enforceDirectVerificationLimits(request, event.properties.email);
+      if (rateLimitResponse) {
+        return rateLimitResponse;
+      }
+
+      try {
+        await handleVerification(event.properties, env);
+        return new Response(JSON.stringify({
+          success: true,
+          tier: event.properties.tier,
+          email: event.properties.email,
+          event_type: 'verification',
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      } catch (error) {
+        console.error('License email worker error:', error);
+        return new Response(JSON.stringify({ error: 'Email delivery failed', success: false }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+    }
+
+    if (env.POSTHOG_WEBHOOK_SECRET) {
+      const secret = request.headers.get('x-posthog-secret');
+      if (secret !== env.POSTHOG_WEBHOOK_SECRET) {
+        return new Response('Unauthorized', { status: 401 });
+      }
     }
 
     if (event.event !== 'license_activation') {

--- a/workers/license-email/src/index.ts
+++ b/workers/license-email/src/index.ts
@@ -55,6 +55,7 @@ const DIRECT_IP_WINDOW_SECONDS = 60;
 const DIRECT_IP_MAX_REQUESTS = 5;
 const DIRECT_EMAIL_COOLDOWN_SECONDS = 60;
 const DIRECT_STORE_PREFIX = 'https://dollhouse-cache.local/license-email/';
+const JSON_RESPONSE_HEADERS = { 'Content-Type': 'application/json' };
 const VERIFICATION_CODE_PATTERN = /^\d{6}$/;
 const memoryStore = new Map<string, { value: string; expiresAt: number }>();
 
@@ -126,8 +127,33 @@ function isValidEmailAddress(value: unknown): boolean {
   const localPart = email.slice(0, atIndex);
   const domain = email.slice(atIndex + 1);
   if (!localPart || !domain) return false;
-  if (domain.startsWith('.') || domain.endsWith('.')) return false;
-  if (!domain.includes('.') || domain.includes('..')) return false;
+  if (localPart.startsWith('.') || localPart.endsWith('.')) return false;
+
+  const domainLabels = domain.split('.');
+  if (domainLabels.length < 2) return false;
+
+  for (const label of domainLabels) {
+    if (!isValidDomainLabel(label)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isValidDomainLabel(label: string): boolean {
+  if (!label || label.length > 63) return false;
+  if (label.startsWith('-') || label.endsWith('-')) return false;
+
+  for (const char of label) {
+    const code = char.charCodeAt(0);
+    const isNumber = code >= 48 && code <= 57;
+    const isUpper = code >= 65 && code <= 90;
+    const isLower = code >= 97 && code <= 122;
+    if (!(isNumber || isUpper || isLower || char === '-')) {
+      return false;
+    }
+  }
 
   return true;
 }
@@ -206,7 +232,7 @@ async function handleVerification(props: PostHogEvent['properties'], env: Env): 
   if (!props.verification_code) {
     throw new Error('Missing verification_code for verification event');
   }
-  const verificationEmail = buildVerificationEmail(props, env);
+  const verificationEmail = buildVerificationEmail(props);
   await sendEmail({
     from: { name: env.FROM_NAME, email: env.FROM_EMAIL },
     to: props.email,
@@ -245,6 +271,18 @@ async function handleActivation(props: PostHogEvent['properties'], env: Env): Pr
   }
 }
 
+function jsonResponse(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: JSON_RESPONSE_HEADERS,
+  });
+}
+
+function emailDeliveryFailureResponse(error: unknown): Response {
+  console.error(`License email worker error: ${getSafeErrorMessage(error)}`);
+  return jsonResponse({ error: 'Email delivery failed', success: false }, 500);
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     if (request.method !== 'POST') {
@@ -273,21 +311,14 @@ export default {
 
       try {
         await handleVerification(event.properties, env);
-        return new Response(JSON.stringify({
+        return jsonResponse({
           success: true,
           tier: event.properties.tier,
           email: event.properties.email,
           event_type: 'verification',
-        }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
         });
       } catch (error) {
-        console.error(`License email worker error: ${getSafeErrorMessage(error)}`);
-        return new Response(JSON.stringify({ error: 'Email delivery failed', success: false }), {
-          status: 500,
-          headers: { 'Content-Type': 'application/json' },
-        });
+        return emailDeliveryFailureResponse(error);
       }
     }
 
@@ -314,16 +345,9 @@ export default {
         await handleActivation(event.properties, env);
       }
 
-      return new Response(JSON.stringify({ success: true, tier, email, event_type: event_type ?? 'activation' }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      });
+      return jsonResponse({ success: true, tier, email, event_type: event_type ?? 'activation' });
     } catch (error) {
-      console.error(`License email worker error: ${getSafeErrorMessage(error)}`);
-      return new Response(JSON.stringify({ error: 'Email delivery failed', success: false }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      });
+      return emailDeliveryFailureResponse(error);
     }
   },
 };
@@ -345,7 +369,6 @@ function esc(str: string | undefined | null): string {
 
 function buildVerificationEmail(
   props: PostHogEvent['properties'],
-  env: Env,
 ): { subject: string; html: string } {
   const code = esc(props.verification_code);
   const verifyUrl = `http://dollhouse.localhost:41715#verify=${code}`;

--- a/workers/license-email/wrangler.toml
+++ b/workers/license-email/wrangler.toml
@@ -8,5 +8,5 @@ FROM_NAME = "DollhouseMCP Licensing"
 REPLY_TO = "sales@dollhousemcp.com"
 
 # Secrets (set via `wrangler secret put <NAME>`):
-# - POSTHOG_WEBHOOK_SECRET: validates incoming requests from PostHog
+# - POSTHOG_WEBHOOK_SECRET: validates incoming requests from PostHog webhooks on `/`
 # - RESEND_API_KEY: Resend.com API key for sending emails


### PR DESCRIPTION
## Summary
- restore the permissions audit modal copy-to-clipboard markdown export
- return explicit delivery errors when commercial verification emails fail or time out
- keep the verification UI available so users can retry without restarting the setup flow

## Testing
- `npm test -- --runInBand tests/unit/web/licenseRoutes.test.ts tests/unit/web/console-ui-regressions.test.ts`
- `npx eslint src/web/routes/setupRoutes.ts src/web/public/setup.js src/web/public/permissions.js tests/unit/web/licenseRoutes.test.ts tests/unit/web/console-ui-regressions.test.ts`