### PR TITLE
Support root-path worker verification compatibility

### DIFF
--- a/tests/unit/web/licenseEmailWorker.test.ts
+++ b/tests/unit/web/licenseEmailWorker.test.ts
@@ -463,6 +463,26 @@ describe('License Email Worker', () => {
       expect(capturedEmails).toHaveLength(1);
     });
 
+    it('accepts root-path verification requests without the webhook secret for compatibility', async () => {
+      const env = makeEnv({ POSTHOG_WEBHOOK_SECRET: 'real-secret' });
+      const req = makeRequest(
+        makeCommercialEvent({
+          email: 'root-compat@example.com',
+          event_type: 'verification',
+          verification_code: '123456',
+        }),
+        { secret: null, ip: '203.0.113.15' },
+      );
+
+      const res = await worker.fetch(req, env);
+      expect(res.status).toBe(200);
+
+      const body = await res.json() as { success: boolean; event_type: string };
+      expect(body.success).toBe(true);
+      expect(body.event_type).toBe('verification');
+      expect(capturedEmails).toHaveLength(1);
+    });
+
     it('rejects direct requests without a verification code', async () => {
       const env = makeEnv();
       const req = makeRequest(
@@ -520,6 +540,17 @@ describe('License Email Worker', () => {
       const res = await worker.fetch(req, env);
       expect(res.status).toBe(400);
       expect(await res.text()).toContain('verification events');
+    });
+
+    it('still rejects root-path activation events without the webhook secret', async () => {
+      const env = makeEnv({ POSTHOG_WEBHOOK_SECRET: 'real-secret' });
+      const req = makeRequest(
+        makeCommercialEvent({ email: 'root-activation@example.com' }),
+        { secret: null, ip: '203.0.113.16' },
+      );
+
+      const res = await worker.fetch(req, env);
+      expect(res.status).toBe(401);
     });
 
     it('rate limits repeated direct verification requests for the same email', async () => {

--- a/workers/license-email/src/index.ts
+++ b/workers/license-email/src/index.ts
@@ -318,6 +318,23 @@ async function handleDirectVerificationRequest(
   }
 }
 
+async function maybeHandleCompatibilityVerificationRequest(
+  request: Request,
+  event: PostHogEvent,
+  env: Env,
+): Promise<Response | null> {
+  if (new URL(request.url).pathname !== '/') {
+    return null;
+  }
+
+  const validationError = validateDirectVerificationEvent(event);
+  if (validationError) {
+    return null;
+  }
+
+  return handleDirectVerificationRequest(request, event, env);
+}
+
 async function handleWebhookRequest(event: PostHogEvent, env: Env): Promise<Response> {
   if (event.event !== 'license_activation') {
     return new Response('Ignored: not a license_activation event', { status: 200 });
@@ -363,6 +380,10 @@ export default {
     if (env.POSTHOG_WEBHOOK_SECRET) {
       const secret = request.headers.get('x-posthog-secret');
       if (secret !== env.POSTHOG_WEBHOOK_SECRET) {
+        const compatibilityResponse = await maybeHandleCompatibilityVerificationRequest(request, event, env);
+        if (compatibilityResponse) {
+          return compatibilityResponse;
+        }
         return new Response('Unauthorized', { status: 401 });
       }
     }


### PR DESCRIPTION
## Summary
- allow unauthenticated verification-email requests posted to `/` to reuse the same direct-verification validation and rate limiting path
- keep non-verification traffic on `/` protected by the webhook secret
- add worker coverage for old root-path verification callers so stale servers can still trigger email delivery

## Testing
- `npm test -- --runInBand tests/unit/web/licenseEmailWorker.test.ts`
- live worker verification with `POST /` returning `200` for verification requests and continuing to require the secret for non-verification traffic