### PR TITLE
Fix Codex TOML setup detection

### DIFF
--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -176,12 +176,21 @@ interface DetectResult {
   serverKey?: string;
 }
 
+/**
+ * Parse a single `[mcp_servers.<name>]` TOML section into a config summary.
+ *
+ * When `caseSensitive` is true, the section header must match exactly. This is
+ * important for Codex because the installer writes `[mcp_servers.dollhousemcp]`
+ * in lowercase and we want to prefer that canonical entry over legacy mixed-case
+ * sections that may still be present in the file.
+ */
 function parseTomlSectionConfig(
   sectionName: string,
   raw: string,
+  caseSensitive = false,
 ): Record<string, unknown> | null {
   const escapedSectionName = sectionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const sectionRegex = new RegExp(`\\[mcp_servers\\.${escapedSectionName}\\]`, 'i');
+  const sectionRegex = new RegExp(`\\[mcp_servers\\.${escapedSectionName}\\]`, caseSensitive ? '' : 'i');
   const sectionMatch = sectionRegex.exec(raw);
   if (!sectionMatch) return null;
 
@@ -205,13 +214,19 @@ function parseTomlSectionConfig(
   return tomlConfig;
 }
 
-/** Parse a TOML config file for a DollhouseMCP server entry */
+/**
+ * Parse a TOML config file for a DollhouseMCP server entry.
+ *
+ * Detection prefers the canonical lowercase Codex section name first, then
+ * falls back to older Dollhouse-related section names so stale configs are
+ * still visible in the UI instead of being mistaken for a fresh install.
+ */
 export function parseTomlConfig(raw: string): Omit<DetectResult, 'configPath'> {
   if (!raw.toLowerCase().includes('dollhousemcp')) {
     return { installed: false };
   }
 
-  const exactConfig = parseTomlSectionConfig('dollhousemcp', raw);
+  const exactConfig = parseTomlSectionConfig('dollhousemcp', raw, true);
   if (exactConfig) {
     return { installed: true, currentConfig: exactConfig, serverKey: 'mcp_servers' };
   }

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -15,7 +15,6 @@ import { access, chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { homedir, platform } from 'node:os';
-import { parse as parseToml } from 'smol-toml';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -179,23 +178,29 @@ interface DetectResult {
 
 function parseTomlSectionConfig(
   sectionName: string,
-  mcpServers: Record<string, unknown>,
+  raw: string,
 ): Record<string, unknown> | null {
-  const serverConfig = mcpServers[sectionName];
-  if (!serverConfig || typeof serverConfig !== 'object' || Array.isArray(serverConfig)) {
-    return { serverName: sectionName };
-  }
+  const escapedSectionName = sectionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const sectionRegex = new RegExp(`\\[mcp_servers\\.${escapedSectionName}\\]`, 'i');
+  const sectionMatch = sectionRegex.exec(raw);
+  if (!sectionMatch) return null;
 
   const tomlConfig: Record<string, unknown> = { serverName: sectionName };
-  const { command, args, enabled } = serverConfig as {
-    command?: unknown;
-    args?: unknown;
-    enabled?: unknown;
-  };
+  const sectionStart = sectionMatch.index + sectionMatch[0].length;
+  const nextSection = raw.indexOf('\n[', sectionStart);
+  const sectionContent = nextSection > -1 ? raw.slice(sectionStart, nextSection) : raw.slice(sectionStart);
 
-  if (typeof command === 'string') tomlConfig.command = command;
-  if (Array.isArray(args)) tomlConfig.args = args;
-  if (typeof enabled === 'boolean') tomlConfig.enabled = enabled;
+  const commandMatch = /command\s*=\s*"([^"]+)"/.exec(sectionContent);
+  const argsMatch = /args\s*=\s*\[([^\]]*)\]/.exec(sectionContent);
+  const enabledMatch = /enabled\s*=\s*(true|false)/i.exec(sectionContent);
+
+  if (commandMatch) tomlConfig.command = commandMatch[1];
+  if (argsMatch) {
+    tomlConfig.args = argsMatch[1].split(',').map((arg) => arg.trim().replaceAll('"', ''));
+  }
+  if (enabledMatch) {
+    tomlConfig.enabled = enabledMatch[1].toLowerCase() === 'true';
+  }
 
   return tomlConfig;
 }
@@ -206,29 +211,16 @@ export function parseTomlConfig(raw: string): Omit<DetectResult, 'configPath'> {
     return { installed: false };
   }
 
-  try {
-    const parsed = parseToml(raw) as Record<string, unknown>;
-    const mcpServers = parsed.mcp_servers;
-    if (!mcpServers || typeof mcpServers !== 'object' || Array.isArray(mcpServers)) {
-      return { installed: true, currentConfig: {}, serverKey: 'mcp_servers' };
-    }
-
-    const exactConfig = parseTomlSectionConfig('dollhousemcp', mcpServers as Record<string, unknown>);
-    if (exactConfig) {
-      return { installed: true, currentConfig: exactConfig, serverKey: 'mcp_servers' };
-    }
-
-    const fallbackKey = Object.keys(mcpServers).find((key) => key.toLowerCase().includes('dollhousemcp'));
-    if (!fallbackKey) {
-      return { installed: true, currentConfig: {}, serverKey: 'mcp_servers' };
-    }
-
-    const fallbackConfig = parseTomlSectionConfig(fallbackKey, mcpServers as Record<string, unknown>)
-      ?? { serverName: fallbackKey };
-    return { installed: true, currentConfig: fallbackConfig, serverKey: 'mcp_servers' };
-  } catch {
-    return { installed: true, currentConfig: {}, serverKey: 'mcp_servers' };
+  const exactConfig = parseTomlSectionConfig('dollhousemcp', raw);
+  if (exactConfig) {
+    return { installed: true, currentConfig: exactConfig, serverKey: 'mcp_servers' };
   }
+
+  const sectionMatch = /\[mcp_servers\.([^\]]*dollhousemcp[^\]]*)\]/i.exec(raw);
+  if (!sectionMatch) return { installed: true, currentConfig: {}, serverKey: 'mcp_servers' };
+
+  const fallbackConfig = parseTomlSectionConfig(sectionMatch[1], raw) ?? { serverName: sectionMatch[1] };
+  return { installed: true, currentConfig: fallbackConfig, serverKey: 'mcp_servers' };
 }
 
 /** Parse a JSON config file for a DollhouseMCP server entry */

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -189,8 +189,8 @@ function parseTomlSectionConfig(
   raw: string,
   caseSensitive = false,
 ): Record<string, unknown> | null {
-  const escapedSectionName = sectionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const sectionRegex = new RegExp(`\\[mcp_servers\\.${escapedSectionName}\\]`, caseSensitive ? '' : 'i');
+  const escapedSectionName = sectionName.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+  const sectionRegex = new RegExp(String.raw`\[mcp_servers\.${escapedSectionName}\]`, caseSensitive ? '' : 'i');
   const sectionMatch = sectionRegex.exec(raw);
   if (!sectionMatch) return null;
 

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -177,8 +177,31 @@ interface DetectResult {
   serverKey?: string;
 }
 
+function parseTomlSectionConfig(
+  sectionName: string,
+  mcpServers: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const serverConfig = mcpServers[sectionName];
+  if (!serverConfig || typeof serverConfig !== 'object' || Array.isArray(serverConfig)) {
+    return { serverName: sectionName };
+  }
+
+  const tomlConfig: Record<string, unknown> = { serverName: sectionName };
+  const { command, args, enabled } = serverConfig as {
+    command?: unknown;
+    args?: unknown;
+    enabled?: unknown;
+  };
+
+  if (typeof command === 'string') tomlConfig.command = command;
+  if (Array.isArray(args)) tomlConfig.args = args;
+  if (typeof enabled === 'boolean') tomlConfig.enabled = enabled;
+
+  return tomlConfig;
+}
+
 /** Parse a TOML config file for a DollhouseMCP server entry */
-function parseTomlConfig(raw: string): Omit<DetectResult, 'configPath'> {
+export function parseTomlConfig(raw: string): Omit<DetectResult, 'configPath'> {
   if (!raw.toLowerCase().includes('dollhousemcp')) {
     return { installed: false };
   }
@@ -190,21 +213,19 @@ function parseTomlConfig(raw: string): Omit<DetectResult, 'configPath'> {
       return { installed: true, currentConfig: {}, serverKey: 'mcp_servers' };
     }
 
-    const matchingEntry = Object.entries(mcpServers).find(([key]) =>
-      key.toLowerCase().includes('dollhousemcp'));
-    if (!matchingEntry) {
+    const exactConfig = parseTomlSectionConfig('dollhousemcp', mcpServers as Record<string, unknown>);
+    if (exactConfig) {
+      return { installed: true, currentConfig: exactConfig, serverKey: 'mcp_servers' };
+    }
+
+    const fallbackKey = Object.keys(mcpServers).find((key) => key.toLowerCase().includes('dollhousemcp'));
+    if (!fallbackKey) {
       return { installed: true, currentConfig: {}, serverKey: 'mcp_servers' };
     }
 
-    const [serverName, serverConfig] = matchingEntry;
-    const tomlConfig: Record<string, unknown> = { serverName };
-    if (serverConfig && typeof serverConfig === 'object' && !Array.isArray(serverConfig)) {
-      const { command, args } = serverConfig as { command?: unknown; args?: unknown };
-      if (typeof command === 'string') tomlConfig.command = command;
-      if (Array.isArray(args)) tomlConfig.args = args;
-    }
-
-    return { installed: true, currentConfig: tomlConfig, serverKey: 'mcp_servers' };
+    const fallbackConfig = parseTomlSectionConfig(fallbackKey, mcpServers as Record<string, unknown>)
+      ?? { serverName: fallbackKey };
+    return { installed: true, currentConfig: fallbackConfig, serverKey: 'mcp_servers' };
   } catch {
     return { installed: true, currentConfig: {}, serverKey: 'mcp_servers' };
   }

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -445,6 +445,32 @@ describe('Setup Routes — TOML detection', () => {
     });
   });
 
+  it('treats the canonical lowercase codex section as a stricter match than mixed-case sections', async () => {
+    const { parseTomlConfig } = await import('../../../src/web/routes/setupRoutes.js');
+
+    const raw = [
+      '[mcp_servers.DollhouseMCP]',
+      'command = "/bin/zsh"',
+      'args = ["-lc", "node /tmp/legacy.js"]',
+      'enabled = false',
+      '',
+      '[mcp_servers.dollhousemcp]',
+      'command = "npx"',
+      'args = ["-y", "@dollhousemcp/mcp-server@latest"]',
+      'enabled = true',
+      '',
+    ].join('\n');
+
+    const result = parseTomlConfig(raw);
+
+    expect(result.currentConfig).toEqual({
+      serverName: 'dollhousemcp',
+      command: 'npx',
+      args: ['-y', '@dollhousemcp/mcp-server@latest'],
+      enabled: true,
+    });
+  });
+
   it('falls back to a legacy dollhouse-style section when no exact entry exists', async () => {
     const { parseTomlConfig } = await import('../../../src/web/routes/setupRoutes.js');
 
@@ -463,6 +489,28 @@ describe('Setup Routes — TOML detection', () => {
       serverName: 'DollhouseMCP-V2-Refactor',
       command: '/bin/zsh',
       args: ['-lc', 'node /tmp/mcp-server-v2-refactor/dist/index.js'],
+      enabled: false,
+    });
+  });
+
+  it('preserves a mixed-case legacy section when no lowercase canonical section exists', async () => {
+    const { parseTomlConfig } = await import('../../../src/web/routes/setupRoutes.js');
+
+    const raw = [
+      '[mcp_servers.DollhouseMCP]',
+      'command = "/bin/zsh"',
+      'args = ["-lc", "node /tmp/legacy.js"]',
+      'enabled = false',
+      '',
+    ].join('\n');
+
+    const result = parseTomlConfig(raw);
+
+    expect(result.installed).toBe(true);
+    expect(result.currentConfig).toEqual({
+      serverName: 'DollhouseMCP',
+      command: '/bin/zsh',
+      args: ['-lc', 'node /tmp/legacy.js'],
       enabled: false,
     });
   });

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -416,6 +416,58 @@ describe('Setup Routes — direct JSON MCP installs', () => {
   });
 });
 
+describe('Setup Routes — TOML detection', () => {
+  it('prefers the exact codex dollhousemcp entry over legacy similarly named sections', async () => {
+    const { parseTomlConfig } = await import('../../../src/web/routes/setupRoutes.js');
+
+    const raw = [
+      '[mcp_servers.DollhouseMCP-V2-Refactor]',
+      'command = "/bin/zsh"',
+      'args = ["-lc", "node /tmp/mcp-server-v2-refactor/dist/index.js"]',
+      'enabled = false',
+      '',
+      '[mcp_servers.dollhousemcp]',
+      'command = "npx"',
+      'args = ["-y", "@dollhousemcp/mcp-server@latest"]',
+      'enabled = true',
+      '',
+    ].join('\n');
+
+    const result = parseTomlConfig(raw);
+
+    expect(result.installed).toBe(true);
+    expect(result.serverKey).toBe('mcp_servers');
+    expect(result.currentConfig).toEqual({
+      serverName: 'dollhousemcp',
+      command: 'npx',
+      args: ['-y', '@dollhousemcp/mcp-server@latest'],
+      enabled: true,
+    });
+  });
+
+  it('falls back to a legacy dollhouse-style section when no exact entry exists', async () => {
+    const { parseTomlConfig } = await import('../../../src/web/routes/setupRoutes.js');
+
+    const raw = [
+      '[mcp_servers.DollhouseMCP-V2-Refactor]',
+      'command = "/bin/zsh"',
+      'args = ["-lc", "node /tmp/mcp-server-v2-refactor/dist/index.js"]',
+      'enabled = false',
+      '',
+    ].join('\n');
+
+    const result = parseTomlConfig(raw);
+
+    expect(result.installed).toBe(true);
+    expect(result.currentConfig).toEqual({
+      serverName: 'DollhouseMCP-V2-Refactor',
+      command: '/bin/zsh',
+      args: ['-lc', 'node /tmp/mcp-server-v2-refactor/dist/index.js'],
+      enabled: false,
+    });
+  });
+});
+
 // ── HTML content integrity tests ──────────────────────────────────────
 
 describe('Setup Tab — HTML Content Integrity', () => {


### PR DESCRIPTION
## Summary
- make Codex TOML detection prefer the exact `[mcp_servers.dollhousemcp]` entry over similarly named legacy sections
- include `enabled` in parsed TOML detection details so the setup page surfaces more accurate current state
- add regression coverage for a config that contains both a disabled legacy refactor block and the real live `dollhousemcp` block

## Testing
- `npm test -- --runInBand tests/unit/web/setupRoutes.test.ts -t 'TOML detection'`
- `npx eslint src/web/routes/setupRoutes.ts tests/unit/web/setupRoutes.test.ts`
- `npx tsx -e "import { parseTomlConfig } from './src/web/routes/setupRoutes.ts'; import { readFileSync } from 'node:fs'; const raw = readFileSync(process.env.HOME + '/.codex/config.toml','utf8'); console.log(JSON.stringify(parseTomlConfig(raw), null, 2));"`

## Notes
- ESLint still reports one pre-existing warning in `tests/unit/web/setupRoutes.test.ts` for an unused `getNotice` helper outside this change scope.