### PR TITLE
Recover permission hook port discovery when latest file is missing

### DIFF
--- a/scripts/permission-port-discovery.sh
+++ b/scripts/permission-port-discovery.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# permission-port-discovery.sh — shared port discovery helpers for permission hooks
+
+RUN_DIR="${RUN_DIR:-$HOME/.dollhouse/run}"
+PORT_FILE="${PORT_FILE:-$RUN_DIR/permission-server.port}"
+
+read_port_from_file() {
+  local file_path="$1"
+  local port_value
+
+  [[ -f "$file_path" ]] || return 1
+
+  port_value=$(cat "$file_path" 2>/dev/null)
+  [[ "$port_value" =~ ^[0-9]+$ ]] || return 1
+
+  printf '%s\n' "$port_value"
+}
+
+restore_latest_port_file() {
+  local port_value="$1"
+
+  [[ "$port_value" =~ ^[0-9]+$ ]] || return 1
+  mkdir -p "$RUN_DIR" 2>/dev/null || return 1
+  printf '%s' "$port_value" > "$PORT_FILE" 2>/dev/null || return 1
+  debug "Restored shared port file at $PORT_FILE"
+}
+
+find_latest_live_pid_port_file() {
+  local candidate
+  local file_name
+  local pid
+
+  if ! compgen -G "$RUN_DIR/permission-server-*.port" > /dev/null; then
+    debug "No PID port files found in $RUN_DIR"
+    return 1
+  fi
+
+  while IFS= read -r candidate; do
+    [[ -e "$candidate" ]] || continue
+    file_name="${candidate##*/}"
+    pid="${file_name#permission-server-}"
+    pid="${pid%.port}"
+
+    if ! [[ "$pid" =~ ^[0-9]+$ ]]; then
+      debug "Skipping malformed PID port file: $candidate"
+      continue
+    fi
+
+    if kill -0 "$pid" 2>/dev/null; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+
+    debug "Skipping stale PID port file for dead process $pid: $candidate"
+  done < <(ls -1t "$RUN_DIR"/permission-server-*.port 2>/dev/null || true)
+
+  debug "Found PID port files in $RUN_DIR, but none belonged to a live process"
+  return 1
+}
+
+resolve_permission_port() {
+  local candidate_file
+  local port_value
+
+  if port_value=$(read_port_from_file "$PORT_FILE"); then
+    debug "Shared port file found: $port_value"
+    printf '%s\n' "$port_value"
+    return 0
+  fi
+
+  candidate_file=$(find_latest_live_pid_port_file) || return 1
+  port_value=$(read_port_from_file "$candidate_file") || {
+    debug "Fallback PID port file did not contain a valid port: $candidate_file"
+    return 1
+  }
+  debug "Shared port file missing — using fallback PID port file: $candidate_file"
+  restore_latest_port_file "$port_value" || debug "Could not restore shared port file from fallback"
+  printf '%s\n' "$port_value"
+}

--- a/scripts/pretooluse-dollhouse.sh
+++ b/scripts/pretooluse-dollhouse.sh
@@ -21,6 +21,7 @@ PORT_FILE="$RUN_DIR/permission-server.port"
 MAX_RETRIES=2
 INITIAL_TIMEOUT=5
 HOOK_PLATFORM="${DOLLHOUSE_HOOK_PLATFORM:-claude_code}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Debug logging helper — writes to stderr so it doesn't pollute stdout
 debug() {
@@ -59,63 +60,7 @@ normalize_response() {
   return 0
 }
 
-read_port_from_file() {
-  local file_path="$1"
-  local port_value
-
-  [[ -f "$file_path" ]] || return 1
-
-  port_value=$(cat "$file_path" 2>/dev/null)
-  [[ "$port_value" =~ ^[0-9]+$ ]] || return 1
-
-  printf '%s\n' "$port_value"
-}
-
-restore_latest_port_file() {
-  local port_value="$1"
-
-  [[ "$port_value" =~ ^[0-9]+$ ]] || return 1
-  mkdir -p "$RUN_DIR" 2>/dev/null || return 1
-  printf '%s' "$port_value" > "$PORT_FILE" 2>/dev/null || return 1
-  debug "Restored shared port file at $PORT_FILE"
-}
-
-find_latest_live_pid_port_file() {
-  local candidate
-  local file_name
-  local pid
-
-  while IFS= read -r candidate; do
-    [[ -e "$candidate" ]] || continue
-    file_name="${candidate##*/}"
-    pid="${file_name#permission-server-}"
-    pid="${pid%.port}"
-
-    if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done < <(ls -1t "$RUN_DIR"/permission-server-*.port 2>/dev/null || true)
-
-  return 1
-}
-
-resolve_permission_port() {
-  local candidate_file
-  local port_value
-
-  if port_value=$(read_port_from_file "$PORT_FILE"); then
-    debug "Shared port file found: $port_value"
-    printf '%s\n' "$port_value"
-    return 0
-  fi
-
-  candidate_file=$(find_latest_live_pid_port_file) || return 1
-  port_value=$(read_port_from_file "$candidate_file") || return 1
-  debug "Shared port file missing — using fallback PID port file: $candidate_file"
-  restore_latest_port_file "$port_value" || debug "Could not restore shared port file from fallback"
-  printf '%s\n' "$port_value"
-}
+source "$SCRIPT_DIR/permission-port-discovery.sh"
 
 # Discover the port from the shared file or the newest live PID-keyed file
 if ! PORT=$(resolve_permission_port); then

--- a/scripts/pretooluse-dollhouse.sh
+++ b/scripts/pretooluse-dollhouse.sh
@@ -16,7 +16,8 @@
 # Set DOLLHOUSE_HOOK_DEBUG=1 for debug logging to stderr.
 # Set DOLLHOUSE_HOOK_PLATFORM to override the platform sent to the server.
 
-PORT_FILE="$HOME/.dollhouse/run/permission-server.port"
+RUN_DIR="$HOME/.dollhouse/run"
+PORT_FILE="$RUN_DIR/permission-server.port"
 MAX_RETRIES=2
 INITIAL_TIMEOUT=5
 HOOK_PLATFORM="${DOLLHOUSE_HOOK_PLATFORM:-claude_code}"
@@ -58,18 +59,67 @@ normalize_response() {
   return 0
 }
 
-# Discover the port from the port file
-if [[ -f "$PORT_FILE" ]]; then
-  PORT=$(cat "$PORT_FILE" 2>/dev/null)
-  debug "Port file found: $PORT"
-else
-  debug "No port file at $PORT_FILE — fail open"
-  exit 0
-fi
+read_port_from_file() {
+  local file_path="$1"
+  local port_value
 
-# Validate port is a number
-if ! [[ "$PORT" =~ ^[0-9]+$ ]]; then
-  debug "Invalid port value: $PORT — fail open"
+  [[ -f "$file_path" ]] || return 1
+
+  port_value=$(cat "$file_path" 2>/dev/null)
+  [[ "$port_value" =~ ^[0-9]+$ ]] || return 1
+
+  printf '%s\n' "$port_value"
+}
+
+restore_latest_port_file() {
+  local port_value="$1"
+
+  [[ "$port_value" =~ ^[0-9]+$ ]] || return 1
+  mkdir -p "$RUN_DIR" 2>/dev/null || return 1
+  printf '%s' "$port_value" > "$PORT_FILE" 2>/dev/null || return 1
+  debug "Restored shared port file at $PORT_FILE"
+}
+
+find_latest_live_pid_port_file() {
+  local candidate
+  local file_name
+  local pid
+
+  while IFS= read -r candidate; do
+    [[ -e "$candidate" ]] || continue
+    file_name="${candidate##*/}"
+    pid="${file_name#permission-server-}"
+    pid="${pid%.port}"
+
+    if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done < <(ls -1t "$RUN_DIR"/permission-server-*.port 2>/dev/null || true)
+
+  return 1
+}
+
+resolve_permission_port() {
+  local candidate_file
+  local port_value
+
+  if port_value=$(read_port_from_file "$PORT_FILE"); then
+    debug "Shared port file found: $port_value"
+    printf '%s\n' "$port_value"
+    return 0
+  fi
+
+  candidate_file=$(find_latest_live_pid_port_file) || return 1
+  port_value=$(read_port_from_file "$candidate_file") || return 1
+  debug "Shared port file missing — using fallback PID port file: $candidate_file"
+  restore_latest_port_file "$port_value" || debug "Could not restore shared port file from fallback"
+  printf '%s\n' "$port_value"
+}
+
+# Discover the port from the shared file or the newest live PID-keyed file
+if ! PORT=$(resolve_permission_port); then
+  debug "No usable permission server port file found — fail open"
   exit 0
 fi
 

--- a/scripts/pretooluse-vscode.sh
+++ b/scripts/pretooluse-vscode.sh
@@ -5,7 +5,8 @@
 # tool_input field names differ from Claude Code. This adapter normalizes the
 # most relevant built-in tool names into Dollhouse's existing permission model.
 
-PORT_FILE="$HOME/.dollhouse/run/permission-server.port"
+RUN_DIR="$HOME/.dollhouse/run"
+PORT_FILE="$RUN_DIR/permission-server.port"
 MAX_RETRIES=2
 INITIAL_TIMEOUT=5
 HOOK_PLATFORM="vscode"
@@ -17,15 +18,66 @@ debug() {
   return 0
 }
 
-if [[ -f "$PORT_FILE" ]]; then
-  PORT=$(cat "$PORT_FILE" 2>/dev/null)
-else
-  debug "No port file at $PORT_FILE — fail open"
-  exit 0
-fi
+read_port_from_file() {
+  local file_path="$1"
+  local port_value
 
-if ! [[ "$PORT" =~ ^[0-9]+$ ]]; then
-  debug "Invalid port value: $PORT — fail open"
+  [[ -f "$file_path" ]] || return 1
+
+  port_value=$(cat "$file_path" 2>/dev/null)
+  [[ "$port_value" =~ ^[0-9]+$ ]] || return 1
+
+  printf '%s\n' "$port_value"
+}
+
+restore_latest_port_file() {
+  local port_value="$1"
+
+  [[ "$port_value" =~ ^[0-9]+$ ]] || return 1
+  mkdir -p "$RUN_DIR" 2>/dev/null || return 1
+  printf '%s' "$port_value" > "$PORT_FILE" 2>/dev/null || return 1
+  debug "Restored shared port file at $PORT_FILE"
+}
+
+find_latest_live_pid_port_file() {
+  local candidate
+  local file_name
+  local pid
+
+  while IFS= read -r candidate; do
+    [[ -e "$candidate" ]] || continue
+    file_name="${candidate##*/}"
+    pid="${file_name#permission-server-}"
+    pid="${pid%.port}"
+
+    if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done < <(ls -1t "$RUN_DIR"/permission-server-*.port 2>/dev/null || true)
+
+  return 1
+}
+
+resolve_permission_port() {
+  local candidate_file
+  local port_value
+
+  if port_value=$(read_port_from_file "$PORT_FILE"); then
+    debug "Shared port file found: $port_value"
+    printf '%s\n' "$port_value"
+    return 0
+  fi
+
+  candidate_file=$(find_latest_live_pid_port_file) || return 1
+  port_value=$(read_port_from_file "$candidate_file") || return 1
+  debug "Shared port file missing — using fallback PID port file: $candidate_file"
+  restore_latest_port_file "$port_value" || debug "Could not restore shared port file from fallback"
+  printf '%s\n' "$port_value"
+}
+
+if ! PORT=$(resolve_permission_port); then
+  debug "No usable permission server port file found — fail open"
   exit 0
 fi
 

--- a/scripts/pretooluse-vscode.sh
+++ b/scripts/pretooluse-vscode.sh
@@ -10,6 +10,7 @@ PORT_FILE="$RUN_DIR/permission-server.port"
 MAX_RETRIES=2
 INITIAL_TIMEOUT=5
 HOOK_PLATFORM="vscode"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 debug() {
   if [[ "${DOLLHOUSE_HOOK_DEBUG:-0}" == "1" ]]; then
@@ -18,63 +19,7 @@ debug() {
   return 0
 }
 
-read_port_from_file() {
-  local file_path="$1"
-  local port_value
-
-  [[ -f "$file_path" ]] || return 1
-
-  port_value=$(cat "$file_path" 2>/dev/null)
-  [[ "$port_value" =~ ^[0-9]+$ ]] || return 1
-
-  printf '%s\n' "$port_value"
-}
-
-restore_latest_port_file() {
-  local port_value="$1"
-
-  [[ "$port_value" =~ ^[0-9]+$ ]] || return 1
-  mkdir -p "$RUN_DIR" 2>/dev/null || return 1
-  printf '%s' "$port_value" > "$PORT_FILE" 2>/dev/null || return 1
-  debug "Restored shared port file at $PORT_FILE"
-}
-
-find_latest_live_pid_port_file() {
-  local candidate
-  local file_name
-  local pid
-
-  while IFS= read -r candidate; do
-    [[ -e "$candidate" ]] || continue
-    file_name="${candidate##*/}"
-    pid="${file_name#permission-server-}"
-    pid="${pid%.port}"
-
-    if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done < <(ls -1t "$RUN_DIR"/permission-server-*.port 2>/dev/null || true)
-
-  return 1
-}
-
-resolve_permission_port() {
-  local candidate_file
-  local port_value
-
-  if port_value=$(read_port_from_file "$PORT_FILE"); then
-    debug "Shared port file found: $port_value"
-    printf '%s\n' "$port_value"
-    return 0
-  fi
-
-  candidate_file=$(find_latest_live_pid_port_file) || return 1
-  port_value=$(read_port_from_file "$candidate_file") || return 1
-  debug "Shared port file missing — using fallback PID port file: $candidate_file"
-  restore_latest_port_file "$port_value" || debug "Could not restore shared port file from fallback"
-  printf '%s\n' "$port_value"
-}
+source "$SCRIPT_DIR/permission-port-discovery.sh"
 
 if ! PORT=$(resolve_permission_port); then
   debug "No usable permission server port file found — fail open"

--- a/scripts/pretooluse-windsurf.sh
+++ b/scripts/pretooluse-windsurf.sh
@@ -10,6 +10,7 @@ PORT_FILE="$RUN_DIR/permission-server.port"
 MAX_RETRIES=2
 INITIAL_TIMEOUT=5
 HOOK_PLATFORM="windsurf"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 debug() {
   if [[ "${DOLLHOUSE_HOOK_DEBUG:-0}" == "1" ]]; then
@@ -18,63 +19,7 @@ debug() {
   return 0
 }
 
-read_port_from_file() {
-  local file_path="$1"
-  local port_value
-
-  [[ -f "$file_path" ]] || return 1
-
-  port_value=$(cat "$file_path" 2>/dev/null)
-  [[ "$port_value" =~ ^[0-9]+$ ]] || return 1
-
-  printf '%s\n' "$port_value"
-}
-
-restore_latest_port_file() {
-  local port_value="$1"
-
-  [[ "$port_value" =~ ^[0-9]+$ ]] || return 1
-  mkdir -p "$RUN_DIR" 2>/dev/null || return 1
-  printf '%s' "$port_value" > "$PORT_FILE" 2>/dev/null || return 1
-  debug "Restored shared port file at $PORT_FILE"
-}
-
-find_latest_live_pid_port_file() {
-  local candidate
-  local file_name
-  local pid
-
-  while IFS= read -r candidate; do
-    [[ -e "$candidate" ]] || continue
-    file_name="${candidate##*/}"
-    pid="${file_name#permission-server-}"
-    pid="${pid%.port}"
-
-    if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
-      printf '%s\n' "$candidate"
-      return 0
-    fi
-  done < <(ls -1t "$RUN_DIR"/permission-server-*.port 2>/dev/null || true)
-
-  return 1
-}
-
-resolve_permission_port() {
-  local candidate_file
-  local port_value
-
-  if port_value=$(read_port_from_file "$PORT_FILE"); then
-    debug "Shared port file found: $port_value"
-    printf '%s\n' "$port_value"
-    return 0
-  fi
-
-  candidate_file=$(find_latest_live_pid_port_file) || return 1
-  port_value=$(read_port_from_file "$candidate_file") || return 1
-  debug "Shared port file missing — using fallback PID port file: $candidate_file"
-  restore_latest_port_file "$port_value" || debug "Could not restore shared port file from fallback"
-  printf '%s\n' "$port_value"
-}
+source "$SCRIPT_DIR/permission-port-discovery.sh"
 
 if ! PORT=$(resolve_permission_port); then
   debug "No usable permission server port file found — fail open"

--- a/scripts/pretooluse-windsurf.sh
+++ b/scripts/pretooluse-windsurf.sh
@@ -5,7 +5,8 @@
 # This wrapper translates Windsurf hook events into Dollhouse permission
 # evaluations and then maps the response back to Windsurf exit codes.
 
-PORT_FILE="$HOME/.dollhouse/run/permission-server.port"
+RUN_DIR="$HOME/.dollhouse/run"
+PORT_FILE="$RUN_DIR/permission-server.port"
 MAX_RETRIES=2
 INITIAL_TIMEOUT=5
 HOOK_PLATFORM="windsurf"
@@ -17,15 +18,66 @@ debug() {
   return 0
 }
 
-if [[ -f "$PORT_FILE" ]]; then
-  PORT=$(cat "$PORT_FILE" 2>/dev/null)
-else
-  debug "No port file at $PORT_FILE — fail open"
-  exit 0
-fi
+read_port_from_file() {
+  local file_path="$1"
+  local port_value
 
-if ! [[ "$PORT" =~ ^[0-9]+$ ]]; then
-  debug "Invalid port value: $PORT — fail open"
+  [[ -f "$file_path" ]] || return 1
+
+  port_value=$(cat "$file_path" 2>/dev/null)
+  [[ "$port_value" =~ ^[0-9]+$ ]] || return 1
+
+  printf '%s\n' "$port_value"
+}
+
+restore_latest_port_file() {
+  local port_value="$1"
+
+  [[ "$port_value" =~ ^[0-9]+$ ]] || return 1
+  mkdir -p "$RUN_DIR" 2>/dev/null || return 1
+  printf '%s' "$port_value" > "$PORT_FILE" 2>/dev/null || return 1
+  debug "Restored shared port file at $PORT_FILE"
+}
+
+find_latest_live_pid_port_file() {
+  local candidate
+  local file_name
+  local pid
+
+  while IFS= read -r candidate; do
+    [[ -e "$candidate" ]] || continue
+    file_name="${candidate##*/}"
+    pid="${file_name#permission-server-}"
+    pid="${pid%.port}"
+
+    if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done < <(ls -1t "$RUN_DIR"/permission-server-*.port 2>/dev/null || true)
+
+  return 1
+}
+
+resolve_permission_port() {
+  local candidate_file
+  local port_value
+
+  if port_value=$(read_port_from_file "$PORT_FILE"); then
+    debug "Shared port file found: $port_value"
+    printf '%s\n' "$port_value"
+    return 0
+  fi
+
+  candidate_file=$(find_latest_live_pid_port_file) || return 1
+  port_value=$(read_port_from_file "$candidate_file") || return 1
+  debug "Shared port file missing — using fallback PID port file: $candidate_file"
+  restore_latest_port_file "$port_value" || debug "Could not restore shared port file from fallback"
+  printf '%s\n' "$port_value"
+}
+
+if ! PORT=$(resolve_permission_port); then
+  debug "No usable permission server port file found — fail open"
   exit 0
 fi
 

--- a/src/auto-dollhouse/portDiscovery.ts
+++ b/src/auto-dollhouse/portDiscovery.ts
@@ -9,12 +9,21 @@
 import { createServer } from 'node:net';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { mkdir, writeFile, unlink } from 'node:fs/promises';
+import { mkdir, writeFile, unlink, readFile } from 'node:fs/promises';
 
 const MAX_PORT_ATTEMPTS = 10;
 
 /** Directory for runtime state files (port discovery, PID files) */
 const RUN_DIR = join(homedir(), '.dollhouse', 'run');
+const LATEST_PORT_FILENAME = 'permission-server.port';
+
+function pidPortFilePath(dir: string = RUN_DIR, pid: number = process.pid): string {
+  return join(dir, `permission-server-${pid}.port`);
+}
+
+function latestPortFilePath(dir: string = RUN_DIR): string {
+  return join(dir, LATEST_PORT_FILENAME);
+}
 
 /** Track port file path for cleanup */
 let portFilePath: string | null = null;
@@ -53,12 +62,35 @@ export async function findAvailablePort(startPort: number): Promise<number> {
  */
 export async function writePortFile(port: number): Promise<string> {
   await mkdir(RUN_DIR, { recursive: true });
-  const pidFile = join(RUN_DIR, `permission-server-${process.pid}.port`);
-  const latestFile = join(RUN_DIR, 'permission-server.port');
+  const pidFile = pidPortFilePath();
+  const latestFile = latestPortFilePath();
   await writeFile(pidFile, String(port), 'utf-8');
   await writeFile(latestFile, String(port), 'utf-8');
   portFilePath = pidFile;
   return pidFile;
+}
+
+/**
+ * Restore or update the shared latest port file for the active listener.
+ */
+export async function ensureLatestPortFile(port: number, customDir?: string): Promise<boolean> {
+  const dir = customDir || RUN_DIR;
+  const latestFile = latestPortFilePath(dir);
+  const desiredValue = String(port);
+
+  await mkdir(dir, { recursive: true });
+
+  try {
+    const existingValue = (await readFile(latestFile, 'utf-8')).trim();
+    if (existingValue === desiredValue) {
+      return false;
+    }
+  } catch {
+    // Missing/unreadable file — rewrite below.
+  }
+
+  await writeFile(latestFile, desiredValue, 'utf-8');
+  return true;
 }
 
 /**

--- a/src/auto-dollhouse/portDiscovery.ts
+++ b/src/auto-dollhouse/portDiscovery.ts
@@ -9,20 +9,15 @@
 import { createServer } from 'node:net';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { mkdir, writeFile, unlink, readFile } from 'node:fs/promises';
+import { mkdir, writeFile, unlink } from 'node:fs/promises';
+import { ensureLatestPortFile } from '../web/portDiscovery.js';
 
 const MAX_PORT_ATTEMPTS = 10;
 
 /** Directory for runtime state files (port discovery, PID files) */
 const RUN_DIR = join(homedir(), '.dollhouse', 'run');
-const LATEST_PORT_FILENAME = 'permission-server.port';
-
 function pidPortFilePath(dir: string = RUN_DIR, pid: number = process.pid): string {
   return join(dir, `permission-server-${pid}.port`);
-}
-
-function latestPortFilePath(dir: string = RUN_DIR): string {
-  return join(dir, LATEST_PORT_FILENAME);
 }
 
 /** Track port file path for cleanup */
@@ -63,34 +58,10 @@ export async function findAvailablePort(startPort: number): Promise<number> {
 export async function writePortFile(port: number): Promise<string> {
   await mkdir(RUN_DIR, { recursive: true });
   const pidFile = pidPortFilePath();
-  const latestFile = latestPortFilePath();
   await writeFile(pidFile, String(port), 'utf-8');
-  await writeFile(latestFile, String(port), 'utf-8');
+  await ensureLatestPortFile(port, RUN_DIR);
   portFilePath = pidFile;
   return pidFile;
-}
-
-/**
- * Restore or update the shared latest port file for the active listener.
- */
-export async function ensureLatestPortFile(port: number, customDir?: string): Promise<boolean> {
-  const dir = customDir || RUN_DIR;
-  const latestFile = latestPortFilePath(dir);
-  const desiredValue = String(port);
-
-  await mkdir(dir, { recursive: true });
-
-  try {
-    const existingValue = (await readFile(latestFile, 'utf-8')).trim();
-    if (existingValue === desiredValue) {
-      return false;
-    }
-  } catch {
-    // Missing/unreadable file — rewrite below.
-  }
-
-  await writeFile(latestFile, desiredValue, 'utf-8');
-  return true;
 }
 
 /**

--- a/src/utils/permissionHooks.ts
+++ b/src/utils/permissionHooks.ts
@@ -707,8 +707,11 @@ async function installHookAssetsForHost(
   sourceScriptPath?: string,
 ): Promise<{ scriptPath: string }> {
   const normalizedClient = normalizeHookHost(client);
+  const hooksDir = dirname(getPermissionHookScriptPath(homeDir));
   const sharedTargetPath = getPermissionHookScriptPath(homeDir);
   const sharedSourcePath = sourceScriptPath ?? join(repoRootFromModule(), 'scripts', 'pretooluse-dollhouse.sh');
+  const portHelperSourcePath = join(repoRootFromModule(), 'scripts', 'permission-port-discovery.sh');
+  const portHelperTargetPath = join(hooksDir, 'permission-port-discovery.sh');
 
   const sharedStat = statSync(sharedSourcePath);
   if (!sharedStat.isFile()) {
@@ -716,6 +719,13 @@ async function installHookAssetsForHost(
     throw new Error(`Permission hook source script not found: ${sharedSourcePath}`);
   }
   await copyHookAsset(sharedSourcePath, sharedTargetPath);
+
+  const portHelperStat = statSync(portHelperSourcePath);
+  if (!portHelperStat.isFile()) {
+    logger.warn(`[PermissionHooks] Port discovery helper missing for ${normalizedClient}: ${portHelperSourcePath}`);
+    throw new Error(`Permission hook helper script not found: ${portHelperSourcePath}`);
+  }
+  await copyHookAsset(portHelperSourcePath, portHelperTargetPath);
 
   const wrapperTargetPath = getHookWrapperPath(normalizedClient, homeDir);
   if (!wrapperTargetPath) {

--- a/src/web/portDiscovery.ts
+++ b/src/web/portDiscovery.ts
@@ -18,7 +18,7 @@
 import { createServer, type Server } from 'node:net';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { mkdir, writeFile, unlink, readdir } from 'node:fs/promises';
+import { mkdir, writeFile, unlink, readdir, readFile } from 'node:fs/promises';
 import { env } from '../config/env.js';
 import { logger } from '../utils/logger.js';
 
@@ -27,6 +27,15 @@ const DEFAULT_MAX_PORT_ATTEMPTS = 10;
 
 /** Directory for runtime state files (port discovery, PID files) */
 const RUN_DIR = join(homedir(), '.dollhouse', 'run');
+const LATEST_PORT_FILENAME = 'permission-server.port';
+
+function pidPortFilePath(dir: string = RUN_DIR, pid: number = process.pid): string {
+  return join(dir, `permission-server-${pid}.port`);
+}
+
+function latestPortFilePath(dir: string = RUN_DIR): string {
+  return join(dir, LATEST_PORT_FILENAME);
+}
 
 /** Track port file path for cleanup */
 let portFilePath: string | null = null;
@@ -105,13 +114,40 @@ export async function findAvailablePort(
  */
 export async function writePortFile(port: number): Promise<string> {
   await mkdir(RUN_DIR, { recursive: true });
-  const pidFile = join(RUN_DIR, `permission-server-${process.pid}.port`);
-  const latestFile = join(RUN_DIR, 'permission-server.port');
+  const pidFile = pidPortFilePath();
+  const latestFile = latestPortFilePath();
   await writeFile(pidFile, String(port), 'utf-8');
   await writeFile(latestFile, String(port), 'utf-8');
   portFilePath = pidFile;
   logger.debug(`[PortDiscovery] Port file written: ${pidFile}`);
   return pidFile;
+}
+
+/**
+ * Restore or update the shared latest port file for the active listener.
+ *
+ * Returns true when the file had to be written or updated, false when it
+ * already matched the active port.
+ */
+export async function ensureLatestPortFile(port: number, customDir?: string): Promise<boolean> {
+  const dir = customDir || RUN_DIR;
+  const latestFile = latestPortFilePath(dir);
+  const desiredValue = String(port);
+
+  await mkdir(dir, { recursive: true });
+
+  try {
+    const existingValue = (await readFile(latestFile, 'utf-8')).trim();
+    if (existingValue === desiredValue) {
+      return false;
+    }
+  } catch {
+    // Missing/unreadable file — rewrite below.
+  }
+
+  await writeFile(latestFile, desiredValue, 'utf-8');
+  logger.debug(`[PortDiscovery] Shared latest port file refreshed: ${latestFile}`);
+  return true;
 }
 
 /**

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -32,12 +32,64 @@
   const HOOK_BASE_SCRIPT = `#!/bin/bash
 # pretooluse-dollhouse.sh — shared hook bridge for DollhouseMCP
 
-PORT_FILE="$HOME/.dollhouse/run/permission-server.port"
+RUN_DIR="$HOME/.dollhouse/run"
+PORT_FILE="$RUN_DIR/permission-server.port"
 HOOK_PLATFORM="\${DOLLHOUSE_HOOK_PLATFORM:-claude_code}"
 
-[[ -f "$PORT_FILE" ]] || exit 0
-PORT=$(cat "$PORT_FILE" 2>/dev/null)
-[[ "$PORT" =~ ^[0-9]+$ ]] || exit 0
+read_port_from_file() {
+  local file_path="$1"
+  local port_value
+
+  [[ -f "$file_path" ]] || return 1
+  port_value=$(cat "$file_path" 2>/dev/null)
+  [[ "$port_value" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\\n' "$port_value"
+}
+
+restore_latest_port_file() {
+  local port_value="$1"
+
+  [[ "$port_value" =~ ^[0-9]+$ ]] || return 1
+  mkdir -p "$RUN_DIR" 2>/dev/null || return 1
+  printf '%s' "$port_value" > "$PORT_FILE" 2>/dev/null || return 1
+}
+
+find_latest_live_pid_port_file() {
+  local candidate
+  local file_name
+  local pid
+
+  while IFS= read -r candidate; do
+    [[ -e "$candidate" ]] || continue
+    file_name="\${candidate##*/}"
+    pid="\${file_name#permission-server-}"
+    pid="\${pid%.port}"
+
+    if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+      printf '%s\\n' "$candidate"
+      return 0
+    fi
+  done < <(ls -1t "$RUN_DIR"/permission-server-*.port 2>/dev/null || true)
+
+  return 1
+}
+
+resolve_permission_port() {
+  local candidate_file
+  local port_value
+
+  if port_value=$(read_port_from_file "$PORT_FILE"); then
+    printf '%s\\n' "$port_value"
+    return 0
+  fi
+
+  candidate_file=$(find_latest_live_pid_port_file) || return 1
+  port_value=$(read_port_from_file "$candidate_file") || return 1
+  restore_latest_port_file "$port_value" >/dev/null 2>&1 || true
+  printf '%s\\n' "$port_value"
+}
+
+PORT=$(resolve_permission_port) || exit 0
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // .toolName // .tool // .name // empty' 2>/dev/null)

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -11,6 +11,7 @@ import express, { Router } from 'express';
 import { logger } from '../../utils/logger.js';
 import type { MCPAQLHandler } from '../../handlers/mcp-aql/MCPAQLHandler.js';
 import { formatPermissionResponse } from '../../handlers/mcp-aql/evaluatePermission.js';
+import { ensureLatestPortFile } from '../portDiscovery.js';
 
 import { SlidingWindowRateLimiter } from '../../utils/SlidingWindowRateLimiter.js';
 
@@ -280,6 +281,21 @@ function extractKnownPolicySessions(elements: Array<Record<string, unknown>>): K
   return knownSessions.sort((a, b) => a.sessionId.localeCompare(b.sessionId));
 }
 
+async function selfHealLatestPermissionPortFile(port: number | undefined): Promise<void> {
+  if (typeof port !== 'number' || !Number.isInteger(port) || port <= 0) {
+    return;
+  }
+
+  try {
+    await ensureLatestPortFile(port);
+  } catch (err) {
+    logger.debug('[WebUI/Gateway] Could not refresh permission-server.port', {
+      error: err instanceof Error ? err.message : String(err),
+      port,
+    });
+  }
+}
+
 /**
  * Register permission-related routes on a gateway router.
  * Must be called with the MCP-AQL handler for policy evaluation.
@@ -297,6 +313,8 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
     PERMISSION_ROUTE_RATE_LIMIT_WINDOW_MS,
   );
   router.post('/evaluate_permission', express.json(), async (req, res) => {
+    await selfHealLatestPermissionPortFile(req.socket.localPort);
+
     const body = req.body as {
       tool_name?: string;
       input?: Record<string, unknown>;
@@ -367,6 +385,8 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
    */
   router.get('/permissions/status', async (req, res) => {
     try {
+      await selfHealLatestPermissionPortFile(req.socket.localPort);
+
       const sessionId = typeof req.query['sessionId'] === 'string' && req.query['sessionId']
         ? req.query['sessionId']
         : undefined;

--- a/tests/unit/di/permissionServerIntegration.test.ts
+++ b/tests/unit/di/permissionServerIntegration.test.ts
@@ -11,10 +11,11 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import * as http from 'node:http';
-import { execFile, spawn } from 'node:child_process';
+import { spawn } from 'node:child_process';
 
 const RUN_DIR = path.join(os.homedir(), '.dollhouse', 'run');
 const PORT_FILE = path.join(RUN_DIR, 'permission-server.port');
+const PID_PORT_FILE = path.join(RUN_DIR, `permission-server-${process.pid}.port`);
 // Hook script lives in the repo at scripts/ — works on both dev machines and CI
 const HOOK_SCRIPT = path.join(process.cwd(), 'scripts', 'pretooluse-dollhouse.sh');
 const SAFE_TEST_PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
@@ -33,8 +34,7 @@ describe('Permission Server Integration', () => {
       }
       // Clean up port files
       await fs.unlink(PORT_FILE).catch(() => {});
-      const pidFile = path.join(RUN_DIR, `permission-server-${process.pid}.port`);
-      await fs.unlink(pidFile).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
     });
 
     it('should find a port and write a discoverable port file', async () => {
@@ -154,6 +154,7 @@ describe('Permission Server Integration', () => {
 
     afterEach(async () => {
       await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
     });
 
     it('hook script should exist in repo at scripts/', async () => {
@@ -161,19 +162,27 @@ describe('Permission Server Integration', () => {
       expect(exists).toBe(true);
     });
 
-    itBash('hook script should fail open when port file is missing', (done) => {
-      // Ensure port file doesn't exist
-      fs.unlink(PORT_FILE).catch(() => {}).then(() => {
-        execFile(BASH_BINARY, [HOOK_SCRIPT], {
-          env: { HOME: os.homedir(), PATH: SAFE_TEST_PATH },
-        }, (error, stdout, _stderr) => {
-          // Exit code 0 = fail open (allow)
-          expect(error).toBeNull();
-          // No JSON output when failing open
-          expect(stdout.trim()).toBe('');
-          done();
+    itBash('hook script should fail open when port file is missing', async () => {
+      const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'dollhouse-hook-home-'));
+      const { code, stdout } = await new Promise<{ code: number; stdout: string }>((resolve) => {
+        const hookProc = spawn(BASH_BINARY, [HOOK_SCRIPT], {
+          env: { HOME: tempHome, PATH: SAFE_TEST_PATH },
+          stdio: ['pipe', 'pipe', 'pipe'],
         });
+        let out = '';
+        hookProc.stdout.on('data', (data: Buffer) => { out += data.toString(); });
+        hookProc.on('close', (c: number) => resolve({ code: c, stdout: out }));
+        hookProc.stdin.write(JSON.stringify({
+          tool_name: 'Read',
+          tool_input: { file_path: './test-fixture.txt' },
+        }));
+        hookProc.stdin.end();
       });
+
+      await fs.rm(tempHome, { recursive: true, force: true });
+
+      expect(code).toBe(0);
+      expect(stdout.trim()).toBe('');
     });
 
     itBash('hook script should discover server via port file and get a response', async () => {
@@ -228,6 +237,7 @@ describe('Permission Server Integration', () => {
       // Cleanup and assert
       await new Promise<void>(resolve => mockServer.close(() => resolve()));
       await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
 
       expect(code).toBe(0);
       expect(capturedBody).toEqual({
@@ -268,6 +278,7 @@ describe('Permission Server Integration', () => {
 
       await new Promise<void>(resolve => mockServer.close(() => resolve()));
       await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
 
       expect(JSON.parse(stdout.trim())).toEqual({
         hookSpecificOutput: {
@@ -308,6 +319,7 @@ describe('Permission Server Integration', () => {
 
       await new Promise<void>(resolve => mockServer.close(() => resolve()));
       await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
 
       expect(JSON.parse(stdout.trim())).toEqual(wrappedResponse);
     });
@@ -335,9 +347,65 @@ describe('Permission Server Integration', () => {
 
       await new Promise<void>(resolve => mockServer.close(() => resolve()));
       await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
 
       expect(code).toBe(0);
       expect(stdout.trim()).toBe('');
+    });
+
+    itBash('hook script should fall back to the newest live PID-keyed port file and restore the shared file', async () => {
+      const testPort = 49364;
+      let capturedBody: Record<string, unknown> | null = null;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          let body = '';
+          req.on('data', chunk => { body += chunk; });
+          req.on('end', () => {
+            capturedBody = JSON.parse(body);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              hookSpecificOutput: {
+                hookEventName: 'PreToolUse',
+                permissionDecision: 'allow',
+              },
+            }));
+          });
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      await new Promise<void>(resolve => mockServer.listen(testPort, '127.0.0.1', resolve));
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.writeFile(PID_PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout } = await runHookScript({
+        tool_name: 'Read',
+        tool_input: { file_path: './test-fixture.txt' },
+      });
+
+      const restoredPort = await fs.readFile(PORT_FILE, 'utf-8');
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(0);
+      expect(restoredPort.trim()).toBe(String(testPort));
+      expect(capturedBody).toEqual({
+        tool_name: 'Read',
+        input: { file_path: './test-fixture.txt' },
+        platform: 'claude_code',
+        session_id: 'session-hook-test',
+      });
+      expect(JSON.parse(stdout.trim())).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+        },
+      });
     });
   });
 

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -7,6 +7,10 @@
 import { jest } from '@jest/globals';
 import express from 'express';
 import request from 'supertest';
+import { createServer } from 'node:http';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { mkdir, readFile, unlink } from 'node:fs/promises';
 import { registerPermissionRoutes } from '../../../src/web/routes/permissionRoutes.js';
 
 function createMockHandler(readResult?: unknown) {
@@ -34,6 +38,13 @@ function createApp(handler: any) {
 }
 
 describe('permissionRoutes', () => {
+  const runDir = join(homedir(), '.dollhouse', 'run');
+  const latestPortFile = join(runDir, 'permission-server.port');
+
+  afterEach(async () => {
+    await unlink(latestPortFile).catch(() => {});
+  });
+
   describe('POST /api/evaluate_permission', () => {
     it('should return allow for a valid request', async () => {
       const handler = createMockHandler();
@@ -291,6 +302,42 @@ describe('permissionRoutes', () => {
           session_id: 'session-abc',
         },
       });
+    });
+
+    it('should restore the shared latest port file from the active listener port', async () => {
+      const handler = {
+        handleRead: jest.fn().mockResolvedValue([{
+          success: true,
+          data: {
+            activeElementCount: 0,
+            hasAllowlist: false,
+            combinedDenyPatterns: [],
+            combinedAllowPatterns: [],
+            combinedConfirmPatterns: [],
+            elements: [],
+            permissionPromptActive: false,
+            recentDecisions: [],
+          },
+        }]),
+      } as any;
+
+      await mkdir(runDir, { recursive: true });
+      await unlink(latestPortFile).catch(() => {});
+
+      const app = createApp(handler);
+      const server = createServer(app);
+      await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+
+      try {
+        const res = await request(server).get('/api/permissions/status');
+
+        expect(res.status).toBe(200);
+        await expect(readFile(latestPortFile, 'utf-8')).resolves.toBe(String(port));
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
     });
 
     it('should surface top-level gatekeeper rules even when no external tool patterns exist', async () => {

--- a/tests/unit/web/portDiscovery.test.ts
+++ b/tests/unit/web/portDiscovery.test.ts
@@ -9,7 +9,7 @@ import { createServer } from 'node:net';
 import { readFile, unlink, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { findAvailablePort, writePortFile, cleanupPortFile, discoverAndBindPort } from '../../../src/web/portDiscovery.js';
+import { findAvailablePort, writePortFile, cleanupPortFile, discoverAndBindPort, ensureLatestPortFile } from '../../../src/web/portDiscovery.js';
 
 const MAX_PORT_ATTEMPTS = 10;
 const PORT_RANGE_DISCOVERY_ATTEMPTS = 25;
@@ -129,6 +129,16 @@ describe('portDiscovery', () => {
       await cleanupPortFile();
 
       await expect(stat(writtenFile)).rejects.toThrow();
+    });
+
+    it('should restore the shared latest file when it is missing', async () => {
+      const latestFile = join(runDir, 'permission-server.port');
+
+      await unlink(latestFile).catch(() => {});
+      const changed = await ensureLatestPortFile(4244);
+
+      expect(changed).toBe(true);
+      await expect(readFile(latestFile, 'utf-8')).resolves.toBe('4244');
     });
   });
 


### PR DESCRIPTION
## Summary\n- fall back to the newest live permission-server-<pid>.port file when the shared latest file is missing\n- restore permission-server.port from both hook execution and live permission-route traffic\n- cover the missing-latest-file path in hook, route, and port-discovery tests\n\n## Testing\n- npm test -- --runInBand tests/unit/di/permissionServerIntegration.test.ts tests/unit/web/portDiscovery.test.ts tests/unit/web/permissionRoutes.test.ts\n- npx eslint src/web/public/setup.js src/web/portDiscovery.ts src/auto-dollhouse/portDiscovery.ts src/web/routes/permissionRoutes.ts tests/unit/di/permissionServerIntegration.test.ts tests/unit/web/portDiscovery.test.ts tests/unit/web/permissionRoutes.test.ts\n\nCloses #2050