### PR TITLE
Add Dockerized cross-platform permission hook harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:compiled": "npm run build:test && cross-env NODE_OPTIONS='--experimental-vm-modules' jest --config tests/jest.config.compiled.cjs",
     "test:compiled:ci": "npm run build:test && cross-env NODE_OPTIONS='--experimental-vm-modules' jest --config tests/jest.config.compiled.cjs --ci --watchAll=false",
     "test:integration": "cross-env \"NODE_OPTIONS=--experimental-vm-modules --no-warnings\" jest --config tests/jest.integration.config.cjs",
+    "test:integration:hooks:docker": "cross-env \"NODE_OPTIONS=--experimental-vm-modules --no-warnings\" jest --config tests/jest.integration.config.cjs tests/integration/hooks/permission-hook-docker.test.ts",
     "test:integration:watch": "cross-env \"NODE_OPTIONS=--experimental-vm-modules --no-warnings\" jest --config tests/jest.integration.config.cjs --watch",
     "test:integration:coverage": "cross-env \"NODE_OPTIONS=--experimental-vm-modules --no-warnings\" jest --config tests/jest.integration.config.cjs --coverage",
     "test:integration:crud": "cross-env \"NODE_OPTIONS=--experimental-vm-modules --no-warnings\" jest --config tests/jest.config.cjs tests/integration/crud/ --no-coverage",

--- a/tests/docker/permission-hooks/Dockerfile
+++ b/tests/docker/permission-hooks/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-bookworm-slim
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash curl jq ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+COPY scripts /workspace/scripts
+COPY tests/docker/permission-hooks /workspace/tests/docker/permission-hooks
+
+CMD ["node", "/workspace/tests/docker/permission-hooks/run-hook-case.mjs"]

--- a/tests/docker/permission-hooks/Dockerfile
+++ b/tests/docker/permission-hooks/Dockerfile
@@ -2,11 +2,18 @@ FROM node:20-bookworm-slim
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends bash curl jq ca-certificates \
+  && groupadd --system --gid 1001 hookrunner \
+  && useradd --system --uid 1001 --gid 1001 --create-home --shell /usr/sbin/nologin hookrunner \
+  && chown -R hookrunner:hookrunner /workspace 2>/dev/null || true \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace
 
 COPY scripts /workspace/scripts
 COPY tests/docker/permission-hooks /workspace/tests/docker/permission-hooks
+
+RUN chown -R hookrunner:hookrunner /workspace
+
+USER hookrunner
 
 CMD ["node", "/workspace/tests/docker/permission-hooks/run-hook-case.mjs"]

--- a/tests/docker/permission-hooks/Dockerfile
+++ b/tests/docker/permission-hooks/Dockerfile
@@ -14,6 +14,8 @@ COPY tests/docker/permission-hooks /workspace/tests/docker/permission-hooks
 
 RUN chown -R hookrunner:hookrunner /workspace
 
+ENV PATH=/usr/local/bin:/usr/bin:/bin
+
 USER hookrunner
 
 CMD ["node", "/workspace/tests/docker/permission-hooks/run-hook-case.mjs"]

--- a/tests/docker/permission-hooks/README.md
+++ b/tests/docker/permission-hooks/README.md
@@ -1,0 +1,16 @@
+# Dockerized Permission Hook Harness
+
+This harness runs the shipped DollhouseMCP permission hook scripts inside an
+isolated Docker container against a mocked permission server.
+
+It is meant to validate the real shell adapters that we install for clients
+such as Codex, Cursor, Gemini, VS Code, Windsurf, and Claude Code.
+
+The harness intentionally focuses on:
+
+- actual checked-in hook scripts under `scripts/`
+- actual stdin payload shapes those scripts are expected to receive
+- actual stdout / stderr / exit-code behavior that the host platforms consume
+
+It does **not** attempt to stand up the proprietary desktop applications
+themselves inside CI. That can remain a later extension of the suite.

--- a/tests/docker/permission-hooks/fixtures/invalid-json-output.sh
+++ b/tests/docker/permission-hooks/fixtures/invalid-json-output.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cat >/dev/null
+echo "not-json"

--- a/tests/docker/permission-hooks/fixtures/no-output.sh
+++ b/tests/docker/permission-hooks/fixtures/no-output.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exit 1

--- a/tests/docker/permission-hooks/run-hook-case.mjs
+++ b/tests/docker/permission-hooks/run-hook-case.mjs
@@ -5,13 +5,15 @@ import { join } from 'node:path';
 import { spawn } from 'node:child_process';
 
 const BASH_BIN = '/bin/bash';
-const DEFAULT_MOCK_SERVER_PORT = 41715;
+// Keep the harness on the same fixed loopback port our shipped hooks expect to
+// discover so the container exercises the real leader/follower contract.
+const MOCK_PERMISSION_SERVER_PORT = 41715;
 const hookScript = process.env.HOOK_SCRIPT;
 const hookPayloadB64 = process.env.HOOK_PAYLOAD_B64;
 const mockResponseB64 = process.env.MOCK_RESPONSE_B64;
 const hookEnvB64 = process.env.HOOK_ENV_B64;
 const portDiscoveryMode = process.env.PORT_DISCOVERY_MODE ?? 'shared';
-const port = Number(process.env.MOCK_SERVER_PORT ?? String(DEFAULT_MOCK_SERVER_PORT));
+const port = Number(process.env.MOCK_SERVER_PORT ?? String(MOCK_PERMISSION_SERVER_PORT));
 
 if (!hookScript || !hookPayloadB64 || !mockResponseB64) {
   throw new Error('HOOK_SCRIPT, HOOK_PAYLOAD_B64, and MOCK_RESPONSE_B64 are required');
@@ -67,9 +69,9 @@ const server = createServer((req, res) => {
   });
 });
 
-await new Promise((resolve) => server.listen(port, '127.0.0.1', resolve));
+await startMockPermissionServer(server, port);
 
-const result = await new Promise((resolve) => {
+const result = await new Promise((resolve, reject) => {
   const child = spawn(BASH_BIN, [hookScript], {
     env: buildHookEnvironment(hookEnv, tempHome),
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -82,6 +84,14 @@ const result = await new Promise((resolve) => {
   });
   child.stderr.on('data', chunk => {
     stderr += chunk.toString();
+  });
+  child.on('error', error => {
+    reject(new Error(`Failed to spawn hook script ${hookScript}: ${error.message}`));
+  });
+  child.stdin.on('error', error => {
+    if (error.code !== 'EPIPE') {
+      reject(new Error(`Failed to write hook payload to ${hookScript}: ${error.message}`));
+    }
   });
   child.on('close', exitCode => {
     resolve({ exitCode: exitCode ?? 0, stdout, stderr });
@@ -139,4 +149,25 @@ function buildHookEnvironment(hookEnv, tempHomePath) {
     HOME: tempHomePath,
     DOLLHOUSE_SESSION_ID: 'docker-hook-session',
   };
+}
+
+function startMockPermissionServer(server, portNumber) {
+  return new Promise((resolve, reject) => {
+    const handleListening = () => {
+      cleanup();
+      resolve();
+    };
+    const handleError = (error) => {
+      cleanup();
+      reject(new Error(`Failed to start mock permission server on port ${portNumber}: ${error.message}`));
+    };
+    const cleanup = () => {
+      server.off('listening', handleListening);
+      server.off('error', handleError);
+    };
+
+    server.once('listening', handleListening);
+    server.once('error', handleError);
+    server.listen(portNumber, '127.0.0.1');
+  });
 }

--- a/tests/docker/permission-hooks/run-hook-case.mjs
+++ b/tests/docker/permission-hooks/run-hook-case.mjs
@@ -4,21 +4,27 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
 
+const SAFE_CONTAINER_PATH = '/usr/local/bin:/usr/bin:/bin';
+const DEFAULT_MOCK_SERVER_PORT = 41715;
 const hookScript = process.env.HOOK_SCRIPT;
 const hookPayloadB64 = process.env.HOOK_PAYLOAD_B64;
 const mockResponseB64 = process.env.MOCK_RESPONSE_B64;
 const hookEnvB64 = process.env.HOOK_ENV_B64;
 const portDiscoveryMode = process.env.PORT_DISCOVERY_MODE ?? 'shared';
-const port = Number(process.env.MOCK_SERVER_PORT ?? '41715');
+const port = Number(process.env.MOCK_SERVER_PORT ?? String(DEFAULT_MOCK_SERVER_PORT));
 
 if (!hookScript || !hookPayloadB64 || !mockResponseB64) {
   throw new Error('HOOK_SCRIPT, HOOK_PAYLOAD_B64, and MOCK_RESPONSE_B64 are required');
 }
 
-const hookPayload = JSON.parse(Buffer.from(hookPayloadB64, 'base64').toString('utf-8'));
-const mockResponse = JSON.parse(Buffer.from(mockResponseB64, 'base64').toString('utf-8'));
+if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+  throw new Error(`MOCK_SERVER_PORT must be a valid TCP port, received ${process.env.MOCK_SERVER_PORT ?? 'undefined'}`);
+}
+
+const hookPayload = parseJsonEnvironmentVariable(hookPayloadB64, 'HOOK_PAYLOAD_B64');
+const mockResponse = parseJsonEnvironmentVariable(mockResponseB64, 'MOCK_RESPONSE_B64');
 const hookEnv = hookEnvB64
-  ? JSON.parse(Buffer.from(hookEnvB64, 'base64').toString('utf-8'))
+  ? parseStringRecord(parseJsonEnvironmentVariable(hookEnvB64, 'HOOK_ENV_B64'), 'HOOK_ENV_B64')
   : {};
 
 const tempHome = await mkdtemp(join(tmpdir(), 'dollhouse-hook-home-'));
@@ -48,9 +54,16 @@ const server = createServer((req, res) => {
     body += chunk.toString();
   });
   req.on('end', () => {
-    capturedRequestBody = JSON.parse(body);
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(mockResponse));
+    try {
+      capturedRequestBody = JSON.parse(body);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(mockResponse));
+    } catch (error) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        error: `Malformed JSON request body: ${error instanceof Error ? error.message : String(error)}`,
+      }));
+    }
   });
 });
 
@@ -59,10 +72,9 @@ await new Promise((resolve) => server.listen(port, '127.0.0.1', resolve));
 const result = await new Promise((resolve) => {
   const child = spawn('bash', [hookScript], {
     env: {
-      ...process.env,
       ...hookEnv,
       HOME: tempHome,
-      PATH: process.env.PATH ?? '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      PATH: SAFE_CONTAINER_PATH,
       DOLLHOUSE_SESSION_ID: 'docker-hook-session',
     },
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -91,3 +103,33 @@ process.stdout.write(JSON.stringify({
   ...result,
   requestBody: capturedRequestBody,
 }));
+
+function parseJsonEnvironmentVariable(encodedValue, envName) {
+  let decodedValue;
+  try {
+    decodedValue = Buffer.from(encodedValue, 'base64').toString('utf-8');
+  } catch (error) {
+    throw new Error(`${envName} is not valid base64: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  try {
+    return JSON.parse(decodedValue);
+  } catch (error) {
+    throw new Error(`${envName} does not contain valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function parseStringRecord(value, envName) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${envName} must decode to a JSON object`);
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entryValue]) => {
+      if (typeof entryValue !== 'string') {
+        throw new Error(`${envName}.${key} must be a string`);
+      }
+      return [key, entryValue];
+    }),
+  );
+}

--- a/tests/docker/permission-hooks/run-hook-case.mjs
+++ b/tests/docker/permission-hooks/run-hook-case.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
 
+const BASH_BIN = '/bin/bash';
 const DEFAULT_MOCK_SERVER_PORT = 41715;
 const hookScript = process.env.HOOK_SCRIPT;
 const hookPayloadB64 = process.env.HOOK_PAYLOAD_B64;
@@ -69,7 +70,7 @@ const server = createServer((req, res) => {
 await new Promise((resolve) => server.listen(port, '127.0.0.1', resolve));
 
 const result = await new Promise((resolve) => {
-  const child = spawn('bash', [hookScript], {
+  const child = spawn(BASH_BIN, [hookScript], {
     env: buildHookEnvironment(hookEnv, tempHome),
     stdio: ['pipe', 'pipe', 'pipe'],
   });

--- a/tests/docker/permission-hooks/run-hook-case.mjs
+++ b/tests/docker/permission-hooks/run-hook-case.mjs
@@ -4,7 +4,6 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
 
-const SAFE_CONTAINER_PATH = '/usr/local/bin:/usr/bin:/bin';
 const DEFAULT_MOCK_SERVER_PORT = 41715;
 const hookScript = process.env.HOOK_SCRIPT;
 const hookPayloadB64 = process.env.HOOK_PAYLOAD_B64;
@@ -74,7 +73,6 @@ const result = await new Promise((resolve) => {
     env: {
       ...hookEnv,
       HOME: tempHome,
-      PATH: SAFE_CONTAINER_PATH,
       DOLLHOUSE_SESSION_ID: 'docker-hook-session',
     },
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -121,13 +119,13 @@ function parseJsonEnvironmentVariable(encodedValue, envName) {
 
 function parseStringRecord(value, envName) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error(`${envName} must decode to a JSON object`);
+    throw new TypeError(`${envName} must decode to a JSON object`);
   }
 
   return Object.fromEntries(
     Object.entries(value).map(([key, entryValue]) => {
       if (typeof entryValue !== 'string') {
-        throw new Error(`${envName}.${key} must be a string`);
+        throw new TypeError(`${envName}.${key} must be a string`);
       }
       return [key, entryValue];
     }),

--- a/tests/docker/permission-hooks/run-hook-case.mjs
+++ b/tests/docker/permission-hooks/run-hook-case.mjs
@@ -70,11 +70,7 @@ await new Promise((resolve) => server.listen(port, '127.0.0.1', resolve));
 
 const result = await new Promise((resolve) => {
   const child = spawn('bash', [hookScript], {
-    env: {
-      ...hookEnv,
-      HOME: tempHome,
-      DOLLHOUSE_SESSION_ID: 'docker-hook-session',
-    },
+    env: buildHookEnvironment(hookEnv, tempHome),
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
@@ -130,4 +126,16 @@ function parseStringRecord(value, envName) {
       return [key, entryValue];
     }),
   );
+}
+
+function buildHookEnvironment(hookEnv, tempHomePath) {
+  const filteredHookEnv = Object.fromEntries(
+    Object.entries(hookEnv).filter(([key]) => key !== 'PATH'),
+  );
+
+  return {
+    ...filteredHookEnv,
+    HOME: tempHomePath,
+    DOLLHOUSE_SESSION_ID: 'docker-hook-session',
+  };
 }

--- a/tests/docker/permission-hooks/run-hook-case.mjs
+++ b/tests/docker/permission-hooks/run-hook-case.mjs
@@ -1,0 +1,93 @@
+import { createServer } from 'node:http';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+
+const hookScript = process.env.HOOK_SCRIPT;
+const hookPayloadB64 = process.env.HOOK_PAYLOAD_B64;
+const mockResponseB64 = process.env.MOCK_RESPONSE_B64;
+const hookEnvB64 = process.env.HOOK_ENV_B64;
+const portDiscoveryMode = process.env.PORT_DISCOVERY_MODE ?? 'shared';
+const port = Number(process.env.MOCK_SERVER_PORT ?? '41715');
+
+if (!hookScript || !hookPayloadB64 || !mockResponseB64) {
+  throw new Error('HOOK_SCRIPT, HOOK_PAYLOAD_B64, and MOCK_RESPONSE_B64 are required');
+}
+
+const hookPayload = JSON.parse(Buffer.from(hookPayloadB64, 'base64').toString('utf-8'));
+const mockResponse = JSON.parse(Buffer.from(mockResponseB64, 'base64').toString('utf-8'));
+const hookEnv = hookEnvB64
+  ? JSON.parse(Buffer.from(hookEnvB64, 'base64').toString('utf-8'))
+  : {};
+
+const tempHome = await mkdtemp(join(tmpdir(), 'dollhouse-hook-home-'));
+const runDir = join(tempHome, '.dollhouse', 'run');
+const sharedPortFile = join(runDir, 'permission-server.port');
+const pidPortFile = join(runDir, `permission-server-${process.pid}.port`);
+
+await mkdir(runDir, { recursive: true });
+
+if (portDiscoveryMode === 'shared' || portDiscoveryMode === 'both') {
+  await writeFile(sharedPortFile, String(port), 'utf-8');
+}
+if (portDiscoveryMode === 'pid' || portDiscoveryMode === 'both') {
+  await writeFile(pidPortFile, String(port), 'utf-8');
+}
+
+let capturedRequestBody = null;
+const server = createServer((req, res) => {
+  if (req.method !== 'POST' || req.url !== '/api/evaluate_permission') {
+    res.writeHead(404);
+    res.end();
+    return;
+  }
+
+  let body = '';
+  req.on('data', chunk => {
+    body += chunk.toString();
+  });
+  req.on('end', () => {
+    capturedRequestBody = JSON.parse(body);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(mockResponse));
+  });
+});
+
+await new Promise((resolve) => server.listen(port, '127.0.0.1', resolve));
+
+const result = await new Promise((resolve) => {
+  const child = spawn('bash', [hookScript], {
+    env: {
+      ...process.env,
+      ...hookEnv,
+      HOME: tempHome,
+      PATH: process.env.PATH ?? '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      DOLLHOUSE_SESSION_ID: 'docker-hook-session',
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', chunk => {
+    stdout += chunk.toString();
+  });
+  child.stderr.on('data', chunk => {
+    stderr += chunk.toString();
+  });
+  child.on('close', exitCode => {
+    resolve({ exitCode: exitCode ?? 0, stdout, stderr });
+  });
+
+  child.stdin.write(JSON.stringify(hookPayload));
+  child.stdin.end();
+});
+
+await new Promise((resolve) => server.close(() => resolve()));
+await rm(tempHome, { recursive: true, force: true });
+
+process.stdout.write(JSON.stringify({
+  ...result,
+  requestBody: capturedRequestBody,
+}));

--- a/tests/integration/hooks/permission-hook-docker.test.ts
+++ b/tests/integration/hooks/permission-hook-docker.test.ts
@@ -5,12 +5,15 @@ import { resolve } from 'node:path';
 
 jest.setTimeout(180_000);
 
+const SAFE_HOST_PATH = '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin';
+const DOCKER_BIN = resolveDockerBinary();
+
 const DOCKER_AVAILABLE = (() => {
   if (process.env.DOCKER_AVAILABLE === 'false') {
     return false;
   }
   try {
-    execFileSync('docker', ['--version'], { stdio: 'ignore' });
+    execFileSync(DOCKER_BIN, ['--version'], { stdio: 'ignore' });
     return true;
   } catch {
     return false;
@@ -39,7 +42,7 @@ interface HookResult {
 suite('Dockerized permission hook adapters', () => {
   beforeAll(() => {
     execFileSync(
-      'docker',
+      DOCKER_BIN,
       ['build', '-t', IMAGE_TAG, '-f', DOCKERFILE_PATH, '.'],
       { cwd: process.cwd(), stdio: 'inherit' },
     );
@@ -47,9 +50,11 @@ suite('Dockerized permission hook adapters', () => {
 
   afterAll(() => {
     try {
-      execFileSync('docker', ['image', 'rm', '-f', IMAGE_TAG], { stdio: 'ignore' });
-    } catch {
-      // Ignore cleanup failures — image may already be gone.
+      execFileSync(DOCKER_BIN, ['image', 'rm', '-f', IMAGE_TAG], { stdio: 'ignore' });
+    } catch (error) {
+      process.stderr.write(
+        `[permission-hook-docker] Failed to remove Docker image ${IMAGE_TAG}: ${error instanceof Error ? error.message : String(error)}\n`,
+      );
     }
   });
 
@@ -248,6 +253,7 @@ function runHookCase(testCase: HookCase): HookResult {
   args.push(IMAGE_TAG);
 
   const result = spawnSync('docker', args, {
+    env: { PATH: SAFE_HOST_PATH },
     cwd: resolve(process.cwd()),
     encoding: 'utf-8',
   });
@@ -264,5 +270,21 @@ function runHookCase(testCase: HookCase): HookResult {
     throw new Error(`Docker run produced no JSON output for ${testCase.hookScript}`);
   }
 
-  return JSON.parse(result.stdout.trim()) as HookResult;
+  try {
+    return JSON.parse(result.stdout.trim()) as HookResult;
+  } catch (error) {
+    throw new Error(
+      `Docker run returned malformed JSON for ${testCase.hookScript}: ${error instanceof Error ? error.message : String(error)}\n` +
+      `stdout:\n${result.stdout}\n` +
+      `stderr:\n${result.stderr}`,
+    );
+  }
+}
+
+function resolveDockerBinary(): string {
+  return execFileSync(
+    '/usr/bin/env',
+    ['-i', `PATH=${SAFE_HOST_PATH}`, 'sh', '-lc', 'command -v docker'],
+    { encoding: 'utf-8' },
+  ).trim();
 }

--- a/tests/integration/hooks/permission-hook-docker.test.ts
+++ b/tests/integration/hooks/permission-hook-docker.test.ts
@@ -1,0 +1,268 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { resolve } from 'node:path';
+
+jest.setTimeout(180_000);
+
+const DOCKER_AVAILABLE = (() => {
+  if (process.env.DOCKER_AVAILABLE === 'false') {
+    return false;
+  }
+  try {
+    execFileSync('docker', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+const suite = DOCKER_AVAILABLE ? describe : describe.skip;
+const IMAGE_TAG = `dollhouse-hook-harness:${randomUUID().slice(0, 8)}`;
+const DOCKERFILE_PATH = 'tests/docker/permission-hooks/Dockerfile';
+
+interface HookCase {
+  hookScript: string;
+  payload: Record<string, unknown>;
+  response: Record<string, unknown>;
+  hookEnv?: Record<string, string>;
+  portDiscoveryMode?: 'shared' | 'pid' | 'both';
+}
+
+interface HookResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  requestBody: Record<string, unknown>;
+}
+
+suite('Dockerized permission hook adapters', () => {
+  beforeAll(() => {
+    execFileSync(
+      'docker',
+      ['build', '-t', IMAGE_TAG, '-f', DOCKERFILE_PATH, '.'],
+      { cwd: process.cwd(), stdio: 'inherit' },
+    );
+  });
+
+  afterAll(() => {
+    try {
+      execFileSync('docker', ['image', 'rm', '-f', IMAGE_TAG], { stdio: 'ignore' });
+    } catch {
+      // Ignore cleanup failures — image may already be gone.
+    }
+  });
+
+  it('runs the Claude Code shared hook inside Docker and preserves the request contract', () => {
+    const result = runHookCase({
+      hookScript: '/workspace/scripts/pretooluse-dollhouse.sh',
+      hookEnv: { DOLLHOUSE_HOOK_PLATFORM: 'claude_code' },
+      payload: {
+        tool_name: 'Read',
+        tool_input: { file_path: 'README.md' },
+      },
+      response: {
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+        },
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'allow',
+      },
+    });
+    expect(result.requestBody).toEqual({
+      tool_name: 'Read',
+      input: { file_path: 'README.md' },
+      platform: 'claude_code',
+      session_id: 'docker-hook-session',
+    });
+  });
+
+  it('runs the Codex hook inside Docker and forwards Codex-style Bash payloads', () => {
+    const result = runHookCase({
+      hookScript: '/workspace/scripts/pretooluse-codex.sh',
+      payload: {
+        toolName: 'Bash',
+        toolInput: { command: 'pwd' },
+      },
+      response: {
+        hookSpecificOutput: {
+          permissionDecision: 'allow',
+        },
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({
+      hookSpecificOutput: {
+        permissionDecision: 'allow',
+      },
+    });
+    expect(result.requestBody).toEqual({
+      tool_name: 'Bash',
+      input: { command: 'pwd' },
+      platform: 'codex',
+      session_id: 'docker-hook-session',
+    });
+  });
+
+  it('runs the Cursor hook inside Docker and preserves Cursor permission responses', () => {
+    const result = runHookCase({
+      hookScript: '/workspace/scripts/pretooluse-cursor.sh',
+      payload: {
+        toolName: 'Bash',
+        toolInput: { command: 'git status' },
+      },
+      response: {
+        permission: 'deny',
+        reason: 'Blocked by policy',
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({
+      permission: 'deny',
+      reason: 'Blocked by policy',
+    });
+    expect(result.requestBody).toEqual({
+      tool_name: 'Bash',
+      input: { command: 'git status' },
+      platform: 'cursor',
+      session_id: 'docker-hook-session',
+    });
+  });
+
+  it('runs the Gemini hook inside Docker and preserves Gemini decision payloads', () => {
+    const result = runHookCase({
+      hookScript: '/workspace/scripts/pretooluse-gemini.sh',
+      payload: {
+        toolName: 'Write',
+        toolInput: { file_path: 'notes.txt' },
+      },
+      response: {
+        decision: 'deny',
+        reason: 'Blocked by policy',
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({
+      decision: 'deny',
+      reason: 'Blocked by policy',
+    });
+    expect(result.requestBody).toEqual({
+      tool_name: 'Write',
+      input: { file_path: 'notes.txt' },
+      platform: 'gemini',
+      session_id: 'docker-hook-session',
+    });
+  });
+
+  it('runs the VS Code hook inside Docker and normalizes runTerminalCommand into Bash', () => {
+    const result = runHookCase({
+      hookScript: '/workspace/scripts/pretooluse-vscode.sh',
+      payload: {
+        toolName: 'runTerminalCommand',
+        toolInput: { command: 'npm install' },
+        cwd: '/workspace',
+      },
+      response: {
+        allowed: false,
+        reason: 'Blocked by policy',
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: 'Blocked by policy',
+      },
+    });
+    expect(result.requestBody).toEqual({
+      tool_name: 'Bash',
+      input: {
+        command: 'npm install',
+        cwd: '/workspace',
+      },
+      platform: 'vscode',
+      session_id: 'docker-hook-session',
+    });
+  });
+
+  it('runs the Windsurf hook inside Docker and maps deny responses to exit code 2', () => {
+    const result = runHookCase({
+      hookScript: '/workspace/scripts/pretooluse-windsurf.sh',
+      payload: {
+        hook_event_name: 'pre_run_command',
+        tool_info: {
+          command_line: 'rm -rf /tmp/demo',
+          cwd: '/workspace',
+        },
+      },
+      response: {
+        allowed: false,
+        reason: 'Blocked by policy',
+      },
+    });
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout.trim()).toBe('');
+    expect(result.stderr).toContain('Blocked by policy');
+    expect(result.requestBody).toEqual({
+      tool_name: 'Bash',
+      input: {
+        command: 'rm -rf /tmp/demo',
+        cwd: '/workspace',
+      },
+      platform: 'windsurf',
+      session_id: 'docker-hook-session',
+    });
+  });
+});
+
+function runHookCase(testCase: HookCase): HookResult {
+  const args = [
+    'run',
+    '--rm',
+    '-e', `HOOK_SCRIPT=${testCase.hookScript}`,
+    '-e', `HOOK_PAYLOAD_B64=${Buffer.from(JSON.stringify(testCase.payload)).toString('base64')}`,
+    '-e', `MOCK_RESPONSE_B64=${Buffer.from(JSON.stringify(testCase.response)).toString('base64')}`,
+    '-e', `PORT_DISCOVERY_MODE=${testCase.portDiscoveryMode ?? 'shared'}`,
+  ];
+
+  if (testCase.hookEnv && Object.keys(testCase.hookEnv).length > 0) {
+    args.push(
+      '-e',
+      `HOOK_ENV_B64=${Buffer.from(JSON.stringify(testCase.hookEnv)).toString('base64')}`,
+    );
+  }
+
+  args.push(IMAGE_TAG);
+
+  const result = spawnSync('docker', args, {
+    cwd: resolve(process.cwd()),
+    encoding: 'utf-8',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status === null) {
+    throw new Error(`Docker run terminated unexpectedly for ${testCase.hookScript}`);
+  }
+
+  if (!result.stdout.trim()) {
+    throw new Error(`Docker run produced no JSON output for ${testCase.hookScript}`);
+  }
+
+  return JSON.parse(result.stdout.trim()) as HookResult;
+}

--- a/tests/integration/hooks/permission-hook-docker.test.ts
+++ b/tests/integration/hooks/permission-hook-docker.test.ts
@@ -252,8 +252,7 @@ function runHookCase(testCase: HookCase): HookResult {
 
   args.push(IMAGE_TAG);
 
-  const result = spawnSync('docker', args, {
-    env: { PATH: SAFE_HOST_PATH },
+  const result = spawnSync(DOCKER_BIN, args, {
     cwd: resolve(process.cwd()),
     encoding: 'utf-8',
   });

--- a/tests/integration/hooks/permission-hook-docker.test.ts
+++ b/tests/integration/hooks/permission-hook-docker.test.ts
@@ -75,7 +75,7 @@ suite('Dockerized permission hook adapters', () => {
     });
 
     expect(result.exitCode).toBe(0);
-    expect(JSON.parse(result.stdout.trim())).toEqual({
+    expect(parseHookStdout(result, '/workspace/scripts/pretooluse-dollhouse.sh')).toEqual({
       hookSpecificOutput: {
         hookEventName: 'PreToolUse',
         permissionDecision: 'allow',
@@ -104,7 +104,7 @@ suite('Dockerized permission hook adapters', () => {
     });
 
     expect(result.exitCode).toBe(0);
-    expect(JSON.parse(result.stdout.trim())).toEqual({
+    expect(parseHookStdout(result, '/workspace/scripts/pretooluse-codex.sh')).toEqual({
       hookSpecificOutput: {
         permissionDecision: 'allow',
       },
@@ -131,7 +131,7 @@ suite('Dockerized permission hook adapters', () => {
     });
 
     expect(result.exitCode).toBe(0);
-    expect(JSON.parse(result.stdout.trim())).toEqual({
+    expect(parseHookStdout(result, '/workspace/scripts/pretooluse-cursor.sh')).toEqual({
       permission: 'deny',
       reason: 'Blocked by policy',
     });
@@ -157,7 +157,7 @@ suite('Dockerized permission hook adapters', () => {
     });
 
     expect(result.exitCode).toBe(0);
-    expect(JSON.parse(result.stdout.trim())).toEqual({
+    expect(parseHookStdout(result, '/workspace/scripts/pretooluse-gemini.sh')).toEqual({
       decision: 'deny',
       reason: 'Blocked by policy',
     });
@@ -184,7 +184,7 @@ suite('Dockerized permission hook adapters', () => {
     });
 
     expect(result.exitCode).toBe(0);
-    expect(JSON.parse(result.stdout.trim())).toEqual({
+    expect(parseHookStdout(result, '/workspace/scripts/pretooluse-vscode.sh')).toEqual({
       hookSpecificOutput: {
         hookEventName: 'PreToolUse',
         permissionDecision: 'deny',
@@ -231,6 +231,28 @@ suite('Dockerized permission hook adapters', () => {
       session_id: 'docker-hook-session',
     });
   });
+
+  it('surfaces a clear error when a hook exits without emitting JSON', () => {
+    const hookScript = '/workspace/tests/docker/permission-hooks/fixtures/no-output.sh';
+    expect(() => parseHookStdout(runHookCase({
+      hookScript,
+      payload: {},
+      response: { ignored: true },
+    }), hookScript)).toThrow(
+      'Hook /workspace/tests/docker/permission-hooks/fixtures/no-output.sh produced no JSON output (exit 1)',
+    );
+  });
+
+  it('surfaces malformed hook output with stdout and stderr context', () => {
+    const hookScript = '/workspace/tests/docker/permission-hooks/fixtures/invalid-json-output.sh';
+    expect(() => parseHookStdout(runHookCase({
+      hookScript,
+      payload: {},
+      response: { ignored: true },
+    }), hookScript)).toThrow(
+      'Hook /workspace/tests/docker/permission-hooks/fixtures/invalid-json-output.sh returned malformed JSON',
+    );
+  });
 });
 
 function runHookCase(testCase: HookCase): HookResult {
@@ -266,14 +288,36 @@ function runHookCase(testCase: HookCase): HookResult {
   }
 
   if (!result.stdout.trim()) {
-    throw new Error(`Docker run produced no JSON output for ${testCase.hookScript}`);
+    throw new Error(
+      `Docker run produced no JSON output for ${testCase.hookScript} (exit ${result.status})\n` +
+      `stderr:\n${result.stderr}`,
+    );
   }
 
   try {
     return JSON.parse(result.stdout.trim()) as HookResult;
   } catch (error) {
     throw new Error(
-      `Docker run returned malformed JSON for ${testCase.hookScript}: ${error instanceof Error ? error.message : String(error)}\n` +
+      `Docker run returned malformed JSON for ${testCase.hookScript} (exit ${result.status}): ${error instanceof Error ? error.message : String(error)}\n` +
+      `stdout:\n${result.stdout}\n` +
+      `stderr:\n${result.stderr}`,
+    );
+  }
+}
+
+function parseHookStdout(result: HookResult, hookScript: string): unknown {
+  if (!result.stdout.trim()) {
+    throw new Error(
+      `Hook ${hookScript} produced no JSON output (exit ${result.exitCode})\n` +
+      `stderr:\n${result.stderr}`,
+    );
+  }
+
+  try {
+    return JSON.parse(result.stdout.trim());
+  } catch (error) {
+    throw new Error(
+      `Hook ${hookScript} returned malformed JSON (exit ${result.exitCode}): ${error instanceof Error ? error.message : String(error)}\n` +
       `stdout:\n${result.stdout}\n` +
       `stderr:\n${result.stderr}`,
     );


### PR DESCRIPTION
## Summary\n- add a Docker image and runner that execute the shipped permission hook scripts against a mocked permission server\n- verify the end-to-end hook contract for Claude Code, Codex, Cursor, Gemini, VS Code, and Windsurf\n- add a dedicated npm entry point for the Docker-backed hook suite\n\n## Testing\n- npm run test:integration:hooks:docker\n- npx eslint tests/integration/hooks/permission-hook-docker.test.ts\n- node --check tests/docker/permission-hooks/run-hook-case.mjs\n\nCloses #1672