### PR TITLE
Add permission authority foundation

### DIFF
--- a/scripts/pretooluse-dollhouse.sh
+++ b/scripts/pretooluse-dollhouse.sh
@@ -18,6 +18,7 @@
 
 RUN_DIR="$HOME/.dollhouse/run"
 PORT_FILE="$RUN_DIR/permission-server.port"
+AUTHORITY_FILE="$RUN_DIR/permission-authority.json"
 MAX_RETRIES=2
 INITIAL_TIMEOUT=5
 HOOK_PLATFORM="${DOLLHOUSE_HOOK_PLATFORM:-claude_code}"
@@ -27,6 +28,36 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 debug() {
   if [[ "${DOLLHOUSE_HOOK_DEBUG:-0}" == "1" ]]; then
     echo "[pretooluse] $*" >&2
+  fi
+  return 0
+}
+
+authority_host_for_platform() {
+  case "$HOOK_PLATFORM" in
+    claude_code) echo "claude-code" ;;
+    codex) echo "codex" ;;
+    cursor) echo "cursor" ;;
+    vscode) echo "vscode" ;;
+    windsurf) echo "windsurf" ;;
+    gemini) echo "gemini-cli" ;;
+    *) echo "" ;;
+  esac
+}
+
+resolve_authority_mode() {
+  local authority_host="$1"
+
+  if [[ -z "$authority_host" || ! -f "$AUTHORITY_FILE" ]]; then
+    echo "shared"
+    return 0
+  fi
+
+  local resolved
+  resolved=$(jq -r --arg host "$authority_host" '.hosts[$host].mode // .defaultMode // "shared"' "$AUTHORITY_FILE" 2>/dev/null)
+  if [[ -z "$resolved" || "$resolved" == "null" ]]; then
+    echo "shared"
+  else
+    echo "$resolved"
   fi
   return 0
 }
@@ -86,6 +117,15 @@ fi
 
 debug "Evaluating: $TOOL_NAME"
 debug "Platform: $HOOK_PLATFORM"
+
+AUTHORITY_HOST=$(authority_host_for_platform)
+AUTHORITY_MODE=$(resolve_authority_mode "$AUTHORITY_HOST")
+debug "Authority mode for ${AUTHORITY_HOST:-unknown}: $AUTHORITY_MODE"
+
+if [[ "$AUTHORITY_MODE" == "off" ]]; then
+  debug "Authority mode is off — hook no-op"
+  exit 0
+fi
 
 if [[ -n "${DOLLHOUSE_SESSION_ID:-}" ]]; then
   debug "Using DOLLHOUSE_SESSION_ID=${DOLLHOUSE_SESSION_ID}"

--- a/scripts/pretooluse-dollhouse.sh
+++ b/scripts/pretooluse-dollhouse.sh
@@ -42,6 +42,8 @@ authority_host_for_platform() {
     gemini) echo "gemini-cli" ;;
     *) echo "" ;;
   esac
+
+  return 0
 }
 
 resolve_authority_mode() {

--- a/scripts/pretooluse-dollhouse.sh
+++ b/scripts/pretooluse-dollhouse.sh
@@ -19,6 +19,7 @@
 RUN_DIR="$HOME/.dollhouse/run"
 PORT_FILE="$RUN_DIR/permission-server.port"
 AUTHORITY_FILE="$RUN_DIR/permission-authority.json"
+AUTHORITY_CACHE_TTL_SECONDS=2
 MAX_RETRIES=2
 INITIAL_TIMEOUT=5
 HOOK_PLATFORM="${DOLLHOUSE_HOOK_PLATFORM:-claude_code}"
@@ -48,19 +49,47 @@ authority_host_for_platform() {
 
 resolve_authority_mode() {
   local authority_host="$1"
+  local cache_file="$RUN_DIR/permission-authority-${HOOK_PLATFORM}.cache"
+  local resolved
 
   if [[ -z "$authority_host" || ! -f "$AUTHORITY_FILE" ]]; then
     echo "shared"
     return 0
   fi
 
-  local resolved
+  if [[ -f "$cache_file" ]]; then
+    local cache_age
+    cache_age=$(cache_file_age_seconds "$cache_file")
+    if [[ -n "$cache_age" && "$cache_age" -lt "$AUTHORITY_CACHE_TTL_SECONDS" ]]; then
+      resolved=$(tr -d '\r\n' < "$cache_file" 2>/dev/null)
+      if [[ -n "$resolved" ]]; then
+        debug "Authority cache hit for ${authority_host}: $resolved"
+        echo "$resolved"
+        return 0
+      fi
+    fi
+  fi
+
   resolved=$(jq -r --arg host "$authority_host" '.hosts[$host].mode // .defaultMode // "shared"' "$AUTHORITY_FILE" 2>/dev/null)
   if [[ -z "$resolved" || "$resolved" == "null" ]]; then
-    echo "shared"
-  else
-    echo "$resolved"
+    resolved="shared"
   fi
+
+  printf '%s' "$resolved" > "$cache_file" 2>/dev/null || true
+  echo "$resolved"
+  return 0
+}
+
+cache_file_age_seconds() {
+  local file_path="$1"
+  local modified_epoch
+
+  modified_epoch=$(stat -f %m "$file_path" 2>/dev/null || stat -c %Y "$file_path" 2>/dev/null)
+  if [[ -z "$modified_epoch" ]]; then
+    return 1
+  fi
+
+  echo $(( $(date +%s) - modified_epoch ))
   return 0
 }
 

--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -79,6 +79,11 @@ import type { GitHubAuthHandler } from '../GitHubAuthHandler.js';
 import type { ConfigHandler } from '../ConfigHandler.js';
 import type { EnhancedIndexHandler } from '../EnhancedIndexHandler.js';
 import { getPermissionHookStatus } from '../../utils/permissionHooks.js';
+import {
+  PERMISSION_AUTHORITY_HOSTS,
+  PERMISSION_AUTHORITY_MODES,
+  readPermissionAuthorityState,
+} from '../../utils/permissionAuthority.js';
 import type { PersonaHandler } from '../PersonaHandler.js';
 import type { SyncHandler } from '../SyncHandlerV2.js';
 import type { BuildInfoService } from '../../services/BuildInfoService.js';
@@ -3225,6 +3230,23 @@ export class MCPAQLHandler {
           hookHost: hookStatus.host,
           invalidPolicyElementCount: invalidPolicyElements.length,
           advisory,
+        };
+      }
+
+      case 'getPermissionAuthority': {
+        const requestedHost = typeof params.host === 'string' ? params.host : undefined;
+        const authorityState = await readPermissionAuthorityState();
+        return {
+          defaultMode: authorityState.defaultMode,
+          updatedAt: authorityState.updatedAt,
+          supportedHosts: [...PERMISSION_AUTHORITY_HOSTS],
+          supportedModes: [...PERMISSION_AUTHORITY_MODES],
+          aiMutable: false,
+          hosts: authorityState.hosts,
+          host: requestedHost,
+          mode: requestedHost && requestedHost in authorityState.hosts
+            ? authorityState.hosts[requestedHost as keyof typeof authorityState.hosts]?.mode ?? authorityState.defaultMode
+            : authorityState.defaultMode,
         };
       }
 

--- a/src/handlers/mcp-aql/OperationRouter.ts
+++ b/src/handlers/mcp-aql/OperationRouter.ts
@@ -139,6 +139,11 @@ export const OPERATION_ROUTES: Record<string, OperationRoute> = {
     handler: 'Gatekeeper.getEffectiveCliPolicies',
     description: 'Get effective CLI permission policies for the current session (Issue #625 Phase 2)',
   },
+  get_permission_authority: {
+    endpoint: 'READ',
+    handler: 'Gatekeeper.getPermissionAuthority',
+    description: 'Get the current host vs Dollhouse permission authority mode (read-only)',
+  },
   // Issue #625 Phase 3: CLI approval workflow
   approve_cli_permission: {
     endpoint: 'EXECUTE',

--- a/src/handlers/mcp-aql/OperationSchema.ts
+++ b/src/handlers/mcp-aql/OperationSchema.ts
@@ -1500,6 +1500,21 @@ export const GATEKEEPER_SCHEMAS: OperationSchemaMap = {
       '{ operation: "get_effective_cli_policies", params: { tool_name: "Bash", tool_input: { command: "git push" } } }',
     ],
   },
+  get_permission_authority: {
+    endpoint: 'READ',
+    handler: 'mcpAqlHandler',
+    method: 'dispatchGatekeeper',
+    category: 'Security & Permissions',
+    description: 'Get the current permission-authority mode for supported hosts. Read-only: AI can inspect authority state but cannot change it.',
+    params: {
+      host: { type: 'string', description: 'Optional host to inspect (e.g., "claude-code", "codex")' },
+    },
+    returns: { name: 'PermissionAuthorityState', kind: 'object', description: '{ defaultMode, hosts, supportedHosts, supportedModes, aiMutable: false }' },
+    examples: [
+      '{ operation: "get_permission_authority" }',
+      '{ operation: "get_permission_authority", params: { host: "claude-code" } }',
+    ],
+  },
   // Issue #625 Phase 3: CLI approval workflow
   approve_cli_permission: {
     endpoint: 'EXECUTE',

--- a/src/server/tools/MCPAQLTools.ts
+++ b/src/server/tools/MCPAQLTools.ts
@@ -382,6 +382,8 @@ Gatekeeper & CLI policies:
 { operation: "evaluate_permission", params: { tool_name: "Bash", input: { command: "git status" }, platform: "claude_code" } }
 { operation: "get_effective_cli_policies" }
 { operation: "get_pending_cli_approvals" }
+{ operation: "get_permission_authority" }
+{ operation: "get_permission_authority", params: { host: "claude-code" } }
 
 Enhanced index:
 { operation: "find_similar_elements", params: { element_type: "persona", element_name: "Creative-Writer" } }

--- a/src/utils/permissionAuthority.ts
+++ b/src/utils/permissionAuthority.ts
@@ -108,10 +108,8 @@ export async function writePermissionAuthorityState(
   homeDir = homedir(),
 ): Promise<void> {
   const statePath = getPermissionAuthorityStatePath(homeDir);
-  const tempPath = `${statePath}.tmp`;
   await mkdir(dirname(statePath), { recursive: true });
-  await writeFile(tempPath, JSON.stringify(state, null, 2) + '\n', 'utf-8');
-  await rename(tempPath, statePath);
+  await writeTextFileAtomically(statePath, JSON.stringify(state, null, 2) + '\n');
 }
 
 export function getHostAuthorityMode(
@@ -127,61 +125,64 @@ export async function setPermissionAuthorityMode(input: SetPermissionAuthorityMo
   const state = await readPermissionAuthorityState(homeDir);
   const previousHostState = state.hosts[input.host];
   const previousMode = previousHostState?.mode ?? state.defaultMode;
+  try {
+    if (input.mode === 'authoritative') {
+      if (input.host !== 'claude-code') {
+        throw new Error(`Authoritative mode is not implemented yet for ${input.host}.`);
+      }
+      if (!input.policies) {
+        throw new Error('Authoritative mode requires a policy snapshot.');
+      }
 
-  if (input.mode === 'authoritative') {
-    if (input.host !== 'claude-code') {
-      throw new Error(`Authoritative mode is not implemented yet for ${input.host}.`);
-    }
-    if (!input.policies) {
-      throw new Error('Authoritative mode requires a policy snapshot.');
+      const syncResult = await syncClaudeCodeAuthoritativeMode({
+        homeDir,
+        host: input.host,
+        previousBackupPath: previousHostState?.backupPath,
+        policies: input.policies,
+        now,
+      });
+
+      state.hosts[input.host] = {
+        mode: 'authoritative',
+        reason: input.reason,
+        updatedAt: now.toISOString(),
+        backupPath: syncResult.backupPath,
+        lastSyncedAt: syncResult.syncedAt,
+        scope: 'user',
+      };
+    } else {
+      if (previousMode === 'authoritative' && previousHostState?.backupPath) {
+        await restoreAuthorityBackup(previousHostState.backupPath, getHostSettingsPath(input.host, homeDir));
+      }
+
+      state.hosts[input.host] = {
+        mode: input.mode,
+        reason: input.reason,
+        updatedAt: now.toISOString(),
+        scope: 'user',
+      };
     }
 
-    const syncResult = await syncClaudeCodeAuthoritativeMode({
-      homeDir,
-      host: input.host,
-      previousBackupPath: previousHostState?.backupPath,
-      policies: input.policies,
-      now,
+    state.updatedAt = now.toISOString();
+    await writePermissionAuthorityState(state, homeDir);
+
+    SecurityMonitor.logSecurityEvent({
+      type: 'CONFIG_UPDATED',
+      severity: 'LOW',
+      source: 'permissionAuthority.setPermissionAuthorityMode',
+      details: `Permission authority for ${input.host} changed from ${previousMode} to ${input.mode}`,
+      additionalData: {
+        host: input.host,
+        previousMode,
+        mode: input.mode,
+        reason: input.reason,
+      },
     });
 
-    state.hosts[input.host] = {
-      mode: 'authoritative',
-      reason: input.reason,
-      updatedAt: now.toISOString(),
-      backupPath: syncResult.backupPath,
-      lastSyncedAt: syncResult.syncedAt,
-      scope: 'user',
-    };
-  } else {
-    if (previousMode === 'authoritative' && previousHostState?.backupPath) {
-      await restoreAuthorityBackup(previousHostState.backupPath, getHostSettingsPath(input.host, homeDir));
-    }
-
-    state.hosts[input.host] = {
-      mode: input.mode,
-      reason: input.reason,
-      updatedAt: now.toISOString(),
-      scope: 'user',
-    };
+    return state;
+  } catch (error) {
+    throw withAuthorityContext(error, `Failed to set permission authority for ${input.host} to ${input.mode}`);
   }
-
-  state.updatedAt = now.toISOString();
-  await writePermissionAuthorityState(state, homeDir);
-
-  SecurityMonitor.logSecurityEvent({
-    type: 'CONFIG_UPDATED',
-    severity: 'LOW',
-    source: 'permissionAuthority.setPermissionAuthorityMode',
-    details: `Permission authority for ${input.host} changed from ${previousMode} to ${input.mode}`,
-    additionalData: {
-      host: input.host,
-      previousMode,
-      mode: input.mode,
-      reason: input.reason,
-    },
-  });
-
-  return state;
 }
 
 function normalizeHostStateMap(
@@ -258,19 +259,23 @@ async function syncClaudeCodeAuthoritativeMode(input: {
   const settingsPath = getHostSettingsPath(input.host, input.homeDir);
   await mkdir(dirname(settingsPath), { recursive: true });
 
-  const currentRaw = existsSync(settingsPath) ? await readFile(settingsPath, 'utf-8') : null;
-  const backupPath = input.previousBackupPath
-    ?? await createAuthorityBackup(input.homeDir, input.host, currentRaw, input.now);
+  try {
+    const currentRaw = existsSync(settingsPath) ? await readFile(settingsPath, 'utf-8') : null;
+    const backupPath = input.previousBackupPath
+      ?? await createAuthorityBackup(input.homeDir, input.host, currentRaw, input.now);
 
-  const parsed = currentRaw && currentRaw.trim().length > 0
-    ? JSON.parse(currentRaw) as Record<string, unknown>
-    : {};
+    const parsed = currentRaw && currentRaw.trim().length > 0
+      ? JSON.parse(currentRaw) as Record<string, unknown>
+      : {};
 
-  const syncedAt = input.now.toISOString();
-  const synced = buildClaudeAuthoritySettings(parsed, input.policies, syncedAt);
-  await writeFile(settingsPath, JSON.stringify(synced, null, 2) + '\n', 'utf-8');
+    const syncedAt = input.now.toISOString();
+    const synced = buildClaudeAuthoritySettings(parsed, input.policies, syncedAt);
+    await writeTextFileAtomically(settingsPath, JSON.stringify(synced, null, 2) + '\n');
 
-  return { backupPath, syncedAt };
+    return { backupPath, syncedAt };
+  } catch (error) {
+    throw withAuthorityContext(error, `Failed to sync authoritative Claude Code settings at ${settingsPath}`);
+  }
 }
 
 function buildClaudeAuthoritySettings(
@@ -397,19 +402,34 @@ async function createAuthorityBackup(
     ? { version: 1, existed: false }
     : { version: 1, existed: true, raw };
 
-  await writeFile(backupPath, JSON.stringify(backup, null, 2) + '\n', 'utf-8');
+  await writeTextFileAtomically(backupPath, JSON.stringify(backup, null, 2) + '\n');
   return backupPath;
 }
 
 async function restoreAuthorityBackup(backupPath: string, targetPath: string): Promise<void> {
-  const raw = await readFile(backupPath, 'utf-8');
-  const backup = JSON.parse(raw) as PermissionAuthorityBackup;
+  try {
+    const raw = await readFile(backupPath, 'utf-8');
+    const backup = JSON.parse(raw) as PermissionAuthorityBackup;
 
-  if (backup.existed) {
-    await mkdir(dirname(targetPath), { recursive: true });
-    await writeFile(targetPath, backup.raw ?? '', 'utf-8');
-    return;
+    if (backup.existed) {
+      await mkdir(dirname(targetPath), { recursive: true });
+      await writeTextFileAtomically(targetPath, backup.raw ?? '');
+      return;
+    }
+
+    await rm(targetPath, { force: true });
+  } catch (error) {
+    throw withAuthorityContext(error, `Failed to restore authority backup ${backupPath} to ${targetPath}`);
   }
+}
 
-  await rm(targetPath, { force: true });
+async function writeTextFileAtomically(filePath: string, contents: string): Promise<void> {
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tempPath, contents, 'utf-8');
+  await rename(tempPath, filePath);
+}
+
+function withAuthorityContext(error: unknown, context: string): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  return new Error(`${context}: ${message}`);
 }

--- a/src/utils/permissionAuthority.ts
+++ b/src/utils/permissionAuthority.ts
@@ -1,6 +1,6 @@
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { SecurityMonitor } from '../security/securityMonitor.js';
 import { logger } from './logger.js';
@@ -108,8 +108,10 @@ export async function writePermissionAuthorityState(
   homeDir = homedir(),
 ): Promise<void> {
   const statePath = getPermissionAuthorityStatePath(homeDir);
+  const tempPath = `${statePath}.tmp`;
   await mkdir(dirname(statePath), { recursive: true });
-  await writeFile(statePath, JSON.stringify(state, null, 2) + '\n', 'utf-8');
+  await writeFile(tempPath, JSON.stringify(state, null, 2) + '\n', 'utf-8');
+  await rename(tempPath, statePath);
 }
 
 export function getHostAuthorityMode(
@@ -183,7 +185,7 @@ export async function setPermissionAuthorityMode(input: SetPermissionAuthorityMo
 }
 
 function normalizeHostStateMap(
-  rawHosts: Partial<Record<PermissionAuthorityHost, PermissionAuthorityHostState>> | unknown,
+  rawHosts: unknown,
 ): Partial<Record<PermissionAuthorityHost, PermissionAuthorityHostState>> {
   if (!rawHosts || typeof rawHosts !== 'object' || Array.isArray(rawHosts)) {
     return {};
@@ -191,26 +193,39 @@ function normalizeHostStateMap(
 
   const normalized: Partial<Record<PermissionAuthorityHost, PermissionAuthorityHostState>> = {};
   for (const [rawHost, rawState] of Object.entries(rawHosts as Record<string, unknown>)) {
-    if (!isPermissionAuthorityHost(rawHost) || !rawState || typeof rawState !== 'object' || Array.isArray(rawState)) {
+    if (!isPermissionAuthorityHost(rawHost)) {
       continue;
     }
 
-    const hostState = rawState as Partial<PermissionAuthorityHostState>;
-    if (!isPermissionAuthorityMode(hostState.mode)) {
+    const hostState = normalizeHostState(rawState);
+    if (!hostState) {
       continue;
     }
 
-    normalized[rawHost] = {
-      mode: hostState.mode,
-      reason: typeof hostState.reason === 'string' ? hostState.reason : undefined,
-      updatedAt: typeof hostState.updatedAt === 'string' ? hostState.updatedAt : new Date().toISOString(),
-      backupPath: typeof hostState.backupPath === 'string' ? hostState.backupPath : undefined,
-      lastSyncedAt: typeof hostState.lastSyncedAt === 'string' ? hostState.lastSyncedAt : undefined,
-      scope: hostState.scope === 'user' ? 'user' : undefined,
-    };
+    normalized[rawHost] = hostState;
   }
 
   return normalized;
+}
+
+function normalizeHostState(rawState: unknown): PermissionAuthorityHostState | null {
+  if (!rawState || typeof rawState !== 'object' || Array.isArray(rawState)) {
+    return null;
+  }
+
+  const hostState = rawState as Partial<PermissionAuthorityHostState>;
+  if (!isPermissionAuthorityMode(hostState.mode)) {
+    return null;
+  }
+
+  return {
+    mode: hostState.mode,
+    reason: typeof hostState.reason === 'string' ? hostState.reason : undefined,
+    updatedAt: typeof hostState.updatedAt === 'string' ? hostState.updatedAt : new Date().toISOString(),
+    backupPath: typeof hostState.backupPath === 'string' ? hostState.backupPath : undefined,
+    lastSyncedAt: typeof hostState.lastSyncedAt === 'string' ? hostState.lastSyncedAt : undefined,
+    scope: hostState.scope === 'user' ? 'user' : undefined,
+  };
 }
 
 function isPermissionAuthorityMode(value: unknown): value is PermissionAuthorityMode {
@@ -226,12 +241,11 @@ function isMissingFileError(error: unknown): boolean {
 }
 
 function getHostSettingsPath(host: PermissionAuthorityHost, homeDir: string): string {
-  switch (host) {
-    case 'claude-code':
-      return getClaudeHookSettingsPath(homeDir);
-    default:
-      throw new Error(`No host settings path registered for ${host}.`);
+  if (host === 'claude-code') {
+    return getClaudeHookSettingsPath(homeDir);
   }
+
+  throw new Error(`No host settings path registered for ${host}.`);
 }
 
 async function syncClaudeCodeAuthoritativeMode(input: {
@@ -361,7 +375,11 @@ function shouldStripClaudeAskEntry(entry: string, allowPatterns: string[]): bool
     return true;
   }
 
-  return entry.endsWith('*') && allowPatterns.some((pattern) => pattern.startsWith(normalizedEntry));
+  if (!entry.endsWith('*')) {
+    return false;
+  }
+
+  return allowPatterns.some((pattern) => pattern.startsWith(normalizedEntry));
 }
 
 async function createAuthorityBackup(

--- a/src/utils/permissionAuthority.ts
+++ b/src/utils/permissionAuthority.ts
@@ -1,0 +1,397 @@
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { SecurityMonitor } from '../security/securityMonitor.js';
+import { logger } from './logger.js';
+import { getClaudeHookSettingsPath } from './permissionHooks.js';
+
+export const PERMISSION_AUTHORITY_MODES = ['off', 'shared', 'authoritative'] as const;
+export type PermissionAuthorityMode = typeof PERMISSION_AUTHORITY_MODES[number];
+
+export const PERMISSION_AUTHORITY_HOSTS = [
+  'claude-code',
+  'codex',
+  'cursor',
+  'vscode',
+  'windsurf',
+  'gemini-cli',
+] as const;
+export type PermissionAuthorityHost = typeof PERMISSION_AUTHORITY_HOSTS[number];
+
+export interface PermissionAuthorityHostState {
+  mode: PermissionAuthorityMode;
+  reason?: string;
+  updatedAt: string;
+  backupPath?: string;
+  lastSyncedAt?: string;
+  scope?: 'user';
+}
+
+export interface PermissionAuthorityState {
+  version: 1;
+  defaultMode: PermissionAuthorityMode;
+  updatedAt: string;
+  hosts: Partial<Record<PermissionAuthorityHost, PermissionAuthorityHostState>>;
+}
+
+export interface AuthorityPolicySnapshot {
+  combinedAllowPatterns?: string[];
+  combinedConfirmPatterns?: string[];
+  combinedDenyPatterns?: string[];
+}
+
+interface PermissionAuthorityMetadata {
+  version: 1;
+  host: PermissionAuthorityHost;
+  managedPermissions: {
+    allow: string[];
+    ask: string[];
+    deny: string[];
+  };
+  syncedAt: string;
+}
+
+interface PermissionAuthorityBackup {
+  version: 1;
+  existed: boolean;
+  raw?: string;
+}
+
+export interface SetPermissionAuthorityModeInput {
+  host: PermissionAuthorityHost;
+  mode: PermissionAuthorityMode;
+  reason?: string;
+  policies?: AuthorityPolicySnapshot;
+  homeDir?: string;
+  now?: Date;
+}
+
+export function getPermissionAuthorityStatePath(homeDir = homedir()): string {
+  return join(homeDir, '.dollhouse', 'run', 'permission-authority.json');
+}
+
+function getPermissionAuthorityBackupDir(homeDir = homedir()): string {
+  return join(homeDir, '.dollhouse', 'run', 'permission-authority-backups');
+}
+
+export function getDefaultPermissionAuthorityState(now = new Date()): PermissionAuthorityState {
+  return {
+    version: 1,
+    defaultMode: 'shared',
+    updatedAt: now.toISOString(),
+    hosts: {},
+  };
+}
+
+export async function readPermissionAuthorityState(homeDir = homedir()): Promise<PermissionAuthorityState> {
+  const statePath = getPermissionAuthorityStatePath(homeDir);
+  try {
+    const raw = await readFile(statePath, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<PermissionAuthorityState>;
+    return {
+      version: 1,
+      defaultMode: isPermissionAuthorityMode(parsed.defaultMode) ? parsed.defaultMode : 'shared',
+      updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date().toISOString(),
+      hosts: normalizeHostStateMap(parsed.hosts),
+    };
+  } catch (error) {
+    if (!isMissingFileError(error)) {
+      logger.warn(`[PermissionAuthority] Failed to read ${statePath}: ${String(error)}`);
+    }
+    return getDefaultPermissionAuthorityState();
+  }
+}
+
+export async function writePermissionAuthorityState(
+  state: PermissionAuthorityState,
+  homeDir = homedir(),
+): Promise<void> {
+  const statePath = getPermissionAuthorityStatePath(homeDir);
+  await mkdir(dirname(statePath), { recursive: true });
+  await writeFile(statePath, JSON.stringify(state, null, 2) + '\n', 'utf-8');
+}
+
+export function getHostAuthorityMode(
+  state: PermissionAuthorityState,
+  host: PermissionAuthorityHost,
+): PermissionAuthorityMode {
+  return state.hosts[host]?.mode ?? state.defaultMode;
+}
+
+export async function setPermissionAuthorityMode(input: SetPermissionAuthorityModeInput): Promise<PermissionAuthorityState> {
+  const homeDir = input.homeDir ?? homedir();
+  const now = input.now ?? new Date();
+  const state = await readPermissionAuthorityState(homeDir);
+  const previousHostState = state.hosts[input.host];
+  const previousMode = previousHostState?.mode ?? state.defaultMode;
+
+  if (input.mode === 'authoritative') {
+    if (input.host !== 'claude-code') {
+      throw new Error(`Authoritative mode is not implemented yet for ${input.host}.`);
+    }
+    if (!input.policies) {
+      throw new Error('Authoritative mode requires a policy snapshot.');
+    }
+
+    const syncResult = await syncClaudeCodeAuthoritativeMode({
+      homeDir,
+      host: input.host,
+      previousBackupPath: previousHostState?.backupPath,
+      policies: input.policies,
+      now,
+    });
+
+    state.hosts[input.host] = {
+      mode: 'authoritative',
+      reason: input.reason,
+      updatedAt: now.toISOString(),
+      backupPath: syncResult.backupPath,
+      lastSyncedAt: syncResult.syncedAt,
+      scope: 'user',
+    };
+  } else {
+    if (previousMode === 'authoritative' && previousHostState?.backupPath) {
+      await restoreAuthorityBackup(previousHostState.backupPath, getHostSettingsPath(input.host, homeDir));
+    }
+
+    state.hosts[input.host] = {
+      mode: input.mode,
+      reason: input.reason,
+      updatedAt: now.toISOString(),
+      scope: 'user',
+    };
+  }
+
+  state.updatedAt = now.toISOString();
+  await writePermissionAuthorityState(state, homeDir);
+
+  SecurityMonitor.logSecurityEvent({
+    type: 'CONFIG_UPDATED',
+    severity: 'LOW',
+    source: 'permissionAuthority.setPermissionAuthorityMode',
+    details: `Permission authority for ${input.host} changed from ${previousMode} to ${input.mode}`,
+    additionalData: {
+      host: input.host,
+      previousMode,
+      mode: input.mode,
+      reason: input.reason,
+    },
+  });
+
+  return state;
+}
+
+function normalizeHostStateMap(
+  rawHosts: Partial<Record<PermissionAuthorityHost, PermissionAuthorityHostState>> | unknown,
+): Partial<Record<PermissionAuthorityHost, PermissionAuthorityHostState>> {
+  if (!rawHosts || typeof rawHosts !== 'object' || Array.isArray(rawHosts)) {
+    return {};
+  }
+
+  const normalized: Partial<Record<PermissionAuthorityHost, PermissionAuthorityHostState>> = {};
+  for (const [rawHost, rawState] of Object.entries(rawHosts as Record<string, unknown>)) {
+    if (!isPermissionAuthorityHost(rawHost) || !rawState || typeof rawState !== 'object' || Array.isArray(rawState)) {
+      continue;
+    }
+
+    const hostState = rawState as Partial<PermissionAuthorityHostState>;
+    if (!isPermissionAuthorityMode(hostState.mode)) {
+      continue;
+    }
+
+    normalized[rawHost] = {
+      mode: hostState.mode,
+      reason: typeof hostState.reason === 'string' ? hostState.reason : undefined,
+      updatedAt: typeof hostState.updatedAt === 'string' ? hostState.updatedAt : new Date().toISOString(),
+      backupPath: typeof hostState.backupPath === 'string' ? hostState.backupPath : undefined,
+      lastSyncedAt: typeof hostState.lastSyncedAt === 'string' ? hostState.lastSyncedAt : undefined,
+      scope: hostState.scope === 'user' ? 'user' : undefined,
+    };
+  }
+
+  return normalized;
+}
+
+function isPermissionAuthorityMode(value: unknown): value is PermissionAuthorityMode {
+  return typeof value === 'string' && PERMISSION_AUTHORITY_MODES.includes(value as PermissionAuthorityMode);
+}
+
+function isPermissionAuthorityHost(value: string): value is PermissionAuthorityHost {
+  return (PERMISSION_AUTHORITY_HOSTS as readonly string[]).includes(value);
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return Boolean(error && typeof error === 'object' && 'code' in error && (error as { code?: string }).code === 'ENOENT');
+}
+
+function getHostSettingsPath(host: PermissionAuthorityHost, homeDir: string): string {
+  switch (host) {
+    case 'claude-code':
+      return getClaudeHookSettingsPath(homeDir);
+    default:
+      throw new Error(`No host settings path registered for ${host}.`);
+  }
+}
+
+async function syncClaudeCodeAuthoritativeMode(input: {
+  homeDir: string;
+  host: PermissionAuthorityHost;
+  previousBackupPath?: string;
+  policies: AuthorityPolicySnapshot;
+  now: Date;
+}): Promise<{ backupPath: string; syncedAt: string }> {
+  const settingsPath = getHostSettingsPath(input.host, input.homeDir);
+  await mkdir(dirname(settingsPath), { recursive: true });
+
+  const currentRaw = existsSync(settingsPath) ? await readFile(settingsPath, 'utf-8') : null;
+  const backupPath = input.previousBackupPath
+    ?? await createAuthorityBackup(input.homeDir, input.host, currentRaw, input.now);
+
+  const parsed = currentRaw && currentRaw.trim().length > 0
+    ? JSON.parse(currentRaw) as Record<string, unknown>
+    : {};
+
+  const syncedAt = input.now.toISOString();
+  const synced = buildClaudeAuthoritySettings(parsed, input.policies, syncedAt);
+  await writeFile(settingsPath, JSON.stringify(synced, null, 2) + '\n', 'utf-8');
+
+  return { backupPath, syncedAt };
+}
+
+function buildClaudeAuthoritySettings(
+  parsed: Record<string, unknown>,
+  policies: AuthorityPolicySnapshot,
+  syncedAt: string,
+): Record<string, unknown> {
+  const priorMetadata = getAuthorityMetadata(parsed);
+  const priorManaged = priorMetadata?.managedPermissions ?? { allow: [], ask: [], deny: [] };
+  const permissions = getPermissionsRoot(parsed);
+
+  const managedAllow = uniquePatterns(
+    (policies.combinedAllowPatterns ?? []).filter((pattern) => !CLAUDE_REQUIRED_ASK_PATTERNS.includes(pattern)),
+  );
+  const managedAsk = uniquePatterns([
+    ...(policies.combinedConfirmPatterns ?? []),
+    ...CLAUDE_REQUIRED_ASK_PATTERNS,
+  ]);
+  const managedDeny = uniquePatterns(policies.combinedDenyPatterns ?? []);
+
+  const userAllow = removeManagedEntries(permissions.allow, priorManaged.allow);
+  const userAsk = removeManagedEntries(permissions.ask, priorManaged.ask)
+    .filter((entry) => !shouldStripClaudeAskEntry(entry, managedAllow));
+  const userDeny = removeManagedEntries(permissions.deny, priorManaged.deny);
+
+  parsed.permissions = {
+    allow: uniquePatterns([...userAllow, ...managedAllow]),
+    ask: uniquePatterns([...userAsk, ...managedAsk]),
+    deny: uniquePatterns([...userDeny, ...managedDeny]),
+  };
+  parsed['_dollhousePermissionAuthority'] = {
+    version: 1,
+    host: 'claude-code',
+    managedPermissions: {
+      allow: managedAllow,
+      ask: managedAsk,
+      deny: managedDeny,
+    },
+    syncedAt,
+  } satisfies PermissionAuthorityMetadata;
+
+  return parsed;
+}
+
+function getAuthorityMetadata(parsed: Record<string, unknown>): PermissionAuthorityMetadata | null {
+  const metadata = parsed['_dollhousePermissionAuthority'];
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return null;
+  }
+  const raw = metadata as Partial<PermissionAuthorityMetadata>;
+  if (raw.version !== 1 || raw.host !== 'claude-code') {
+    return null;
+  }
+  return {
+    version: 1,
+    host: 'claude-code',
+    syncedAt: typeof raw.syncedAt === 'string' ? raw.syncedAt : new Date().toISOString(),
+    managedPermissions: {
+      allow: Array.isArray(raw.managedPermissions?.allow) ? raw.managedPermissions.allow.filter(isString) : [],
+      ask: Array.isArray(raw.managedPermissions?.ask) ? raw.managedPermissions.ask.filter(isString) : [],
+      deny: Array.isArray(raw.managedPermissions?.deny) ? raw.managedPermissions.deny.filter(isString) : [],
+    },
+  };
+}
+
+function getPermissionsRoot(parsed: Record<string, unknown>): { allow: string[]; ask: string[]; deny: string[] } {
+  const permissionsValue = parsed.permissions;
+  if (!permissionsValue || typeof permissionsValue !== 'object' || Array.isArray(permissionsValue)) {
+    return { allow: [], ask: [], deny: [] };
+  }
+
+  const permissions = permissionsValue as Record<string, unknown>;
+  return {
+    allow: Array.isArray(permissions.allow) ? permissions.allow.filter(isString) : [],
+    ask: Array.isArray(permissions.ask) ? permissions.ask.filter(isString) : [],
+    deny: Array.isArray(permissions.deny) ? permissions.deny.filter(isString) : [],
+  };
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function uniquePatterns(patterns: string[]): string[] {
+  return Array.from(new Set(patterns));
+}
+
+function removeManagedEntries(entries: string[], managedEntries: string[]): string[] {
+  const managed = new Set(managedEntries);
+  return entries.filter((entry) => !managed.has(entry));
+}
+
+const CLAUDE_REQUIRED_ASK_PATTERNS = ['mcp__DollhouseMCP__mcp_aql_execute*'];
+
+function shouldStripClaudeAskEntry(entry: string, allowPatterns: string[]): boolean {
+  if (allowPatterns.includes(entry)) {
+    return true;
+  }
+
+  const normalizedEntry = entry.endsWith('*') ? entry.slice(0, -1) : entry;
+  if (!normalizedEntry.includes(':') && allowPatterns.some((pattern) => pattern.startsWith(`${normalizedEntry}:`))) {
+    return true;
+  }
+
+  return entry.endsWith('*') && allowPatterns.some((pattern) => pattern.startsWith(normalizedEntry));
+}
+
+async function createAuthorityBackup(
+  homeDir: string,
+  host: PermissionAuthorityHost,
+  raw: string | null,
+  now: Date,
+): Promise<string> {
+  const backupDir = getPermissionAuthorityBackupDir(homeDir);
+  await mkdir(backupDir, { recursive: true });
+
+  const filename = `${host}-${now.toISOString().replaceAll(':', '-')}.json`;
+  const backupPath = join(backupDir, filename);
+  const backup: PermissionAuthorityBackup = raw === null
+    ? { version: 1, existed: false }
+    : { version: 1, existed: true, raw };
+
+  await writeFile(backupPath, JSON.stringify(backup, null, 2) + '\n', 'utf-8');
+  return backupPath;
+}
+
+async function restoreAuthorityBackup(backupPath: string, targetPath: string): Promise<void> {
+  const raw = await readFile(backupPath, 'utf-8');
+  const backup = JSON.parse(raw) as PermissionAuthorityBackup;
+
+  if (backup.existed) {
+    await mkdir(dirname(targetPath), { recursive: true });
+    await writeFile(targetPath, backup.raw ?? '', 'utf-8');
+    return;
+  }
+
+  await rm(targetPath, { force: true });
+}

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -18,12 +18,33 @@
   let latestAggregateData = null;
   let latestSelectedData = null;
   let latestPollRequestId = 0;
+  const AUTHORITY_AUTHORITATIVE_HOSTS = new Set(['claude-code']);
+  const authorityUiState = {
+    selectedHost: 'claude-code',
+    selectedMode: 'shared',
+    draftReason: '',
+    dirty: false,
+    saving: false,
+    feedback: '',
+    feedbackKind: 'info',
+  };
 
   async function fetchPermissionStatus(sessionId) {
     const query = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : '';
     const res = await DollhouseAuth.apiFetch(`/api/permissions/status${query}`);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return res.json();
+  }
+
+  async function updatePermissionAuthority(payload) {
+    const res = await DollhouseAuth.apiFetch('/api/permissions/authority', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const data = await res.json().catch(function () { return {}; });
+    if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+    return data;
   }
 
   // ── Public API ─────────────────────────────────────────────
@@ -65,6 +86,7 @@
 
     root.innerHTML = buildDashboardHTML();
     attachCardToggles();
+    attachAuthorityControls();
     poll(); // immediate first fetch
     pollTimer = setInterval(poll, POLL_INTERVAL_MS);
   }
@@ -107,6 +129,7 @@
 
     const sessionId = window.DollhouseSessions?.getFilterSessionId?.() || '';
     latestSelectedData = deriveSelectedSessionData(latestAggregateData, sessionId);
+    renderAuthorityMode(latestAggregateData);
     renderPolicySources(latestAggregateData, latestSelectedData);
     renderSelectedSessionDetail(latestSelectedData);
   }
@@ -115,6 +138,7 @@
 
   function render(data, selectedData) {
     renderStatusBar(data);
+    renderAuthorityMode(data);
     renderSummaryStats(data);
     renderAdvisory(data);
     renderPolicySources(data, selectedData);
@@ -194,6 +218,71 @@
     setText('perm-stat-allowed', allowed);
     setText('perm-stat-denied', denied);
     setText('perm-stat-asked', asked);
+  }
+
+  function renderAuthorityMode(data) {
+    const card = document.getElementById('perm-authority-card');
+    const hostSelect = document.getElementById('perm-authority-host');
+    const saveButton = document.getElementById('perm-authority-save-btn');
+    const message = document.getElementById('perm-authority-message');
+    const currentMode = document.getElementById('perm-authority-current-mode');
+    const currentHost = document.getElementById('perm-authority-current-host');
+    const explanation = document.getElementById('perm-authority-explanation');
+    const reasonInput = document.getElementById('perm-authority-reason');
+    const note = document.getElementById('perm-authority-note');
+
+    if (!card || !hostSelect || !saveButton || !message || !currentMode || !currentHost || !explanation || !reasonInput || !note) {
+      return;
+    }
+
+    const supportedHosts = Array.isArray(data?.authoritySupportedHosts) && data.authoritySupportedHosts.length
+      ? data.authoritySupportedHosts
+      : ['claude-code'];
+    const authority = data?.authority || { defaultMode: 'shared', hosts: {} };
+
+    if (!supportedHosts.includes(authorityUiState.selectedHost)) {
+      authorityUiState.selectedHost = supportedHosts[0];
+      authorityUiState.dirty = false;
+    }
+
+    const serverMode = getAuthorityModeForHost(authority, authorityUiState.selectedHost);
+    if (!authorityUiState.dirty) {
+      authorityUiState.selectedMode = serverMode;
+    }
+
+    hostSelect.innerHTML = supportedHosts.map(function (host) {
+      return `<option value="${esc(host)}">${esc(formatAuthorityHost(host))}</option>`;
+    }).join('');
+    hostSelect.value = authorityUiState.selectedHost;
+    reasonInput.value = authorityUiState.draftReason;
+
+    const authoritativeSupported = AUTHORITY_AUTHORITATIVE_HOSTS.has(authorityUiState.selectedHost);
+    const desiredMode = authoritativeSupported ? authorityUiState.selectedMode : fallbackAuthorityMode(authorityUiState.selectedMode);
+
+    setAuthorityRadioState('perm-authority-mode-off', desiredMode === 'off', false);
+    setAuthorityRadioState('perm-authority-mode-shared', desiredMode === 'shared', false);
+    setAuthorityRadioState('perm-authority-mode-authoritative', desiredMode === 'authoritative', !authoritativeSupported);
+
+    currentMode.textContent = formatAuthorityMode(serverMode);
+    currentHost.textContent = formatAuthorityHost(authorityUiState.selectedHost);
+    explanation.textContent = buildAuthorityExplanation(serverMode, authoritativeSupported);
+    note.textContent = authoritativeSupported
+      ? 'Human-only control. AI can read authority mode but cannot change it through MCP.'
+      : 'Authoritative settings sync currently ships for Claude Code only. Other hosts can use Off or Shared mode for now.';
+
+    if (authorityUiState.feedback) {
+      message.hidden = false;
+      message.textContent = authorityUiState.feedback;
+      message.dataset.kind = authorityUiState.feedbackKind;
+    } else {
+      message.hidden = true;
+      message.textContent = '';
+      message.dataset.kind = 'info';
+    }
+
+    saveButton.disabled = authorityUiState.saving || desiredMode === serverMode;
+    saveButton.textContent = authorityUiState.saving ? 'Saving...' : 'Save Authority Mode';
+    card.hidden = false;
   }
 
   function renderAdvisory(data) {
@@ -608,6 +697,57 @@
           </div>
         </div>
 
+        <div class="perm-card perm-card--full" data-collapsed="false" id="perm-authority-card">
+          <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
+            <h3 class="perm-card-title">Authority Mode</h3>
+            <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
+          </div>
+          <div class="perm-card-body">
+            <div class="perm-selected-header perm-selected-header--compact">
+              <div>
+                <div class="perm-selected-title">Human-Only Permission Authority</div>
+                <div class="perm-selected-subtitle">Choose whether the host's native permission system or DollhouseMCP is the final authority for tool approvals.</div>
+              </div>
+            </div>
+
+            <div class="perm-selected-grid">
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Current State</h4>
+                <ul class="perm-pattern-list">
+                  <li class="perm-pattern-item">
+                    <span class="perm-pattern-badge perm-pattern-badge--allow">host</span>
+                    <span class="perm-pattern-text" id="perm-authority-current-host">Claude Code</span>
+                  </li>
+                  <li class="perm-pattern-item">
+                    <span class="perm-pattern-badge perm-pattern-badge--ask">mode</span>
+                    <span class="perm-pattern-text" id="perm-authority-current-mode">Shared</span>
+                  </li>
+                </ul>
+                <p class="perm-selected-subtitle" id="perm-authority-explanation"></p>
+              </div>
+
+              <div class="perm-selected-panel">
+                <h4 class="perm-selected-panel-title">Change Mode</h4>
+                <label class="perm-selected-subtitle" for="perm-authority-host">Host</label>
+                <select id="perm-authority-host" class="perm-panel-action" style="width:100%;margin:0.35rem 0 0.75rem 0;"></select>
+
+                <div style="display:grid;gap:0.45rem;">
+                  <label><input type="radio" name="perm-authority-mode" id="perm-authority-mode-off" value="off"> Off</label>
+                  <label><input type="radio" name="perm-authority-mode" id="perm-authority-mode-shared" value="shared"> Shared</label>
+                  <label><input type="radio" name="perm-authority-mode" id="perm-authority-mode-authoritative" value="authoritative"> Authoritative</label>
+                </div>
+
+                <label class="perm-selected-subtitle" for="perm-authority-reason" style="display:block;margin-top:0.75rem;">Reason (optional)</label>
+                <input id="perm-authority-reason" type="text" maxlength="200" placeholder="Why are you changing authority mode?" style="width:100%;margin-top:0.35rem;">
+
+                <p class="perm-selected-subtitle" id="perm-authority-note" style="margin-top:0.75rem;"></p>
+                <div class="perm-inline-warning" id="perm-authority-message" hidden></div>
+                <button type="button" class="perm-panel-action" id="perm-authority-save-btn" style="margin-top:0.75rem;">Save Authority Mode</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <!-- Selected Session Detail -->
         <div class="perm-card perm-card--full" data-collapsed="false" id="perm-selected-card" hidden>
           <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
@@ -775,6 +915,44 @@
     }
   }
 
+  function attachAuthorityControls() {
+    const hostSelect = document.getElementById('perm-authority-host');
+    const reasonInput = document.getElementById('perm-authority-reason');
+    const saveButton = document.getElementById('perm-authority-save-btn');
+
+    if (hostSelect) {
+      hostSelect.addEventListener('change', function (event) {
+        authorityUiState.selectedHost = event.target.value;
+        authorityUiState.feedback = '';
+        authorityUiState.feedbackKind = 'info';
+        authorityUiState.dirty = false;
+        renderAuthorityMode(latestAggregateData);
+      });
+    }
+
+    document.querySelectorAll('input[name="perm-authority-mode"]').forEach(function (input) {
+      input.addEventListener('change', function (event) {
+        authorityUiState.selectedMode = event.target.value;
+        authorityUiState.feedback = '';
+        authorityUiState.feedbackKind = 'info';
+        authorityUiState.dirty = true;
+        renderAuthorityMode(latestAggregateData);
+      });
+    });
+
+    if (reasonInput) {
+      reasonInput.addEventListener('input', function (event) {
+        authorityUiState.draftReason = event.target.value;
+      });
+    }
+
+    if (saveButton) {
+      saveButton.addEventListener('click', function () {
+        saveAuthorityMode();
+      });
+    }
+  }
+
   function openAuditModal() {
     const auditModal = document.getElementById('perm-audit-modal');
     if (!auditModal) return;
@@ -846,6 +1024,108 @@
 
   function truncate(str, len) {
     return str.length > len ? str.slice(0, len) + '...' : str;
+  }
+
+  function getAuthorityModeForHost(authority, host) {
+    return authority?.hosts?.[host]?.mode || authority?.defaultMode || 'shared';
+  }
+
+  function formatAuthorityHost(host) {
+    return String(host || '')
+      .split('-')
+      .map(function (part) { return part ? part.charAt(0).toUpperCase() + part.slice(1) : part; })
+      .join(' ');
+  }
+
+  function formatAuthorityMode(mode) {
+    return mode === 'off'
+      ? 'Off'
+      : mode === 'authoritative'
+        ? 'Authoritative'
+        : 'Shared';
+  }
+
+  function buildAuthorityExplanation(mode, authoritativeSupported) {
+    if (mode === 'off') {
+      return 'Dollhouse hooks no-op and the host-native permission system is the sole gate.';
+    }
+    if (mode === 'authoritative') {
+      return 'Dollhouse is writing managed allow/ask/deny entries into the host settings and preserving user-authored entries outside the managed slice.';
+    }
+    return authoritativeSupported
+      ? 'Dollhouse participates in permission checks, but the host can still be more restrictive.'
+      : 'This host currently supports shared/advisory mode while authoritative settings sync is still being added.';
+  }
+
+  function fallbackAuthorityMode(mode) {
+    return mode === 'authoritative' ? 'shared' : mode;
+  }
+
+  function setAuthorityRadioState(id, checked, disabled) {
+    const radio = document.getElementById(id);
+    if (!radio) return;
+    radio.checked = checked;
+    radio.disabled = disabled;
+  }
+
+  async function saveAuthorityMode() {
+    if (!latestAggregateData || authorityUiState.saving) {
+      return;
+    }
+
+    const authority = latestAggregateData.authority || { defaultMode: 'shared', hosts: {} };
+    const currentMode = getAuthorityModeForHost(authority, authorityUiState.selectedHost);
+    const requestedMode = AUTHORITY_AUTHORITATIVE_HOSTS.has(authorityUiState.selectedHost)
+      ? authorityUiState.selectedMode
+      : fallbackAuthorityMode(authorityUiState.selectedMode);
+
+    if (requestedMode === currentMode) {
+      authorityUiState.feedback = 'No authority-mode change to save.';
+      authorityUiState.feedbackKind = 'info';
+      renderAuthorityMode(latestAggregateData);
+      return;
+    }
+
+    const confirmMessage = [
+      `Change ${formatAuthorityHost(authorityUiState.selectedHost)} from ${formatAuthorityMode(currentMode)} to ${formatAuthorityMode(requestedMode)}?`,
+      '',
+      requestedMode === 'authoritative'
+        ? 'Dollhouse will take a backup and write managed host permission settings.'
+        : requestedMode === 'off'
+          ? 'Dollhouse hooks will no-op and the host permission system will become the only gate.'
+          : 'Dollhouse will stay active, but the host will remain authoritative on conflicts.',
+    ].join('\n');
+
+    if (!window.confirm(confirmMessage)) {
+      return;
+    }
+
+    authorityUiState.saving = true;
+    authorityUiState.feedback = '';
+    renderAuthorityMode(latestAggregateData);
+
+    try {
+      const response = await updatePermissionAuthority({
+        host: authorityUiState.selectedHost,
+        mode: requestedMode,
+        reason: authorityUiState.draftReason.trim() || undefined,
+      });
+
+      latestAggregateData = {
+        ...latestAggregateData,
+        authority: response.authority,
+      };
+      authorityUiState.selectedMode = requestedMode;
+      authorityUiState.dirty = false;
+      authorityUiState.feedback = `Saved ${formatAuthorityMode(requestedMode)} mode for ${formatAuthorityHost(authorityUiState.selectedHost)}.`;
+      authorityUiState.feedbackKind = 'success';
+    } catch (error) {
+      authorityUiState.feedback = error instanceof Error ? error.message : 'Failed to update permission authority.';
+      authorityUiState.feedbackKind = 'error';
+    } finally {
+      authorityUiState.saving = false;
+      renderAuthorityMode(latestAggregateData);
+    }
   }
 
   function dataAdvisoryPlaceholder() {

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -8,12 +8,21 @@
  */
 
 import express, { Router } from 'express';
+import { homedir } from 'node:os';
 import { logger } from '../../utils/logger.js';
 import type { MCPAQLHandler } from '../../handlers/mcp-aql/MCPAQLHandler.js';
 import { formatPermissionResponse } from '../../handlers/mcp-aql/evaluatePermission.js';
 import { ensureLatestPortFile } from '../portDiscovery.js';
 
 import { SlidingWindowRateLimiter } from '../../utils/SlidingWindowRateLimiter.js';
+import {
+  type PermissionAuthorityHost,
+  type PermissionAuthorityMode,
+  PERMISSION_AUTHORITY_HOSTS,
+  PERMISSION_AUTHORITY_MODES,
+  readPermissionAuthorityState,
+  setPermissionAuthorityMode,
+} from '../../utils/permissionAuthority.js';
 
 // ── Permission Decision Tracking ─────────────────────────────────────────────
 // Ring buffer of recent permission decisions for the live dashboard feed.
@@ -300,7 +309,16 @@ async function selfHealLatestPermissionPortFile(port: number | undefined): Promi
  * Register permission-related routes on a gateway router.
  * Must be called with the MCP-AQL handler for policy evaluation.
  */
-export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler): void {
+export interface RegisterPermissionRoutesOptions {
+  homeDir?: string;
+}
+
+export function registerPermissionRoutes(
+  router: Router,
+  handler: MCPAQLHandler,
+  options: RegisterPermissionRoutesOptions = {},
+): void {
+  const authorityHomeDir = options.homeDir ?? homedir();
   const decisionTracker = createPermissionDecisionTracker();
   /**
    * POST /api/evaluate_permission
@@ -405,6 +423,7 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
       }
 
       const data = opResult.data as Record<string, unknown>;
+      const authorityState = await readPermissionAuthorityState(authorityHomeDir);
       const elements = normalizePolicyElements((data.elements || []) as Array<Record<string, unknown>>);
 
       const denyPatterns = (data.combinedDenyPatterns as string[] | undefined) ?? [];
@@ -432,6 +451,7 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
         permissionPromptActive: data.permissionPromptActive,
         hookInstalled: data.hookInstalled,
         hookHost: data.hookHost,
+        authority: authorityState,
         enforcementReady: data.enforcementReady,
         invalidPolicyElementCount: data.invalidPolicyElementCount ?? 0,
         advisory: data.advisory,
@@ -442,4 +462,90 @@ export function registerPermissionRoutes(router: Router, handler: MCPAQLHandler)
       res.status(500).json({ error: 'Failed to get permission status' });
     }
   });
+
+  router.get('/permissions/authority', async (_req, res) => {
+    try {
+      const authorityState = await readPermissionAuthorityState(authorityHomeDir);
+      res.json({
+        ...authorityState,
+        supportedHosts: [...PERMISSION_AUTHORITY_HOSTS],
+        supportedModes: [...PERMISSION_AUTHORITY_MODES],
+        aiMutable: false,
+      });
+    } catch (err) {
+      logger.error('[WebUI/Gateway] permissions/authority error:', err);
+      res.status(500).json({ error: 'Failed to get permission authority' });
+    }
+  });
+
+  router.post('/permissions/authority', express.json(), async (req, res) => {
+    try {
+      const host = normalizeAuthorityHost(req.body?.host);
+      const mode = normalizeAuthorityMode(req.body?.mode);
+      const reason = typeof req.body?.reason === 'string' && req.body.reason.trim() !== ''
+        ? req.body.reason.trim()
+        : undefined;
+
+      if (!host || !mode) {
+        res.status(400).json({
+          error: 'host and mode are required',
+          supportedHosts: [...PERMISSION_AUTHORITY_HOSTS],
+          supportedModes: [...PERMISSION_AUTHORITY_MODES],
+        });
+        return;
+      }
+
+      let policies: Record<string, unknown> | undefined;
+      if (mode === 'authoritative') {
+        const policyResult = asSingleResult(await handler.handleRead({
+          operation: 'get_effective_cli_policies',
+          params: { reporting_scope: 'dashboard' },
+        }));
+
+        if (!policyResult.success) {
+          res.status(500).json({ error: policyResult.error || 'Failed to fetch effective policies' });
+          return;
+        }
+
+        policies = policyResult.data as Record<string, unknown>;
+      }
+
+      const authorityState = await setPermissionAuthorityMode({
+        host,
+        mode,
+        reason,
+        homeDir: authorityHomeDir,
+        policies: mode === 'authoritative'
+          ? {
+            combinedAllowPatterns: asStringArray(policies?.combinedAllowPatterns),
+            combinedConfirmPatterns: asStringArray(policies?.combinedConfirmPatterns),
+            combinedDenyPatterns: asStringArray(policies?.combinedDenyPatterns),
+          }
+          : undefined,
+      });
+
+      res.json({ success: true, authority: authorityState });
+    } catch (err) {
+      logger.error('[WebUI/Gateway] permissions/authority update error:', err);
+      res.status(500).json({
+        error: err instanceof Error ? err.message : 'Failed to update permission authority',
+      });
+    }
+  });
+}
+
+function normalizeAuthorityHost(value: unknown): PermissionAuthorityHost | null {
+  return typeof value === 'string' && PERMISSION_AUTHORITY_HOSTS.includes(value as PermissionAuthorityHost)
+    ? value as PermissionAuthorityHost
+    : null;
+}
+
+function normalizeAuthorityMode(value: unknown): PermissionAuthorityMode | null {
+  return typeof value === 'string' && PERMISSION_AUTHORITY_MODES.includes(value as PermissionAuthorityMode)
+    ? value as PermissionAuthorityMode
+    : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [];
 }

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -452,6 +452,9 @@ export function registerPermissionRoutes(
         hookInstalled: data.hookInstalled,
         hookHost: data.hookHost,
         authority: authorityState,
+        authoritySupportedHosts: [...PERMISSION_AUTHORITY_HOSTS],
+        authoritySupportedModes: [...PERMISSION_AUTHORITY_MODES],
+        authorityAiMutable: false,
         enforcementReady: data.enforcementReady,
         invalidPolicyElementCount: data.invalidPolicyElementCount ?? 0,
         advisory: data.advisory,
@@ -526,7 +529,10 @@ export function registerPermissionRoutes(
 
       res.json({ success: true, authority: authorityState });
     } catch (err) {
-      logger.error('[WebUI/Gateway] permissions/authority update error:', err);
+      logger.error(
+        `[WebUI/Gateway] permissions/authority update error (host=${String(req.body?.host ?? '')}, mode=${String(req.body?.mode ?? '')}):`,
+        err,
+      );
       res.status(500).json({
         error: err instanceof Error ? err.message : 'Failed to update permission authority',
       });

--- a/tests/unit/di/permissionServerIntegration.test.ts
+++ b/tests/unit/di/permissionServerIntegration.test.ts
@@ -185,6 +185,47 @@ describe('Permission Server Integration', () => {
       expect(stdout.trim()).toBe('');
     });
 
+    itBash('hook script should no-op when authority mode is off for Claude Code', async () => {
+      const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'dollhouse-hook-home-'));
+      const runDir = path.join(tempHome, '.dollhouse', 'run');
+      await fs.mkdir(runDir, { recursive: true });
+      await fs.writeFile(
+        path.join(runDir, 'permission-authority.json'),
+        JSON.stringify({
+          version: 1,
+          defaultMode: 'shared',
+          updatedAt: '2026-04-17T00:00:00.000Z',
+          hosts: {
+            'claude-code': {
+              mode: 'off',
+              updatedAt: '2026-04-17T00:00:00.000Z',
+            },
+          },
+        }),
+        'utf-8',
+      );
+
+      const { code, stdout } = await new Promise<{ code: number; stdout: string }>((resolve) => {
+        const hookProc = spawn(BASH_BINARY, [HOOK_SCRIPT], {
+          env: { HOME: tempHome, PATH: SAFE_TEST_PATH },
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        let out = '';
+        hookProc.stdout.on('data', (data: Buffer) => { out += data.toString(); });
+        hookProc.on('close', (c: number) => resolve({ code: c, stdout: out }));
+        hookProc.stdin.write(JSON.stringify({
+          tool_name: 'Read',
+          tool_input: { file_path: './test-fixture.txt' },
+        }));
+        hookProc.stdin.end();
+      });
+
+      await fs.rm(tempHome, { recursive: true, force: true });
+
+      expect(code).toBe(0);
+      expect(stdout.trim()).toBe('');
+    });
+
     itBash('hook script should discover server via port file and get a response', async () => {
       const testPort = 49360;
       let capturedBody: Record<string, unknown> | null = null;

--- a/tests/unit/handlers/mcp-aql/OperationRouter.test.ts
+++ b/tests/unit/handlers/mcp-aql/OperationRouter.test.ts
@@ -96,6 +96,7 @@ describe('OperationRouter', () => {
         'resume_from_handoff',
       'confirm_operation',
       'get_effective_cli_policies', // Issue #625 Phase 2
+      'get_permission_authority',
       'approve_cli_permission', // Issue #625 Phase 3
       'get_pending_cli_approvals', // Issue #625 Phase 3
   ];

--- a/tests/unit/handlers/mcp-aql/OperationSchema.test.ts
+++ b/tests/unit/handlers/mcp-aql/OperationSchema.test.ts
@@ -619,14 +619,15 @@ describe('OperationSchema', () => {
     });
 
     describe('GATEKEEPER_SCHEMAS', () => {
-      it('should define 9 gatekeeper operations', () => {
-        expect(Object.keys(GATEKEEPER_SCHEMAS)).toHaveLength(9);
+      it('should define 10 gatekeeper operations', () => {
+        expect(Object.keys(GATEKEEPER_SCHEMAS)).toHaveLength(10);
         expect(GATEKEEPER_SCHEMAS.confirm_operation).toBeDefined();
         expect(GATEKEEPER_SCHEMAS.verify_challenge).toBeDefined();
         expect(GATEKEEPER_SCHEMAS.release_deadlock).toBeDefined();
         expect(GATEKEEPER_SCHEMAS.beetlejuice_beetlejuice_beetlejuice).toBeDefined();
         expect(GATEKEEPER_SCHEMAS.permission_prompt).toBeDefined();
         expect(GATEKEEPER_SCHEMAS.get_effective_cli_policies).toBeDefined();
+        expect(GATEKEEPER_SCHEMAS.get_permission_authority).toBeDefined();
         expect(GATEKEEPER_SCHEMAS.approve_cli_permission).toBeDefined();
         expect(GATEKEEPER_SCHEMAS.get_pending_cli_approvals).toBeDefined();
       });

--- a/tests/unit/utils/permissionAuthority.test.ts
+++ b/tests/unit/utils/permissionAuthority.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  getPermissionAuthorityStatePath,
+  readPermissionAuthorityState,
+  setPermissionAuthorityMode,
+} from '../../../src/utils/permissionAuthority.js';
+
+describe('permissionAuthority', () => {
+  let tempHome: string;
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(join(tmpdir(), 'permission-authority-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempHome, { recursive: true, force: true });
+  });
+
+  it('defaults to shared mode when no state file exists', async () => {
+    const state = await readPermissionAuthorityState(tempHome);
+
+    expect(state.defaultMode).toBe('shared');
+    expect(state.hosts).toEqual({});
+  });
+
+  it('writes authoritative Claude Code permissions with managed metadata and strips conflicting ask entries', async () => {
+    const settingsPath = join(tempHome, '.claude', 'settings.json');
+    await mkdir(join(tempHome, '.claude'), { recursive: true });
+    await writeFile(settingsPath, JSON.stringify({
+      permissions: {
+        allow: ['Read'],
+        ask: ['Bash', 'Write'],
+        deny: ['Delete'],
+      },
+    }, null, 2) + '\n', 'utf-8');
+
+    const state = await setPermissionAuthorityMode({
+      homeDir: tempHome,
+      host: 'claude-code',
+      mode: 'authoritative',
+      reason: 'test sync',
+      now: new Date('2026-04-17T14:00:00.000Z'),
+      policies: {
+        combinedAllowPatterns: ['Bash:git status*'],
+        combinedConfirmPatterns: ['Write:README.md'],
+        combinedDenyPatterns: ['Bash:rm -rf*'],
+      },
+    });
+
+    expect(state.hosts['claude-code']?.mode).toBe('authoritative');
+
+    const raw = await readFile(settingsPath, 'utf-8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    expect(parsed.permissions).toEqual({
+      allow: ['Read', 'Bash:git status*'],
+      ask: ['Write', 'Write:README.md', 'mcp__DollhouseMCP__mcp_aql_execute*'],
+      deny: ['Delete', 'Bash:rm -rf*'],
+    });
+    expect(parsed['_dollhousePermissionAuthority']).toMatchObject({
+      version: 1,
+      host: 'claude-code',
+      managedPermissions: {
+        allow: ['Bash:git status*'],
+        ask: ['Write:README.md', 'mcp__DollhouseMCP__mcp_aql_execute*'],
+        deny: ['Bash:rm -rf*'],
+      },
+    });
+  });
+
+  it('restores the original Claude Code settings when leaving authoritative mode', async () => {
+    const settingsPath = join(tempHome, '.claude', 'settings.json');
+    await mkdir(join(tempHome, '.claude'), { recursive: true });
+    const original = JSON.stringify({
+      permissions: {
+        ask: ['Bash'],
+      },
+    }, null, 2) + '\n';
+    await writeFile(settingsPath, original, 'utf-8');
+
+    await setPermissionAuthorityMode({
+      homeDir: tempHome,
+      host: 'claude-code',
+      mode: 'authoritative',
+      now: new Date('2026-04-17T14:10:00.000Z'),
+      policies: {
+        combinedAllowPatterns: ['Bash:git status*'],
+      },
+    });
+
+    const reverted = await setPermissionAuthorityMode({
+      homeDir: tempHome,
+      host: 'claude-code',
+      mode: 'shared',
+      now: new Date('2026-04-17T14:11:00.000Z'),
+    });
+
+    expect(reverted.hosts['claude-code']?.mode).toBe('shared');
+    expect(await readFile(settingsPath, 'utf-8')).toBe(original);
+  });
+
+  it('persists off mode for hooks to read from the authority state file', async () => {
+    await setPermissionAuthorityMode({
+      homeDir: tempHome,
+      host: 'claude-code',
+      mode: 'off',
+      now: new Date('2026-04-17T14:12:00.000Z'),
+    });
+
+    const raw = await readFile(getPermissionAuthorityStatePath(tempHome), 'utf-8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    expect((parsed.hosts as Record<string, { mode: string }>)['claude-code'].mode).toBe('off');
+  });
+});

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -437,6 +437,190 @@ describe('Web console cleanup regressions', () => {
     cleanup();
   });
 
+  it('renders the authority card as a human-only control and disables unsupported authoritative hosts', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="session-indicator"></div>
+      <div id="tab-logs"><div class="log-controls"></div></div>
+      <div id="console-tabs"><button class="console-tab" data-tab="permissions">Permissions</button></div>
+      <div id="permissions-dashboard-root"></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn((url: string) => {
+      if (url === '/api/sessions') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ sessions: [] }),
+        });
+      }
+
+      if (url === '/api/permissions/status') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            activeElementCount: 0,
+            hasAllowlist: false,
+            denyPatterns: [],
+            allowPatterns: [],
+            confirmPatterns: [],
+            denyRules: [],
+            allowRules: [],
+            confirmRules: [],
+            elements: [],
+            knownSessions: [],
+            recentDecisions: [],
+            permissionPromptActive: false,
+            authority: {
+              defaultMode: 'shared',
+              hosts: {
+                'claude-code': { mode: 'shared', updatedAt: '2026-04-17T14:00:00.000Z' },
+                codex: { mode: 'off', updatedAt: '2026-04-17T14:00:00.000Z' },
+              },
+            },
+            authoritySupportedHosts: ['claude-code', 'codex'],
+          }),
+        });
+      }
+
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+    win.DollhouseConsoleConfig = {
+      sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
+      sessionFilterInjectionMaxRetries: 5,
+    };
+
+    win.eval(sessionsSource);
+    win.eval(permissionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    win.DollhouseConsole.permissions.init();
+    await wait(SESSION_FILTER_INJECTION_WAIT_MS);
+
+    expect(win.document.getElementById('perm-authority-card')?.hidden).toBe(false);
+    expect(win.document.getElementById('perm-authority-note')?.textContent).toContain('Human-only control');
+
+    const hostSelect = win.document.getElementById('perm-authority-host') as HTMLSelectElement | null;
+    const authoritativeRadio = win.document.getElementById('perm-authority-mode-authoritative') as HTMLInputElement | null;
+    expect(hostSelect).not.toBeNull();
+    expect(authoritativeRadio?.disabled).toBe(false);
+
+    if (hostSelect) {
+      hostSelect.value = 'codex';
+      hostSelect.dispatchEvent(new win.Event('change', { bubbles: true }));
+    }
+    await wait(DEFAULT_WAIT_MS);
+
+    expect(authoritativeRadio?.disabled).toBe(true);
+    expect(win.document.getElementById('perm-authority-note')?.textContent).toContain('Claude Code only');
+
+    cleanup();
+  });
+
+  it('posts authority-mode changes from the permissions card through the human-only local API', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="session-indicator"></div>
+      <div id="tab-logs"><div class="log-controls"></div></div>
+      <div id="console-tabs"><button class="console-tab" data-tab="permissions">Permissions</button></div>
+      <div id="permissions-dashboard-root"></div>
+    `);
+
+    const apiFetch = jest.fn((url: string, options?: any) => {
+      if (url === '/api/sessions') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ sessions: [] }),
+        });
+      }
+
+      if (url === '/api/permissions/status') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            activeElementCount: 0,
+            hasAllowlist: false,
+            denyPatterns: [],
+            allowPatterns: [],
+            confirmPatterns: [],
+            denyRules: [],
+            allowRules: [],
+            confirmRules: [],
+            elements: [],
+            knownSessions: [],
+            recentDecisions: [],
+            permissionPromptActive: false,
+            authority: {
+              defaultMode: 'shared',
+              hosts: {
+                'claude-code': { mode: 'shared', updatedAt: '2026-04-17T14:00:00.000Z' },
+              },
+            },
+            authoritySupportedHosts: ['claude-code'],
+          }),
+        });
+      }
+
+      if (url === '/api/permissions/authority') {
+        expect(options?.method).toBe('POST');
+        expect(JSON.parse(options?.body || '{}')).toEqual({
+          host: 'claude-code',
+          mode: 'authoritative',
+          reason: 'Hands-off bridge run',
+        });
+
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            success: true,
+            authority: {
+              defaultMode: 'shared',
+              hosts: {
+                'claude-code': {
+                  mode: 'authoritative',
+                  updatedAt: '2026-04-17T14:05:00.000Z',
+                  lastSyncedAt: '2026-04-17T14:05:00.000Z',
+                },
+              },
+            },
+          }),
+        });
+      }
+
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    win.DollhouseAuth.apiFetch = apiFetch;
+    win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+    win.DollhouseConsoleConfig = {
+      sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
+      sessionFilterInjectionMaxRetries: 5,
+    };
+    win.confirm = jest.fn().mockReturnValue(true);
+
+    win.eval(sessionsSource);
+    win.eval(permissionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    win.DollhouseConsole.permissions.init();
+    await wait(SESSION_FILTER_INJECTION_WAIT_MS);
+
+    const authoritativeRadio = win.document.getElementById('perm-authority-mode-authoritative') as HTMLInputElement | null;
+    authoritativeRadio!.checked = true;
+    authoritativeRadio!.dispatchEvent(new win.Event('change', { bubbles: true }));
+
+    const reasonInput = win.document.getElementById('perm-authority-reason') as HTMLInputElement | null;
+    reasonInput!.value = 'Hands-off bridge run';
+    reasonInput!.dispatchEvent(new win.Event('input', { bubbles: true }));
+
+    const saveButton = win.document.getElementById('perm-authority-save-btn') as HTMLButtonElement | null;
+    saveButton?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    expect(win.confirm).toHaveBeenCalled();
+    expect(win.document.getElementById('perm-authority-current-mode')?.textContent).toContain('Authoritative');
+    expect(win.document.getElementById('perm-authority-message')?.textContent).toContain('Saved Authoritative mode');
+
+    cleanup();
+  });
+
   it('ignores malformed persisted policy session entries in the picker', async () => {
     const { window: win, cleanup } = createDom(`
       <div id="session-indicator"></div>

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -8,10 +8,9 @@ import { jest } from '@jest/globals';
 import express from 'express';
 import request from 'supertest';
 import { createServer } from 'node:http';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { mkdir, mkdtemp, readFile, rm, unlink } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
 import { registerPermissionRoutes } from '../../../src/web/routes/permissionRoutes.js';
 
 function createMockHandler(readResult?: unknown) {

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -10,7 +10,8 @@ import request from 'supertest';
 import { createServer } from 'node:http';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { mkdir, readFile, unlink } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, unlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { registerPermissionRoutes } from '../../../src/web/routes/permissionRoutes.js';
 
 function createMockHandler(readResult?: unknown) {
@@ -29,10 +30,10 @@ function createMockHandler(readResult?: unknown) {
   } as any;
 }
 
-function createApp(handler: any) {
+function createApp(handler: any, options?: { homeDir?: string }) {
   const app = express();
   const router = express.Router();
-  registerPermissionRoutes(router, handler);
+  registerPermissionRoutes(router, handler, options);
   app.use('/api', router);
   return app;
 }
@@ -40,9 +41,15 @@ function createApp(handler: any) {
 describe('permissionRoutes', () => {
   const runDir = join(homedir(), '.dollhouse', 'run');
   const latestPortFile = join(runDir, 'permission-server.port');
+  let tempHome: string;
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(join(tmpdir(), 'permission-routes-home-'));
+  });
 
   afterEach(async () => {
     await unlink(latestPortFile).catch(() => {});
+    await rm(tempHome, { recursive: true, force: true });
   });
 
   describe('POST /api/evaluate_permission', () => {
@@ -662,6 +669,35 @@ describe('permissionRoutes', () => {
         { label: 'File', value: '/opt/dollhouse/example.txt', monospace: true },
         { label: 'Matched Pattern', value: 'Edit:*', monospace: true },
       ]));
+    });
+  });
+
+  describe('permission authority routes', () => {
+    it('GET /api/permissions/authority returns default shared state', async () => {
+      const handler = createMockHandler();
+      const app = createApp(handler, { homeDir: tempHome });
+
+      const res = await request(app).get('/api/permissions/authority');
+
+      expect(res.status).toBe(200);
+      expect(res.body.defaultMode).toBe('shared');
+      expect(res.body.aiMutable).toBe(false);
+      expect(res.body.supportedModes).toEqual(expect.arrayContaining(['off', 'shared', 'authoritative']));
+    });
+
+    it('POST /api/permissions/authority persists off mode without calling policy sync', async () => {
+      const handler = createMockHandler();
+      const app = createApp(handler, { homeDir: tempHome });
+
+      const res = await request(app)
+        .post('/api/permissions/authority')
+        .send({ host: 'claude-code', mode: 'off', reason: 'test' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.authority.hosts['claude-code'].mode).toBe('off');
+      expect(handler.handleRead).not.toHaveBeenCalledWith(expect.objectContaining({
+        operation: 'get_effective_cli_policies',
+      }));
     });
   });
 });


### PR DESCRIPTION
## Summary
- add the first server-side slice of permission-authority mode tracking for #2053
- expose read-only authority state through MCP-AQL and the local permissions API
- add a human-only local route to change host authority mode, with Claude Code authoritative sync + backup/restore
- teach the shared PreToolUse hook to no-op when authority mode is `off`

## What this includes
- new persisted authority state under `~/.dollhouse/run/permission-authority.json`
- new read-only MCP op: `get_permission_authority`
- new local routes:
  - `GET /api/permissions/authority`
  - `POST /api/permissions/authority`
- Claude Code authoritative mode sync that:
  - backs up `~/.claude/settings.json`
  - writes managed `permissions.allow` / `permissions.ask` / `permissions.deny`
  - preserves user-authored entries by removing only the previously-managed slice
  - restores the original file when leaving authoritative mode
- hook behavior change so `off` mode exits cleanly without participating in permissioning

## What this does not include yet
- authoritative writers for Codex / Cursor / VS Code / Windsurf / Gemini CLI
- automatic re-sync on every activation change
- Permissions-tab UI controls for changing the mode

## Validation
- `npm test -- --runInBand tests/unit/utils/permissionAuthority.test.ts tests/unit/web/permissionRoutes.test.ts tests/unit/di/permissionServerIntegration.test.ts tests/unit/handlers/mcp-aql/OperationRouter.test.ts tests/unit/handlers/mcp-aql/OperationSchema.test.ts`
- `npx eslint src/utils/permissionAuthority.ts src/web/routes/permissionRoutes.ts src/handlers/mcp-aql/MCPAQLHandler.ts src/handlers/mcp-aql/OperationRouter.ts src/handlers/mcp-aql/OperationSchema.ts tests/unit/utils/permissionAuthority.test.ts tests/unit/web/permissionRoutes.test.ts tests/unit/di/permissionServerIntegration.test.ts tests/unit/handlers/mcp-aql/OperationRouter.test.ts tests/unit/handlers/mcp-aql/OperationSchema.test.ts`

## Links
- server issue: #2053
- bridge design issue: DollhouseMCP/bridge#159
