### PR TITLE
Polish authority mode permissions UX

### DIFF
--- a/src/utils/permissionAuthority.ts
+++ b/src/utils/permissionAuthority.ts
@@ -3,9 +3,14 @@ import { dirname, join } from 'node:path';
 import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { SecurityMonitor } from '../security/securityMonitor.js';
+import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
 import { logger } from './logger.js';
 import { getClaudeHookSettingsPath } from './permissionHooks.js';
 
+// These modes intentionally describe who has the final say when Dollhouse and the host disagree:
+// - off: the host permission system is fully in charge
+// - shared: both systems participate, but the host can still be stricter
+// - authoritative: Dollhouse is the source of truth for the managed host slice
 export const PERMISSION_AUTHORITY_MODES = ['off', 'shared', 'authoritative'] as const;
 export type PermissionAuthorityMode = typeof PERMISSION_AUTHORITY_MODES[number];
 
@@ -123,12 +128,15 @@ export async function setPermissionAuthorityMode(input: SetPermissionAuthorityMo
   const homeDir = input.homeDir ?? homedir();
   const now = input.now ?? new Date();
   const state = await readPermissionAuthorityState(homeDir);
-  const previousHostState = state.hosts[input.host];
+  const normalizedHost = normalizeAuthorityHostInput(input.host);
+  const normalizedMode = normalizeAuthorityModeInput(input.mode);
+  const normalizedReason = normalizeAuthorityReason(input.reason);
+  const previousHostState = state.hosts[normalizedHost];
   const previousMode = previousHostState?.mode ?? state.defaultMode;
   try {
-    if (input.mode === 'authoritative') {
-      if (input.host !== 'claude-code') {
-        throw new Error(`Authoritative mode is not implemented yet for ${input.host}.`);
+    if (normalizedMode === 'authoritative') {
+      if (normalizedHost !== 'claude-code') {
+        throw new Error(`Authoritative mode is not implemented yet for ${normalizedHost}.`);
       }
       if (!input.policies) {
         throw new Error('Authoritative mode requires a policy snapshot.');
@@ -136,15 +144,15 @@ export async function setPermissionAuthorityMode(input: SetPermissionAuthorityMo
 
       const syncResult = await syncClaudeCodeAuthoritativeMode({
         homeDir,
-        host: input.host,
+        host: normalizedHost,
         previousBackupPath: previousHostState?.backupPath,
         policies: input.policies,
         now,
       });
 
-      state.hosts[input.host] = {
+      state.hosts[normalizedHost] = {
         mode: 'authoritative',
-        reason: input.reason,
+        reason: normalizedReason,
         updatedAt: now.toISOString(),
         backupPath: syncResult.backupPath,
         lastSyncedAt: syncResult.syncedAt,
@@ -152,12 +160,12 @@ export async function setPermissionAuthorityMode(input: SetPermissionAuthorityMo
       };
     } else {
       if (previousMode === 'authoritative' && previousHostState?.backupPath) {
-        await restoreAuthorityBackup(previousHostState.backupPath, getHostSettingsPath(input.host, homeDir));
+        await restoreAuthorityBackup(previousHostState.backupPath, getHostSettingsPath(normalizedHost, homeDir));
       }
 
-      state.hosts[input.host] = {
-        mode: input.mode,
-        reason: input.reason,
+      state.hosts[normalizedHost] = {
+        mode: normalizedMode,
+        reason: normalizedReason,
         updatedAt: now.toISOString(),
         scope: 'user',
       };
@@ -170,19 +178,48 @@ export async function setPermissionAuthorityMode(input: SetPermissionAuthorityMo
       type: 'CONFIG_UPDATED',
       severity: 'LOW',
       source: 'permissionAuthority.setPermissionAuthorityMode',
-      details: `Permission authority for ${input.host} changed from ${previousMode} to ${input.mode}`,
+      details: `Permission authority for ${normalizedHost} changed from ${previousMode} to ${normalizedMode}`,
       additionalData: {
-        host: input.host,
+        host: normalizedHost,
         previousMode,
-        mode: input.mode,
-        reason: input.reason,
+        mode: normalizedMode,
+        reason: normalizedReason,
       },
     });
 
     return state;
   } catch (error) {
-    throw withAuthorityContext(error, `Failed to set permission authority for ${input.host} to ${input.mode}`);
+    throw withAuthorityContext(error, `Failed to set permission authority for ${normalizedHost} to ${normalizedMode}`);
   }
+}
+
+function normalizeAuthorityText(value: string): string {
+  return UnicodeValidator.normalize(value).normalizedContent.trim();
+}
+
+function normalizeAuthorityHostInput(value: PermissionAuthorityHost): PermissionAuthorityHost {
+  const normalized = normalizeAuthorityText(value).toLowerCase();
+  if (!isPermissionAuthorityHost(normalized)) {
+    throw new Error(`Unsupported permission authority host: ${value}`);
+  }
+  return normalized;
+}
+
+function normalizeAuthorityModeInput(value: PermissionAuthorityMode): PermissionAuthorityMode {
+  const normalized = normalizeAuthorityText(value).toLowerCase();
+  if (!isPermissionAuthorityMode(normalized)) {
+    throw new Error(`Unsupported permission authority mode: ${value}`);
+  }
+  return normalized;
+}
+
+function normalizeAuthorityReason(value: string | undefined): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = normalizeAuthorityText(value);
+  return normalized === '' ? undefined : normalized;
 }
 
 function normalizeHostStateMap(

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -230,6 +230,193 @@
   outline: none;
 }
 
+.perm-authority-host-select,
+.perm-authority-reason-input {
+  width: 100%;
+  margin-top: 0.35rem;
+}
+
+.perm-authority-host-select {
+  margin-bottom: 0.9rem;
+}
+
+.perm-authority-reason-input {
+  border: 1px solid var(--ink-100, #cbd5e1);
+  border-radius: 0.75rem;
+  background: var(--paper-strong, #fff);
+  color: var(--ink-800, #1e293b);
+  padding: 0.7rem 0.8rem;
+  font: inherit;
+}
+
+.perm-authority-reason-input:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--signal-2, #3b82f6) 28%, transparent);
+  outline-offset: 1px;
+  border-color: var(--signal-2, #3b82f6);
+}
+
+.perm-authority-field-label {
+  display: block;
+  margin-top: 0.85rem;
+}
+
+.perm-authority-field-label:first-of-type {
+  margin-top: 0;
+}
+
+.perm-authority-options {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.perm-authority-option {
+  display: block;
+  border: 1px solid var(--ink-100, #d8e0ea);
+  border-radius: 0.9rem;
+  background: var(--paper-strong, #fff);
+  padding: 0.8rem 0.9rem;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.perm-authority-option:hover {
+  border-color: color-mix(in srgb, var(--signal-2, #3b82f6) 32%, var(--ink-100, #d8e0ea));
+}
+
+.perm-authority-option[data-checked="true"] {
+  border-color: color-mix(in srgb, var(--signal-2, #3b82f6) 48%, var(--ink-100, #d8e0ea));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--signal-2, #3b82f6) 14%, transparent);
+}
+
+.perm-authority-option[data-disabled="true"] {
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--ink-50, #f8fafc) 96%, white), color-mix(in srgb, var(--ink-100, #e2e8f0) 58%, white));
+  border-style: dashed;
+  border-color: color-mix(in srgb, #f59e0b 44%, var(--ink-100, #d8e0ea));
+}
+
+.perm-authority-option-main {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.perm-authority-option-main input {
+  margin-top: 0.2rem;
+}
+
+.perm-authority-option-copy {
+  display: grid;
+  gap: 0.28rem;
+  min-width: 0;
+}
+
+.perm-authority-option-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.perm-authority-option-title {
+  color: var(--ink-900, #0f172a);
+  font-family: var(--font-heading, 'Plus Jakarta Sans', sans-serif);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.perm-authority-option-description {
+  color: var(--ink-500, #64748b);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.perm-authority-inline-note {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.18rem 0.48rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, #f59e0b 14%, white);
+  border: 1px solid color-mix(in srgb, #f59e0b 32%, white);
+  color: #9a3412;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.perm-authority-human-note {
+  margin-top: 0.85rem;
+}
+
+.perm-authority-save-shell {
+  margin-top: 0.85rem;
+  border: 1px solid var(--ink-100, #d8e0ea);
+  border-radius: 0.95rem;
+  background: color-mix(in srgb, var(--paper-base, #f8fafc) 84%, white);
+  padding: 0.85rem;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+.perm-authority-save-shell[data-dirty="true"] {
+  border-color: color-mix(in srgb, var(--signal-2, #3b82f6) 48%, var(--ink-100, #d8e0ea));
+  background: color-mix(in srgb, var(--signal-2, #3b82f6) 9%, white);
+  box-shadow: 0 10px 30px color-mix(in srgb, var(--signal-2, #3b82f6) 10%, transparent);
+}
+
+.perm-authority-dirty-state {
+  margin-bottom: 0.7rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.8rem;
+  background: color-mix(in srgb, var(--signal-2, #3b82f6) 11%, white);
+  border: 1px solid color-mix(in srgb, var(--signal-2, #3b82f6) 24%, white);
+  color: var(--ink-800, #1e293b);
+  font-size: 0.8rem;
+  line-height: 1.45;
+  font-weight: 600;
+}
+
+.perm-authority-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.perm-authority-save-copy {
+  color: var(--ink-600, #475569);
+  font-size: 0.8rem;
+  line-height: 1.45;
+  max-width: 34rem;
+}
+
+.perm-authority-save-btn {
+  padding-inline: 0.95rem;
+  padding-block: 0.5rem;
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.perm-authority-save-btn[data-dirty="true"] {
+  background: linear-gradient(135deg, color-mix(in srgb, var(--signal-2, #3b82f6) 94%, white), color-mix(in srgb, #0f766e 18%, var(--signal-2, #3b82f6)));
+  border-color: color-mix(in srgb, var(--signal-2, #3b82f6) 70%, #0f172a);
+  color: white;
+  box-shadow: 0 10px 22px color-mix(in srgb, var(--signal-2, #3b82f6) 28%, transparent);
+}
+
+.perm-authority-save-btn[data-dirty="true"]:hover,
+.perm-authority-save-btn[data-dirty="true"]:focus-visible {
+  color: white;
+  border-color: color-mix(in srgb, var(--signal-2, #3b82f6) 78%, #0f172a);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--signal-2, #3b82f6) 98%, white), color-mix(in srgb, #0f766e 24%, var(--signal-2, #3b82f6)));
+}
+
+.perm-authority-save-btn:disabled {
+  cursor: default;
+  opacity: 0.74;
+  box-shadow: none;
+}
+
 .perm-source-item--selected {
   background: color-mix(in srgb, var(--signal-2, #3b82f6) 10%, transparent);
   border-left: 3px solid var(--signal-2, #3b82f6);
@@ -667,6 +854,59 @@
 [data-theme="dark"] .perm-panel-action:hover,
 [data-theme="dark"] .perm-panel-action:focus-visible {
   background: color-mix(in srgb, var(--surface-2) 78%, var(--paper-strong));
+}
+
+[data-theme="dark"] .perm-authority-option {
+  background: color-mix(in srgb, var(--surface-1) 82%, var(--paper-strong));
+  border-color: color-mix(in srgb, var(--line, #2b3445) 90%, transparent);
+}
+
+[data-theme="dark"] .perm-authority-option[data-checked="true"] {
+  border-color: color-mix(in srgb, var(--signal-2) 48%, var(--line, #2b3445));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--signal-2) 20%, transparent);
+}
+
+[data-theme="dark"] .perm-authority-option[data-disabled="true"] {
+  background: linear-gradient(135deg, color-mix(in srgb, var(--surface-1) 94%, var(--paper-strong)), color-mix(in srgb, #7c2d12 16%, var(--surface-1)));
+  border-color: color-mix(in srgb, #f59e0b 48%, var(--line, #2b3445));
+}
+
+[data-theme="dark"] .perm-authority-option-title,
+[data-theme="dark"] .perm-authority-reason-input {
+  color: var(--ink-200, #e2e8f0);
+}
+
+[data-theme="dark"] .perm-authority-option-description,
+[data-theme="dark"] .perm-authority-save-copy {
+  color: var(--ink-400, #94a3b8);
+}
+
+[data-theme="dark"] .perm-authority-inline-note {
+  background: color-mix(in srgb, #7c2d12 54%, var(--surface-1));
+  border-color: color-mix(in srgb, #fdba74 28%, var(--line, #2b3445));
+  color: #fdba74;
+}
+
+[data-theme="dark"] .perm-authority-reason-input {
+  background: color-mix(in srgb, var(--surface-2) 62%, var(--paper-strong));
+  border-color: color-mix(in srgb, var(--line, #2b3445) 94%, transparent);
+}
+
+[data-theme="dark"] .perm-authority-save-shell {
+  background: color-mix(in srgb, var(--surface-1) 82%, var(--paper-strong));
+  border-color: color-mix(in srgb, var(--line, #2b3445) 92%, transparent);
+}
+
+[data-theme="dark"] .perm-authority-save-shell[data-dirty="true"] {
+  background: color-mix(in srgb, var(--signal-2) 10%, var(--surface-1));
+  border-color: color-mix(in srgb, var(--signal-2) 42%, var(--line, #2b3445));
+  box-shadow: 0 10px 30px color-mix(in srgb, var(--signal-2) 16%, transparent);
+}
+
+[data-theme="dark"] .perm-authority-dirty-state {
+  background: color-mix(in srgb, var(--signal-2) 16%, var(--surface-1));
+  border-color: color-mix(in srgb, var(--signal-2) 24%, var(--line, #2b3445));
+  color: var(--ink-200, #e2e8f0);
 }
 
 [data-theme="dark"] .perm-stat-value {

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -74,6 +74,25 @@
 }
 
 #tab-permissions {
+  --perm-authority-warning-base: #b45309;
+  --perm-authority-warning-ink: #7c2d12;
+  --perm-authority-cta-accent: #0f766e;
+  --perm-authority-host-claude-bg: #fff1e8;
+  --perm-authority-host-claude-ink: #9a3412;
+  --perm-authority-host-codex-bg: #e8f1ff;
+  --perm-authority-host-codex-ink: #1d4ed8;
+  --perm-authority-host-cursor-bg: #ecfdf3;
+  --perm-authority-host-cursor-ink: #047857;
+  --perm-authority-host-vscode-bg: #e0f2fe;
+  --perm-authority-host-vscode-ink: #0369a1;
+  --perm-authority-host-windsurf-bg: #eef2ff;
+  --perm-authority-host-windsurf-ink: #4338ca;
+  --perm-authority-host-gemini-bg: #fef3c7;
+  --perm-authority-host-gemini-ink: #b45309;
+  --perm-authority-host-cline-bg: #f5f3ff;
+  --perm-authority-host-cline-ink: #6d28d9;
+  --perm-authority-host-generic-bg: #f1f5f9;
+  --perm-authority-host-generic-ink: #475569;
   padding-inline: clamp(0.5rem, 1vw, 1rem);
   padding-bottom: calc(var(--site-footer-height, 4.5rem) + 1.5rem);
 }
@@ -233,9 +252,6 @@
 .perm-authority-reason-input {
   width: 100%;
   margin-top: 0.35rem;
-}
-
-.perm-authority-reason-input {
   border: 1px solid var(--ink-100, #cbd5e1);
   border-radius: 0.75rem;
   background: var(--paper-strong, #fff);
@@ -331,9 +347,9 @@
   align-items: center;
   padding: 0.18rem 0.48rem;
   border-radius: 999px;
-  background: color-mix(in srgb, #f59e0b 14%, white);
-  border: 1px solid color-mix(in srgb, #f59e0b 32%, white);
-  color: #9a3412;
+  background: color-mix(in srgb, var(--perm-authority-warning-base) 12%, white);
+  border: 1px solid color-mix(in srgb, var(--perm-authority-warning-base) 28%, white);
+  color: var(--perm-authority-warning-ink);
   font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.02em;
@@ -389,44 +405,44 @@
 }
 
 .perm-authority-host-mark--claude {
-  background: #fff1e8;
-  color: #9a3412;
+  background: var(--perm-authority-host-claude-bg);
+  color: var(--perm-authority-host-claude-ink);
 }
 
 .perm-authority-host-mark--codex {
-  background: #e8f1ff;
-  color: #1d4ed8;
+  background: var(--perm-authority-host-codex-bg);
+  color: var(--perm-authority-host-codex-ink);
 }
 
 .perm-authority-host-mark--cursor {
-  background: #ecfdf3;
-  color: #047857;
+  background: var(--perm-authority-host-cursor-bg);
+  color: var(--perm-authority-host-cursor-ink);
 }
 
 .perm-authority-host-mark--vscode {
-  background: #e0f2fe;
-  color: #0369a1;
+  background: var(--perm-authority-host-vscode-bg);
+  color: var(--perm-authority-host-vscode-ink);
 }
 
 .perm-authority-host-mark--windsurf {
-  background: #eef2ff;
-  color: #4338ca;
+  background: var(--perm-authority-host-windsurf-bg);
+  color: var(--perm-authority-host-windsurf-ink);
 }
 
 .perm-authority-host-mark--gemini {
-  background: #fef3c7;
-  color: #b45309;
+  background: var(--perm-authority-host-gemini-bg);
+  color: var(--perm-authority-host-gemini-ink);
 }
 
 .perm-authority-host-mark--cline {
-  background: #f5f3ff;
-  color: #6d28d9;
+  background: var(--perm-authority-host-cline-bg);
+  color: var(--perm-authority-host-cline-ink);
 }
 
 .perm-authority-host-mark--lmstudio,
 .perm-authority-host-mark--generic {
-  background: #f1f5f9;
-  color: #475569;
+  background: var(--perm-authority-host-generic-bg);
+  color: var(--perm-authority-host-generic-ink);
 }
 
 .perm-authority-current-host-copy {
@@ -508,7 +524,11 @@
 }
 
 .perm-authority-save-btn[data-dirty="true"] {
-  background: linear-gradient(135deg, color-mix(in srgb, var(--signal-2, #3b82f6) 94%, white), color-mix(in srgb, #0f766e 18%, var(--signal-2, #3b82f6)));
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--signal-2, #3b82f6) 78%, #0f172a),
+    color-mix(in srgb, var(--perm-authority-cta-accent) 72%, #0f172a)
+  );
   border-color: color-mix(in srgb, var(--signal-2, #3b82f6) 70%, #0f172a);
   color: white;
   box-shadow: 0 10px 22px color-mix(in srgb, var(--signal-2, #3b82f6) 28%, transparent);
@@ -518,7 +538,11 @@
 .perm-authority-save-btn[data-dirty="true"]:focus-visible {
   color: white;
   border-color: color-mix(in srgb, var(--signal-2, #3b82f6) 78%, #0f172a);
-  background: linear-gradient(135deg, color-mix(in srgb, var(--signal-2, #3b82f6) 98%, white), color-mix(in srgb, #0f766e 24%, var(--signal-2, #3b82f6)));
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--signal-2, #3b82f6) 72%, #0f172a),
+    color-mix(in srgb, var(--perm-authority-cta-accent) 78%, #0f172a)
+  );
 }
 
 .perm-authority-save-btn:disabled {
@@ -992,7 +1016,7 @@
 }
 
 [data-theme="dark"] .perm-authority-inline-note {
-  background: color-mix(in srgb, #7c2d12 54%, var(--surface-1));
+  background: color-mix(in srgb, var(--perm-authority-warning-ink) 54%, var(--surface-1));
   border-color: color-mix(in srgb, #fdba74 28%, var(--line, #2b3445));
   color: #fdba74;
 }

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -230,14 +230,9 @@
   outline: none;
 }
 
-.perm-authority-host-select,
 .perm-authority-reason-input {
   width: 100%;
   margin-top: 0.35rem;
-}
-
-.perm-authority-host-select {
-  margin-bottom: 0.9rem;
 }
 
 .perm-authority-reason-input {
@@ -355,6 +350,8 @@
 }
 
 .perm-authority-current-host {
+  appearance: none;
+  width: 100%;
   display: flex;
   align-items: center;
   gap: 0.7rem;
@@ -362,11 +359,19 @@
   border: 1px solid var(--ink-100, #d8e0ea);
   border-radius: 0.85rem;
   background: var(--paper-strong, #fff);
+  text-align: left;
+  cursor: pointer;
 }
 
 .perm-authority-current-host[data-selected="true"] {
   border-color: color-mix(in srgb, var(--signal-2, #3b82f6) 42%, var(--ink-100, #d8e0ea));
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--signal-2, #3b82f6) 10%, transparent);
+}
+
+.perm-authority-current-host:hover,
+.perm-authority-current-host:focus-visible {
+  border-color: color-mix(in srgb, var(--signal-2, #3b82f6) 32%, var(--ink-100, #d8e0ea));
+  outline: none;
 }
 
 .perm-authority-host-mark {
@@ -443,6 +448,14 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
+}
+
+.perm-authority-selected-host {
+  color: var(--ink-900, #0f172a);
+  font-family: var(--font-heading, 'Plus Jakarta Sans', sans-serif);
+  font-size: 1rem;
+  font-weight: 800;
+  margin-bottom: 0.25rem;
 }
 
 .perm-authority-save-shell {
@@ -1004,7 +1017,16 @@
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--signal-2) 16%, transparent);
 }
 
+[data-theme="dark"] .perm-authority-current-host:hover,
+[data-theme="dark"] .perm-authority-current-host:focus-visible {
+  border-color: color-mix(in srgb, var(--signal-2) 34%, var(--line, #2b3445));
+}
+
 [data-theme="dark"] .perm-authority-current-host-name {
+  color: var(--ink-200, #e2e8f0);
+}
+
+[data-theme="dark"] .perm-authority-selected-host {
   color: var(--ink-200, #e2e8f0);
 }
 

--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -348,6 +348,103 @@
   margin-top: 0.85rem;
 }
 
+.perm-authority-current-list {
+  display: grid;
+  gap: 0.55rem;
+  margin-top: 0.9rem;
+}
+
+.perm-authority-current-host {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.7rem 0.75rem;
+  border: 1px solid var(--ink-100, #d8e0ea);
+  border-radius: 0.85rem;
+  background: var(--paper-strong, #fff);
+}
+
+.perm-authority-current-host[data-selected="true"] {
+  border-color: color-mix(in srgb, var(--signal-2, #3b82f6) 42%, var(--ink-100, #d8e0ea));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--signal-2, #3b82f6) 10%, transparent);
+}
+
+.perm-authority-host-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.65rem;
+  font-family: var(--font-heading, 'Plus Jakarta Sans', sans-serif);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+
+.perm-authority-host-mark--claude {
+  background: #fff1e8;
+  color: #9a3412;
+}
+
+.perm-authority-host-mark--codex {
+  background: #e8f1ff;
+  color: #1d4ed8;
+}
+
+.perm-authority-host-mark--cursor {
+  background: #ecfdf3;
+  color: #047857;
+}
+
+.perm-authority-host-mark--vscode {
+  background: #e0f2fe;
+  color: #0369a1;
+}
+
+.perm-authority-host-mark--windsurf {
+  background: #eef2ff;
+  color: #4338ca;
+}
+
+.perm-authority-host-mark--gemini {
+  background: #fef3c7;
+  color: #b45309;
+}
+
+.perm-authority-host-mark--cline {
+  background: #f5f3ff;
+  color: #6d28d9;
+}
+
+.perm-authority-host-mark--lmstudio,
+.perm-authority-host-mark--generic {
+  background: #f1f5f9;
+  color: #475569;
+}
+
+.perm-authority-current-host-copy {
+  display: grid;
+  gap: 0.14rem;
+  min-width: 0;
+}
+
+.perm-authority-current-host-name {
+  color: var(--ink-900, #0f172a);
+  font-family: var(--font-heading, 'Plus Jakarta Sans', sans-serif);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.perm-authority-current-host-mode {
+  color: var(--ink-500, #64748b);
+  font-size: 0.76rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
 .perm-authority-save-shell {
   margin-top: 0.85rem;
   border: 1px solid var(--ink-100, #d8e0ea);
@@ -895,6 +992,24 @@
 [data-theme="dark"] .perm-authority-save-shell {
   background: color-mix(in srgb, var(--surface-1) 82%, var(--paper-strong));
   border-color: color-mix(in srgb, var(--line, #2b3445) 92%, transparent);
+}
+
+[data-theme="dark"] .perm-authority-current-host {
+  background: color-mix(in srgb, var(--surface-1) 82%, var(--paper-strong));
+  border-color: color-mix(in srgb, var(--line, #2b3445) 92%, transparent);
+}
+
+[data-theme="dark"] .perm-authority-current-host[data-selected="true"] {
+  border-color: color-mix(in srgb, var(--signal-2) 40%, var(--line, #2b3445));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--signal-2) 16%, transparent);
+}
+
+[data-theme="dark"] .perm-authority-current-host-name {
+  color: var(--ink-200, #e2e8f0);
+}
+
+[data-theme="dark"] .perm-authority-current-host-mode {
+  color: var(--ink-400, #94a3b8);
 }
 
 [data-theme="dark"] .perm-authority-save-shell[data-dirty="true"] {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -28,6 +28,16 @@
     feedback: '',
     feedbackKind: 'info',
   };
+  const AUTHORITY_HOST_META = {
+    'claude-code': { label: 'Claude Code', shortLabel: 'CC', tone: 'claude' },
+    'codex': { label: 'Codex', shortLabel: 'CX', tone: 'codex' },
+    'cursor': { label: 'Cursor', shortLabel: 'CU', tone: 'cursor' },
+    'vscode': { label: 'VS Code', shortLabel: 'VS', tone: 'vscode' },
+    'windsurf': { label: 'Windsurf', shortLabel: 'WS', tone: 'windsurf' },
+    'gemini': { label: 'Gemini CLI', shortLabel: 'GM', tone: 'gemini' },
+    'cline': { label: 'Cline', shortLabel: 'CL', tone: 'cline' },
+    'lmstudio': { label: 'LM Studio', shortLabel: 'LM', tone: 'lmstudio' },
+  };
 
   async function fetchPermissionStatus(sessionId) {
     const query = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : '';
@@ -228,6 +238,7 @@
     const currentMode = document.getElementById('perm-authority-current-mode');
     const currentHost = document.getElementById('perm-authority-current-host');
     const explanation = document.getElementById('perm-authority-explanation');
+    const currentHostList = document.getElementById('perm-authority-current-host-list');
     const reasonInput = document.getElementById('perm-authority-reason');
     const note = document.getElementById('perm-authority-note');
     const authoritativeNote = document.getElementById('perm-authority-authoritative-note');
@@ -235,7 +246,7 @@
     const saveCopy = document.getElementById('perm-authority-save-copy');
     const saveShell = document.getElementById('perm-authority-save-shell');
 
-    if (!card || !hostSelect || !saveButton || !message || !currentMode || !currentHost || !explanation || !reasonInput || !note || !authoritativeNote || !dirtyState || !saveCopy || !saveShell) {
+    if (!card || !hostSelect || !saveButton || !message || !currentMode || !currentHost || !explanation || !currentHostList || !reasonInput || !note || !authoritativeNote || !dirtyState || !saveCopy || !saveShell) {
       return;
     }
 
@@ -271,6 +282,7 @@
     currentMode.textContent = formatAuthorityMode(serverMode);
     currentHost.textContent = formatAuthorityHost(authorityUiState.selectedHost);
     explanation.textContent = buildAuthorityExplanation(serverMode, authoritativeSupported);
+    currentHostList.innerHTML = renderAuthorityCurrentHostList(authority, supportedHosts, authorityUiState.selectedHost);
     note.textContent = 'Human-only control. AI can read authority mode but cannot change it through MCP.';
     authoritativeNote.hidden = authoritativeSupported;
     authoritativeNote.textContent = authoritativeSupported
@@ -749,6 +761,7 @@
                   </li>
                 </ul>
                 <p class="perm-selected-subtitle" id="perm-authority-explanation"></p>
+                <div class="perm-authority-current-list" id="perm-authority-current-host-list"></div>
               </div>
 
               <div class="perm-selected-panel">
@@ -762,7 +775,7 @@
                       <input type="radio" name="perm-authority-mode" id="perm-authority-mode-off" value="off">
                       <span class="perm-authority-option-copy">
                         <span class="perm-authority-option-title">Off</span>
-                        <span class="perm-authority-option-description">Dollhouse hooks no-op and the host-native permission system becomes the only gate.</span>
+                        <span class="perm-authority-option-description">Dollhouse steps out of the way. The host's own permission system handles approvals by itself.</span>
                       </span>
                     </span>
                   </label>
@@ -783,7 +796,7 @@
                           <span class="perm-authority-option-title">Authoritative</span>
                           <span class="perm-authority-inline-note" id="perm-authority-authoritative-note" hidden></span>
                         </span>
-                        <span class="perm-authority-option-description">Dollhouse writes managed allow, ask, and deny settings into the host while preserving user-authored entries outside the managed slice.</span>
+                        <span class="perm-authority-option-description">Dollhouse becomes the permission authority. It syncs Dollhouse allow, ask, and deny rules into the host so Dollhouse decides conflicts instead of the host's own approval flow.</span>
                       </span>
                     </span>
                   </label>
@@ -1089,6 +1102,10 @@
   }
 
   function formatAuthorityHost(host) {
+    const meta = AUTHORITY_HOST_META[String(host || '')];
+    if (meta?.label) {
+      return meta.label;
+    }
     return String(host || '')
       .split('-')
       .map(function (part) { return part ? part.charAt(0).toUpperCase() + part.slice(1) : part; })
@@ -1105,10 +1122,10 @@
 
   function buildAuthorityExplanation(mode, authoritativeSupported) {
     if (mode === 'off') {
-      return 'Dollhouse hooks no-op and the host-native permission system is the sole gate.';
+      return 'Dollhouse is not participating in approvals here. The host handles permissions on its own.';
     }
     if (mode === 'authoritative') {
-      return 'Dollhouse is writing managed allow/ask/deny entries into the host settings and preserving user-authored entries outside the managed slice.';
+      return 'Dollhouse is the source of truth for permissions here. The host follows Dollhouse-synced allow, ask, and deny rules, while user-authored entries outside Dollhouse-managed settings are still preserved.';
     }
     return authoritativeSupported
       ? 'Dollhouse participates in permission checks, but the host can still be more restrictive.'
@@ -1139,6 +1156,35 @@
       return `Review the change and save to apply ${formatAuthorityMode(state.desiredMode)} mode for ${formatAuthorityHost(state.host)}.`;
     }
     return `${formatAuthorityHost(state.host)} is currently saved in ${formatAuthorityMode(state.currentMode)} mode.`;
+  }
+
+  function renderAuthorityCurrentHostList(authority, supportedHosts, selectedHost) {
+    const explicitHosts = Object.keys(authority?.hosts || {});
+    const hostIds = Array.from(new Set(explicitHosts.concat(supportedHosts || [])));
+    const orderedHosts = hostIds.sort(function (left, right) {
+      if (left === selectedHost) return -1;
+      if (right === selectedHost) return 1;
+      return formatAuthorityHost(left).localeCompare(formatAuthorityHost(right));
+    });
+
+    if (orderedHosts.length === 0) {
+      return '<div class="perm-pattern-empty">No host authority settings saved yet.</div>';
+    }
+
+    return orderedHosts.map(function (host) {
+      const mode = getAuthorityModeForHost(authority, host);
+      const meta = AUTHORITY_HOST_META[host] || { shortLabel: formatAuthorityHost(host).slice(0, 2).toUpperCase(), tone: 'generic' };
+      const selectedAttr = host === selectedHost ? 'true' : 'false';
+      return `
+        <div class="perm-authority-current-host" data-selected="${selectedAttr}">
+          <span class="perm-authority-host-mark perm-authority-host-mark--${esc(meta.tone || 'generic')}" aria-hidden="true">${esc(meta.shortLabel || 'DH')}</span>
+          <span class="perm-authority-current-host-copy">
+            <span class="perm-authority-current-host-name">${esc(formatAuthorityHost(host))}</span>
+            <span class="perm-authority-current-host-mode">${esc(formatAuthorityMode(mode))}</span>
+          </span>
+        </div>
+      `;
+    }).join('');
   }
 
   async function saveAuthorityMode() {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -232,13 +232,10 @@
 
   function renderAuthorityMode(data) {
     const card = document.getElementById('perm-authority-card');
-    const hostSelect = document.getElementById('perm-authority-host');
     const saveButton = document.getElementById('perm-authority-save-btn');
     const message = document.getElementById('perm-authority-message');
-    const currentMode = document.getElementById('perm-authority-current-mode');
-    const currentHost = document.getElementById('perm-authority-current-host');
-    const explanation = document.getElementById('perm-authority-explanation');
     const currentHostList = document.getElementById('perm-authority-current-host-list');
+    const selectedHostHeading = document.getElementById('perm-authority-selected-host');
     const reasonInput = document.getElementById('perm-authority-reason');
     const note = document.getElementById('perm-authority-note');
     const authoritativeNote = document.getElementById('perm-authority-authoritative-note');
@@ -246,7 +243,7 @@
     const saveCopy = document.getElementById('perm-authority-save-copy');
     const saveShell = document.getElementById('perm-authority-save-shell');
 
-    if (!card || !hostSelect || !saveButton || !message || !currentMode || !currentHost || !explanation || !currentHostList || !reasonInput || !note || !authoritativeNote || !dirtyState || !saveCopy || !saveShell) {
+    if (!card || !saveButton || !message || !currentHostList || !selectedHostHeading || !reasonInput || !note || !authoritativeNote || !dirtyState || !saveCopy || !saveShell) {
       return;
     }
 
@@ -265,10 +262,6 @@
       authorityUiState.selectedMode = serverMode;
     }
 
-    hostSelect.innerHTML = supportedHosts.map(function (host) {
-      return `<option value="${esc(host)}">${esc(formatAuthorityHost(host))}</option>`;
-    }).join('');
-    hostSelect.value = authorityUiState.selectedHost;
     reasonInput.value = authorityUiState.draftReason;
 
     const authoritativeSupported = AUTHORITY_AUTHORITATIVE_HOSTS.has(authorityUiState.selectedHost);
@@ -279,10 +272,8 @@
     setAuthorityRadioState('perm-authority-mode-shared', desiredMode === 'shared', false);
     setAuthorityRadioState('perm-authority-mode-authoritative', desiredMode === 'authoritative', !authoritativeSupported);
 
-    currentMode.textContent = formatAuthorityMode(serverMode);
-    currentHost.textContent = formatAuthorityHost(authorityUiState.selectedHost);
-    explanation.textContent = buildAuthorityExplanation(serverMode, authoritativeSupported);
     currentHostList.innerHTML = renderAuthorityCurrentHostList(authority, supportedHosts, authorityUiState.selectedHost);
+    selectedHostHeading.textContent = formatAuthorityHost(authorityUiState.selectedHost);
     note.textContent = 'Human-only control. AI can read authority mode but cannot change it through MCP.';
     authoritativeNote.hidden = authoritativeSupported;
     authoritativeNote.textContent = authoritativeSupported
@@ -750,24 +741,13 @@
             <div class="perm-selected-grid">
               <div class="perm-selected-panel">
                 <h4 class="perm-selected-panel-title">Current Permission State</h4>
-                <ul class="perm-pattern-list">
-                  <li class="perm-pattern-item">
-                    <span class="perm-pattern-badge perm-pattern-badge--allow">host</span>
-                    <span class="perm-pattern-text" id="perm-authority-current-host">Claude Code</span>
-                  </li>
-                  <li class="perm-pattern-item">
-                    <span class="perm-pattern-badge perm-pattern-badge--ask">mode</span>
-                    <span class="perm-pattern-text" id="perm-authority-current-mode">Shared Permissioning</span>
-                  </li>
-                </ul>
-                <p class="perm-selected-subtitle" id="perm-authority-explanation"></p>
                 <div class="perm-authority-current-list" id="perm-authority-current-host-list"></div>
               </div>
 
               <div class="perm-selected-panel">
                 <h4 class="perm-selected-panel-title">Change Permission Mode</h4>
-                <label class="perm-selected-subtitle perm-authority-field-label" for="perm-authority-host">Host</label>
-                <select id="perm-authority-host" class="perm-panel-action perm-authority-host-select"></select>
+                <div class="perm-authority-selected-host" id="perm-authority-selected-host">Claude Code</div>
+                <div class="perm-selected-subtitle">Choose how this host should handle permission decisions.</div>
 
                 <div class="perm-authority-options" role="radiogroup" aria-label="Authority mode">
                   <label class="perm-authority-option" id="perm-authority-option-off">
@@ -987,13 +967,21 @@
   }
 
   function attachAuthorityControls() {
-    const hostSelect = document.getElementById('perm-authority-host');
+    const currentHostList = document.getElementById('perm-authority-current-host-list');
     const reasonInput = document.getElementById('perm-authority-reason');
     const saveButton = document.getElementById('perm-authority-save-btn');
 
-    if (hostSelect) {
-      hostSelect.addEventListener('change', function (event) {
-        authorityUiState.selectedHost = event.target.value;
+    if (currentHostList) {
+      currentHostList.addEventListener('click', function (event) {
+        const row = event.target.closest('.perm-authority-current-host[data-host]');
+        if (!row) {
+          return;
+        }
+        const host = row.getAttribute('data-host');
+        if (!host || host === authorityUiState.selectedHost) {
+          return;
+        }
+        authorityUiState.selectedHost = host;
         authorityUiState.feedback = '';
         authorityUiState.feedbackKind = 'info';
         authorityUiState.dirty = false;
@@ -1162,8 +1150,6 @@
     const explicitHosts = Object.keys(authority?.hosts || {});
     const hostIds = Array.from(new Set(explicitHosts.concat(supportedHosts || [])));
     const orderedHosts = hostIds.sort(function (left, right) {
-      if (left === selectedHost) return -1;
-      if (right === selectedHost) return 1;
       return formatAuthorityHost(left).localeCompare(formatAuthorityHost(right));
     });
 
@@ -1176,13 +1162,13 @@
       const meta = AUTHORITY_HOST_META[host] || { shortLabel: formatAuthorityHost(host).slice(0, 2).toUpperCase(), tone: 'generic' };
       const selectedAttr = host === selectedHost ? 'true' : 'false';
       return `
-        <div class="perm-authority-current-host" data-selected="${selectedAttr}">
+        <button type="button" class="perm-authority-current-host" data-selected="${selectedAttr}" data-host="${esc(host)}" aria-pressed="${selectedAttr}">
           <span class="perm-authority-host-mark perm-authority-host-mark--${esc(meta.tone || 'generic')}" aria-hidden="true">${esc(meta.shortLabel || 'DH')}</span>
           <span class="perm-authority-current-host-copy">
             <span class="perm-authority-current-host-name">${esc(formatAuthorityHost(host))}</span>
             <span class="perm-authority-current-host-mode">${esc(formatAuthorityMode(mode))}</span>
           </span>
-        </div>
+        </button>
       `;
     }).join('');
   }

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -230,8 +230,12 @@
     const explanation = document.getElementById('perm-authority-explanation');
     const reasonInput = document.getElementById('perm-authority-reason');
     const note = document.getElementById('perm-authority-note');
+    const authoritativeNote = document.getElementById('perm-authority-authoritative-note');
+    const dirtyState = document.getElementById('perm-authority-dirty-state');
+    const saveCopy = document.getElementById('perm-authority-save-copy');
+    const saveShell = document.getElementById('perm-authority-save-shell');
 
-    if (!card || !hostSelect || !saveButton || !message || !currentMode || !currentHost || !explanation || !reasonInput || !note) {
+    if (!card || !hostSelect || !saveButton || !message || !currentMode || !currentHost || !explanation || !reasonInput || !note || !authoritativeNote || !dirtyState || !saveCopy || !saveShell) {
       return;
     }
 
@@ -258,6 +262,7 @@
 
     const authoritativeSupported = AUTHORITY_AUTHORITATIVE_HOSTS.has(authorityUiState.selectedHost);
     const desiredMode = authoritativeSupported ? authorityUiState.selectedMode : fallbackAuthorityMode(authorityUiState.selectedMode);
+    const dirty = desiredMode !== serverMode;
 
     setAuthorityRadioState('perm-authority-mode-off', desiredMode === 'off', false);
     setAuthorityRadioState('perm-authority-mode-shared', desiredMode === 'shared', false);
@@ -266,9 +271,24 @@
     currentMode.textContent = formatAuthorityMode(serverMode);
     currentHost.textContent = formatAuthorityHost(authorityUiState.selectedHost);
     explanation.textContent = buildAuthorityExplanation(serverMode, authoritativeSupported);
-    note.textContent = authoritativeSupported
-      ? 'Human-only control. AI can read authority mode but cannot change it through MCP.'
-      : 'Authoritative settings sync currently ships for Claude Code only. Other hosts can use Off or Shared mode for now.';
+    note.textContent = 'Human-only control. AI can read authority mode but cannot change it through MCP.';
+    authoritativeNote.hidden = authoritativeSupported;
+    authoritativeNote.textContent = authoritativeSupported
+      ? ''
+      : 'Claude Code only for now. Other hosts can use Off or Shared mode.';
+    dirtyState.hidden = !dirty;
+    dirtyState.textContent = dirty
+      ? `Unsaved change: ${formatAuthorityHost(authorityUiState.selectedHost)} will move from ${formatAuthorityMode(serverMode)} to ${formatAuthorityMode(desiredMode)} after you save.`
+      : '';
+    saveCopy.textContent = buildAuthoritySaveCopy({
+      host: authorityUiState.selectedHost,
+      currentMode: serverMode,
+      desiredMode,
+      dirty,
+      saving: authorityUiState.saving,
+    });
+    saveShell.dataset.dirty = dirty ? 'true' : 'false';
+    card.dataset.authorityDirty = dirty ? 'true' : 'false';
 
     if (authorityUiState.feedback) {
       message.hidden = false;
@@ -280,8 +300,13 @@
       message.dataset.kind = 'info';
     }
 
-    saveButton.disabled = authorityUiState.saving || desiredMode === serverMode;
-    saveButton.textContent = authorityUiState.saving ? 'Saving...' : 'Save Authority Mode';
+    saveButton.disabled = authorityUiState.saving || !dirty;
+    saveButton.textContent = authorityUiState.saving
+      ? `Saving ${formatAuthorityMode(desiredMode)}...`
+      : dirty
+        ? `Save ${formatAuthorityMode(desiredMode)} Mode for ${formatAuthorityHost(authorityUiState.selectedHost)}`
+        : `Saved for ${formatAuthorityHost(authorityUiState.selectedHost)}`;
+    saveButton.dataset.dirty = dirty ? 'true' : 'false';
     card.hidden = false;
   }
 
@@ -728,21 +753,54 @@
 
               <div class="perm-selected-panel">
                 <h4 class="perm-selected-panel-title">Change Mode</h4>
-                <label class="perm-selected-subtitle" for="perm-authority-host">Host</label>
-                <select id="perm-authority-host" class="perm-panel-action" style="width:100%;margin:0.35rem 0 0.75rem 0;"></select>
+                <label class="perm-selected-subtitle perm-authority-field-label" for="perm-authority-host">Host</label>
+                <select id="perm-authority-host" class="perm-panel-action perm-authority-host-select"></select>
 
-                <div style="display:grid;gap:0.45rem;">
-                  <label><input type="radio" name="perm-authority-mode" id="perm-authority-mode-off" value="off"> Off</label>
-                  <label><input type="radio" name="perm-authority-mode" id="perm-authority-mode-shared" value="shared"> Shared</label>
-                  <label><input type="radio" name="perm-authority-mode" id="perm-authority-mode-authoritative" value="authoritative"> Authoritative</label>
+                <div class="perm-authority-options" role="radiogroup" aria-label="Authority mode">
+                  <label class="perm-authority-option" id="perm-authority-option-off">
+                    <span class="perm-authority-option-main">
+                      <input type="radio" name="perm-authority-mode" id="perm-authority-mode-off" value="off">
+                      <span class="perm-authority-option-copy">
+                        <span class="perm-authority-option-title">Off</span>
+                        <span class="perm-authority-option-description">Dollhouse hooks no-op and the host-native permission system becomes the only gate.</span>
+                      </span>
+                    </span>
+                  </label>
+                  <label class="perm-authority-option" id="perm-authority-option-shared">
+                    <span class="perm-authority-option-main">
+                      <input type="radio" name="perm-authority-mode" id="perm-authority-mode-shared" value="shared">
+                      <span class="perm-authority-option-copy">
+                        <span class="perm-authority-option-title">Shared</span>
+                        <span class="perm-authority-option-description">Dollhouse stays active, but the host permission system can still be more restrictive.</span>
+                      </span>
+                    </span>
+                  </label>
+                  <label class="perm-authority-option perm-authority-option--authoritative" id="perm-authority-option-authoritative">
+                    <span class="perm-authority-option-main">
+                      <input type="radio" name="perm-authority-mode" id="perm-authority-mode-authoritative" value="authoritative">
+                      <span class="perm-authority-option-copy">
+                        <span class="perm-authority-option-title-row">
+                          <span class="perm-authority-option-title">Authoritative</span>
+                          <span class="perm-authority-inline-note" id="perm-authority-authoritative-note" hidden></span>
+                        </span>
+                        <span class="perm-authority-option-description">Dollhouse writes managed allow, ask, and deny settings into the host while preserving user-authored entries outside the managed slice.</span>
+                      </span>
+                    </span>
+                  </label>
                 </div>
 
-                <label class="perm-selected-subtitle" for="perm-authority-reason" style="display:block;margin-top:0.75rem;">Reason (optional)</label>
-                <input id="perm-authority-reason" type="text" maxlength="200" placeholder="Why are you changing authority mode?" style="width:100%;margin-top:0.35rem;">
+                <label class="perm-selected-subtitle perm-authority-field-label" for="perm-authority-reason">Reason (optional)</label>
+                <input id="perm-authority-reason" class="perm-authority-reason-input" type="text" maxlength="200" placeholder="Why are you changing authority mode?">
 
-                <p class="perm-selected-subtitle" id="perm-authority-note" style="margin-top:0.75rem;"></p>
-                <div class="perm-inline-warning" id="perm-authority-message" hidden></div>
-                <button type="button" class="perm-panel-action" id="perm-authority-save-btn" style="margin-top:0.75rem;">Save Authority Mode</button>
+                <p class="perm-selected-subtitle perm-authority-human-note" id="perm-authority-note"></p>
+                <div class="perm-authority-save-shell" id="perm-authority-save-shell" data-dirty="false">
+                  <div class="perm-authority-dirty-state" id="perm-authority-dirty-state" hidden></div>
+                  <div class="perm-inline-warning" id="perm-authority-message" hidden></div>
+                  <div class="perm-authority-actions">
+                    <div class="perm-authority-save-copy" id="perm-authority-save-copy"></div>
+                    <button type="button" class="perm-panel-action perm-authority-save-btn" id="perm-authority-save-btn">Save Authority Mode</button>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -1066,6 +1124,21 @@
     if (!radio) return;
     radio.checked = checked;
     radio.disabled = disabled;
+    const option = radio.closest('.perm-authority-option');
+    if (option) {
+      option.dataset.checked = checked ? 'true' : 'false';
+      option.dataset.disabled = disabled ? 'true' : 'false';
+    }
+  }
+
+  function buildAuthoritySaveCopy(state) {
+    if (state.saving) {
+      return `Applying ${formatAuthorityMode(state.desiredMode)} mode for ${formatAuthorityHost(state.host)}...`;
+    }
+    if (state.dirty) {
+      return `Review the change and save to apply ${formatAuthorityMode(state.desiredMode)} mode for ${formatAuthorityHost(state.host)}.`;
+    }
+    return `${formatAuthorityHost(state.host)} is currently saved in ${formatAuthorityMode(state.currentMode)} mode.`;
   }
 
   async function saveAuthorityMode() {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -287,7 +287,7 @@
     authoritativeNote.hidden = authoritativeSupported;
     authoritativeNote.textContent = authoritativeSupported
       ? ''
-      : 'Claude Code only for now. Other hosts can use Off or Shared mode.';
+      : 'Claude Code only for now. Other hosts can use Host-Controlled or Shared Permissioning mode.';
     dirtyState.hidden = !dirty;
     dirtyState.textContent = dirty
       ? `Unsaved change: ${formatAuthorityHost(authorityUiState.selectedHost)} will move from ${formatAuthorityMode(serverMode)} to ${formatAuthorityMode(desiredMode)} after you save.`
@@ -736,7 +736,7 @@
 
         <div class="perm-card perm-card--full" data-collapsed="false" id="perm-authority-card">
           <div class="perm-card-header" role="button" tabindex="0" aria-expanded="true">
-            <h3 class="perm-card-title">Authority Mode</h3>
+            <h3 class="perm-card-title">Permission Authority Mode</h3>
             <span class="perm-card-toggle" aria-hidden="true">&#9662;</span>
           </div>
           <div class="perm-card-body">
@@ -749,7 +749,7 @@
 
             <div class="perm-selected-grid">
               <div class="perm-selected-panel">
-                <h4 class="perm-selected-panel-title">Current State</h4>
+                <h4 class="perm-selected-panel-title">Current Permission State</h4>
                 <ul class="perm-pattern-list">
                   <li class="perm-pattern-item">
                     <span class="perm-pattern-badge perm-pattern-badge--allow">host</span>
@@ -757,7 +757,7 @@
                   </li>
                   <li class="perm-pattern-item">
                     <span class="perm-pattern-badge perm-pattern-badge--ask">mode</span>
-                    <span class="perm-pattern-text" id="perm-authority-current-mode">Shared</span>
+                    <span class="perm-pattern-text" id="perm-authority-current-mode">Shared Permissioning</span>
                   </li>
                 </ul>
                 <p class="perm-selected-subtitle" id="perm-authority-explanation"></p>
@@ -765,7 +765,7 @@
               </div>
 
               <div class="perm-selected-panel">
-                <h4 class="perm-selected-panel-title">Change Mode</h4>
+                <h4 class="perm-selected-panel-title">Change Permission Mode</h4>
                 <label class="perm-selected-subtitle perm-authority-field-label" for="perm-authority-host">Host</label>
                 <select id="perm-authority-host" class="perm-panel-action perm-authority-host-select"></select>
 
@@ -774,7 +774,7 @@
                     <span class="perm-authority-option-main">
                       <input type="radio" name="perm-authority-mode" id="perm-authority-mode-off" value="off">
                       <span class="perm-authority-option-copy">
-                        <span class="perm-authority-option-title">Off</span>
+                        <span class="perm-authority-option-title">Host-Controlled Permissions</span>
                         <span class="perm-authority-option-description">Dollhouse steps out of the way. The host's own permission system handles approvals by itself.</span>
                       </span>
                     </span>
@@ -783,7 +783,7 @@
                     <span class="perm-authority-option-main">
                       <input type="radio" name="perm-authority-mode" id="perm-authority-mode-shared" value="shared">
                       <span class="perm-authority-option-copy">
-                        <span class="perm-authority-option-title">Shared</span>
+                        <span class="perm-authority-option-title">Shared Permissioning</span>
                         <span class="perm-authority-option-description">Dollhouse stays active, but the host permission system can still be more restrictive.</span>
                       </span>
                     </span>
@@ -793,7 +793,7 @@
                       <input type="radio" name="perm-authority-mode" id="perm-authority-mode-authoritative" value="authoritative">
                       <span class="perm-authority-option-copy">
                         <span class="perm-authority-option-title-row">
-                          <span class="perm-authority-option-title">Authoritative</span>
+                          <span class="perm-authority-option-title">Dollhouse-Controlled Permissions</span>
                           <span class="perm-authority-inline-note" id="perm-authority-authoritative-note" hidden></span>
                         </span>
                         <span class="perm-authority-option-description">Dollhouse becomes the permission authority. It syncs Dollhouse allow, ask, and deny rules into the host so Dollhouse decides conflicts instead of the host's own approval flow.</span>
@@ -803,7 +803,7 @@
                 </div>
 
                 <label class="perm-selected-subtitle perm-authority-field-label" for="perm-authority-reason">Reason (optional)</label>
-                <input id="perm-authority-reason" class="perm-authority-reason-input" type="text" maxlength="200" placeholder="Why are you changing authority mode?">
+                <input id="perm-authority-reason" class="perm-authority-reason-input" type="text" maxlength="200" placeholder="Why are you changing the permission authority mode?">
 
                 <p class="perm-selected-subtitle perm-authority-human-note" id="perm-authority-note"></p>
                 <div class="perm-authority-save-shell" id="perm-authority-save-shell" data-dirty="false">
@@ -1114,10 +1114,10 @@
 
   function formatAuthorityMode(mode) {
     return mode === 'off'
-      ? 'Off'
+      ? 'Host-Controlled Permissions'
       : mode === 'authoritative'
-        ? 'Authoritative'
-        : 'Shared';
+        ? 'Dollhouse-Controlled Permissions'
+        : 'Shared Permissioning';
   }
 
   function buildAuthorityExplanation(mode, authoritativeSupported) {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -247,10 +247,34 @@
       return;
     }
 
-    const supportedHosts = Array.isArray(data?.authoritySupportedHosts) && data.authoritySupportedHosts.length
+    const supportedHosts = Array.isArray(data?.authoritySupportedHosts)
       ? data.authoritySupportedHosts
       : ['claude-code'];
     const authority = data?.authority || { defaultMode: 'shared', hosts: {} };
+
+    if (supportedHosts.length === 0) {
+      currentHostList.innerHTML = '<div class="perm-pattern-empty">No installed permission hosts detected yet.</div>';
+      selectedHostHeading.textContent = 'No installed hosts';
+      note.textContent = 'Install Dollhouse permission hooks for a host before changing permission authority mode here.';
+      authoritativeNote.hidden = true;
+      authoritativeNote.textContent = '';
+      dirtyState.hidden = true;
+      dirtyState.textContent = '';
+      message.hidden = true;
+      message.textContent = '';
+      message.dataset.kind = 'info';
+      saveCopy.textContent = 'Once a host is installed and configured, it will appear on the left for editing.';
+      saveShell.dataset.dirty = 'false';
+      card.dataset.authorityDirty = 'false';
+      reasonInput.value = authorityUiState.draftReason;
+      setAuthorityRadioState('perm-authority-mode-off', false, true);
+      setAuthorityRadioState('perm-authority-mode-shared', false, true);
+      setAuthorityRadioState('perm-authority-mode-authoritative', false, true);
+      saveButton.disabled = true;
+      saveButton.textContent = 'No Installed Hosts Yet';
+      card.hidden = false;
+      return;
+    }
 
     if (!supportedHosts.includes(authorityUiState.selectedHost)) {
       authorityUiState.selectedHost = supportedHosts[0];

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -18,13 +18,21 @@
   let latestAggregateData = null;
   let latestSelectedData = null;
   let latestPollRequestId = 0;
+  const AUTHORITY_MODE_REQUEST_STATES = {
+    idle: 'idle',
+    saving: 'saving',
+  };
   const AUTHORITY_AUTHORITATIVE_HOSTS = new Set(['claude-code']);
+  // Authority modes are intentionally phrased in human terms in the UI:
+  // - off => host-controlled permissions
+  // - shared => both Dollhouse and the host participate
+  // - authoritative => Dollhouse is the source of truth
   const authorityUiState = {
     selectedHost: 'claude-code',
     selectedMode: 'shared',
     draftReason: '',
     dirty: false,
-    saving: false,
+    requestState: AUTHORITY_MODE_REQUEST_STATES.idle,
     feedback: '',
     feedbackKind: 'info',
   };
@@ -265,13 +273,16 @@
       message.dataset.kind = 'info';
       saveCopy.textContent = 'Once a host is installed and configured, it will appear on the left for editing.';
       saveShell.dataset.dirty = 'false';
+      saveShell.dataset.busy = 'false';
       card.dataset.authorityDirty = 'false';
+      card.setAttribute('aria-busy', 'false');
       reasonInput.value = authorityUiState.draftReason;
       setAuthorityRadioState('perm-authority-mode-off', false, true);
       setAuthorityRadioState('perm-authority-mode-shared', false, true);
       setAuthorityRadioState('perm-authority-mode-authoritative', false, true);
       saveButton.disabled = true;
       saveButton.textContent = 'No Installed Hosts Yet';
+      saveButton.setAttribute('aria-busy', 'false');
       card.hidden = false;
       return;
     }
@@ -312,10 +323,12 @@
       currentMode: serverMode,
       desiredMode,
       dirty,
-      saving: authorityUiState.saving,
+      saving: authorityUiState.requestState === AUTHORITY_MODE_REQUEST_STATES.saving,
     });
     saveShell.dataset.dirty = dirty ? 'true' : 'false';
+    saveShell.dataset.busy = authorityUiState.requestState === AUTHORITY_MODE_REQUEST_STATES.saving ? 'true' : 'false';
     card.dataset.authorityDirty = dirty ? 'true' : 'false';
+    card.setAttribute('aria-busy', authorityUiState.requestState === AUTHORITY_MODE_REQUEST_STATES.saving ? 'true' : 'false');
 
     if (authorityUiState.feedback) {
       message.hidden = false;
@@ -327,13 +340,14 @@
       message.dataset.kind = 'info';
     }
 
-    saveButton.disabled = authorityUiState.saving || !dirty;
-    saveButton.textContent = authorityUiState.saving
+    saveButton.disabled = authorityUiState.requestState === AUTHORITY_MODE_REQUEST_STATES.saving || !dirty;
+    saveButton.textContent = authorityUiState.requestState === AUTHORITY_MODE_REQUEST_STATES.saving
       ? `Saving ${formatAuthorityMode(desiredMode)}...`
       : dirty
         ? `Save ${formatAuthorityMode(desiredMode)} Mode for ${formatAuthorityHost(authorityUiState.selectedHost)}`
         : `Saved for ${formatAuthorityHost(authorityUiState.selectedHost)}`;
     saveButton.dataset.dirty = dirty ? 'true' : 'false';
+    saveButton.setAttribute('aria-busy', authorityUiState.requestState === AUTHORITY_MODE_REQUEST_STATES.saving ? 'true' : 'false');
     card.hidden = false;
   }
 
@@ -1198,7 +1212,7 @@
   }
 
   async function saveAuthorityMode() {
-    if (!latestAggregateData || authorityUiState.saving) {
+    if (!latestAggregateData || authorityUiState.requestState === AUTHORITY_MODE_REQUEST_STATES.saving) {
       return;
     }
 
@@ -1229,7 +1243,7 @@
       return;
     }
 
-    authorityUiState.saving = true;
+    authorityUiState.requestState = AUTHORITY_MODE_REQUEST_STATES.saving;
     authorityUiState.feedback = '';
     renderAuthorityMode(latestAggregateData);
 
@@ -1252,7 +1266,7 @@
       authorityUiState.feedback = error instanceof Error ? error.message : 'Failed to update permission authority.';
       authorityUiState.feedbackKind = 'error';
     } finally {
-      authorityUiState.saving = false;
+      authorityUiState.requestState = AUTHORITY_MODE_REQUEST_STATES.idle;
       renderAuthorityMode(latestAggregateData);
     }
   }

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -13,6 +13,7 @@ import { logger } from '../../utils/logger.js';
 import type { MCPAQLHandler } from '../../handlers/mcp-aql/MCPAQLHandler.js';
 import { formatPermissionResponse } from '../../handlers/mcp-aql/evaluatePermission.js';
 import { ensureLatestPortFile } from '../portDiscovery.js';
+import { getPermissionHookStatusAsync } from '../../utils/permissionHooks.js';
 
 import { SlidingWindowRateLimiter } from '../../utils/SlidingWindowRateLimiter.js';
 import {
@@ -305,6 +306,28 @@ async function selfHealLatestPermissionPortFile(port: number | undefined): Promi
   }
 }
 
+async function resolveInstalledPermissionAuthorityHosts(
+  homeDir: string,
+  authorityState: Awaited<ReturnType<typeof readPermissionAuthorityState>>,
+): Promise<PermissionAuthorityHost[]> {
+  const installedStatuses = await Promise.all(
+    PERMISSION_AUTHORITY_HOSTS.map(async (host) => ({
+      host,
+      status: await getPermissionHookStatusAsync(homeDir, host),
+    })),
+  );
+
+  const installedHosts = installedStatuses
+    .filter(({ status }) => status.installed)
+    .map(({ host }) => host);
+
+  const persistedHosts = Object.keys(authorityState.hosts || {}).filter((host): host is PermissionAuthorityHost =>
+    (PERMISSION_AUTHORITY_HOSTS as readonly string[]).includes(host),
+  );
+
+  return Array.from(new Set(installedHosts.concat(persistedHosts)));
+}
+
 /**
  * Register permission-related routes on a gateway router.
  * Must be called with the MCP-AQL handler for policy evaluation.
@@ -424,6 +447,7 @@ export function registerPermissionRoutes(
 
       const data = opResult.data as Record<string, unknown>;
       const authorityState = await readPermissionAuthorityState(authorityHomeDir);
+      const installedAuthorityHosts = await resolveInstalledPermissionAuthorityHosts(authorityHomeDir, authorityState);
       const elements = normalizePolicyElements((data.elements || []) as Array<Record<string, unknown>>);
 
       const denyPatterns = (data.combinedDenyPatterns as string[] | undefined) ?? [];
@@ -452,7 +476,7 @@ export function registerPermissionRoutes(
         hookInstalled: data.hookInstalled,
         hookHost: data.hookHost,
         authority: authorityState,
-        authoritySupportedHosts: [...PERMISSION_AUTHORITY_HOSTS],
+        authoritySupportedHosts: installedAuthorityHosts,
         authoritySupportedModes: [...PERMISSION_AUTHORITY_MODES],
         authorityAiMutable: false,
         enforcementReady: data.enforcementReady,
@@ -469,9 +493,10 @@ export function registerPermissionRoutes(
   router.get('/permissions/authority', async (_req, res) => {
     try {
       const authorityState = await readPermissionAuthorityState(authorityHomeDir);
+      const installedAuthorityHosts = await resolveInstalledPermissionAuthorityHosts(authorityHomeDir, authorityState);
       res.json({
         ...authorityState,
-        supportedHosts: [...PERMISSION_AUTHORITY_HOSTS],
+        supportedHosts: installedAuthorityHosts,
         supportedModes: [...PERMISSION_AUTHORITY_MODES],
         aiMutable: false,
       });

--- a/tests/unit/utils/permissionAuthority.test.ts
+++ b/tests/unit/utils/permissionAuthority.test.ts
@@ -114,4 +114,16 @@ describe('permissionAuthority', () => {
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     expect((parsed.hosts as Record<string, { mode: string }>)['claude-code'].mode).toBe('off');
   });
+
+  it('normalizes authority mode reasons before persisting them', async () => {
+    const state = await setPermissionAuthorityMode({
+      homeDir: tempHome,
+      host: 'claude-code',
+      mode: 'shared',
+      reason: 'Cafe\u0301 review',
+      now: new Date('2026-04-17T14:15:00.000Z'),
+    });
+
+    expect(state.hosts['claude-code']?.reason).toBe('Café review');
+  });
 });

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -500,6 +500,9 @@ describe('Web console cleanup regressions', () => {
     expect(win.document.getElementById('perm-authority-note')?.textContent).toContain('Human-only control');
     expect(win.document.getElementById('perm-authority-authoritative-note')?.hidden).toBe(true);
     expect(win.document.getElementById('perm-authority-dirty-state')?.hidden).toBe(true);
+    expect(win.document.getElementById('perm-authority-current-host-list')?.textContent).toContain('Claude Code');
+    expect(win.document.getElementById('perm-authority-current-host-list')?.textContent).toContain('Codex');
+    expect(win.document.getElementById('perm-authority-option-off')?.textContent).toContain('steps out of the way');
 
     const hostSelect = win.document.getElementById('perm-authority-host') as HTMLSelectElement | null;
     const authoritativeRadio = win.document.getElementById('perm-authority-mode-authoritative') as HTMLInputElement | null;
@@ -515,6 +518,7 @@ describe('Web console cleanup regressions', () => {
     expect(authoritativeRadio?.disabled).toBe(true);
     expect(win.document.getElementById('perm-authority-authoritative-note')?.hidden).toBe(false);
     expect(win.document.getElementById('perm-authority-authoritative-note')?.textContent).toContain('Claude Code only');
+    expect(win.document.getElementById('perm-authority-explanation')?.textContent).toContain('host handles permissions on its own');
 
     const sharedRadio = win.document.getElementById('perm-authority-mode-shared') as HTMLInputElement | null;
     sharedRadio!.checked = true;

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -503,22 +503,20 @@ describe('Web console cleanup regressions', () => {
     expect(win.document.getElementById('perm-authority-current-host-list')?.textContent).toContain('Claude Code');
     expect(win.document.getElementById('perm-authority-current-host-list')?.textContent).toContain('Codex');
     expect(win.document.getElementById('perm-authority-option-off')?.textContent).toContain('steps out of the way');
+    expect(win.document.getElementById('perm-authority-selected-host')?.textContent).toContain('Claude Code');
 
-    const hostSelect = win.document.getElementById('perm-authority-host') as HTMLSelectElement | null;
     const authoritativeRadio = win.document.getElementById('perm-authority-mode-authoritative') as HTMLInputElement | null;
-    expect(hostSelect).not.toBeNull();
     expect(authoritativeRadio?.disabled).toBe(false);
 
-    if (hostSelect) {
-      hostSelect.value = 'codex';
-      hostSelect.dispatchEvent(new win.Event('change', { bubbles: true }));
-    }
+    const codexHostButton = win.document.querySelector('.perm-authority-current-host[data-host="codex"]') as HTMLButtonElement | null;
+    expect(codexHostButton).not.toBeNull();
+    codexHostButton?.click();
     await wait(DEFAULT_WAIT_MS);
 
     expect(authoritativeRadio?.disabled).toBe(true);
     expect(win.document.getElementById('perm-authority-authoritative-note')?.hidden).toBe(false);
     expect(win.document.getElementById('perm-authority-authoritative-note')?.textContent).toContain('Claude Code only');
-    expect(win.document.getElementById('perm-authority-explanation')?.textContent).toContain('host handles permissions on its own');
+    expect(win.document.getElementById('perm-authority-selected-host')?.textContent).toContain('Codex');
 
     const sharedRadio = win.document.getElementById('perm-authority-mode-shared') as HTMLInputElement | null;
     sharedRadio!.checked = true;
@@ -635,7 +633,7 @@ describe('Web console cleanup regressions', () => {
     await wait(DEFAULT_WAIT_MS);
 
     expect(win.confirm).toHaveBeenCalled();
-    expect(win.document.getElementById('perm-authority-current-mode')?.textContent).toContain('Dollhouse-Controlled Permissions');
+    expect(win.document.getElementById('perm-authority-current-host-list')?.textContent).toContain('Dollhouse-Controlled Permissions');
     expect(win.document.getElementById('perm-authority-message')?.textContent).toContain('Saved Dollhouse-Controlled Permissions mode');
     expect(win.document.getElementById('perm-authority-save-shell')?.getAttribute('data-dirty')).toBe('false');
     expect(win.document.getElementById('perm-authority-save-btn')?.textContent).toContain('Saved for Claude Code');

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -527,7 +527,7 @@ describe('Web console cleanup regressions', () => {
 
     expect(win.document.getElementById('perm-authority-dirty-state')?.hidden).toBe(false);
     expect(win.document.getElementById('perm-authority-dirty-state')?.textContent).toContain('Codex');
-    expect(win.document.getElementById('perm-authority-save-btn')?.textContent).toContain('Save Shared Mode for Codex');
+    expect(win.document.getElementById('perm-authority-save-btn')?.textContent).toContain('Save Shared Permissioning Mode for Codex');
     expect(win.document.getElementById('perm-authority-save-shell')?.getAttribute('data-dirty')).toBe('true');
 
     cleanup();
@@ -626,16 +626,17 @@ describe('Web console cleanup regressions', () => {
     const reasonInput = win.document.getElementById('perm-authority-reason') as HTMLInputElement | null;
     reasonInput!.value = 'Hands-off bridge run';
     reasonInput!.dispatchEvent(new win.Event('input', { bubbles: true }));
+    expect(reasonInput?.getAttribute('placeholder')).toContain('permission authority mode');
 
     const saveButton = win.document.getElementById('perm-authority-save-btn') as HTMLButtonElement | null;
-    expect(saveButton?.textContent).toContain('Save Authoritative Mode for Claude Code');
+    expect(saveButton?.textContent).toContain('Save Dollhouse-Controlled Permissions Mode for Claude Code');
     expect(win.document.getElementById('perm-authority-dirty-state')?.textContent).toContain('Unsaved change');
     saveButton?.click();
     await wait(DEFAULT_WAIT_MS);
 
     expect(win.confirm).toHaveBeenCalled();
-    expect(win.document.getElementById('perm-authority-current-mode')?.textContent).toContain('Authoritative');
-    expect(win.document.getElementById('perm-authority-message')?.textContent).toContain('Saved Authoritative mode');
+    expect(win.document.getElementById('perm-authority-current-mode')?.textContent).toContain('Dollhouse-Controlled Permissions');
+    expect(win.document.getElementById('perm-authority-message')?.textContent).toContain('Saved Dollhouse-Controlled Permissions mode');
     expect(win.document.getElementById('perm-authority-save-shell')?.getAttribute('data-dirty')).toBe('false');
     expect(win.document.getElementById('perm-authority-save-btn')?.textContent).toContain('Saved for Claude Code');
 

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -526,7 +526,7 @@ describe('Web console cleanup regressions', () => {
     expect(win.document.getElementById('perm-authority-dirty-state')?.hidden).toBe(false);
     expect(win.document.getElementById('perm-authority-dirty-state')?.textContent).toContain('Codex');
     expect(win.document.getElementById('perm-authority-save-btn')?.textContent).toContain('Save Shared Permissioning Mode for Codex');
-    expect(win.document.getElementById('perm-authority-save-shell')?.getAttribute('data-dirty')).toBe('true');
+    expect((win.document.getElementById('perm-authority-save-shell') as HTMLElement | null)?.dataset.dirty).toBe('true');
 
     cleanup();
   });
@@ -635,7 +635,7 @@ describe('Web console cleanup regressions', () => {
     expect(win.confirm).toHaveBeenCalled();
     expect(win.document.getElementById('perm-authority-current-host-list')?.textContent).toContain('Dollhouse-Controlled Permissions');
     expect(win.document.getElementById('perm-authority-message')?.textContent).toContain('Saved Dollhouse-Controlled Permissions mode');
-    expect(win.document.getElementById('perm-authority-save-shell')?.getAttribute('data-dirty')).toBe('false');
+    expect((win.document.getElementById('perm-authority-save-shell') as HTMLElement | null)?.dataset.dirty).toBe('false');
     expect(win.document.getElementById('perm-authority-save-btn')?.textContent).toContain('Saved for Claude Code');
 
     cleanup();

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -498,6 +498,8 @@ describe('Web console cleanup regressions', () => {
 
     expect(win.document.getElementById('perm-authority-card')?.hidden).toBe(false);
     expect(win.document.getElementById('perm-authority-note')?.textContent).toContain('Human-only control');
+    expect(win.document.getElementById('perm-authority-authoritative-note')?.hidden).toBe(true);
+    expect(win.document.getElementById('perm-authority-dirty-state')?.hidden).toBe(true);
 
     const hostSelect = win.document.getElementById('perm-authority-host') as HTMLSelectElement | null;
     const authoritativeRadio = win.document.getElementById('perm-authority-mode-authoritative') as HTMLInputElement | null;
@@ -511,7 +513,18 @@ describe('Web console cleanup regressions', () => {
     await wait(DEFAULT_WAIT_MS);
 
     expect(authoritativeRadio?.disabled).toBe(true);
-    expect(win.document.getElementById('perm-authority-note')?.textContent).toContain('Claude Code only');
+    expect(win.document.getElementById('perm-authority-authoritative-note')?.hidden).toBe(false);
+    expect(win.document.getElementById('perm-authority-authoritative-note')?.textContent).toContain('Claude Code only');
+
+    const sharedRadio = win.document.getElementById('perm-authority-mode-shared') as HTMLInputElement | null;
+    sharedRadio!.checked = true;
+    sharedRadio!.dispatchEvent(new win.Event('change', { bubbles: true }));
+    await wait(DEFAULT_WAIT_MS);
+
+    expect(win.document.getElementById('perm-authority-dirty-state')?.hidden).toBe(false);
+    expect(win.document.getElementById('perm-authority-dirty-state')?.textContent).toContain('Codex');
+    expect(win.document.getElementById('perm-authority-save-btn')?.textContent).toContain('Save Shared Mode for Codex');
+    expect(win.document.getElementById('perm-authority-save-shell')?.getAttribute('data-dirty')).toBe('true');
 
     cleanup();
   });
@@ -611,12 +624,16 @@ describe('Web console cleanup regressions', () => {
     reasonInput!.dispatchEvent(new win.Event('input', { bubbles: true }));
 
     const saveButton = win.document.getElementById('perm-authority-save-btn') as HTMLButtonElement | null;
+    expect(saveButton?.textContent).toContain('Save Authoritative Mode for Claude Code');
+    expect(win.document.getElementById('perm-authority-dirty-state')?.textContent).toContain('Unsaved change');
     saveButton?.click();
     await wait(DEFAULT_WAIT_MS);
 
     expect(win.confirm).toHaveBeenCalled();
     expect(win.document.getElementById('perm-authority-current-mode')?.textContent).toContain('Authoritative');
     expect(win.document.getElementById('perm-authority-message')?.textContent).toContain('Saved Authoritative mode');
+    expect(win.document.getElementById('perm-authority-save-shell')?.getAttribute('data-dirty')).toBe('false');
+    expect(win.document.getElementById('perm-authority-save-btn')?.textContent).toContain('Saved for Claude Code');
 
     cleanup();
   });

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -10,8 +10,9 @@ import request from 'supertest';
 import { createServer } from 'node:http';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { mkdir, mkdtemp, readFile, rm, unlink } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, unlink, writeFile } from 'node:fs/promises';
 import { registerPermissionRoutes } from '../../../src/web/routes/permissionRoutes.js';
+import { getPermissionHookMarkerPath } from '../../../src/utils/permissionHooks.js';
 
 function createMockHandler(readResult?: unknown) {
   return {
@@ -308,6 +309,66 @@ describe('permissionRoutes', () => {
           session_id: 'session-abc',
         },
       });
+    });
+
+    it('should only return installed authority hosts plus any persisted authority hosts', async () => {
+      const handler = {
+        handleRead: jest.fn().mockResolvedValue([{
+          success: true,
+          data: {
+            activeElementCount: 0,
+            hasAllowlist: false,
+            combinedDenyPatterns: [],
+            combinedAllowPatterns: [],
+            combinedConfirmPatterns: [],
+            elements: [],
+            permissionPromptActive: false,
+            recentDecisions: [],
+          },
+        }]),
+      } as any;
+
+      const installedScriptPath = join(tempHome, '.dollhouse', 'hooks', 'pretooluse-codex.sh');
+      const installedSettingsPath = join(tempHome, '.codex', 'hooks.json');
+      await mkdir(join(tempHome, '.dollhouse', 'hooks'), { recursive: true });
+      await mkdir(join(tempHome, '.codex'), { recursive: true });
+      await writeFile(installedScriptPath, '#!/bin/bash\n', 'utf-8');
+      await writeFile(installedSettingsPath, '{}\n', 'utf-8');
+      await mkdir(join(tempHome, '.dollhouse', 'run'), { recursive: true });
+      await writeFile(
+        getPermissionHookMarkerPath(tempHome, 'codex'),
+        JSON.stringify({
+          host: 'codex',
+          scriptPath: installedScriptPath,
+          settingsPath: installedSettingsPath,
+          configured: true,
+          installedAt: '2026-04-17T15:00:00.000Z',
+        }),
+        'utf-8',
+      );
+
+      await mkdir(join(tempHome, '.dollhouse', 'run'), { recursive: true });
+      await writeFile(
+        join(tempHome, '.dollhouse', 'run', 'permission-authority.json'),
+        JSON.stringify({
+          version: 1,
+          defaultMode: 'shared',
+          updatedAt: '2026-04-17T15:00:00.000Z',
+          hosts: {
+            'claude-code': {
+              mode: 'authoritative',
+              updatedAt: '2026-04-17T15:00:00.000Z',
+            },
+          },
+        }),
+        'utf-8',
+      );
+
+      const app = createApp(handler, { homeDir: tempHome });
+      const res = await request(app).get('/api/permissions/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.authoritySupportedHosts).toEqual(['codex', 'claude-code']);
     });
 
     it('should restore the shared latest port file from the active listener port', async () => {


### PR DESCRIPTION
## Summary
- make the authority mode options read like explicit selectable cards instead of plain radio rows
- move the unsupported Authoritative host note next to the Authoritative option itself
- add a high-visibility unsaved draft state with host-specific save messaging and stronger save affordances
- extend the UI regression tests to cover unsupported hosts and dirty-save behavior

## Testing
- npm test -- --runInBand tests/unit/web/console-ui-regressions.test.ts
- npx eslint src/web/public/permissions.js tests/unit/web/console-ui-regressions.test.ts

Closes #2055