### PR TITLE
Polish permissions debug views and audit modal UX

### DIFF
--- a/src/web/public/permissions.css
+++ b/src/web/public/permissions.css
@@ -754,6 +754,7 @@
 
 .perm-audit-modal .modal-body {
   display: flex;
+  align-items: stretch;
   min-height: 0;
   padding: 0;
 }
@@ -763,10 +764,16 @@
 }
 
 .perm-audit-modal .perm-feed--modal {
+  flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
   padding: 0.875rem 1rem 1rem;
 }
 
 .perm-audit-entry {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
   border: 1px solid var(--ink-100, #e2e8f0);
   border-radius: 0.75rem;
   background: var(--paper-strong, #fff);
@@ -877,6 +884,48 @@
 .perm-audit-detail-value--mono {
   font-family: var(--font-mono, 'IBM Plex Mono', monospace);
   font-size: 0.82rem;
+}
+
+@media (max-width: 720px) {
+  .perm-audit-modal-dialog {
+    width: min(calc(100vw - 1rem), 82rem);
+  }
+
+  .perm-audit-modal .modal-header {
+    grid-template-areas:
+      "heading"
+      "meta"
+      "actions";
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .perm-audit-modal .modal-header-actions {
+    justify-self: start;
+    flex-wrap: wrap;
+  }
+
+  .perm-audit-modal .perm-feed--modal {
+    padding: 0.75rem;
+  }
+
+  .perm-audit-entry {
+    margin-bottom: 0.625rem;
+  }
+
+  .perm-audit-summary-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.45rem;
+    padding: 0.75rem 0.875rem;
+  }
+
+  .perm-audit-entry-body {
+    padding: 0.85rem 0.875rem 0.9rem;
+  }
+
+  .perm-audit-detail-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.25rem;
+  }
 }
 
 /* ── Source Elements ───────────────────────────────────────── */
@@ -1100,6 +1149,12 @@
 [data-theme="dark"] .perm-pattern-list,
 [data-theme="dark"] .perm-feed {
   background: color-mix(in srgb, var(--paper) 36%, var(--surface-1));
+}
+
+[data-theme="dark"] .perm-detail-refresh {
+  background: color-mix(in srgb, var(--signal-2) 14%, var(--surface-1));
+  border-color: color-mix(in srgb, var(--signal-2) 24%, var(--line, #2b3445));
+  color: var(--ink-300, #cbd5e1);
 }
 
 [data-theme="dark"] .perm-audit-entry {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -87,9 +87,15 @@
           if (dc && dc.permissions) {
             if (!initialized) dc.permissions.init();
             else if (dc.permissions.refresh) dc.permissions.refresh();
-          }
-        }
-      });
+      }
+    }
+
+    window.addEventListener('dollhouse:policy-debug-visibility-changed', function () {
+      if (initialized) {
+        renderFromCache();
+      }
+    });
+  });
     }
   });
 
@@ -127,13 +133,14 @@
         return;
       }
 
+      const visibleAggregateData = getVisibleAggregateData(aggregateData);
       const currentSessionId = window.DollhouseSessions?.getFilterSessionId?.() || '';
-      const selectedData = deriveSelectedSessionData(aggregateData, currentSessionId);
+      const selectedData = deriveSelectedSessionData(visibleAggregateData, currentSessionId);
 
       latestAggregateData = aggregateData;
       latestSelectedData = selectedData;
       window.DollhouseSessions?.setPolicySessions?.(aggregateData.knownSessions || []);
-      render(aggregateData, selectedData);
+      render(visibleAggregateData, selectedData);
     } catch (err) {
       renderError(err.message);
     }
@@ -146,10 +153,9 @@
     }
 
     const sessionId = window.DollhouseSessions?.getFilterSessionId?.() || '';
-    latestSelectedData = deriveSelectedSessionData(latestAggregateData, sessionId);
-    renderAuthorityMode(latestAggregateData);
-    renderPolicySources(latestAggregateData, latestSelectedData);
-    renderSelectedSessionDetail(latestSelectedData);
+    const visibleAggregateData = getVisibleAggregateData(latestAggregateData);
+    latestSelectedData = deriveSelectedSessionData(visibleAggregateData, sessionId);
+    render(visibleAggregateData, latestSelectedData);
   }
 
   // ── Rendering ──────────────────────────────────────────────
@@ -655,6 +661,56 @@
     };
   }
 
+  function shouldShowPersistedPolicyDebug() {
+    return window.DollhouseSessions?.isPolicyDebugVisible?.() === true;
+  }
+
+  function getVisibleAggregateData(data) {
+    if (!data || shouldShowPersistedPolicyDebug()) {
+      return data;
+    }
+
+    const hiddenPolicySessions = Array.isArray(data.knownSessions) ? data.knownSessions : [];
+    if (hiddenPolicySessions.length === 0) {
+      return data;
+    }
+
+    const hiddenPolicySessionIds = new Set(
+      hiddenPolicySessions
+        .map(function (session) { return session && typeof session.sessionId === 'string' ? session.sessionId : ''; })
+        .filter(Boolean),
+    );
+
+    const filteredElements = ((data.elements || []).filter(function (element) {
+      const sessionIds = Array.isArray(element?.sessionIds) ? element.sessionIds.filter(function (sessionId) {
+        return typeof sessionId === 'string' && sessionId !== '';
+      }) : [];
+      if (sessionIds.length === 0) {
+        return true;
+      }
+      return sessionIds.some(function (sessionId) {
+        return !hiddenPolicySessionIds.has(sessionId);
+      });
+    }));
+
+    return {
+      ...data,
+      activeElementCount: filteredElements.length,
+      hasAllowlist: filteredElements.some(function (element) {
+        return (Array.isArray(element.allowRules) && element.allowRules.length > 0)
+          || (Array.isArray(element.allowPatterns) && element.allowPatterns.length > 0);
+      }),
+      elements: filteredElements,
+      knownSessions: [],
+      denyPatterns: flattenElementPatterns(filteredElements, 'denyPatterns'),
+      allowPatterns: flattenElementPatterns(filteredElements, 'allowPatterns'),
+      confirmPatterns: flattenElementPatterns(filteredElements, 'confirmPatterns'),
+      denyRules: flattenElementPatterns(filteredElements, 'denyRules'),
+      allowRules: flattenElementPatterns(filteredElements, 'allowRules'),
+      confirmRules: flattenElementPatterns(filteredElements, 'confirmRules'),
+    };
+  }
+
   function flattenElementPatterns(elements, key) {
     return elements.flatMap(function (element) {
       return Array.isArray(element[key]) ? element[key] : [];
@@ -939,8 +995,10 @@
               <span>Aggregate decision log across all sessions</span>
               <span id="perm-audit-modal-count">0 captured entries</span>
             </div>
-            <button type="button" class="modal-action-btn" id="perm-audit-copy-btn">Copy Markdown</button>
-            <button type="button" class="modal-close" id="perm-audit-modal-close" aria-label="Close audit view">✕</button>
+            <div class="modal-header-actions">
+              <button type="button" class="modal-action-btn" id="perm-audit-copy-btn">Copy Markdown</button>
+              <button type="button" class="modal-close" id="perm-audit-modal-close" aria-label="Close audit view">✕</button>
+            </div>
           </header>
           <div class="modal-body">
             <div class="perm-feed perm-feed--modal" id="perm-audit-modal-feed" role="log" aria-live="polite" aria-label="Full permission decision audit feed">
@@ -1093,10 +1151,52 @@
 
   async function copyTextToClipboard(text) {
     if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(text);
-      return;
+      try {
+        await navigator.clipboard.writeText(text);
+        return;
+      } catch {
+        // Fall through to the user-gesture fallback below. Some embedded browsers
+        // expose the clipboard API but still reject writes in modal contexts.
+      }
     }
-    throw new Error('Clipboard API unavailable');
+
+    copyTextWithSelectionFallback(text);
+  }
+
+  function copyTextWithSelectionFallback(text) {
+    const textarea = document.createElement('textarea');
+    let handled = false;
+
+    function handleCopy(event) {
+      if (!event.clipboardData) {
+        return;
+      }
+      event.clipboardData.setData('text/plain', text);
+      event.preventDefault();
+      handled = true;
+    }
+
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.setAttribute('aria-hidden', 'true');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '-9999px';
+    textarea.style.left = '-9999px';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    document.addEventListener('copy', handleCopy, true);
+    textarea.focus();
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+
+    try {
+      if (!document.execCommand || !document.execCommand('copy') || !handled) {
+        throw new Error('Clipboard copy command unavailable');
+      }
+    } finally {
+      document.removeEventListener('copy', handleCopy, true);
+      textarea.remove();
+    }
   }
 
   function setText(id, value) {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -82,12 +82,24 @@
     if (tabs) {
       tabs.addEventListener('click', function (e) {
         const btn = e.target.closest('.console-tab');
-        if (btn && btn.dataset.tab === 'permissions') {
-          var dc = window.DollhouseConsole;
-          if (dc && dc.permissions) {
-            if (!initialized) dc.permissions.init();
-            else if (dc.permissions.refresh) dc.permissions.refresh();
-      }
+        if (!btn || btn.dataset.tab !== 'permissions') {
+          return;
+        }
+
+        const dc = window.DollhouseConsole;
+        if (!dc || !dc.permissions) {
+          return;
+        }
+
+        if (!initialized) {
+          dc.permissions.init();
+          return;
+        }
+
+        if (dc.permissions.refresh) {
+          dc.permissions.refresh();
+        }
+      });
     }
 
     window.addEventListener('dollhouse:policy-debug-visibility-changed', function () {
@@ -95,8 +107,6 @@
         renderFromCache();
       }
     });
-  });
-    }
   });
 
   // ── Initialization ─────────────────────────────────────────
@@ -661,6 +671,10 @@
     };
   }
 
+  /**
+   * Persisted policy state rows are primarily a debugging aid, so the
+   * dashboard treats them as opt-in and mirrors the explicit sessions UI flag.
+   */
   function shouldShowPersistedPolicyDebug() {
     return window.DollhouseSessions?.isPolicyDebugVisible?.() === true;
   }

--- a/src/web/public/sessions.css
+++ b/src/web/public/sessions.css
@@ -86,6 +86,96 @@
   border-bottom: 1px solid var(--line, #c8d5e9);
 }
 
+.session-dropdown-heading--toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.session-dropdown-heading-label {
+  min-width: 0;
+}
+
+.session-dropdown-toggle-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-shrink: 0;
+}
+
+.session-dropdown-toggle-label {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--ink-500, #677893);
+  text-transform: none;
+  letter-spacing: 0.02em;
+}
+
+.session-dropdown-switch {
+  --session-toggle-width: 3.8rem;
+  --session-toggle-height: 1.55rem;
+  appearance: none;
+  border: 1px solid var(--line, #c8d5e9);
+  border-radius: 999px;
+  background: var(--paper-strong, #fff);
+  color: var(--ink-700, #324563);
+  width: var(--session-toggle-width);
+  height: var(--session-toggle-height);
+  padding: 0;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+  position: relative;
+  display: inline-grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: center;
+  overflow: hidden;
+}
+
+.session-dropdown-switch[data-state="on"] {
+  background: color-mix(in srgb, var(--signal-2, #3b82f6) 12%, var(--paper-strong, #fff));
+  border-color: color-mix(in srgb, var(--signal-2, #3b82f6) 45%, var(--line, #c8d5e9));
+  color: var(--signal, #1e40af);
+}
+
+.session-dropdown-switch:hover,
+.session-dropdown-switch:focus-visible {
+  border-color: var(--signal-2, #3b82f6);
+  outline: none;
+}
+
+.session-dropdown-switch-label {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.66rem;
+  font-weight: 700;
+  color: var(--ink-500, #677893);
+  transition: color 0.15s;
+}
+
+.session-dropdown-switch[data-state="off"] .session-dropdown-switch-label--off,
+.session-dropdown-switch[data-state="on"] .session-dropdown-switch-label--on {
+  color: var(--signal, #1e40af);
+}
+
+.session-dropdown-switch-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: calc((var(--session-toggle-width) - 6px) / 2);
+  height: calc(var(--session-toggle-height) - 6px);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--signal-2, #3b82f6) 16%, var(--paper-strong, #fff));
+  transition: transform 0.18s ease;
+}
+
+.session-dropdown-switch[data-state="on"] .session-dropdown-switch-thumb {
+  transform: translateX(calc((var(--session-toggle-width) - 6px) / 2));
+}
+
 .session-dropdown-divider {
   height: 1px;
   background: var(--line, #c8d5e9);
@@ -195,6 +285,35 @@
 
 [data-theme="dark"] .session-dropdown-name {
   color: var(--ink-900, #e0e8f0);
+}
+
+[data-theme="dark"] .session-dropdown-toggle-label {
+  color: var(--ink-500, #8899bb);
+}
+
+[data-theme="dark"] .session-dropdown-switch {
+  background: var(--paper-strong, #1a1a2e);
+  border-color: var(--line, #2a3a5e);
+  color: var(--ink-900, #e0e8f0);
+}
+
+[data-theme="dark"] .session-dropdown-switch[data-state="on"] {
+  background: color-mix(in srgb, var(--signal-2, #3b82f6) 18%, var(--paper-strong, #1a1a2e));
+  border-color: color-mix(in srgb, var(--signal-2, #3b82f6) 55%, var(--line, #2a3a5e));
+  color: var(--signal-2, #93c5fd);
+}
+
+[data-theme="dark"] .session-dropdown-switch-label {
+  color: var(--ink-500, #8899bb);
+}
+
+[data-theme="dark"] .session-dropdown-switch[data-state="off"] .session-dropdown-switch-label--off,
+[data-theme="dark"] .session-dropdown-switch[data-state="on"] .session-dropdown-switch-label--on {
+  color: var(--signal-2, #93c5fd);
+}
+
+[data-theme="dark"] .session-dropdown-switch-thumb {
+  background: color-mix(in srgb, var(--signal-2, #3b82f6) 24%, var(--paper-strong, #1a1a2e));
 }
 
 /* Kill button */

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -24,6 +24,7 @@
   var SESSION_FILTER_INJECTION_RETRY_INTERVAL = getConfiguredNumber('sessionFilterInjectionRetryIntervalMs', 500);
   var SESSION_FILTER_INJECTION_MAX_RETRIES = getConfiguredNumber('sessionFilterInjectionMaxRetries', 20);
   var LEADER_RELOAD_DEBOUNCE_MS = getConfiguredNumber('leaderReloadDebounceMs', 150);
+  var POLICY_DEBUG_VISIBILITY_KEY = 'dollhouse.policyDebugVisible';
   var sessions = [];
   var policySessions = [];
   var filterSessionId = '';
@@ -31,6 +32,23 @@
   var lastSessionKey = ''; // tracks session list identity to avoid unnecessary rebuilds
   var lastReloadTargetVersion = '';
   var pendingLeaderReloadTimer = null;
+  var showPolicySessions = loadPolicyDebugVisibility();
+
+  function loadPolicyDebugVisibility() {
+    try {
+      return window.localStorage.getItem(POLICY_DEBUG_VISIBILITY_KEY) === 'true';
+    } catch (err) {
+      return false;
+    }
+  }
+
+  function persistPolicyDebugVisibility(nextVisible) {
+    try {
+      window.localStorage.setItem(POLICY_DEBUG_VISIBILITY_KEY, nextVisible ? 'true' : 'false');
+    } catch (err) {
+      // best-effort only
+    }
+  }
 
   function parseSemver(version) {
     if (typeof version !== 'string') return null;
@@ -175,6 +193,9 @@
 
   function getSelectableSessions() {
     var live = getLiveSessions();
+    if (!showPolicySessions) {
+      return live;
+    }
     var liveIds = new Set(live.map(function(s) { return s.sessionId; }));
     var merged = live.slice();
     for (var i = 0; i < policySessions.length; i++) {
@@ -234,7 +255,31 @@
   function sessionListKey(list) {
     return list.map(function(s) {
       return s.sessionId + ':' + s.status + ':' + (isPolicyOnlySession(s) ? 'policy' : 'live');
-    }).join(',');
+    }).join(',')
+      + '|policyDebug:' + (showPolicySessions ? 'on' : 'off')
+      + '|knownPolicy:' + policySessions.map(function(session) { return session.sessionId; }).join(',');
+  }
+
+  function setPolicyDebugVisibility(nextVisible, keepDropdownOpen) {
+    var normalized = !!nextVisible;
+    if (showPolicySessions === normalized) return;
+    showPolicySessions = normalized;
+    persistPolicyDebugVisibility(showPolicySessions);
+
+    if (!showPolicySessions) {
+      var current = getSelectableSessions().find(function(session) {
+        return session.sessionId === filterSessionId;
+      });
+      if (!current && filterSessionId) {
+        applyFilter('');
+      }
+    }
+
+    updateSessionIndicator({ keepOpen: !!keepDropdownOpen });
+    updateSessionFilterOptions();
+    window.dispatchEvent(new CustomEvent('dollhouse:policy-debug-visibility-changed', {
+      detail: { visible: showPolicySessions },
+    }));
   }
 
   // Apply session filter and update all UI to reflect it
@@ -343,10 +388,11 @@
   }
 
   // Build or rebuild the session indicator — only when session list actually changes
-  function updateSessionIndicator() {
+  function updateSessionIndicator(options) {
+    var keepOpen = !!(options && options.keepOpen);
     var active = getLiveSessions();
     var selectable = getSelectableSessions();
-    var policyOnly = selectable.filter(function(s) { return isPolicyOnlySession(s); });
+    var visiblePolicyOnly = selectable.filter(function(s) { return isPolicyOnlySession(s); });
     var key = sessionListKey(selectable);
 
     // If sessions haven't changed, just refresh selection state
@@ -385,7 +431,7 @@
     var dropdown = document.createElement('div');
     dropdown.className = 'session-dropdown';
     dropdown.setAttribute('role', 'listbox');
-    dropdown.hidden = true;
+    dropdown.hidden = !keepOpen;
 
     // "All Sessions" item
     var allItem = document.createElement('div');
@@ -403,7 +449,7 @@
 
     var allCount = document.createElement('span');
     allCount.className = 'session-dropdown-role';
-    allCount.textContent = allSessionsSummary(count, policyOnly.length);
+    allCount.textContent = allSessionsSummary(count, visiblePolicyOnly.length);
     allItem.appendChild(allCount);
 
     allItem.addEventListener('click', function(e) {
@@ -422,6 +468,42 @@
       var heading = document.createElement('div');
       heading.className = 'session-dropdown-heading';
       heading.textContent = text;
+      dropdown.appendChild(heading);
+    }
+
+    function appendDebugHeading() {
+      var heading = document.createElement('div');
+      heading.className = 'session-dropdown-heading session-dropdown-heading--toggle';
+
+      var title = document.createElement('span');
+      title.className = 'session-dropdown-heading-label';
+      title.textContent = 'Persisted Policy State (Debug Info)';
+      heading.appendChild(title);
+
+      var controls = document.createElement('div');
+      controls.className = 'session-dropdown-toggle-group';
+
+      var visibleLabel = document.createElement('span');
+      visibleLabel.className = 'session-dropdown-toggle-label';
+      visibleLabel.textContent = 'Visible';
+      controls.appendChild(visibleLabel);
+
+      var toggle = document.createElement('button');
+      toggle.type = 'button';
+      toggle.className = 'session-dropdown-switch';
+      toggle.dataset.state = showPolicySessions ? 'on' : 'off';
+      toggle.setAttribute('aria-pressed', showPolicySessions ? 'true' : 'false');
+      toggle.setAttribute('aria-label', 'Toggle persisted policy state debug visibility');
+      toggle.innerHTML = '<span class="session-dropdown-switch-label session-dropdown-switch-label--off">Off</span>'
+        + '<span class="session-dropdown-switch-label session-dropdown-switch-label--on">On</span>'
+        + '<span class="session-dropdown-switch-thumb" aria-hidden="true"></span>';
+      toggle.addEventListener('click', function(e) {
+        e.stopPropagation();
+        setPolicyDebugVisibility(!showPolicySessions, true);
+      });
+      controls.appendChild(toggle);
+
+      heading.appendChild(controls);
       dropdown.appendChild(heading);
     }
 
@@ -546,11 +628,11 @@
       }
     }
 
-    if (policyOnly.length > 0) {
+    if (policySessions.length > 0) {
       appendDivider();
-      appendHeading('Persisted Policy State (Debug Info)');
-      for (var j = 0; j < policyOnly.length; j++) {
-        appendSessionItem(policyOnly[j]);
+      appendDebugHeading();
+      for (var j = 0; j < visiblePolicyOnly.length; j++) {
+        appendSessionItem(visiblePolicyOnly[j]);
       }
     }
 
@@ -561,6 +643,7 @@
     indicator.appendChild(wrapper);
 
     dropdownBuilt = true;
+    box.setAttribute('aria-expanded', keepOpen ? 'true' : 'false');
 
     // Apply current selection state
     refreshSelectionState();
@@ -661,8 +744,11 @@
     getFilterSessionId: function() { return filterSessionId; },
     displayName: displayName,
     getSessions: function() { return sessions; },
+    getLiveSessions: getLiveSessions,
     getSelectableSessions: getSelectableSessions,
     setPolicySessions: setPolicySessions,
+    isPolicyDebugVisible: function() { return showPolicySessions; },
+    setPolicyDebugVisibility: setPolicyDebugVisibility,
   };
 
   function init() {

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -986,7 +986,7 @@ body.modal-open { overflow: hidden; }
 
 .modal-header {
   display: grid;
-  grid-template-areas: "heading close" "meta close";
+  grid-template-areas: "heading actions" "meta actions";
   grid-template-columns: 1fr auto;
   gap: 0.2rem 0.65rem;
   padding: 0.9rem 1rem 0.75rem;
@@ -1049,8 +1049,21 @@ body.modal-open { overflow: hidden; }
   flex-wrap: wrap;
 }
 
+.modal-header-actions {
+  grid-area: actions;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  justify-self: end;
+}
+
+.modal-header-actions .modal-action-btn {
+  min-height: 1.85rem;
+  border-radius: 999px;
+  padding: 0.26rem 0.78rem;
+}
+
 .modal-close {
-  grid-area: close;
   align-self: start;
   appearance: none;
   border: 1px solid color-mix(in srgb, var(--line) 82%, var(--paper-strong));

--- a/tests/unit/di/permissionServerIntegration.test.ts
+++ b/tests/unit/di/permissionServerIntegration.test.ts
@@ -59,11 +59,6 @@ describe('Permission Server Integration', () => {
     });
 
     it('should accept POST /api/evaluate_permission and return a decision', async () => {
-      const { findAvailablePort } = await import(
-        '../../../src/auto-dollhouse/portDiscovery.js'
-      );
-      testPort = await findAvailablePort(49310);
-
       // Start a minimal mock server that mimics the evaluate_permission endpoint
       server = http.createServer((req, res) => {
         if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
@@ -91,7 +86,7 @@ describe('Permission Server Integration', () => {
         }
       });
 
-      await new Promise<void>(resolve => server!.listen(testPort, '127.0.0.1', resolve));
+      testPort = await listenOnLoopback(server);
 
       // Test safe tool
       const allowResponse = await httpPost(testPort, {
@@ -227,7 +222,7 @@ describe('Permission Server Integration', () => {
     });
 
     itBash('hook script should discover server via port file and get a response', async () => {
-      const testPort = 49360;
+      let testPort = 0;
       let capturedBody: Record<string, unknown> | null = null;
       const mockServer = http.createServer((req, res) => {
         if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
@@ -250,7 +245,7 @@ describe('Permission Server Integration', () => {
       });
 
       // Start server and write port file
-      await new Promise<void>(resolve => mockServer.listen(testPort, '127.0.0.1', resolve));
+      testPort = await listenOnLoopback(mockServer);
       await fs.mkdir(RUN_DIR, { recursive: true });
       await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
 
@@ -294,7 +289,7 @@ describe('Permission Server Integration', () => {
     });
 
     itBash('hook script should translate legacy flat Claude responses', async () => {
-      const testPort = 49361;
+      let testPort = 0;
       const mockServer = http.createServer((req, res) => {
         if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
           res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -308,7 +303,7 @@ describe('Permission Server Integration', () => {
         }
       });
 
-      await new Promise<void>(resolve => mockServer.listen(testPort, '127.0.0.1', resolve));
+      testPort = await listenOnLoopback(mockServer);
       await fs.mkdir(RUN_DIR, { recursive: true });
       await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
 
@@ -331,7 +326,7 @@ describe('Permission Server Integration', () => {
     });
 
     itBash('hook script should pass through already-wrapped Claude responses unchanged', async () => {
-      const testPort = 49362;
+      let testPort = 0;
       const wrappedResponse = {
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
@@ -349,7 +344,7 @@ describe('Permission Server Integration', () => {
         }
       });
 
-      await new Promise<void>(resolve => mockServer.listen(testPort, '127.0.0.1', resolve));
+      testPort = await listenOnLoopback(mockServer);
       await fs.mkdir(RUN_DIR, { recursive: true });
       await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
 
@@ -366,7 +361,7 @@ describe('Permission Server Integration', () => {
     });
 
     itBash('hook script should fail open silently on malformed Claude responses', async () => {
-      const testPort = 49363;
+      let testPort = 0;
       const mockServer = http.createServer((req, res) => {
         if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
           res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -377,7 +372,7 @@ describe('Permission Server Integration', () => {
         }
       });
 
-      await new Promise<void>(resolve => mockServer.listen(testPort, '127.0.0.1', resolve));
+      testPort = await listenOnLoopback(mockServer);
       await fs.mkdir(RUN_DIR, { recursive: true });
       await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
 
@@ -395,7 +390,7 @@ describe('Permission Server Integration', () => {
     });
 
     itBash('hook script should fall back to the newest live PID-keyed port file and restore the shared file', async () => {
-      const testPort = 49364;
+      let testPort = 0;
       let capturedBody: Record<string, unknown> | null = null;
       const mockServer = http.createServer((req, res) => {
         if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
@@ -417,7 +412,7 @@ describe('Permission Server Integration', () => {
         }
       });
 
-      await new Promise<void>(resolve => mockServer.listen(testPort, '127.0.0.1', resolve));
+      testPort = await listenOnLoopback(mockServer);
       await fs.mkdir(RUN_DIR, { recursive: true });
       await fs.unlink(PORT_FILE).catch(() => {});
       await fs.writeFile(PID_PORT_FILE, String(testPort), 'utf-8');
@@ -469,7 +464,8 @@ describe('Permission Server Integration', () => {
 
     it('should handle unreachable server in HTTP request gracefully', async () => {
       // Hitting a port where nothing is listening should not crash
-      const response = await httpPost(49399, {
+      const unusedPort = await reserveUnusedLoopbackPort();
+      const response = await httpPost(unusedPort, {
         tool_name: 'Read',
         input: {},
         platform: 'claude_code',
@@ -515,6 +511,43 @@ function httpPost(port: number, body: Record<string, unknown>): Promise<any> {
     req.write(data);
     req.end();
   });
+}
+
+/**
+ * Bind a test server on loopback using an OS-assigned port.
+ */
+function listenOnLoopback(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Unable to determine loopback port'));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+/**
+ * Reserve an unused loopback port, then immediately release it so the caller
+ * can verify connection-failure behavior against a realistically free port.
+ */
+async function reserveUnusedLoopbackPort(): Promise<number> {
+  const placeholderServer = http.createServer();
+  const port = await listenOnLoopback(placeholderServer);
+  await new Promise<void>((resolve, reject) => {
+    placeholderServer.close((error?: Error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+  return port;
 }
 
 function runHookScript(payload: Record<string, unknown>): Promise<{ code: number; stdout: string }> {

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -218,6 +218,7 @@ describe('Web console cleanup regressions', () => {
     win.DollhouseConsoleConfig = {
       sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
       sessionFilterInjectionMaxRetries: 5,
+      permissionDetailRefreshSpinnerDelayMs: 0,
     };
 
     win.eval(sessionsSource);
@@ -318,13 +319,17 @@ describe('Web console cleanup regressions', () => {
     win.DollhouseConsoleConfig = {
       sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
       sessionFilterInjectionMaxRetries: 5,
+      permissionDetailRefreshSpinnerDelayMs: 0,
     };
 
     win.eval(sessionsSource);
     win.eval(permissionsSource);
     win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
     win.DollhouseConsole.permissions.init();
-    await wait(SESSION_FILTER_INJECTION_WAIT_MS);
+    await wait(200);
+
+    expect(win.document.getElementById('perm-source-list')?.textContent).toContain('No active elements with policies');
+    expect(win.document.getElementById('perm-selected-card')?.hidden).toBe(true);
 
     const sessionBox = win.document.querySelector('.session-box') as HTMLButtonElement | null;
     expect(sessionBox).not.toBeNull();
@@ -333,7 +338,17 @@ describe('Web console cleanup regressions', () => {
 
     const debugHeading = Array.from(win.document.querySelectorAll('.session-dropdown-heading'))
       .map(node => node.textContent);
-    expect(debugHeading).toContain('Persisted Policy State (Debug Info)');
+    expect(debugHeading.some(text => text?.includes('Persisted Policy State (Debug Info)'))).toBe(true);
+    const debugToggle = win.document.querySelector('.session-dropdown-switch') as HTMLButtonElement | null;
+    expect(debugToggle?.dataset.state).toBe('off');
+    expect(win.document.querySelector('.session-dropdown-item[data-session-id="session-focus"]')).toBeNull();
+
+    debugToggle?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    expect((win.document.querySelector('.session-dropdown') as HTMLDivElement | null)?.hidden).toBe(false);
+    const enabledToggle = win.document.querySelector('.session-dropdown-switch') as HTMLButtonElement | null;
+    expect(enabledToggle?.dataset.state).toBe('on');
 
     const persistedItem = win.document.querySelector('.session-dropdown-item[data-session-id="session-focus"]') as HTMLElement | null;
     expect(persistedItem).not.toBeNull();
@@ -360,6 +375,17 @@ describe('Web console cleanup regressions', () => {
       .map(([url]) => url)
       .filter((url): url is string => typeof url === 'string' && url.includes('sessionId=session-focus'));
     expect(selectedSessionRequests).toHaveLength(0);
+
+    const currentSessionBox = win.document.querySelector('.session-box') as HTMLButtonElement | null;
+    currentSessionBox?.click();
+    await wait(DEFAULT_WAIT_MS);
+    const hideToggle = win.document.querySelector('.session-dropdown-switch') as HTMLButtonElement | null;
+    hideToggle?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    expect(win.document.querySelector('.session-dropdown-item[data-session-id="session-focus"]')).toBeNull();
+    expect(win.document.getElementById('perm-selected-card')?.hidden).toBe(true);
+    expect(win.document.getElementById('perm-source-list')?.textContent).toContain('No active elements with policies');
 
     cleanup();
   });
@@ -422,13 +448,14 @@ describe('Web console cleanup regressions', () => {
     win.DollhouseConsoleConfig = {
       sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
       sessionFilterInjectionMaxRetries: 5,
+      permissionDetailRefreshSpinnerDelayMs: 0,
     };
 
     win.eval(sessionsSource);
     win.eval(permissionsSource);
     win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
     win.DollhouseConsole.permissions.init();
-    await wait(SESSION_FILTER_INJECTION_WAIT_MS);
+    await wait(200);
 
     expect(win.document.getElementById('perm-all-invalid-policy-summary')?.textContent).toContain('malformed gatekeeper policy');
     expect(win.document.getElementById('perm-source-list')?.textContent).toContain('broken-guardian');
@@ -488,6 +515,7 @@ describe('Web console cleanup regressions', () => {
     win.DollhouseConsoleConfig = {
       sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
       sessionFilterInjectionMaxRetries: 5,
+      permissionDetailRefreshSpinnerDelayMs: 0,
     };
 
     win.eval(sessionsSource);
@@ -608,6 +636,7 @@ describe('Web console cleanup regressions', () => {
     win.DollhouseConsoleConfig = {
       sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
       sessionFilterInjectionMaxRetries: 5,
+      permissionDetailRefreshSpinnerDelayMs: 0,
     };
     win.confirm = jest.fn().mockReturnValue(true);
 
@@ -666,6 +695,7 @@ describe('Web console cleanup regressions', () => {
     win.DollhouseConsoleConfig = {
       sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
       sessionFilterInjectionMaxRetries: 5,
+      permissionDetailRefreshSpinnerDelayMs: 0,
     };
 
     win.eval(sessionsSource);
@@ -679,6 +709,19 @@ describe('Web console cleanup regressions', () => {
       { sessionId: 'session-good', displayName: 'duplicate' },
       { sessionId: 42, displayName: 'bad-type' },
     ]);
+
+    expect(Array.from((win.document.getElementById('log-session-filter') as HTMLSelectElement | null)?.options ?? []).map(option => option.value)).toEqual([
+      '',
+      'console-1',
+    ]);
+
+    const sessionBox = win.document.querySelector('.session-box') as HTMLButtonElement | null;
+    sessionBox?.click();
+    await wait(DEFAULT_WAIT_MS);
+    const debugToggle = win.document.querySelector('.session-dropdown-switch') as HTMLButtonElement | null;
+    expect(debugToggle?.dataset.state).toBe('off');
+    debugToggle?.click();
+    await wait(DEFAULT_WAIT_MS);
 
     const select = win.document.getElementById('log-session-filter') as HTMLSelectElement | null;
     expect(select).not.toBeNull();
@@ -759,13 +802,14 @@ describe('Web console cleanup regressions', () => {
     win.DollhouseConsoleConfig = {
       sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
       sessionFilterInjectionMaxRetries: 5,
+      permissionDetailRefreshSpinnerDelayMs: 0,
     };
 
     win.eval(sessionsSource);
     win.eval(permissionsSource);
     win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
     win.DollhouseConsole.permissions.init();
-    await wait(SESSION_FILTER_INJECTION_WAIT_MS);
+    await wait(SESSION_FILTER_INJECTION_WAIT_MS + DEFAULT_WAIT_MS);
 
     const openButton = win.document.getElementById('perm-feed-expand-btn') as HTMLButtonElement | null;
     expect(openButton).not.toBeNull();
@@ -788,6 +832,8 @@ describe('Web console cleanup regressions', () => {
 
     const copyButton = win.document.getElementById('perm-audit-copy-btn') as HTMLButtonElement | null;
     expect(copyButton).not.toBeNull();
+    expect(copyButton?.parentElement?.classList.contains('modal-header-actions')).toBe(true);
+    expect(copyButton?.nextElementSibling?.id).toBe('perm-audit-modal-close');
     copyButton?.click();
     await wait(DEFAULT_WAIT_MS);
     expect(writeText).toHaveBeenCalledTimes(1);
@@ -799,6 +845,107 @@ describe('Web console cleanup regressions', () => {
     closeButton?.click();
     await wait(DEFAULT_WAIT_MS);
     expect(modal?.hasAttribute('open')).toBe(false);
+
+    cleanup();
+  });
+
+  it('falls back to selection-based copy when the clipboard API write fails', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="session-indicator"></div>
+      <div id="tab-logs"><div class="log-controls"></div></div>
+      <div id="console-tabs"><button class="console-tab" data-tab="permissions">Permissions</button></div>
+      <div id="permissions-dashboard-root"></div>
+    `);
+
+    const writeText = jest.fn().mockRejectedValue(new Error('clipboard denied'));
+    Object.defineProperty(win.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const execCommand = jest.fn().mockImplementation((command: string) => {
+      if (command !== 'copy') {
+        return false;
+      }
+      const event = new win.Event('copy', { bubbles: true, cancelable: true }) as Event & {
+        clipboardData?: { setData: jest.Mock };
+      };
+      event.clipboardData = { setData: jest.fn() };
+      win.document.dispatchEvent(event);
+      return true;
+    });
+    Object.defineProperty(win.document, 'execCommand', {
+      configurable: true,
+      value: execCommand,
+    });
+
+    win.DollhouseAuth.apiFetch = jest.fn((url: string) => {
+      if (url === '/api/sessions') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ sessions: [] }),
+        });
+      }
+
+      if (url === '/api/permissions/status') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            activeElementCount: 1,
+            hasAllowlist: false,
+            denyPatterns: [],
+            allowPatterns: [],
+            confirmPatterns: [],
+            denyRules: [],
+            allowRules: [],
+            confirmRules: [],
+            elements: [],
+            recentDecisions: [
+              {
+                id: 'd-1',
+                timestamp: '2026-04-15T20:10:11.000Z',
+                tool_name: 'Edit',
+                decision: 'ask',
+                reason: 'Needs confirmation before editing a protected file.',
+                platform: 'cursor',
+                target: '/opt/dollhouse/important.txt',
+                targetLabel: 'File',
+                details: [
+                  { label: 'Platform', value: 'cursor', monospace: true },
+                ],
+              },
+            ],
+            permissionPromptActive: false,
+          }),
+        });
+      }
+
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+    win.DollhouseConsoleConfig = {
+      sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
+      sessionFilterInjectionMaxRetries: 5,
+    };
+
+    win.eval(sessionsSource);
+    win.eval(permissionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    win.DollhouseConsole.permissions.init();
+    await wait(SESSION_FILTER_INJECTION_WAIT_MS);
+
+    const openButton = win.document.getElementById('perm-feed-expand-btn') as HTMLButtonElement | null;
+    openButton?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    const copyButton = win.document.getElementById('perm-audit-copy-btn') as HTMLButtonElement | null;
+    copyButton?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(copyButton?.textContent).toBe('Copied!');
 
     cleanup();
   });
@@ -848,4 +995,5 @@ describe('Web console cleanup regressions', () => {
 
     cleanup();
   });
+
 });


### PR DESCRIPTION
## Summary
- polish the permissions audit modal header, copy flow, and responsive layout
- add a persisted-policy debug visibility toggle in the session picker and filter aggregate permissions views when it is off
- refine the human-only authority card layout and host selection presentation in the previewed permissions UI

## Testing
- npm test -- --runInBand tests/unit/web/console-ui-regressions.test.ts
- npx eslint src/web/public/permissions.js tests/unit/web/console-ui-regressions.test.ts