### PR TITLE
Patch Dependabot alerts for dompurify and hono

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dollhousemcp/safety": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.25.1",
         "chalk": "^5.6.2",
-        "dompurify": "^3.3.1",
+        "dompurify": "^3.4.0",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "extract-zip": "^2.0.1",
@@ -5924,9 +5924,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -7199,9 +7199,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "@dollhousemcp/safety": "^1.0.0",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "chalk": "^5.6.2",
-    "dompurify": "^3.3.1",
+    "dompurify": "^3.4.0",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "extract-zip": "^2.0.1",
@@ -235,7 +235,7 @@
     "@istanbuljs/load-nyc-config": {
       "js-yaml": "3.14.2"
     },
-    "hono": "4.12.12",
+    "hono": "4.12.14",
     "@hono/node-server": "1.19.13"
   }
 }


### PR DESCRIPTION
## Summary
- bump direct `dompurify` dependency to the first patched release
- update the `hono` override so the SDK's transitive install resolves to the first patched release
- refresh `package-lock.json` so Dependabot alerts #100 and #101 clear on install

## Verification
- `npm ls dompurify hono --package-lock-only`
- `npm test -- --runInBand tests/unit/web/contentPipeline.test.ts tests/unit/web/contentPipeline.security.test.ts`

Closes https://github.com/DollhouseMCP/mcp-server/security/dependabot/100
Closes https://github.com/DollhouseMCP/mcp-server/security/dependabot/101
