### PR TITLE
Fix session meta injection for direct index shell requests

### DIFF
--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -388,6 +388,8 @@ export async function startWebServer(options: WebServerOptions): Promise<WebServ
       : { maxAge: '1y', immutable: true }),
   });
   app.use((req, res, next) => {
+    // Skip shell HTML files from express.static so the SPA fallback can inject
+    // the current token, session IDs, and asset version placeholders.
     const requestedExt = extname(req.path.normalize('NFC')).toLowerCase();
     if (ALLOWED_PAGE_EXTENSIONS.has(requestedExt)) {
       next();

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -379,14 +379,22 @@ export async function startWebServer(options: WebServerOptions): Promise<WebServ
   // meta tag). Without this, express.static serves the raw template
   // and the browser never gets the auth token (#1780).
   const isDebug = Boolean(process.env.DOLLHOUSE_DEBUG || process.env.ENABLE_DEBUG);
-  app.use(express.static(publicDir, {
+  const staticPublicAssets = express.static(publicDir, {
     index: false,
     // In debug mode, disable caching on all static assets (JS, CSS) so
     // UI changes are picked up on normal reload without Cmd+Shift+R.
     ...(isDebug
       ? { etag: false, lastModified: false, maxAge: 0 }
       : { maxAge: '1y', immutable: true }),
-  }));
+  });
+  app.use((req, res, next) => {
+    const requestedExt = extname(req.path.normalize('NFC')).toLowerCase();
+    if (ALLOWED_PAGE_EXTENSIONS.has(requestedExt)) {
+      next();
+      return;
+    }
+    staticPublicAssets(req, res, next);
+  });
 
   // SPA fallback with console token injection (#1780).
   // Reads index.html on first request, substitutes the {{CONSOLE_TOKEN}} placeholder

--- a/tests/unit/web/tokenInjection.test.ts
+++ b/tests/unit/web/tokenInjection.test.ts
@@ -113,6 +113,7 @@ describe('token injection into index.html (#1804)', () => {
   beforeEach(async () => {
     testDir = await mkdtemp(join(tmpdir(), 'dollhouse-token-inject-test-'));
     await writeFile(join(testDir, 'index.html'), INDEX_TEMPLATE, 'utf8');
+    await writeFile(join(testDir, 'index.htm'), INDEX_TEMPLATE, 'utf8');
     await writeFile(join(testDir, 'styles.css'), 'body { color: red; }', 'utf8');
     await writeFile(join(testDir, 'app.js'), 'console.log("ok");', 'utf8');
   });
@@ -253,6 +254,27 @@ describe('token injection into index.html (#1804)', () => {
     });
 
     const res = await request(app).get('/index.html');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.text).toContain(`content="${TEST_TOKEN}"`);
+    expect(res.text).toContain(`content="${TEST_SESSION_ID}"`);
+    expect(res.text).toContain(`content="${TEST_RUNTIME_SESSION_ID}"`);
+    expect(res.text).not.toContain('{{CONSOLE_TOKEN}}');
+    expect(res.text).not.toContain('{{DOLLHOUSE_SESSION_ID}}');
+    expect(res.text).not.toContain('{{DOLLHOUSE_RUNTIME_SESSION_ID}}');
+    expect(res.text).not.toContain('{{DOLLHOUSE_ASSET_VERSION}}');
+  });
+
+  it('serves /index.htm through the injected shell instead of raw placeholders', async () => {
+    const app = await buildTestApp({
+      publicDir: testDir,
+      getToken: () => TEST_TOKEN,
+      getSessionId: () => TEST_SESSION_ID,
+      getRuntimeSessionId: () => TEST_RUNTIME_SESSION_ID,
+      getAssetVersion: () => '2.0.18',
+    });
+
+    const res = await request(app).get('/index.htm');
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toContain('text/html');
     expect(res.text).toContain(`content="${TEST_TOKEN}"`);

--- a/tests/unit/web/tokenInjection.test.ts
+++ b/tests/unit/web/tokenInjection.test.ts
@@ -19,6 +19,8 @@ const INDEX_TEMPLATE = `<!DOCTYPE html>
 <html>
 <head>
   <meta name="dollhouse-console-token" content="{{CONSOLE_TOKEN}}">
+  <meta name="dollhouse-session-id" content="{{DOLLHOUSE_SESSION_ID}}">
+  <meta name="dollhouse-runtime-session-id" content="{{DOLLHOUSE_RUNTIME_SESSION_ID}}">
   <meta name="dollhouse-console-asset-version" content="{{DOLLHOUSE_ASSET_VERSION}}">
   <link rel="stylesheet" href="styles.css?v={{DOLLHOUSE_ASSET_VERSION}}">
 </head>
@@ -26,11 +28,15 @@ const INDEX_TEMPLATE = `<!DOCTYPE html>
 </html>`;
 
 const TOKEN_META_PLACEHOLDER = '{{CONSOLE_TOKEN}}';
+const SESSION_ID_META_PLACEHOLDER = '{{DOLLHOUSE_SESSION_ID}}';
+const RUNTIME_SESSION_ID_META_PLACEHOLDER = '{{DOLLHOUSE_RUNTIME_SESSION_ID}}';
 const ASSET_VERSION_PLACEHOLDER = '{{DOLLHOUSE_ASSET_VERSION}}';
 
 /** A valid 64-hex-char token. */
 const TEST_TOKEN = 'a'.repeat(64);
 const ROTATED_TOKEN = 'b'.repeat(64);
+const TEST_SESSION_ID = 'stable-session';
+const TEST_RUNTIME_SESSION_ID = 'runtime-session';
 
 /**
  * Build a minimal Express app that replicates the server's static file
@@ -40,18 +46,29 @@ const ROTATED_TOKEN = 'b'.repeat(64);
 async function buildTestApp(options: {
   publicDir: string;
   getToken: () => string;
+  getSessionId?: () => string;
+  getRuntimeSessionId?: () => string;
   getAssetVersion?: () => string;
 }) {
   const app = express();
 
   // Same pattern as server.ts: static with index: false, then SPA fallback
-  app.use(express.static(options.publicDir, { index: false }));
+  const staticAssets = express.static(options.publicDir, { index: false });
+  app.use((req, res, next) => {
+    if (req.path.endsWith('.html') || req.path.endsWith('.htm')) {
+      next();
+      return;
+    }
+    staticAssets(req, res, next);
+  });
 
   let cachedHtml: string | null = null;
   let cachedToken: string | null = null;
 
   app.get('/{*path}', async (_req, res) => {
     const currentToken = options.getToken();
+    const currentSessionId = options.getSessionId ? options.getSessionId() : '';
+    const currentRuntimeSessionId = options.getRuntimeSessionId ? options.getRuntimeSessionId() : '';
     const currentAssetVersion = options.getAssetVersion ? options.getAssetVersion() : '2.0.18';
     if (cachedHtml !== null && cachedToken === currentToken) {
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
@@ -66,7 +83,21 @@ async function buildTestApp(options: {
       .replaceAll("'", '&#39;')
       .replaceAll('<', '&lt;')
       .replaceAll('>', '&gt;');
+    const escapedSessionId = currentSessionId
+      .replaceAll('&', '&amp;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;');
+    const escapedRuntimeSessionId = currentRuntimeSessionId
+      .replaceAll('&', '&amp;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;');
     cachedHtml = template.replaceAll(TOKEN_META_PLACEHOLDER, escaped);
+    cachedHtml = cachedHtml.replaceAll(SESSION_ID_META_PLACEHOLDER, escapedSessionId);
+    cachedHtml = cachedHtml.replaceAll(RUNTIME_SESSION_ID_META_PLACEHOLDER, escapedRuntimeSessionId);
     cachedHtml = cachedHtml.replaceAll(ASSET_VERSION_PLACEHOLDER, currentAssetVersion);
     cachedToken = currentToken;
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
@@ -94,6 +125,8 @@ describe('token injection into index.html (#1804)', () => {
     const app = await buildTestApp({
       publicDir: testDir,
       getToken: () => TEST_TOKEN,
+      getSessionId: () => TEST_SESSION_ID,
+      getRuntimeSessionId: () => TEST_RUNTIME_SESSION_ID,
       getAssetVersion: () => '2.0.18',
     });
 
@@ -101,7 +134,11 @@ describe('token injection into index.html (#1804)', () => {
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toContain('text/html');
     expect(res.text).toContain(`content="${TEST_TOKEN}"`);
+    expect(res.text).toContain(`content="${TEST_SESSION_ID}"`);
+    expect(res.text).toContain(`content="${TEST_RUNTIME_SESSION_ID}"`);
     expect(res.text).not.toContain('{{CONSOLE_TOKEN}}');
+    expect(res.text).not.toContain('{{DOLLHOUSE_SESSION_ID}}');
+    expect(res.text).not.toContain('{{DOLLHOUSE_RUNTIME_SESSION_ID}}');
     expect(res.text).toContain('content="2.0.18"');
     expect(res.text).toContain('styles.css?v=2.0.18');
     expect(res.text).toContain('app.js?v=2.0.18');
@@ -112,6 +149,8 @@ describe('token injection into index.html (#1804)', () => {
     const app = await buildTestApp({
       publicDir: testDir,
       getToken: () => '',
+      getSessionId: () => '',
+      getRuntimeSessionId: () => '',
       getAssetVersion: () => '2.0.18',
     });
 
@@ -125,6 +164,8 @@ describe('token injection into index.html (#1804)', () => {
     const app = await buildTestApp({
       publicDir: testDir,
       getToken: () => TEST_TOKEN,
+      getSessionId: () => TEST_SESSION_ID,
+      getRuntimeSessionId: () => TEST_RUNTIME_SESSION_ID,
       getAssetVersion: () => '2.0.18',
     });
 
@@ -138,6 +179,8 @@ describe('token injection into index.html (#1804)', () => {
     const app = await buildTestApp({
       publicDir: testDir,
       getToken: () => TEST_TOKEN,
+      getSessionId: () => TEST_SESSION_ID,
+      getRuntimeSessionId: () => TEST_RUNTIME_SESSION_ID,
       getAssetVersion: () => '2.0.18',
     });
 
@@ -151,6 +194,8 @@ describe('token injection into index.html (#1804)', () => {
     const app = await buildTestApp({
       publicDir: testDir,
       getToken: () => currentToken,
+      getSessionId: () => TEST_SESSION_ID,
+      getRuntimeSessionId: () => TEST_RUNTIME_SESSION_ID,
       getAssetVersion: () => '2.0.18',
     });
 
@@ -171,18 +216,24 @@ describe('token injection into index.html (#1804)', () => {
     const app = await buildTestApp({
       publicDir: testDir,
       getToken: () => 'a"b<c&d',
+      getSessionId: () => 'session<id>"',
+      getRuntimeSessionId: () => 'runtime<id>"',
       getAssetVersion: () => '2.0.18',
     });
 
     const res = await request(app).get('/');
     expect(res.text).toContain('content="a&quot;b&lt;c&amp;d"');
     expect(res.text).not.toContain('content="a"b<c&d"');
+    expect(res.text).toContain('content="session&lt;id&gt;&quot;"');
+    expect(res.text).toContain('content="runtime&lt;id&gt;&quot;"');
   });
 
   it('SPA fallback handles deep paths without breaking', async () => {
     const app = await buildTestApp({
       publicDir: testDir,
       getToken: () => TEST_TOKEN,
+      getSessionId: () => TEST_SESSION_ID,
+      getRuntimeSessionId: () => TEST_RUNTIME_SESSION_ID,
       getAssetVersion: () => '2.0.18',
     });
 
@@ -190,5 +241,26 @@ describe('token injection into index.html (#1804)', () => {
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toContain('text/html');
     expect(res.text).toContain(`content="${TEST_TOKEN}"`);
+  });
+
+  it('serves /index.html through the injected shell instead of raw placeholders', async () => {
+    const app = await buildTestApp({
+      publicDir: testDir,
+      getToken: () => TEST_TOKEN,
+      getSessionId: () => TEST_SESSION_ID,
+      getRuntimeSessionId: () => TEST_RUNTIME_SESSION_ID,
+      getAssetVersion: () => '2.0.18',
+    });
+
+    const res = await request(app).get('/index.html');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+    expect(res.text).toContain(`content="${TEST_TOKEN}"`);
+    expect(res.text).toContain(`content="${TEST_SESSION_ID}"`);
+    expect(res.text).toContain(`content="${TEST_RUNTIME_SESSION_ID}"`);
+    expect(res.text).not.toContain('{{CONSOLE_TOKEN}}');
+    expect(res.text).not.toContain('{{DOLLHOUSE_SESSION_ID}}');
+    expect(res.text).not.toContain('{{DOLLHOUSE_RUNTIME_SESSION_ID}}');
+    expect(res.text).not.toContain('{{DOLLHOUSE_ASSET_VERSION}}');
   });
 });


### PR DESCRIPTION
## Summary
- route direct /index.html requests through the injected SPA shell instead of raw express.static output
- keep static assets on express.static while skipping HTML shell files
- add regression coverage for session/runtime session/asset placeholder injection on both / and /index.html

## Testing
- npm test -- --runInBand tests/unit/web/tokenInjection.test.ts
- npx eslint src/web/server.ts tests/unit/web/tokenInjection.test.ts