### PR TITLE
Add favicon for the web console

### DIFF
--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -18,6 +18,8 @@
   <meta name="dollhouse-runtime-session-id" content="{{DOLLHOUSE_RUNTIME_SESSION_ID}}">
   <!-- Asset version — injected at request time for cache-busting local CSS/JS/img files. -->
   <meta name="dollhouse-console-asset-version" content="{{DOLLHOUSE_ASSET_VERSION}}">
+  <link rel="icon" type="image/png" href="dollhouse-logo.png?v={{DOLLHOUSE_ASSET_VERSION}}">
+  <link rel="apple-touch-icon" href="dollhouse-logo.png?v={{DOLLHOUSE_ASSET_VERSION}}">
   <link rel="stylesheet" href="fonts.css?v={{DOLLHOUSE_ASSET_VERSION}}">
   <link rel="stylesheet" href="styles.css?v={{DOLLHOUSE_ASSET_VERSION}}">
   <link rel="stylesheet" href="logs.css?v={{DOLLHOUSE_ASSET_VERSION}}">

--- a/tests/unit/web/cacheBustingSources.test.ts
+++ b/tests/unit/web/cacheBustingSources.test.ts
@@ -17,6 +17,7 @@ describe('cache busting source wiring', () => {
     const html = readFileSync(join(PUBLIC_DIR, 'index.html'), 'utf-8');
     expect(html).toContain('name="dollhouse-console-asset-version"');
     expect(html).toContain('{{DOLLHOUSE_ASSET_VERSION}}');
+    expect(html).toContain('href="dollhouse-logo.png?v={{DOLLHOUSE_ASSET_VERSION}}"');
     expect(html).toContain('styles.css?v={{DOLLHOUSE_ASSET_VERSION}}');
     expect(html).toContain('app.js?v={{DOLLHOUSE_ASSET_VERSION}}');
     expect(html).toContain('sessions.js?v={{DOLLHOUSE_ASSET_VERSION}}');

--- a/tests/unit/web/tokenInjection.test.ts
+++ b/tests/unit/web/tokenInjection.test.ts
@@ -22,6 +22,7 @@ const INDEX_TEMPLATE = `<!DOCTYPE html>
   <meta name="dollhouse-session-id" content="{{DOLLHOUSE_SESSION_ID}}">
   <meta name="dollhouse-runtime-session-id" content="{{DOLLHOUSE_RUNTIME_SESSION_ID}}">
   <meta name="dollhouse-console-asset-version" content="{{DOLLHOUSE_ASSET_VERSION}}">
+  <link rel="icon" type="image/png" href="dollhouse-logo.png?v={{DOLLHOUSE_ASSET_VERSION}}">
   <link rel="stylesheet" href="styles.css?v={{DOLLHOUSE_ASSET_VERSION}}">
 </head>
 <body><h1>DollhouseMCP Console</h1><script src="app.js?v={{DOLLHOUSE_ASSET_VERSION}}"></script></body>
@@ -141,6 +142,7 @@ describe('token injection into index.html (#1804)', () => {
     expect(res.text).not.toContain('{{DOLLHOUSE_SESSION_ID}}');
     expect(res.text).not.toContain('{{DOLLHOUSE_RUNTIME_SESSION_ID}}');
     expect(res.text).toContain('content="2.0.18"');
+    expect(res.text).toContain('href="dollhouse-logo.png?v=2.0.18"');
     expect(res.text).toContain('styles.css?v=2.0.18');
     expect(res.text).toContain('app.js?v=2.0.18');
     expect(res.text).not.toContain('{{DOLLHOUSE_ASSET_VERSION}}');
@@ -263,6 +265,7 @@ describe('token injection into index.html (#1804)', () => {
     expect(res.text).not.toContain('{{DOLLHOUSE_SESSION_ID}}');
     expect(res.text).not.toContain('{{DOLLHOUSE_RUNTIME_SESSION_ID}}');
     expect(res.text).not.toContain('{{DOLLHOUSE_ASSET_VERSION}}');
+    expect(res.text).toContain('href="dollhouse-logo.png?v=2.0.18"');
   });
 
   it('serves /index.htm through the injected shell instead of raw placeholders', async () => {
@@ -284,5 +287,6 @@ describe('token injection into index.html (#1804)', () => {
     expect(res.text).not.toContain('{{DOLLHOUSE_SESSION_ID}}');
     expect(res.text).not.toContain('{{DOLLHOUSE_RUNTIME_SESSION_ID}}');
     expect(res.text).not.toContain('{{DOLLHOUSE_ASSET_VERSION}}');
+    expect(res.text).toContain('href="dollhouse-logo.png?v=2.0.18"');
   });
 });


### PR DESCRIPTION
## Summary
- add a browser-tab favicon for the DollhouseMCP web console using the existing logo asset
- keep the favicon on the asset-versioned shell so cache busting stays aligned with other console assets
- extend the cache-busting and token-injection regression tests to cover the favicon link

## Testing
- npm test -- --runInBand tests/unit/web/cacheBustingSources.test.ts tests/unit/web/tokenInjection.test.ts
- npx eslint tests/unit/web/cacheBustingSources.test.ts tests/unit/web/tokenInjection.test.ts