### PR TITLE
Add running version to web console footer

### DIFF
--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -105,6 +105,7 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
   let activeSort = 'date-desc';
   let activeSource = 'all'; // 'all' | 'collection' | 'portfolio'
   let searchQuery = '';
+  const DOLLHOUSE_SERVER_VERSION = document.querySelector('meta[name="dollhouse-server-version"]')?.content || '';
   const DOLLHOUSE_SESSION_ID = document.querySelector('meta[name="dollhouse-session-id"]')?.content || '';
   const DOLLHOUSE_RUNTIME_SESSION_ID = document.querySelector('meta[name="dollhouse-runtime-session-id"]')?.content || '';
 
@@ -128,6 +129,12 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
       </span>`
       : '';
     return `${primaryMarkup}${sessionMarkup}`;
+  }
+
+  function updateFooterVersion() {
+    const footerVersion = document.getElementById('footer-version');
+    if (!footerVersion) return;
+    footerVersion.textContent = `Version: ${DOLLHOUSE_SERVER_VERSION || 'unknown'}`;
   }
 
   // ── Bootstrap ──────────────────────────────────────────────────────────────
@@ -1877,6 +1884,7 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
   // ── Event wiring ───────────────────────────────────────────────────────────
 
   document.addEventListener('DOMContentLoaded', () => {
+    updateFooterVersion();
 
     // Theme toggle
     const themeToggleBtn  = document.getElementById('theme-toggle');

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -132,6 +132,8 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
   }
 
   function updateFooterVersion() {
+    // Keep the running build visible in the fixed footer so operators can
+    // quickly confirm which console version a given tab or machine is serving.
     const footerVersion = document.getElementById('footer-version');
     if (!footerVersion) return;
     footerVersion.textContent = `Version: ${DOLLHOUSE_SERVER_VERSION || 'unknown'}`;

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -572,7 +572,7 @@ npm install @dollhousemcp/mcp-server</code></pre>
       <a href="https://github.com/DollhouseMCP/mcp-server" class="footer-link">GitHub Repository</a>
       <a href="./collection-index.json" class="footer-link">JSON API</a>
       <a href="https://dollhousemcp.com" class="footer-link">DollhouseMCP</a>
-      <span class="footer-version" id="footer-version"></span>
+      <span class="footer-version" id="footer-version" aria-live="polite" aria-atomic="true"></span>
       <span class="footer-updated" id="footer-updated"></span>
       <span class="footer-copyright">&copy; 2026 DollhouseMCP</span>
     </div>

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -572,6 +572,7 @@ npm install @dollhousemcp/mcp-server</code></pre>
       <a href="https://github.com/DollhouseMCP/mcp-server" class="footer-link">GitHub Repository</a>
       <a href="./collection-index.json" class="footer-link">JSON API</a>
       <a href="https://dollhousemcp.com" class="footer-link">DollhouseMCP</a>
+      <span class="footer-version" id="footer-version"></span>
       <span class="footer-updated" id="footer-updated"></span>
       <span class="footer-copyright">&copy; 2026 DollhouseMCP</span>
     </div>

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -1430,11 +1430,15 @@ body.modal-open { overflow: hidden; }
   margin-left: auto;
 }
 
+.footer-version,
 .footer-updated {
-  margin-left: auto;
   font-family: var(--font-mono);
   font-size: 0.72rem;
   color: var(--ink-500);
+}
+
+.footer-updated {
+  margin-left: auto;
 }
 
 /* ── Topic filters ───────────────────────────────────────────────────────── */

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -141,7 +141,7 @@ describe('Web console cleanup regressions', () => {
       <div id="results-announcer"></div>
       <div id="elements-grid"></div>
       <div id="pagination" hidden><button id="btn-prev-page"></button><button id="btn-next-page"></button><span id="page-info"></span></div>
-      <div id="footer-version"></div>
+      <div id="footer-version" aria-live="polite" aria-atomic="true"></div>
       <div id="footer-updated"></div>
     `);
 
@@ -166,6 +166,7 @@ describe('Web console cleanup regressions', () => {
     await wait(DEFAULT_WAIT_MS);
 
     expect(win.document.getElementById('footer-version')?.textContent).toBe(`Version: ${PACKAGE_VERSION}`);
+    expect(win.document.getElementById('footer-version')?.getAttribute('aria-live')).toBe('polite');
 
     cleanup();
   });

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, beforeAll, afterEach, jest } from '@jest/globals'
 import { JSDOM } from 'jsdom';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { PACKAGE_VERSION } from '../../../src/generated/version.js';
 
 let appSource = '';
 let sessionsSource = '';
@@ -118,6 +119,57 @@ function installBannerHelper(win: Record<string, any>) {
 }
 
 describe('Web console cleanup regressions', () => {
+  it('shows the running server version in the footer', async () => {
+    const { window: win, cleanup } = createDom(`
+      <meta name="dollhouse-server-version" content="${PACKAGE_VERSION}">
+      <button id="theme-toggle"></button>
+      <span id="theme-toggle-icon"></span>
+      <span id="theme-toggle-label"></span>
+      <link id="hljs-theme-light">
+      <link id="hljs-theme-dark">
+      <div id="view-toggle"><button class="view-btn" data-view="grid"></button></div>
+      <select id="sort-select"><option value="date-desc">date-desc</option></select>
+      <input id="search-input">
+      <div id="source-toggle"><button data-source="all"></button></div>
+      <button id="btn-portfolio"></button>
+      <div id="console-tabs"><button class="console-tab active" data-tab="portfolio"></button></div>
+      <div id="tab-portfolio" class="tab-panel active"></div>
+      <div id="stats"></div>
+      <div><div id="type-filters"></div></div>
+      <div id="topic-filters"></div>
+      <div id="results-count"></div>
+      <div id="results-announcer"></div>
+      <div id="elements-grid"></div>
+      <div id="pagination" hidden><button id="btn-prev-page"></button><button id="btn-next-page"></button><span id="page-info"></span></div>
+      <div id="footer-version"></div>
+      <div id="footer-updated"></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn((url: string) => {
+      if (url === '/api/elements') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ elements: { personas: [] }, totalCount: 0 }),
+        });
+      }
+      if (url === '/api/collection') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ index: { personas: [] } }),
+        });
+      }
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    win.eval(appSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    await wait(DEFAULT_WAIT_MS);
+
+    expect(win.document.getElementById('footer-version')?.textContent).toBe(`Version: ${PACKAGE_VERSION}`);
+
+    cleanup();
+  });
+
   it('shows a visible collection banner when the community collection fetch fails', async () => {
     const { window: win, cleanup } = createDom(`
       <button id="theme-toggle"></button>


### PR DESCRIPTION
## Summary
- show the running DollhouseMCP version in the management console footer
- source the value from the injected server-version meta tag already used elsewhere in the console
- add a focused UI regression so the footer version stays wired up

## Testing
- npm test -- --runInBand tests/unit/web/console-ui-regressions.test.ts
- npx eslint src/web/public/app.js tests/unit/web/console-ui-regressions.test.ts

Closes #2041