### PR TITLE
Improve console header responsiveness at mid widths

### DIFF
--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -139,6 +139,88 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
     footerVersion.textContent = `Version: ${DOLLHOUSE_SERVER_VERSION || 'unknown'}`;
   }
 
+  function wireThemeToggle() {
+    const themeToggleBtn  = document.getElementById('theme-toggle');
+    const themeToggleIcon = document.getElementById('theme-toggle-icon');
+    const themeToggleLbl  = document.getElementById('theme-toggle-label');
+    const html = document.documentElement;
+
+    function applyTheme(theme) {
+      html.dataset.theme = theme;
+      const isDark = theme === 'dark';
+      if (themeToggleIcon) themeToggleIcon.textContent = isDark ? '☀' : '☾';
+      if (themeToggleLbl) themeToggleLbl.textContent = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+      if (themeToggleBtn) themeToggleBtn.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
+      const hljsLight = document.getElementById('hljs-theme-light');
+      const hljsDark = document.getElementById('hljs-theme-dark');
+      if (hljsLight) hljsLight.disabled = isDark;
+      if (hljsDark) hljsDark.disabled = !isDark;
+      try { localStorage.setItem('color-scheme', theme); } catch {}
+    }
+
+    const saved = (() => { try { return localStorage.getItem('color-scheme'); } catch {} })();
+    const preferred = saved || (globalThis.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+    applyTheme(preferred);
+
+    if (themeToggleBtn) {
+      themeToggleBtn.addEventListener('click', () => {
+        applyTheme(html.dataset.theme === 'dark' ? 'light' : 'dark');
+      });
+    }
+  }
+
+  function wireViewToggle() {
+    const viewToggle = document.getElementById('view-toggle');
+    const elemGrid = document.getElementById('elements-grid');
+    let activeView = (() => { try { return localStorage.getItem('collection-view') || 'grid'; } catch { return 'grid'; } })();
+
+    function applyView(view) {
+      activeView = view;
+      if (elemGrid) elemGrid.dataset.view = view;
+      viewToggle?.querySelectorAll('.view-btn').forEach(btn => {
+        const on = btn.dataset.view === view;
+        btn.classList.toggle('active', on);
+        btn.setAttribute('aria-pressed', on);
+      });
+      try { localStorage.setItem('collection-view', view); } catch {}
+    }
+
+    applyView(activeView);
+
+    viewToggle?.addEventListener('click', e => {
+      const btn = e.target.closest('[data-view]');
+      if (btn) applyView(btn.dataset.view);
+    });
+  }
+
+  function wireSortControls() {
+    const sortSelect = document.getElementById('sort-select');
+    if (!sortSelect) return;
+    sortSelect.value = activeSort;
+    sortSelect.addEventListener('change', e => {
+      activeSort = e.target.value;
+      applyFilters();
+    });
+  }
+
+  function wireSourceToggle() {
+    const sourceToggle = document.getElementById('source-toggle');
+    if (!sourceToggle) return;
+    sourceToggle.addEventListener('click', e => {
+      const btn = e.target.closest('[data-source]');
+      if (!btn) return;
+      activeSource = btn.dataset.source;
+      sourceToggle.querySelectorAll('[data-source]').forEach(b => {
+        const on = b.dataset.source === activeSource;
+        b.classList.toggle('active', on);
+        b.setAttribute('aria-pressed', on);
+      });
+      renderTypeFilters();
+      renderTopicFilters();
+      applyFilters();
+    });
+  }
+
   // ── Bootstrap ──────────────────────────────────────────────────────────────
 
   function mergeCollectionData(data) {
@@ -1887,70 +1969,9 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
 
   document.addEventListener('DOMContentLoaded', () => {
     updateFooterVersion();
-
-    // Theme toggle
-    const themeToggleBtn  = document.getElementById('theme-toggle');
-    const themeToggleIcon = document.getElementById('theme-toggle-icon');
-    const themeToggleLbl  = document.getElementById('theme-toggle-label');
-    const html = document.documentElement;
-
-    function applyTheme(theme) {
-      html.dataset.theme = theme;
-      const isDark = theme === 'dark';
-      if (themeToggleIcon) themeToggleIcon.textContent = isDark ? '☀' : '☾';
-      if (themeToggleLbl)  themeToggleLbl.textContent  = isDark ? 'Switch to light mode' : 'Switch to dark mode';
-      if (themeToggleBtn)  themeToggleBtn.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
-      // Sync highlight.js theme
-      const hljsLight = document.getElementById('hljs-theme-light');
-      const hljsDark  = document.getElementById('hljs-theme-dark');
-      if (hljsLight) hljsLight.disabled = isDark;
-      if (hljsDark)  hljsDark.disabled  = !isDark;
-      try { localStorage.setItem('color-scheme', theme); } catch {}
-    }
-
-    // Restore saved preference; fall back to OS preference
-    const saved = (() => { try { return localStorage.getItem('color-scheme'); } catch {} })();
-    const preferred = saved || (globalThis.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-    applyTheme(preferred);
-
-    if (themeToggleBtn) {
-      themeToggleBtn.addEventListener('click', () => {
-        applyTheme(html.dataset.theme === 'dark' ? 'light' : 'dark');
-      });
-    }
-
-    // View toggle
-    const viewToggle = document.getElementById('view-toggle');
-    const elemGrid   = document.getElementById('elements-grid');
-    let activeView = (() => { try { return localStorage.getItem('collection-view') || 'grid'; } catch { return 'grid'; } })();
-
-    function applyView(view) {
-      activeView = view;
-      if (elemGrid) elemGrid.dataset.view = view;
-      viewToggle?.querySelectorAll('.view-btn').forEach(btn => {
-        const on = btn.dataset.view === view;
-        btn.classList.toggle('active', on);
-        btn.setAttribute('aria-pressed', on);
-      });
-      try { localStorage.setItem('collection-view', view); } catch {}
-    }
-
-    applyView(activeView);
-
-    viewToggle?.addEventListener('click', e => {
-      const btn = e.target.closest('[data-view]');
-      if (btn) applyView(btn.dataset.view);
-    });
-
-    // Sort
-    const sortSelect = document.getElementById('sort-select');
-    if (sortSelect) {
-      sortSelect.value = activeSort;
-      sortSelect.addEventListener('change', e => {
-        activeSort = e.target.value;
-        applyFilters();
-      });
-    }
+    wireThemeToggle();
+    wireViewToggle();
+    wireSortControls();
 
     // Search
     const searchInput = document.getElementById('search-input');
@@ -1985,23 +2006,7 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
       }
     });
 
-    // Source toggle
-    const sourceToggle = document.getElementById('source-toggle');
-    if (sourceToggle) {
-      sourceToggle.addEventListener('click', e => {
-        const btn = e.target.closest('[data-source]');
-        if (!btn) return;
-        activeSource = btn.dataset.source;
-        sourceToggle.querySelectorAll('[data-source]').forEach(b => {
-          const on = b.dataset.source === activeSource;
-          b.classList.toggle('active', on);
-          b.setAttribute('aria-pressed', on);
-        });
-        renderTypeFilters();
-        renderTopicFilters();
-        applyFilters();
-      });
-    }
+    wireSourceToggle();
 
     // Portfolio button
     document.getElementById('btn-portfolio')?.addEventListener('click', loadLocalPortfolio);
@@ -2326,7 +2331,7 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
 
     consoleTabMenu?.addEventListener('click', (e) => {
       const btn = e.target.closest('.console-tab-menu-item');
-      if (!btn || !btn.dataset.tab) return;
+      if (!btn?.dataset.tab) return;
       const tab = btn.dataset.tab;
       switchToTab(tab);
       localStorage.setItem(TAB_KEY, tab);

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -2008,6 +2008,9 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
 
     // ── Tab switching ─────────────────────────────────────────────────────────
     const consoleTabs = document.getElementById('console-tabs');
+    const headerNavRow = document.querySelector('.header-nav-row');
+    const consoleTabMenuToggle = document.getElementById('console-tab-menu-toggle');
+    const consoleTabMenu = document.getElementById('console-tab-menu');
     const tabInits = { logs: false, metrics: false, permissions: false, security: false };
 
     const TAB_KEY = 'dollhousemcp-active-tab';
@@ -2092,7 +2095,70 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
         p.hidden = p.id !== 'tab-' + tabName;
         p.classList.toggle('active', p.id === 'tab-' + tabName);
       });
+      syncConsoleTabMenuSelection();
+      closeConsoleTabMenu();
+      scheduleConsoleTabOverflowCheck();
     };
+
+    function renderConsoleTabMenu() {
+      if (!consoleTabs || !consoleTabMenu) return;
+      consoleTabMenu.innerHTML = '';
+      consoleTabs.querySelectorAll('.console-tab').forEach((btn) => {
+        const item = document.createElement('button');
+        item.type = 'button';
+        item.className = 'console-tab-menu-item';
+        item.dataset.tab = btn.dataset.tab || '';
+        item.setAttribute('role', 'menuitem');
+        item.textContent = btn.textContent || '';
+        if (btn.classList.contains('active')) item.classList.add('active');
+        consoleTabMenu.appendChild(item);
+      });
+    }
+
+    function syncConsoleTabMenuSelection() {
+      if (!consoleTabs || !consoleTabMenu) return;
+      const activeTab = consoleTabs.querySelector('.console-tab.active')?.dataset.tab || '';
+      consoleTabMenu.querySelectorAll('.console-tab-menu-item').forEach((item) => {
+        item.classList.toggle('active', item.dataset.tab === activeTab);
+      });
+    }
+
+    function closeConsoleTabMenu() {
+      if (!consoleTabMenu || !consoleTabMenuToggle) return;
+      consoleTabMenu.hidden = true;
+      consoleTabMenuToggle.setAttribute('aria-expanded', 'false');
+    }
+
+    function tabsNeedOverflowMenu() {
+      if (!consoleTabs) return false;
+      const buttons = Array.from(consoleTabs.querySelectorAll('.console-tab'));
+      if (buttons.length < 2) return false;
+      const firstTop = buttons[0].offsetTop;
+      return buttons.some((btn) => btn.offsetTop !== firstTop);
+    }
+
+    let consoleTabOverflowFrame = 0;
+    function updateConsoleTabOverflow() {
+      if (!consoleTabs || !headerNavRow || !consoleTabMenuToggle) return;
+      headerNavRow.classList.remove('header-nav-row--collapsed');
+      consoleTabMenuToggle.hidden = true;
+      const shouldCollapse = tabsNeedOverflowMenu();
+      if (shouldCollapse) {
+        headerNavRow.classList.add('header-nav-row--collapsed');
+        consoleTabMenuToggle.hidden = false;
+      }
+      if (!shouldCollapse) {
+        closeConsoleTabMenu();
+      }
+    }
+
+    function scheduleConsoleTabOverflowCheck() {
+      if (consoleTabOverflowFrame) cancelAnimationFrame(consoleTabOverflowFrame);
+      consoleTabOverflowFrame = requestAnimationFrame(() => {
+        consoleTabOverflowFrame = 0;
+        updateConsoleTabOverflow();
+      });
+    }
 
     /**
      * Parse the URL hash into tab name and query parameters.
@@ -2228,6 +2294,15 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
     // Handle hash changes for deep-linking (e.g., open_logs operation)
     globalThis.addEventListener('hashchange', () => applyHashTab());
 
+    renderConsoleTabMenu();
+    syncConsoleTabMenuSelection();
+    scheduleConsoleTabOverflowCheck();
+    globalThis.addEventListener('resize', scheduleConsoleTabOverflowCheck);
+    if (typeof ResizeObserver === 'function' && headerNavRow) {
+      const tabOverflowObserver = new ResizeObserver(() => scheduleConsoleTabOverflowCheck());
+      tabOverflowObserver.observe(headerNavRow);
+    }
+
     if (consoleTabs) {
       consoleTabs.addEventListener('click', (e) => {
         const btn = e.target.closest('.console-tab');
@@ -2241,6 +2316,31 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
         lazyInitTab(tab, tabInits);
       });
     }
+
+    consoleTabMenuToggle?.addEventListener('click', () => {
+      if (!consoleTabMenu) return;
+      const willOpen = consoleTabMenu.hidden;
+      consoleTabMenu.hidden = !willOpen;
+      consoleTabMenuToggle.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+    });
+
+    consoleTabMenu?.addEventListener('click', (e) => {
+      const btn = e.target.closest('.console-tab-menu-item');
+      if (!btn || !btn.dataset.tab) return;
+      const tab = btn.dataset.tab;
+      switchToTab(tab);
+      localStorage.setItem(TAB_KEY, tab);
+      lazyInitTab(tab, tabInits);
+    });
+
+    globalThis.addEventListener('click', (e) => {
+      if (!consoleTabMenu || !consoleTabMenuToggle) return;
+      if (consoleTabMenu.hidden) return;
+      const target = e.target;
+      if (!(target instanceof Element)) return;
+      if (consoleTabMenu.contains(target) || consoleTabMenuToggle.contains(target)) return;
+      closeConsoleTabMenu();
+    });
 
     function lazyInitTab(tab, tabInits, params) {
       const dc = globalThis.DollhouseConsole;

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -43,7 +43,14 @@
         <p class="site-tagline">Management Console</p>
       </div>
     </div>
-    <div class="header-right">
+    <div class="header-controls">
+      <div class="site-stats" id="stats" aria-live="polite"></div>
+      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode" title="Switch to dark mode">
+        <span class="theme-toggle-icon" id="theme-toggle-icon" aria-hidden="true">&#9790;</span>
+        <span class="sr-only" id="theme-toggle-label">Switch to dark mode</span>
+      </button>
+    </div>
+    <div class="header-nav-row">
       <nav class="console-tabs" id="console-tabs" aria-label="Console tabs">
         <button class="console-tab" data-tab="setup">Setup</button>
         <button class="console-tab" data-tab="security">Auth</button>
@@ -52,12 +59,14 @@
         <button class="console-tab" data-tab="permissions">Permissions</button>
         <button class="console-tab active" data-tab="portfolio">Portfolio</button>
       </nav>
+      <div class="console-tab-menu-shell" id="console-tab-menu-shell">
+        <button class="console-tab-menu-toggle" id="console-tab-menu-toggle" type="button" hidden aria-haspopup="menu" aria-expanded="false" aria-controls="console-tab-menu">
+          <span class="console-tab-menu-icon" aria-hidden="true">&#9776;</span>
+          <span class="console-tab-menu-label">Menu</span>
+        </button>
+        <div class="console-tab-menu" id="console-tab-menu" role="menu" hidden></div>
+      </div>
       <div class="session-indicator" id="session-indicator" title="Active sessions"></div>
-      <div class="site-stats" id="stats" aria-live="polite"></div>
-      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode" title="Switch to dark mode">
-        <span class="theme-toggle-icon" id="theme-toggle-icon" aria-hidden="true">&#9790;</span>
-        <span class="sr-only" id="theme-toggle-label">Switch to dark mode</span>
-      </button>
     </div>
   </header>
 

--- a/src/web/public/logs.css
+++ b/src/web/public/logs.css
@@ -6,7 +6,7 @@
 .log-viewer {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 120px);
+  height: calc(100dvh - var(--site-footer-height, 4.5rem) - 120px);
   font-family: var(--font-mono);
   font-size: 12.5px;
   line-height: 1.5;
@@ -469,4 +469,160 @@
 
 .log-jump-bottom:hover {
   background: var(--signal-2);
+}
+
+@media (max-width: 48rem) {
+  .log-viewer {
+    height: calc(100dvh - var(--site-footer-height, 4.5rem) - 104px);
+  }
+
+  .log-controls {
+    padding: 10px;
+    gap: 10px;
+  }
+
+  .log-filter-group {
+    flex: 1 1 calc(50% - 10px);
+    min-width: 0;
+  }
+
+  .log-filter-group label {
+    flex-shrink: 0;
+  }
+
+  .log-controls select,
+  .log-controls input,
+  .log-search {
+    min-width: 0;
+    width: 100%;
+    max-width: none;
+  }
+
+  .log-status-bar {
+    flex-wrap: wrap;
+    row-gap: 6px;
+    padding: 8px 10px;
+  }
+
+  .log-entry-count {
+    margin-left: 0;
+    width: 100%;
+    order: 10;
+  }
+
+  .log-entry {
+    display: grid;
+    grid-template-columns: auto auto auto minmax(0, 1fr) auto;
+    grid-template-areas:
+      "checkbox time level source corr"
+      ". message message message message";
+    align-items: start;
+    gap: 4px 8px;
+    padding: 6px 10px;
+    min-height: 74px;
+    white-space: normal;
+  }
+
+  .log-checkbox {
+    grid-area: checkbox;
+    margin-top: 1px;
+  }
+
+  .log-time {
+    grid-area: time;
+    width: auto;
+  }
+
+  .log-level {
+    grid-area: level;
+    width: auto;
+    min-width: 42px;
+    padding-inline: 6px;
+  }
+
+  .log-category {
+    display: none;
+  }
+
+  .log-source {
+    grid-area: source;
+    max-width: none;
+    min-width: 0;
+  }
+
+  .log-corr-badge {
+    grid-area: corr;
+    width: auto;
+    justify-self: end;
+  }
+
+  .log-message {
+    grid-area: message;
+    white-space: normal;
+    overflow: hidden;
+    text-overflow: initial;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    line-height: 1.45;
+  }
+
+  .log-detail-card {
+    width: min(680px, calc(100vw - 1rem));
+    max-height: calc(100vh - 1rem);
+    border-radius: 0.9rem;
+  }
+
+  .log-detail-card-header {
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: flex-start;
+  }
+
+  .log-detail-card-actions {
+    width: 100%;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
+
+  .log-detail-field {
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .log-detail-field-label {
+    min-width: 0;
+  }
+
+  .log-jump-bottom {
+    right: 12px;
+    bottom: 12px;
+  }
+}
+
+@media (max-width: 32rem) {
+  .log-filter-group {
+    flex: 1 1 100%;
+  }
+
+  .log-entry {
+    grid-template-columns: auto auto minmax(0, 1fr) auto;
+    grid-template-areas:
+      "checkbox level source corr"
+      ". time time time"
+      ". message message message";
+    min-height: 96px;
+  }
+
+  .log-time {
+    color: var(--ink-700);
+  }
+
+  .log-source {
+    font-size: 10px;
+  }
+
+  .log-status-indicator {
+    width: 100%;
+  }
 }

--- a/src/web/public/logs.js
+++ b/src/web/public/logs.js
@@ -13,10 +13,14 @@
 
 (() => {
   const BUFFER_SIZE = 10000;
-  const ROW_HEIGHT = 22;
+  const DEFAULT_ROW_HEIGHT = 22;
+  const COMPACT_ROW_HEIGHT = 74;
+  const EXTRA_COMPACT_ROW_HEIGHT = 96;
   const OVERSCAN = 5;
   const RECONNECT_DELAY_MS = 3000;
   const SEARCH_DEBOUNCE_MS = 300;
+  const COMPACT_LOG_LAYOUT_QUERY = '(max-width: 48rem)';
+  const EXTRA_COMPACT_LOG_LAYOUT_QUERY = '(max-width: 32rem)';
 
   // ── State ────────────────────────────────────────────────────────────────
   const buffer = [];
@@ -27,6 +31,8 @@
   let searchTimer = null;
   let pendingEntries = [];
   let rafScheduled = false;
+  let compactLogLayoutMedia = null;
+  let extraCompactLogLayoutMedia = null;
 
   // Selection state
   const selectedIds = new Set();
@@ -78,6 +84,7 @@
     if (urlParams) applyLogUrlParams(urlParams);
 
     bindEvents();
+    bindResponsiveLayout();
     connectSSE();
 
     requestAnimationFrame(() => {
@@ -141,6 +148,14 @@
     if (eventSource) {
       eventSource.close();
       eventSource = null;
+    }
+    if (compactLogLayoutMedia) {
+      compactLogLayoutMedia.removeEventListener?.('change', handleResponsiveLayoutChange);
+      compactLogLayoutMedia = null;
+    }
+    if (extraCompactLogLayoutMedia) {
+      extraCompactLogLayoutMedia.removeEventListener?.('change', handleResponsiveLayoutChange);
+      extraCompactLogLayoutMedia = null;
     }
   }
 
@@ -287,6 +302,35 @@
     document.getElementById('log-trace-clear').addEventListener('click', clearTraceFilter);
   }
 
+  function isCompactLogLayout() {
+    return !!compactLogLayoutMedia?.matches;
+  }
+
+  function isExtraCompactLogLayout() {
+    return !!extraCompactLogLayoutMedia?.matches;
+  }
+
+  function getRowHeight() {
+    if (isExtraCompactLogLayout()) return EXTRA_COMPACT_ROW_HEIGHT;
+    if (isCompactLogLayout()) return COMPACT_ROW_HEIGHT;
+    return DEFAULT_ROW_HEIGHT;
+  }
+
+  function handleResponsiveLayoutChange() {
+    requestAnimationFrame(() => {
+      renderViewport();
+      if (autoScroll) scrollToBottom();
+    });
+  }
+
+  function bindResponsiveLayout() {
+    if (typeof globalThis.matchMedia !== 'function') return;
+    compactLogLayoutMedia = globalThis.matchMedia(COMPACT_LOG_LAYOUT_QUERY);
+    extraCompactLogLayoutMedia = globalThis.matchMedia(EXTRA_COMPACT_LOG_LAYOUT_QUERY);
+    compactLogLayoutMedia.addEventListener?.('change', handleResponsiveLayoutChange);
+    extraCompactLogLayoutMedia.addEventListener?.('change', handleResponsiveLayoutChange);
+  }
+
   function setTraceFilter(correlationId) {
     filterCorrelationId = correlationId;
     const banner = document.getElementById('log-trace-banner');
@@ -415,14 +459,15 @@
 
   function renderViewport() {
     const totalItems = getVisibleCount();
-    scrollSpacer.style.height = (totalItems * ROW_HEIGHT) + 'px';
+    const rowHeight = getRowHeight();
+    scrollSpacer.style.height = (totalItems * rowHeight) + 'px';
 
     const scrollTop = viewport.scrollTop;
     let viewHeight = viewport.clientHeight;
     if (viewHeight === 0) viewHeight = 600;
 
-    const startIdx = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN);
-    const endIdx = Math.min(totalItems, Math.ceil((scrollTop + viewHeight) / ROW_HEIGHT) + OVERSCAN);
+    const startIdx = Math.max(0, Math.floor(scrollTop / rowHeight) - OVERSCAN);
+    const endIdx = Math.min(totalItems, Math.ceil((scrollTop + viewHeight) / rowHeight) + OVERSCAN);
     const needed = endIdx - startIdx;
 
     while (rowPool.length < needed) {
@@ -452,8 +497,9 @@
 
   function updateRow(row, entry, visibleIndex) {
     const isSelected = selectedIds.has(entry.id);
-    row.style.top = (visibleIndex * ROW_HEIGHT) + 'px';
-    row.style.height = ROW_HEIGHT + 'px';
+    const rowHeight = getRowHeight();
+    row.style.top = (visibleIndex * rowHeight) + 'px';
+    row.style.height = rowHeight + 'px';
     row.dataset.entryId = entry.id;
     row.dataset.visibleIndex = visibleIndex;
     row.className = 'log-entry level-' + escapeHtml(entry.level) + (isSelected ? ' selected' : '');
@@ -622,7 +668,8 @@
 
   // ── Scroll & status ──────────────────────────────────────────────────────
   function onScroll() {
-    const atBottom = viewport.scrollTop + viewport.clientHeight >= viewport.scrollHeight - ROW_HEIGHT * 2;
+    const rowHeight = getRowHeight();
+    const atBottom = viewport.scrollTop + viewport.clientHeight >= viewport.scrollHeight - rowHeight * 2;
     autoScroll = atBottom;
     jumpBtn.classList.toggle('visible', !atBottom && getVisibleCount() > 0);
     renderViewport();
@@ -634,8 +681,8 @@
       requestAnimationFrame(() => {
         rafScheduled = false;
         updateEntryCount();
-        renderViewport();
         if (autoScroll) scrollToBottom();
+        else renderViewport();
       });
     }
   }
@@ -643,6 +690,7 @@
   // ── Helpers ──────────────────────────────────────────────────────────────
   function scrollToBottom() {
     viewport.scrollTop = viewport.scrollHeight;
+    renderViewport();
   }
 
   function setStatus(status) {

--- a/src/web/public/sessions.css
+++ b/src/web/public/sessions.css
@@ -66,7 +66,8 @@
   position: absolute;
   top: calc(100% + 0.4rem);
   right: 0;
-  min-width: 480px;
+  min-width: min(480px, calc(100vw - (2 * var(--gutter, 1rem))));
+  max-width: calc(100vw - (2 * var(--gutter, 1rem)));
   background: var(--paper-strong, #fff);
   border: 1px solid var(--line, #c8d5e9);
   border-radius: var(--radius-md, 0.85rem);

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -146,12 +146,15 @@ p, li { max-width: 69ch; }
   position: sticky;
   top: 0;
   z-index: 35;
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-areas:
+    "brand controls"
+    "nav nav";
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.55rem var(--gutter);
+  column-gap: 1rem;
+  row-gap: 0.12rem;
+  padding: 0.44rem var(--gutter) 0.4rem;
   border-bottom: 1px solid var(--line);
   background: color-mix(in srgb, var(--paper-strong) 90%, transparent);
   backdrop-filter: blur(8px);
@@ -169,8 +172,8 @@ p, li { max-width: 69ch; }
   pointer-events: none;
 }
 
-.header-brand { display: flex; flex-direction: row; align-items: center; gap: 0.6rem; min-width: 0; }
-.header-brand-text { display: flex; flex-direction: column; gap: 0.05rem; min-width: 0; }
+.header-brand { grid-area: brand; display: flex; flex-direction: row; align-items: center; gap: 0.6rem; min-width: 0; min-height: 2.35rem; }
+.header-brand-text { display: flex; flex-direction: column; justify-content: center; gap: 0.05rem; min-width: 0; min-height: 2.35rem; }
 .header-logo { width: 32px; height: 32px; flex-shrink: 0; }
 
 .site-title {
@@ -187,16 +190,37 @@ p, li { max-width: 69ch; }
   font-size: var(--step--1);
   color: var(--ink-700);
   max-width: none;
+  line-height: 1.15;
 }
 
-.header-right {
+.header-controls {
+  grid-area: controls;
   display: flex;
   align-items: center;
   justify-content: flex-end;
   flex-wrap: wrap;
   gap: 0.65rem;
-  flex: 1 1 auto;
+  width: auto;
+  max-width: 100%;
   min-width: 0;
+}
+
+.header-nav-row {
+  grid-area: nav;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: nowrap;
+  gap: 0.55rem;
+  width: 100%;
+  min-width: 0;
+}
+
+.console-tab-menu-shell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
 }
 
 .site-stats {
@@ -1346,6 +1370,85 @@ body.modal-open { overflow: hidden; }
   border-radius: var(--radius-sm);
   padding: 2px;
   min-width: 0;
+  width: fit-content;
+  max-width: 100%;
+  flex-wrap: wrap;
+}
+
+.console-tab-menu-toggle {
+  display: none;
+  align-items: center;
+  gap: 0.42rem;
+  border: 1px solid color-mix(in srgb, var(--signal) 24%, var(--line));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-1) 70%, var(--paper-strong));
+  color: var(--ink-700);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.48rem 0.78rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.console-tab-menu-toggle:hover,
+.console-tab-menu-toggle:focus-visible {
+  background: color-mix(in srgb, var(--surface-1) 88%, var(--paper-strong));
+  outline: 2px solid var(--signal);
+  outline-offset: 2px;
+}
+
+.console-tab-menu-icon {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.console-tab-menu {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  right: 0;
+  min-width: 13rem;
+  max-width: min(18rem, calc(100vw - (2 * var(--gutter, 1rem))));
+  background: var(--paper-strong);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-soft);
+  padding: 0.3rem;
+  z-index: 200;
+}
+
+.console-tab-menu-item {
+  width: 100%;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--ink-700);
+  font-family: var(--font-body);
+  font-size: var(--step--1);
+  font-weight: 600;
+  text-align: left;
+  padding: 0.52rem 0.68rem;
+  cursor: pointer;
+}
+
+.console-tab-menu-item:hover,
+.console-tab-menu-item:focus-visible {
+  background: var(--surface-1);
+  outline: none;
+}
+
+.console-tab-menu-item.active {
+  background: color-mix(in srgb, var(--signal-2) 10%, var(--paper-strong));
+  color: var(--signal);
+}
+
+.header-nav-row--collapsed .console-tabs {
+  display: none;
+}
+
+.header-nav-row--collapsed .console-tab-menu-toggle:not([hidden]) {
+  display: inline-flex;
 }
 
 .console-tab {
@@ -1373,40 +1476,153 @@ body.modal-open { overflow: hidden; }
   box-shadow: 0 1px 3px rgba(0,0,0,0.08);
 }
 
-@media (max-width: 1100px) {
-  .site-header {
-    align-items: flex-start;
-  }
-
-  .header-right {
-    width: 100%;
-    justify-content: flex-start;
-    row-gap: 0.55rem;
-  }
-
-  .console-tabs {
-    order: 3;
-    width: 100%;
-    flex-wrap: wrap;
+@media (max-width: 960px) {
+  .header-controls {
+    align-items: center;
+    justify-content: flex-end;
+    width: auto;
+    max-width: 100%;
+    gap: 0.5rem;
   }
 
   .site-stats {
-    flex: 1 1 auto;
-    justify-content: flex-start;
+    flex: 0 1 auto;
+    width: auto;
+    justify-content: flex-end;
+  }
+}
+
+@media (max-width: 860px) {
+  .site-header {
+    column-gap: 0.7rem;
+  }
+
+  .header-brand {
+    gap: 0.5rem;
+    min-height: 0;
+  }
+
+  .header-brand-text {
+    min-height: 0;
+    gap: 0;
+  }
+
+  .header-brand .site-tagline {
+    display: none;
+  }
+
+  .header-controls,
+  .site-stats {
+    gap: 0.35rem;
+  }
+
+  .header-controls {
+    align-items: center;
+  }
+
+  .stat {
+    padding: 0.12rem 0.34rem;
+  }
+
+  .stat strong {
+    font-size: 0.92rem;
+  }
+
+  .stat--session strong {
+    font-size: 0.74rem;
   }
 
   .theme-toggle {
-    margin-left: auto;
+    width: 1.85rem;
+    height: 1.85rem;
+  }
+
+  .console-tab {
+    padding: 4px 11px;
+  }
+}
+
+@media (max-width: 46rem) {
+  .stat--session {
+    display: none;
+  }
+}
+
+@media (max-width: 31rem) {
+  .site-stats .stat:nth-child(2) {
+    display: none;
+  }
+}
+
+@media (max-width: 28rem) {
+  .site-header {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    grid-template-areas: "brand nav controls";
+    column-gap: 0.45rem;
+  }
+
+  .header-brand {
+    gap: 0;
+    min-width: 0;
+  }
+
+  .header-logo {
+    display: block;
+    width: 28px;
+    height: 28px;
+  }
+
+  .header-brand-text {
+    display: none;
+  }
+
+  .site-stats {
+    display: none;
+  }
+
+  .header-controls {
+    width: auto;
+    justify-content: flex-end;
+  }
+
+  .header-nav-row {
+    width: auto;
+    min-width: 0;
+    justify-content: flex-end;
+    gap: 0.4rem;
+  }
+}
+
+@media (max-width: 24rem) {
+  .site-header {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "brand"
+      "controls"
+      "nav";
+  }
+
+  .header-controls {
+    justify-content: flex-end;
+    width: 100%;
+  }
+
+  .site-stats {
+    justify-content: flex-end;
+  }
+
+  .header-nav-row {
+    width: 100%;
+    justify-content: flex-end;
   }
 }
 
 @media (max-width: 640px) {
   .console-tabs {
-    order: -1;
-    width: 100%;
+    width: fit-content;
+    max-width: 100%;
   }
   .console-tab {
-    flex: 1;
     text-align: center;
   }
 }
@@ -1723,16 +1939,19 @@ fieldset.topic-filters {
 
 /* ── Responsive ──────────────────────────────────────────────────────────── */
 
-@media (max-width: 52rem) {
+@media (max-width: 40rem) {
   .header-brand .site-tagline { display: none; }
-  .stat { display: none; }
-  .stat:first-child { display: inline-flex; }
+  .stat--session { display: none; }
   .elements-grid { grid-template-columns: repeat(auto-fill, minmax(min(100%, 11.5rem), 1fr)); }
   .elements-grid[data-view="detail"] { grid-template-columns: 1fr; }
   .modal-dialog { height: calc(100vh - 0.5rem); border-radius: 0; }
   .modal-toolbar { flex-wrap: wrap; }
   .elements-grid[data-view="list"] .card-header { width: 9rem; }
   .elements-grid[data-view="list"] .card-description { display: none; }
+}
+
+@media (max-width: 30rem) {
+  .stat:nth-child(2) { display: none; }
 }
 
 /* ── Directive-style instructions ─────────────────────────────────── */

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -147,6 +147,7 @@ p, li { max-width: 69ch; }
   top: 0;
   z-index: 35;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
@@ -168,8 +169,8 @@ p, li { max-width: 69ch; }
   pointer-events: none;
 }
 
-.header-brand { display: flex; flex-direction: row; align-items: center; gap: 0.6rem; }
-.header-brand-text { display: flex; flex-direction: column; gap: 0.05rem; }
+.header-brand { display: flex; flex-direction: row; align-items: center; gap: 0.6rem; min-width: 0; }
+.header-brand-text { display: flex; flex-direction: column; gap: 0.05rem; min-width: 0; }
 .header-logo { width: 32px; height: 32px; flex-shrink: 0; }
 
 .site-title {
@@ -191,17 +192,23 @@ p, li { max-width: 69ch; }
 .header-right {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
   gap: 0.65rem;
-  flex-shrink: 0;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .site-stats {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 0.5rem;
   font-family: var(--font-mono);
   font-size: 0.72rem;
   color: var(--ink-500);
+  min-width: 0;
 }
 
 .stat {
@@ -1338,6 +1345,7 @@ body.modal-open { overflow: hidden; }
   background: var(--surface-1);
   border-radius: var(--radius-sm);
   padding: 2px;
+  min-width: 0;
 }
 
 .console-tab {
@@ -1363,6 +1371,33 @@ body.modal-open { overflow: hidden; }
   background: var(--paper-strong);
   color: var(--signal);
   box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+}
+
+@media (max-width: 1100px) {
+  .site-header {
+    align-items: flex-start;
+  }
+
+  .header-right {
+    width: 100%;
+    justify-content: flex-start;
+    row-gap: 0.55rem;
+  }
+
+  .console-tabs {
+    order: 3;
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .site-stats {
+    flex: 1 1 auto;
+    justify-content: flex-start;
+  }
+
+  .theme-toggle {
+    margin-left: auto;
+  }
 }
 
 @media (max-width: 640px) {

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -47,6 +47,10 @@ function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function normalizeNewlines(value: string): string {
+  return value.replaceAll('\r\n', '\n');
+}
+
 function createDom(html: string): { window: JSDOM['window']; cleanup: () => void } {
   const dom = new JSDOM(`<!DOCTYPE html><html><body>${html}</body></html>`, {
     url: 'http://localhost:41715',
@@ -255,13 +259,14 @@ describe('Web console cleanup regressions', () => {
   });
 
   it('hides the session chip before collapsing the compact header into a single-column stack', () => {
-    expect(stylesCssSource).toContain('@media (max-width: 46rem)');
-    expect(stylesCssSource).toContain('.stat--session {\n    display: none;');
-    expect(stylesCssSource).toContain('@media (max-width: 28rem)');
-    expect(stylesCssSource).toContain('grid-template-areas: "brand nav controls";');
-    expect(stylesCssSource).toContain('.header-brand-text {\n    display: none;');
-    expect(stylesCssSource).toContain('@media (max-width: 24rem)');
-    expect(stylesCssSource).toContain('grid-template-areas:\n      "brand"\n      "controls"\n      "nav";');
+    const normalizedStyles = normalizeNewlines(stylesCssSource);
+    expect(normalizedStyles).toContain('@media (max-width: 46rem)');
+    expect(normalizedStyles).toContain('.stat--session {\n    display: none;');
+    expect(normalizedStyles).toContain('@media (max-width: 28rem)');
+    expect(normalizedStyles).toContain('grid-template-areas: "brand nav controls";');
+    expect(normalizedStyles).toContain('.header-brand-text {\n    display: none;');
+    expect(normalizedStyles).toContain('@media (max-width: 24rem)');
+    expect(normalizedStyles).toContain('grid-template-areas:\n      "brand"\n      "controls"\n      "nav";');
   });
 
   it('shows a visible collection banner when the community collection fetch fails', async () => {
@@ -1231,8 +1236,9 @@ describe('Web console cleanup regressions', () => {
   });
 
   it('keeps the logs viewport above the fixed footer in CSS', () => {
-    expect(logsCssSource).toContain('height: calc(100dvh - var(--site-footer-height, 4.5rem) - 120px);');
-    expect(logsCssSource).toContain('height: calc(100dvh - var(--site-footer-height, 4.5rem) - 104px);');
+    const normalizedLogsCss = normalizeNewlines(logsCssSource);
+    expect(normalizedLogsCss).toContain('height: calc(100dvh - var(--site-footer-height, 4.5rem) - 120px);');
+    expect(normalizedLogsCss).toContain('height: calc(100dvh - var(--site-footer-height, 4.5rem) - 104px);');
   });
 
   it('shows a visible metrics banner when the latest metrics fetch fails', async () => {

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -171,6 +171,85 @@ describe('Web console cleanup regressions', () => {
     cleanup();
   });
 
+  it('collapses wrapped console tabs into a hamburger menu instead of a second row', async () => {
+    const { window: win, cleanup } = createDom(`
+      <button id="theme-toggle"></button>
+      <span id="theme-toggle-icon"></span>
+      <span id="theme-toggle-label"></span>
+      <link id="hljs-theme-light">
+      <link id="hljs-theme-dark">
+      <div id="view-toggle"><button class="view-btn" data-view="grid"></button></div>
+      <select id="sort-select"><option value="date-desc">date-desc</option></select>
+      <input id="search-input">
+      <div id="source-toggle"><button data-source="all"></button></div>
+      <button id="btn-portfolio"></button>
+      <div class="header-nav-row">
+        <div id="console-tabs">
+          <button class="console-tab active" data-tab="portfolio">Portfolio</button>
+          <button class="console-tab" data-tab="permissions">Permissions</button>
+        </div>
+        <div id="console-tab-menu-shell">
+          <button id="console-tab-menu-toggle" hidden aria-expanded="false"></button>
+          <div id="console-tab-menu" hidden></div>
+        </div>
+      </div>
+      <div id="tab-portfolio" class="tab-panel active"></div>
+      <div id="tab-permissions" class="tab-panel"></div>
+      <div id="stats"></div>
+      <div><div id="type-filters"></div></div>
+      <div id="topic-filters"></div>
+      <div id="results-count"></div>
+      <div id="results-announcer"></div>
+      <div id="elements-grid"></div>
+      <div id="pagination" hidden><button id="btn-prev-page"></button><button id="btn-next-page"></button><span id="page-info"></span></div>
+      <div id="footer-updated"></div>
+      <div id="session-indicator"></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn((url: string) => {
+      if (url === '/api/elements') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ elements: { personas: [] }, totalCount: 0 }),
+        });
+      }
+      if (url === '/api/collection') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ elements: {}, totalCount: 0, updatedAt: null }),
+        });
+      }
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    win.eval(appSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    await wait(DEFAULT_WAIT_MS);
+
+    const tabButtons = Array.from(win.document.querySelectorAll('#console-tabs .console-tab')) as HTMLElement[];
+    Object.defineProperty(tabButtons[0], 'offsetTop', { configurable: true, get: () => 0 });
+    Object.defineProperty(tabButtons[1], 'offsetTop', { configurable: true, get: () => 24 });
+    win.dispatchEvent(new win.Event('resize'));
+    await wait(DEFAULT_WAIT_MS);
+
+    const navRow = win.document.querySelector('.header-nav-row');
+    const menuToggle = win.document.getElementById('console-tab-menu-toggle') as HTMLButtonElement | null;
+    expect(navRow?.classList.contains('header-nav-row--collapsed')).toBe(true);
+    expect(menuToggle?.hidden).toBe(false);
+
+    menuToggle?.click();
+    await wait(DEFAULT_WAIT_MS);
+    const menuButton = win.document.querySelector('.console-tab-menu-item[data-tab="permissions"]') as HTMLButtonElement | null;
+    expect(menuButton).not.toBeNull();
+    menuButton?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    expect(win.document.querySelector('#console-tabs .console-tab.active')?.getAttribute('data-tab')).toBe('permissions');
+    expect(win.document.getElementById('tab-permissions')?.classList.contains('active')).toBe(true);
+
+    cleanup();
+  });
+
   it('shows a visible collection banner when the community collection fetch fails', async () => {
     const { window: win, cleanup } = createDom(`
       <button id="theme-toggle"></button>

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -15,8 +15,10 @@ import { PACKAGE_VERSION } from '../../../src/generated/version.js';
 let appSource = '';
 let sessionsSource = '';
 let logsSource = '';
+let logsCssSource = '';
 let metricsSource = '';
 let permissionsSource = '';
+let stylesCssSource = '';
 
 type TestWindow = JSDOM['window'] & typeof globalThis & Record<string, any>;
 
@@ -26,12 +28,14 @@ const SESSION_FILTER_INJECTION_WAIT_MS = 40;
 
 beforeAll(async () => {
   const base = join(process.cwd(), 'src/web/public');
-  [appSource, sessionsSource, logsSource, metricsSource, permissionsSource] = await Promise.all([
+  [appSource, sessionsSource, logsSource, logsCssSource, metricsSource, permissionsSource, stylesCssSource] = await Promise.all([
     readFile(join(base, 'app.js'), 'utf8'),
     readFile(join(base, 'sessions.js'), 'utf8'),
     readFile(join(base, 'logs.js'), 'utf8'),
+    readFile(join(base, 'logs.css'), 'utf8'),
     readFile(join(base, 'metrics.js'), 'utf8'),
     readFile(join(base, 'permissions.js'), 'utf8'),
+    readFile(join(base, 'styles.css'), 'utf8'),
   ]);
 });
 
@@ -248,6 +252,16 @@ describe('Web console cleanup regressions', () => {
     expect(win.document.getElementById('tab-permissions')?.classList.contains('active')).toBe(true);
 
     cleanup();
+  });
+
+  it('hides the session chip before collapsing the compact header into a single-column stack', () => {
+    expect(stylesCssSource).toContain('@media (max-width: 46rem)');
+    expect(stylesCssSource).toContain('.stat--session {\n    display: none;');
+    expect(stylesCssSource).toContain('@media (max-width: 28rem)');
+    expect(stylesCssSource).toContain('grid-template-areas: "brand nav controls";');
+    expect(stylesCssSource).toContain('.header-brand-text {\n    display: none;');
+    expect(stylesCssSource).toContain('@media (max-width: 24rem)');
+    expect(stylesCssSource).toContain('grid-template-areas:\n      "brand"\n      "controls"\n      "nav";');
   });
 
   it('shows a visible collection banner when the community collection fetch fails', async () => {
@@ -1106,6 +1120,119 @@ describe('Web console cleanup regressions', () => {
     expect(banner?.textContent).toBe('Connection lost - reconnecting...');
 
     cleanup();
+  });
+
+  it('uses taller compact log rows at narrow widths so entries do not overlap', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="tab-logs"></div>
+      <div id="log-viewer-root"></div>
+    `);
+
+    const mediaStates = new Map<string, boolean>([
+      ['(max-width: 48rem)', true],
+      ['(max-width: 32rem)', false],
+    ]);
+    win.matchMedia = jest.fn((query: string) => ({
+      matches: mediaStates.get(query) === true,
+      media: query,
+      onchange: null,
+      addListener() { /* legacy no-op */ },
+      removeListener() { /* legacy no-op */ },
+      addEventListener() { /* no-op */ },
+      removeEventListener() { /* no-op */ },
+      dispatchEvent() { return false; },
+    }));
+
+    const eventSource = {} as Record<string, ((event?: any) => void) | null>;
+    win.DollhouseAuth.apiEventSource = jest.fn(() => eventSource);
+    installBannerHelper(win);
+
+    win.eval(logsSource);
+    win.DollhouseConsole.logs.init();
+
+    const viewport = win.document.getElementById('log-viewport') as HTMLElement | null;
+    expect(viewport).not.toBeNull();
+    if (viewport) {
+      Object.defineProperty(viewport, 'clientHeight', { value: 320, configurable: true });
+    }
+
+    eventSource.onopen?.({});
+    eventSource.onmessage?.({
+      data: JSON.stringify({
+        id: 'log-1',
+        timestamp: '2026-04-18T18:00:00.000Z',
+        level: 'info',
+        category: 'application',
+        source: 'DollhouseMCP',
+        message: 'Compact rows should have enough height to show wrapped content without overlap.',
+      }),
+    });
+    await wait(DEFAULT_WAIT_MS);
+
+    const row = win.document.querySelector('.log-entry') as HTMLElement | null;
+    expect(row).not.toBeNull();
+    expect(row?.style.height).toBe('74px');
+
+    cleanup();
+  });
+
+  it('uses extra-tall compact log rows at very narrow widths', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="tab-logs"></div>
+      <div id="log-viewer-root"></div>
+    `);
+
+    const mediaStates = new Map<string, boolean>([
+      ['(max-width: 48rem)', true],
+      ['(max-width: 32rem)', true],
+    ]);
+    win.matchMedia = jest.fn((query: string) => ({
+      matches: mediaStates.get(query) === true,
+      media: query,
+      onchange: null,
+      addListener() { /* legacy no-op */ },
+      removeListener() { /* legacy no-op */ },
+      addEventListener() { /* no-op */ },
+      removeEventListener() { /* no-op */ },
+      dispatchEvent() { return false; },
+    }));
+
+    const eventSource = {} as Record<string, ((event?: any) => void) | null>;
+    win.DollhouseAuth.apiEventSource = jest.fn(() => eventSource);
+    installBannerHelper(win);
+
+    win.eval(logsSource);
+    win.DollhouseConsole.logs.init();
+
+    const viewport = win.document.getElementById('log-viewport') as HTMLElement | null;
+    expect(viewport).not.toBeNull();
+    if (viewport) {
+      Object.defineProperty(viewport, 'clientHeight', { value: 320, configurable: true });
+    }
+
+    eventSource.onopen?.({});
+    eventSource.onmessage?.({
+      data: JSON.stringify({
+        id: 'log-2',
+        timestamp: '2026-04-18T18:00:00.000Z',
+        level: 'warn',
+        category: 'security',
+        source: 'SecurityMonitor',
+        message: 'Extra compact rows need a taller height because the time and message split across more lines on narrow screens.',
+      }),
+    });
+    await wait(DEFAULT_WAIT_MS);
+
+    const row = win.document.querySelector('.log-entry') as HTMLElement | null;
+    expect(row).not.toBeNull();
+    expect(row?.style.height).toBe('96px');
+
+    cleanup();
+  });
+
+  it('keeps the logs viewport above the fixed footer in CSS', () => {
+    expect(logsCssSource).toContain('height: calc(100dvh - var(--site-footer-height, 4.5rem) - 120px);');
+    expect(logsCssSource).toContain('height: calc(100dvh - var(--site-footer-height, 4.5rem) - 104px);');
   });
 
   it('shows a visible metrics banner when the latest metrics fetch fails', async () => {

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -248,7 +248,7 @@ describe('Web console cleanup regressions', () => {
     menuButton?.click();
     await wait(DEFAULT_WAIT_MS);
 
-    expect(win.document.querySelector('#console-tabs .console-tab.active')?.getAttribute('data-tab')).toBe('permissions');
+    expect((win.document.querySelector('#console-tabs .console-tab.active') as HTMLElement | null)?.dataset.tab).toBe('permissions');
     expect(win.document.getElementById('tab-permissions')?.classList.contains('active')).toBe(true);
 
     cleanup();


### PR DESCRIPTION
## Summary
- let the header right-hand controls shrink and wrap instead of crowding the tab row
- move the console tabs onto their own row earlier at mid-width viewports around 1100px
- keep the existing mobile fallback while making portrait and mid-width layouts feel consistent with the permissions cards below

## Testing
- npm test -- --runInBand tests/unit/web/console-ui-regressions.test.ts

Closes #1990