### PR TITLE
Harden collection author metadata rendering

### DIFF
--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -118,6 +118,10 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
       .replaceAll("'", '&#39;');
   }
 
+  function normalizeInlineMetaText(value) {
+    return typeof value === 'string' ? value.trim() : '';
+  }
+
   function renderHeaderStatsMarkup(primaryMarkup) {
     const sessionTitle = DOLLHOUSE_RUNTIME_SESSION_ID && DOLLHOUSE_RUNTIME_SESSION_ID !== DOLLHOUSE_SESSION_ID
       ? `Stable session ${DOLLHOUSE_SESSION_ID}; runtime ${DOLLHOUSE_RUNTIME_SESSION_ID}`
@@ -549,6 +553,7 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
       const idx = pageStart + i; // absolute index into filteredElements
       const unavailable = el._unavailable;
       const compSummary = renderComponentSummary(el);
+      const author = normalizeInlineMetaText(el.author);
       return `
       <article
         class="element-card"
@@ -574,7 +579,7 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
         ${compSummary}
         <footer class="card-footer">
           <div class="card-meta">
-            ${el.author   ? `<span class="meta-author">${escapeHtml(el.author)}</span>` : ''}
+            ${author      ? `<span class="meta-author">by ${escapeHtml(author)}</span>` : ''}
             ${el.version  ? `<span class="meta-version">v${escapeHtml(el.version)}</span>` : ''}
             ${el.category ? `<span class="meta-category">${escapeHtml(el.category)}</span>` : ''}
             ${el.created  ? `<span class="meta-date">${formatDate(el.created)}</span>` : ''}
@@ -773,9 +778,10 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
   }
 
   function setupModalMeta(element, modal) {
+    const author = normalizeInlineMetaText(element.author);
     modal.querySelector('.modal-title').textContent   = element.name;
     modal.querySelector('.modal-type').textContent    = capitalize(element.type);
-    modal.querySelector('.modal-author').textContent  = element.author ? `by ${element.author}` : '';
+    modal.querySelector('.modal-author').textContent  = author ? `by ${author}` : '';
     modal.querySelector('.modal-version').textContent = element.version ? `v${element.version}` : '';
     const modalDate   = modal.querySelector('.modal-date');
     const modalSource = modal.querySelector('.modal-source');

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -766,12 +766,6 @@ p, li { max-width: 69ch; }
   color: var(--ink-500);
 }
 
-/* "by" prefix handled by CSS so JS can pass raw author value */
-.meta-author::before {
-  content: "by\00a0";
-  opacity: 0.65;
-}
-
 .meta-version {
   border: 1px solid color-mix(in srgb, var(--line) 82%, var(--paper-strong));
   border-radius: 0.24rem;

--- a/tests/unit/web/collectionMetadataSource.test.ts
+++ b/tests/unit/web/collectionMetadataSource.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const PUBLIC_DIR = join(process.cwd(), 'src', 'web', 'public');
+
+describe('collection metadata author rendering', () => {
+  it('normalizes author text before rendering card and modal metadata', () => {
+    const appJs = readFileSync(join(PUBLIC_DIR, 'app.js'), 'utf-8');
+
+    expect(appJs).toContain("function normalizeInlineMetaText(value)");
+    expect(appJs).toContain("const author = normalizeInlineMetaText(el.author);");
+    expect(appJs).toContain('${author      ? `<span class="meta-author">by ${escapeHtml(author)}</span>` : \'\'}');
+    expect(appJs).toContain("const author = normalizeInlineMetaText(element.author);");
+    expect(appJs).toContain("modal.querySelector('.modal-author').textContent  = author ? `by ${author}` : '';");
+  });
+
+  it('does not inject a CSS-only by prefix for author metadata chips', () => {
+    const styles = readFileSync(join(PUBLIC_DIR, 'styles.css'), 'utf-8');
+
+    expect(styles).not.toContain('.meta-author::before');
+    expect(styles).not.toContain('content: "by\\00a0";');
+  });
+});

--- a/tests/unit/web/collectionMetadataSource.test.ts
+++ b/tests/unit/web/collectionMetadataSource.test.ts
@@ -19,6 +19,6 @@ describe('collection metadata author rendering', () => {
     const styles = readFileSync(join(PUBLIC_DIR, 'styles.css'), 'utf-8');
 
     expect(styles).not.toContain('.meta-author::before');
-    expect(styles).not.toContain('content: "by\\00a0";');
+    expect(styles).not.toContain(String.raw`content: "by\00a0";`);
   });
 });


### PR DESCRIPTION
## Summary
- normalize author metadata before rendering collection cards and modal metadata
- stop using a CSS-generated `by` prefix so empty or malformed author chips cannot paint stray text
- add a focused regression test for author metadata rendering

## Testing
- npm test -- --runInBand tests/unit/web/collectionMetadataSource.test.ts
- npx eslint src/web/public/app.js tests/unit/web/collectionMetadataSource.test.ts