### PR TITLE
Log permission rate-limit bypass events

### DIFF
--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -69,6 +69,13 @@ interface PermissionDecisionTracker {
   getRecentDecisions(): PermissionDecision[];
 }
 
+interface PermissionRateLimitLogContext {
+  tool_name?: string;
+  platform: string;
+  session_id?: string;
+  input_fields: string[];
+}
+
 const CLAUDE_COMPATIBLE_HOOK_PLATFORMS = new Set(['claude_code', 'vscode']);
 const NORMALIZABLE_PERMISSION_DECISIONS = new Set(['allow', 'deny', 'ask']);
 type NormalizablePermissionDecision = 'allow' | 'deny' | 'ask';
@@ -104,6 +111,21 @@ function extractReason(result: Record<string, unknown>): string {
   }
 
   return extractString(result, ['reason', 'message'], '');
+}
+
+function buildPermissionRateLimitLogContext(
+  toolName: string | undefined,
+  platform: string,
+  sessionId: string | undefined,
+  input: Record<string, unknown> | undefined,
+): PermissionRateLimitLogContext {
+  const inputFields = input ? Object.keys(input).sort().slice(0, 12) : [];
+  return {
+    ...(toolName ? { tool_name: toolName } : {}),
+    platform,
+    ...(sessionId ? { session_id: sessionId } : {}),
+    input_fields: inputFields,
+  };
 }
 
 function shouldNormalizeClaudeHook(platform: string | undefined): boolean {
@@ -363,17 +385,20 @@ export function registerPermissionRoutes(
       session_id?: string;
     };
     const platform = typeof body.platform === 'string' ? body.platform.normalize('NFC') : 'claude_code';
+    const tool_name = typeof body.tool_name === 'string' ? body.tool_name.normalize('NFC') : undefined;
+    const session_id = typeof body.session_id === 'string' ? body.session_id.normalize('NFC') : undefined;
+    const input = body.input;
 
     if (!permissionLimiter.tryAcquire()) {
+      logger.warn(
+        '[WebUI/Gateway] evaluate_permission rate limit exceeded; failing open',
+        buildPermissionRateLimitLogContext(tool_name, platform, session_id, input),
+      );
       res.json(formatPermissionResponse('allow', platform, {})); // fail open on rate limit
       return;
     }
 
     // Unicode normalization (NFC) on string inputs to prevent homograph attacks
-    const tool_name = typeof body.tool_name === 'string' ? body.tool_name.normalize('NFC') : undefined;
-    const session_id = typeof body.session_id === 'string' ? body.session_id.normalize('NFC') : undefined;
-    const input = body.input;
-
     if (!tool_name) {
       res.json(formatPermissionResponse('allow', platform, input || {})); // fail open on bad input
       return;

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -119,7 +119,11 @@ function buildPermissionRateLimitLogContext(
   sessionId: string | undefined,
   input: Record<string, unknown> | undefined,
 ): PermissionRateLimitLogContext {
-  const inputFields = input ? Object.keys(input).sort().slice(0, 12) : [];
+  const inputFields = input
+    ? Object.keys(input)
+      .sort((left, right) => left.localeCompare(right))
+      .slice(0, 12)
+    : [];
   return {
     ...(toolName ? { tool_name: toolName } : {}),
     platform,

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -64,7 +64,7 @@ describe('permissionRoutes', () => {
           .post('/api/evaluate_permission')
           .send({
             tool_name: 'Bash',
-            input: { command: 'printf super-secret', path: '/tmp/example' },
+            input: { command: 'printf super-secret', path: join(tempHome, 'example') },
             platform: 'claude_code',
             session_id: 'session-follower-1',
           }),

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -13,6 +13,7 @@ import { join } from 'node:path';
 import { mkdir, mkdtemp, readFile, rm, unlink, writeFile } from 'node:fs/promises';
 import { registerPermissionRoutes } from '../../../src/web/routes/permissionRoutes.js';
 import { getPermissionHookMarkerPath } from '../../../src/utils/permissionHooks.js';
+import { logger } from '../../../src/utils/logger.js';
 
 function createMockHandler(readResult?: unknown) {
   return {
@@ -53,6 +54,46 @@ describe('permissionRoutes', () => {
   });
 
   describe('POST /api/evaluate_permission', () => {
+    it('should log rate-limit bypass events without raw request payloads', async () => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+      const handler = createMockHandler();
+      const app = createApp(handler);
+
+      const requests = Array.from({ length: 121 }, () =>
+        request(app)
+          .post('/api/evaluate_permission')
+          .send({
+            tool_name: 'Bash',
+            input: { command: 'printf super-secret', path: '/tmp/example' },
+            platform: 'claude_code',
+            session_id: 'session-follower-1',
+          }),
+      );
+
+      const responses = await Promise.all(requests);
+      const bypass = responses[responses.length - 1];
+
+      expect(bypass.status).toBe(200);
+      expect(bypass.body).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+        },
+      });
+      expect(handler.handleRead).toHaveBeenCalledTimes(120);
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[WebUI/Gateway] evaluate_permission rate limit exceeded; failing open',
+        {
+          tool_name: 'Bash',
+          platform: 'claude_code',
+          session_id: 'session-follower-1',
+          input_fields: ['command', 'path'],
+        },
+      );
+      expect(warnSpy.mock.calls.at(-1)?.[1]).not.toHaveProperty('command');
+      warnSpy.mockRestore();
+    });
+
     it('should return allow for a valid request', async () => {
       const handler = createMockHandler();
       const app = createApp(handler);


### PR DESCRIPTION
## Summary
- log evaluate_permission rate-limit fail-open events with safe structured context
- preserve fail-open behavior while recording the bypass for monitoring
- add regression coverage that proves raw request payloads are not logged

## Testing
- npm test -- --runInBand tests/unit/web/permissionRoutes.test.ts
- npx eslint src/web/routes/permissionRoutes.ts tests/unit/web/permissionRoutes.test.ts