### PR TITLE
fix(ensembles): warn once for legacy name/type fields

### DIFF
--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -71,6 +71,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
   private validationService: ValidationService;
   private serializationService: SerializationService;
   private activeEnsembleNames: Set<string> = new Set();
+  private legacyElementFieldWarnings: Set<string> = new Set();
 
   constructor(
     portfolioManager: PortfolioManager,
@@ -91,6 +92,23 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
 
   protected override getElementLabel(): string {
     return 'ensemble';
+  }
+
+  private warnOnceForLegacyElementField(
+    ensembleName: string,
+    index: number,
+    field: 'name' | 'type',
+    replacement: 'element_name' | 'element_type',
+  ): void {
+    const fingerprint = `${ensembleName}:${index}:${field}`;
+    if (this.legacyElementFieldWarnings.has(fingerprint)) {
+      return;
+    }
+
+    this.legacyElementFieldWarnings.add(fingerprint);
+    logger.warn(
+      `Ensemble '${ensembleName}' element at index ${index} uses deprecated '${field}' field. Use '${replacement}' instead.`,
+    );
   }
 
   /**
@@ -217,7 +235,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       }
       // Log deprecation warning if using legacy 'name' field
       if (elem.name && !elem.element_name) {
-        logger.warn(`Ensemble element at index ${index} uses deprecated 'name' field. Use 'element_name' instead.`);
+        this.warnOnceForLegacyElementField(name, index, 'name', 'element_name');
       }
       const elementNameResult = this.validationService.validateAndSanitizeInput(
         String(rawElementName),
@@ -233,7 +251,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       const rawElementType = elem.element_type || elem.type || 'skill';
       // Log deprecation warning if using legacy 'type' field
       if (elem.type && !elem.element_type) {
-        logger.warn(`Ensemble element at index ${index} uses deprecated 'type' field. Use 'element_type' instead.`);
+        this.warnOnceForLegacyElementField(name, index, 'type', 'element_type');
       }
       const elementTypeResult = this.validationService.validateAndSanitizeInput(
         String(rawElementType),
@@ -642,7 +660,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       }
       // Log deprecation warning if using legacy 'name' field
       if (elem.name && !elem.element_name) {
-        logger.warn(`Ensemble element at index ${index} uses deprecated 'name' field. Use 'element_name' instead.`);
+        this.warnOnceForLegacyElementField(metadata.name, index, 'name', 'element_name');
       }
 
       // Support both element_type (new standard) and type (legacy)
@@ -657,7 +675,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       }
       // Log deprecation warning if using legacy 'type' field
       if (elem.type && !elem.element_type) {
-        logger.warn(`Ensemble element at index ${index} uses deprecated 'type' field. Use 'element_type' instead.`);
+        this.warnOnceForLegacyElementField(metadata.name, index, 'type', 'element_type');
       }
 
       return {

--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -65,6 +65,14 @@ export const resolveEnsembleElementTypes = resolveElementTypes;
  * - Ensemble creation and validation
  * - Element reference management
  * - Import/export in multiple formats
+ *
+ * MEMORY BEHAVIOR:
+ * - Tracks warned legacy element-field fingerprints in memory so repeated parses
+ *   of the same ensemble/element/field combination do not keep spamming logs.
+ * - Fingerprints are scoped to the manager lifetime and grow with the number of
+ *   unique legacy field sightings.
+ * - Long-running servers can clear this history explicitly with
+ *   clearLegacyElementWarningHistory(), and dispose() also clears it.
  */
 export class EnsembleManager extends BaseElementManager<Ensemble> {
   private readonly ensemblesDir: string;
@@ -92,6 +100,21 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
 
   protected override getElementLabel(): string {
     return 'ensemble';
+  }
+
+  /**
+   * Clear warn-once state for legacy ensemble element fields.
+   *
+   * Useful for long-lived processes that want to cap in-memory warning history
+   * or intentionally re-emit migration guidance after a maintenance boundary.
+   */
+  public clearLegacyElementWarningHistory(): void {
+    this.legacyElementFieldWarnings.clear();
+  }
+
+  override dispose(): void {
+    super.dispose();
+    this.clearLegacyElementWarningHistory();
   }
 
   private warnOnceForLegacyElementField(

--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -71,7 +71,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
   private validationService: ValidationService;
   private serializationService: SerializationService;
   private activeEnsembleNames: Set<string> = new Set();
-  private legacyElementFieldWarnings: Set<string> = new Set();
+  private readonly legacyElementFieldWarnings: Set<string> = new Set();
 
   constructor(
     portfolioManager: PortfolioManager,
@@ -100,6 +100,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
     field: 'name' | 'type',
     replacement: 'element_name' | 'element_type',
   ): void {
+    // Keep the fingerprint stable across parse/create paths for the same ensemble element.
     const fingerprint = `${ensembleName}:${index}:${field}`;
     if (this.legacyElementFieldWarnings.has(fingerprint)) {
       return;
@@ -647,6 +648,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
     if (!metadata.name) {
       throw new Error('Ensemble must have a name');
     }
+    const ensembleName = metadata.name;
 
     let rawElements = metadata.elements || [];
 
@@ -660,7 +662,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       }
       // Log deprecation warning if using legacy 'name' field
       if (elem.name && !elem.element_name) {
-        this.warnOnceForLegacyElementField(metadata.name, index, 'name', 'element_name');
+        this.warnOnceForLegacyElementField(ensembleName, index, 'name', 'element_name');
       }
 
       // Support both element_type (new standard) and type (legacy)
@@ -675,7 +677,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       }
       // Log deprecation warning if using legacy 'type' field
       if (elem.type && !elem.element_type) {
-        this.warnOnceForLegacyElementField(metadata.name, index, 'type', 'element_type');
+        this.warnOnceForLegacyElementField(ensembleName, index, 'type', 'element_type');
       }
 
       return {

--- a/tests/unit/elements/ensembles/EnsembleManager.test.ts
+++ b/tests/unit/elements/ensembles/EnsembleManager.test.ts
@@ -213,6 +213,29 @@ describe('EnsembleManager', () => {
       warnSpy.mockRestore();
     });
 
+    it('should allow warning history to be cleared for long-running managers', async () => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+      const metadata: any = {
+        name: 'Legacy Resettable Warning Ensemble',
+        elements: [
+          {
+            name: 'legacy-skill',
+            type: 'skill',
+            role: 'primary',
+            priority: 80,
+            activation: 'always'
+          }
+        ]
+      };
+
+      await (ensembleManager as any).parseMetadata(metadata);
+      ensembleManager.clearLegacyElementWarningHistory();
+      await (ensembleManager as any).parseMetadata(metadata);
+
+      expect(warnSpy).toHaveBeenCalledTimes(4);
+      warnSpy.mockRestore();
+    });
+
     it('should reject duplicate metadata name even with different filename (Issue #613)', async () => {
       // Create a mock ensemble that list() will return
       const mockEnsemble = {

--- a/tests/unit/elements/ensembles/EnsembleManager.test.ts
+++ b/tests/unit/elements/ensembles/EnsembleManager.test.ts
@@ -26,6 +26,7 @@ import { createTestMetadataService } from '../../../helpers/di-mocks.js';
 import { ValidationRegistry } from '../../../../src/services/validation/ValidationRegistry.js';
 import { TriggerValidationService } from '../../../../src/services/validation/TriggerValidationService.js';
 import { ValidationService } from '../../../../src/services/validation/ValidationService.js';
+import { logger } from '../../../../src/utils/logger.js';
 
 describe('EnsembleManager', () => {
   let ensembleManager: EnsembleManager;
@@ -157,6 +158,59 @@ describe('EnsembleManager', () => {
       // Verify migration happened - element should have element_name/element_type
       expect(ensemble.metadata.elements[0].element_name).toBe('legacy-skill');
       expect(ensemble.metadata.elements[0].element_type).toBe('skill');
+    });
+
+    it('should warn once for repeated legacy field parsing on the same ensemble', async () => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+      const legacyMetadata = {
+        name: 'Legacy Parse Ensemble',
+        elements: [
+          {
+            name: 'legacy-skill',
+            type: 'skill',
+            role: 'primary',
+            priority: 80,
+            activation: 'always'
+          }
+        ]
+      };
+
+      await (ensembleManager as any).parseMetadata(legacyMetadata);
+      await (ensembleManager as any).parseMetadata(legacyMetadata);
+
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      expect(warnSpy).toHaveBeenNthCalledWith(
+        1,
+        "Ensemble 'Legacy Parse Ensemble' element at index 0 uses deprecated 'name' field. Use 'element_name' instead."
+      );
+      expect(warnSpy).toHaveBeenNthCalledWith(
+        2,
+        "Ensemble 'Legacy Parse Ensemble' element at index 0 uses deprecated 'type' field. Use 'element_type' instead."
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('should not re-warn for the same legacy fields across create and parse paths', async () => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+      const metadata: any = {
+        name: 'Legacy Shared Warning Ensemble',
+        description: 'Testing bounded legacy warnings',
+        elements: [
+          {
+            name: 'legacy-skill',
+            type: 'skill',
+            role: 'primary',
+            priority: 80,
+            activation: 'always'
+          }
+        ]
+      };
+
+      await ensembleManager.create(metadata);
+      await (ensembleManager as any).parseMetadata(metadata);
+
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      warnSpy.mockRestore();
     });
 
     it('should reject duplicate metadata name even with different filename (Issue #613)', async () => {


### PR DESCRIPTION
## Summary
- bound legacy ensemble field deprecation warnings per ensemble/element fingerprint
- route both parse paths through the same warn-once helper
- add regression coverage for repeated parse and create/parse flows

## Testing
- npm test -- --runInBand tests/unit/elements/ensembles/EnsembleManager.test.ts
- npx eslint src/elements/ensembles/EnsembleManager.ts tests/unit/elements/ensembles/EnsembleManager.test.ts

Closes #2076