### PR TITLE
fix(logging): coalesce repeated content-injection alerts

### DIFF
--- a/src/logging/LogHooks.ts
+++ b/src/logging/LogHooks.ts
@@ -15,6 +15,7 @@
 import type { LogManager } from './LogManager.js';
 import type { LogLevel, UnifiedLogEntry } from './types.js';
 import { SecurityMonitor } from '../security/securityMonitor.js';
+import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
 import { DefaultElementProvider } from '../portfolio/DefaultElementProvider.js';
 import { LRUCache } from '../cache/LRUCache.js';
 import { EventDeduplicator } from '../utils/EventDeduplicator.js';
@@ -43,7 +44,8 @@ function extractContentInjectionKey(value: unknown): string | null {
     return null;
   }
 
-  const normalized = value.replace(/^Detected pattern:\s*/i, '').trim();
+  const normalizedValue = UnicodeValidator.normalize(value).normalizedContent;
+  const normalized = normalizedValue.replace(/^Detected pattern:\s*/i, '').trim();
   return normalized === '' ? null : `CONTENT_INJECTION\0${normalized}`;
 }
 

--- a/src/logging/LogHooks.ts
+++ b/src/logging/LogHooks.ts
@@ -17,6 +17,7 @@ import type { LogLevel, UnifiedLogEntry } from './types.js';
 import { SecurityMonitor } from '../security/securityMonitor.js';
 import { DefaultElementProvider } from '../portfolio/DefaultElementProvider.js';
 import { LRUCache } from '../cache/LRUCache.js';
+import { EventDeduplicator } from '../utils/EventDeduplicator.js';
 
 // ---------------------------------------------------------------------------
 // Severity → LogLevel helper (shared by SecurityMonitor, SecurityTelemetry,
@@ -33,6 +34,18 @@ const SEVERITY_TO_LEVEL: Record<string, LogLevel> = {
   medium: 'warn',
   low: 'info',
 };
+
+const CONTENT_INJECTION_VISIBILITY_WINDOW_MS = 10 * 60_000;
+const CONTENT_INJECTION_VISIBILITY_MAX_KEYS = 500;
+
+function extractContentInjectionKey(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.replace(/^Detected pattern:\s*/i, '').trim();
+  return normalized === '' ? null : `CONTENT_INJECTION\0${normalized}`;
+}
 
 // ---------------------------------------------------------------------------
 // CorrelationId provider interface (subset of ContextTracker)
@@ -102,6 +115,10 @@ export function wireLogHooks(
   container: { resolve<T>(name: string): T },
 ): (() => void)[] {
   const cleanups: (() => void)[] = [];
+  const contentInjectionVisibilityDedup = new EventDeduplicator(
+    CONTENT_INJECTION_VISIBILITY_WINDOW_MS,
+    CONTENT_INJECTION_VISIBILITY_MAX_KEYS,
+  );
 
   // Resolve ContextTracker for correlationId injection
   let contextTracker: CorrelationIdProvider | null = null;
@@ -115,6 +132,15 @@ export function wireLogHooks(
       addLogListener(fn: (entry: { timestamp: Date; level: string; message: string; data?: any }) => void): () => void;
     }>('MCPLogger');
     const unsub = mcpLogger.addLogListener((logEntry) => {
+      const contentInjectionKey =
+        logEntry.message === '[CRITICAL SECURITY ALERT]' &&
+        logEntry.data?.type === 'CONTENT_INJECTION_ATTEMPT'
+          ? extractContentInjectionKey(logEntry.data?.details)
+          : null;
+      if (contentInjectionKey !== null && contentInjectionVisibilityDedup.shouldSuppress(contentInjectionKey)) {
+        return;
+      }
+
       const entry: UnifiedLogEntry = {
         id: logManager.generateId(),
         timestamp: logEntry.timestamp.toISOString(),
@@ -133,6 +159,14 @@ export function wireLogHooks(
   // --- SecurityMonitor (security, static) ---------------------------------
   {
     const unsub = SecurityMonitor.addLogListener((logEntry) => {
+      const contentInjectionKey =
+        logEntry.type === 'CONTENT_INJECTION_ATTEMPT'
+          ? extractContentInjectionKey(logEntry.details)
+          : null;
+      if (contentInjectionKey !== null && contentInjectionVisibilityDedup.shouldSuppress(contentInjectionKey)) {
+        return;
+      }
+
       const entry: UnifiedLogEntry = {
         id: logManager.generateId(),
         timestamp: logEntry.timestamp,
@@ -162,6 +196,14 @@ export function wireLogHooks(
       }) => void): () => void;
     }>('SecurityTelemetry');
     const unsub = secTelemetry.addLogListener((telEntry) => {
+      const contentInjectionKey =
+        telEntry.attackType === 'CONTENT_INJECTION'
+          ? extractContentInjectionKey(telEntry.pattern)
+          : null;
+      if (contentInjectionKey !== null && contentInjectionVisibilityDedup.shouldSuppress(contentInjectionKey)) {
+        return;
+      }
+
       const entry: UnifiedLogEntry = {
         id: logManager.generateId(),
         timestamp: telEntry.timestamp,

--- a/tests/unit/logging/LogHooks.test.ts
+++ b/tests/unit/logging/LogHooks.test.ts
@@ -289,6 +289,97 @@ describe('LogHooks', () => {
 
       expect(mockLogManager.logCalls[0].level).toBe('warn');
     });
+
+    it('should suppress duplicate content-injection rows across monitor, alert, and telemetry channels', () => {
+      const mcpListener = jest.fn();
+      const telemetryListener = jest.fn();
+      let securityMonitorListener: any;
+      const securitySpy = jest.spyOn(SecurityMonitor, 'addLogListener').mockImplementation((fn: any) => {
+        securityMonitorListener = fn;
+        return jest.fn() as any;
+      });
+      const mcpLogger = {
+        addLogListener: jest.fn((fn) => {
+          mcpListener.mockImplementation(fn);
+          return jest.fn();
+        }),
+      };
+      const secTelemetry = {
+        addLogListener: jest.fn((fn) => {
+          telemetryListener.mockImplementation(fn);
+          return jest.fn();
+        }),
+      };
+      const container = makeMockContainer({ MCPLogger: mcpLogger, SecurityTelemetry: secTelemetry });
+
+      wireLogHooks(mockLogManager, container);
+
+      securityMonitorListener({
+        timestamp: '2026-02-10T12:00:00.000Z',
+        type: 'CONTENT_INJECTION_ATTEMPT',
+        severity: 'CRITICAL',
+        source: 'content_validation',
+        details: 'Detected pattern: HTML script injection',
+      });
+
+      mcpListener({
+        timestamp: new Date('2026-02-10T12:00:00.100Z'),
+        level: 'error',
+        message: '[CRITICAL SECURITY ALERT]',
+        data: {
+          type: 'CONTENT_INJECTION_ATTEMPT',
+          details: 'Detected pattern: HTML script injection',
+        },
+      });
+
+      telemetryListener({
+        timestamp: '2026-02-10T12:00:00.200Z',
+        attackType: 'CONTENT_INJECTION',
+        pattern: 'HTML script injection',
+        severity: 'CRITICAL',
+        source: 'content_validation',
+      });
+
+      expect(mockLogManager.logCalls).toHaveLength(1);
+      expect(mockLogManager.logCalls[0]).toMatchObject({
+        category: 'security',
+        source: 'SecurityMonitor',
+        message: '[CONTENT_INJECTION_ATTEMPT] Detected pattern: HTML script injection',
+      });
+      securitySpy.mockRestore();
+    });
+
+    it('should keep distinct content-injection patterns visible', () => {
+      let securityMonitorListener: any;
+      const securitySpy = jest.spyOn(SecurityMonitor, 'addLogListener').mockImplementation((fn: any) => {
+        securityMonitorListener = fn;
+        return jest.fn() as any;
+      });
+      const container = makeMockContainer({});
+
+      wireLogHooks(mockLogManager, container);
+
+      securityMonitorListener({
+        timestamp: '2026-02-10T12:00:00.000Z',
+        type: 'CONTENT_INJECTION_ATTEMPT',
+        severity: 'CRITICAL',
+        source: 'content_validation',
+        details: 'Detected pattern: HTML script injection',
+      });
+
+      securityMonitorListener({
+        timestamp: '2026-02-10T12:00:01.000Z',
+        type: 'CONTENT_INJECTION_ATTEMPT',
+        severity: 'CRITICAL',
+        source: 'content_validation',
+        details: 'Detected pattern: Instruction override',
+      });
+
+      expect(mockLogManager.logCalls).toHaveLength(2);
+      expect(mockLogManager.logCalls[0].message).toContain('HTML script injection');
+      expect(mockLogManager.logCalls[1].message).toContain('Instruction override');
+      securitySpy.mockRestore();
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- coalesce repeated content-injection visibility in the unified log bridge
- suppress duplicate rows across SecurityMonitor, MCPLogger critical alerts, and SecurityTelemetry
- keep distinct blocked patterns visible in the web console

## Testing
- npm test -- --runInBand tests/unit/logging/LogHooks.test.ts
- npx eslint src/logging/LogHooks.ts tests/unit/logging/LogHooks.test.ts

Closes #2074