### PR TITLE
fix: re-evaluate follower console authority

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -217,6 +217,34 @@ const envSchema = z.object({
   DOLLHOUSE_CONSOLE_MAX_FORWARD_FAILURES: z.coerce.number().int().min(1).max(100).default(10),
 
   /**
+   * How often a follower re-evaluates whether it should take over console
+   * leadership in a heterogeneous mixed-version environment.
+   * Default: 15000ms.
+   */
+  DOLLHOUSE_CONSOLE_AUTHORITY_RECHECK_MS: z.coerce.number().int().min(1_000).max(300_000).default(15_000),
+
+  /**
+   * Additional per-session jitter added to authority rechecks so large mixed
+   * fleets do not all wake up in the same instant.
+   * Default: 5000ms.
+   */
+  DOLLHOUSE_CONSOLE_AUTHORITY_RECHECK_JITTER_MS: z.coerce.number().int().min(0).max(60_000).default(5_000),
+
+  /**
+   * Number of consecutive authority recheck failures before the follower opens
+   * its local circuit breaker and stops retrying until the cooldown expires.
+   * Default: 3.
+   */
+  DOLLHOUSE_CONSOLE_AUTHORITY_RECHECK_FAILURE_THRESHOLD: z.coerce.number().int().min(1).max(100).default(3),
+
+  /**
+   * Cooldown period after the follower authority monitor opens its circuit
+   * breaker due to repeated failures.
+   * Default: 60000ms.
+   */
+  DOLLHOUSE_CONSOLE_AUTHORITY_RECHECK_FAILURE_COOLDOWN_MS: z.coerce.number().int().min(1_000).max(900_000).default(60_000),
+
+  /**
    * Issue #1780: Phase 2 — require a confirmation code (OS dialog or TOTP)
    * for privileged actions like token rotation. Default is true for safety;
    * set to false for headless CI and scripted deployments that need to rotate

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -64,6 +64,7 @@ const DEFAULT_CONSOLE_PORT = env.DOLLHOUSE_WEB_CONSOLE_PORT;
 const LEGACY_CONSOLE_FALLBACK_PORT = 3939;
 const SYNTHETIC_PORT_OWNER_SESSION_PREFIX = 'port-owner-';
 const LEADER_DISCOVERY_TIMEOUT_MS = 2_000;
+const FOLLOWER_AUTHORITY_RECHECK_MS = 15_000;
 
 function currentTimestamp(): string {
   return new Date().toISOString();
@@ -205,6 +206,12 @@ interface FollowerAuthorityDependencies {
   discoverLeaderServingPortImpl?: typeof discoverLeaderServingPort;
   forceClaimLeadershipImpl?: typeof forceClaimLeadership;
   deleteLeaderLockImpl?: typeof deleteLeaderLock;
+}
+
+interface FollowerAuthorityMonitorDependencies extends FollowerAuthorityDependencies {
+  resolveFollowerAuthorityImpl?: typeof resolveFollowerAuthority;
+  setIntervalImpl?: typeof setInterval;
+  clearIntervalImpl?: typeof clearInterval;
 }
 
 interface DiscoveryDependencies {
@@ -540,6 +547,83 @@ export async function resolveFollowerAuthority(
     discovery,
     replacement,
     forcedClaim: false,
+  };
+}
+
+export function startFollowerAuthorityMonitor(
+  options: UnifiedConsoleOptions,
+  consolePort: number,
+  election: ElectionResult,
+  promotionMgr: PromotionManager,
+  forwardingSink: LeaderForwardingLogSink,
+  sessionHeartbeat: SessionHeartbeat,
+  deps: FollowerAuthorityMonitorDependencies = {},
+): () => void {
+  const resolveFollowerAuthorityImpl = deps.resolveFollowerAuthorityImpl ?? resolveFollowerAuthority;
+  const setIntervalImpl = deps.setIntervalImpl ?? setInterval;
+  const clearIntervalImpl = deps.clearIntervalImpl ?? clearInterval;
+  let currentElection = election;
+  let checkInProgress = false;
+  let promotionQueued = false;
+  let authorityTimer: ReturnType<typeof setInterval> | null = null;
+
+  authorityTimer = setIntervalImpl(() => {
+    if (checkInProgress || promotionQueued) {
+      return;
+    }
+
+    checkInProgress = true;
+    resolveFollowerAuthorityImpl(options.sessionId, consolePort, currentElection)
+      .then((resolved) => {
+        currentElection = resolved.election;
+
+        if (resolved.election.role !== 'leader') {
+          return;
+        }
+
+        promotionQueued = true;
+        if (authorityTimer) {
+          clearIntervalImpl(authorityTimer);
+          authorityTimer = null;
+        }
+
+        logger.warn('[UnifiedConsole] Follower authority re-evaluation queued a leader takeover', {
+          sessionId: options.sessionId,
+          stableSessionId: options.stableSessionId,
+          port: consolePort,
+          electedLeaderPid: election.leaderInfo.pid,
+          electedLeaderSessionId: election.leaderInfo.sessionId,
+          resolvedLeaderPid: resolved.election.leaderInfo.pid,
+          resolvedLeaderSessionId: resolved.election.leaderInfo.sessionId,
+          replacementReason: resolved.replacement?.preference?.reason ?? null,
+          forcedClaim: resolved.forcedClaim,
+        });
+
+        queueMicrotask(() => {
+          promotionMgr.promote(forwardingSink, sessionHeartbeat)
+            .catch((err) => logger.error('[UnifiedConsole] Authority-based promotion crashed', {
+              error: String(err),
+            }));
+        });
+      })
+      .catch((err) => {
+        logger.debug('[UnifiedConsole] Follower authority re-evaluation failed', {
+          error: err instanceof Error ? err.message : String(err),
+          sessionId: options.sessionId,
+          port: consolePort,
+        });
+      })
+      .finally(() => {
+        checkInProgress = false;
+      });
+  }, FOLLOWER_AUTHORITY_RECHECK_MS);
+  authorityTimer.unref();
+
+  return () => {
+    if (authorityTimer) {
+      clearIntervalImpl(authorityTimer);
+      authorityTimer = null;
+    }
   };
 }
 
@@ -893,6 +977,15 @@ async function startAsFollower(
   sessionHeartbeat = new SessionHeartbeat(leaderUrl, options.sessionId, process.pid, authToken);
   await sessionHeartbeat.start();
 
+  const stopAuthorityMonitor = startFollowerAuthorityMonitor(
+    options,
+    consolePort,
+    election,
+    promotionMgr,
+    forwardingSink,
+    sessionHeartbeat,
+  );
+
   logger.info('[UnifiedConsole] Follower started', {
     sessionId: options.sessionId, pid: process.pid, role: 'follower',
     leaderSession: election.leaderInfo.sessionId, leaderPid: election.leaderInfo.pid,
@@ -903,6 +996,7 @@ async function startAsFollower(
     role: 'follower',
     election,
     cleanup: async () => {
+      stopAuthorityMonitor();
       await sessionHeartbeat.stop();
       await forwardingSink.close();
     },

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -65,9 +65,19 @@ const LEGACY_CONSOLE_FALLBACK_PORT = 3939;
 const SYNTHETIC_PORT_OWNER_SESSION_PREFIX = 'port-owner-';
 const LEADER_DISCOVERY_TIMEOUT_MS = 2_000;
 const FOLLOWER_AUTHORITY_RECHECK_MS = 15_000;
+const FOLLOWER_AUTHORITY_RECHECK_JITTER_MS = 5_000;
 
 function currentTimestamp(): string {
   return new Date().toISOString();
+}
+
+function computeFollowerAuthorityRecheckInterval(sessionId: string): number {
+  const normalizedSessionId = UnicodeValidator.normalize(sessionId).normalizedContent;
+  let hash = 0;
+  for (let index = 0; index < normalizedSessionId.length; index += 1) {
+    hash = (hash * 31 + normalizedSessionId.charCodeAt(index)) >>> 0;
+  }
+  return FOLLOWER_AUTHORITY_RECHECK_MS + (hash % (FOLLOWER_AUTHORITY_RECHECK_JITTER_MS + 1));
 }
 
 /**
@@ -566,6 +576,54 @@ export function startFollowerAuthorityMonitor(
   let checkInProgress = false;
   let promotionQueued = false;
   let authorityTimer: ReturnType<typeof setInterval> | null = null;
+  const recheckIntervalMs = computeFollowerAuthorityRecheckInterval(options.sessionId);
+
+  const queueAuthorityPromotion = () => {
+    queueMicrotask(() => {
+      promotionMgr.promote(forwardingSink, sessionHeartbeat)
+        .catch((err) => logger.error('[UnifiedConsole] Authority-based promotion crashed', {
+          error: String(err),
+        }));
+    });
+  };
+
+  const handleResolvedAuthority = (resolved: FollowerAuthorityResolution) => {
+    currentElection = resolved.election;
+
+    if (resolved.election.role !== 'leader') {
+      return;
+    }
+
+    promotionQueued = true;
+    if (authorityTimer) {
+      clearIntervalImpl(authorityTimer);
+      authorityTimer = null;
+    }
+
+    logger.warn('[UnifiedConsole] Follower authority re-evaluation queued a leader takeover', {
+      sessionId: options.sessionId,
+      stableSessionId: options.stableSessionId,
+      port: consolePort,
+      recheckIntervalMs,
+      electedLeaderPid: election.leaderInfo.pid,
+      electedLeaderSessionId: election.leaderInfo.sessionId,
+      resolvedLeaderPid: resolved.election.leaderInfo.pid,
+      resolvedLeaderSessionId: resolved.election.leaderInfo.sessionId,
+      replacementReason: resolved.replacement?.preference?.reason ?? null,
+      forcedClaim: resolved.forcedClaim,
+    });
+
+    queueAuthorityPromotion();
+  };
+
+  const handleAuthorityFailure = (err: unknown) => {
+    logger.debug('[UnifiedConsole] Follower authority re-evaluation failed', {
+      error: err instanceof Error ? err.message : String(err),
+      sessionId: options.sessionId,
+      port: consolePort,
+      recheckIntervalMs,
+    });
+  };
 
   authorityTimer = setIntervalImpl(() => {
     if (checkInProgress || promotionQueued) {
@@ -574,49 +632,12 @@ export function startFollowerAuthorityMonitor(
 
     checkInProgress = true;
     resolveFollowerAuthorityImpl(options.sessionId, consolePort, currentElection)
-      .then((resolved) => {
-        currentElection = resolved.election;
-
-        if (resolved.election.role !== 'leader') {
-          return;
-        }
-
-        promotionQueued = true;
-        if (authorityTimer) {
-          clearIntervalImpl(authorityTimer);
-          authorityTimer = null;
-        }
-
-        logger.warn('[UnifiedConsole] Follower authority re-evaluation queued a leader takeover', {
-          sessionId: options.sessionId,
-          stableSessionId: options.stableSessionId,
-          port: consolePort,
-          electedLeaderPid: election.leaderInfo.pid,
-          electedLeaderSessionId: election.leaderInfo.sessionId,
-          resolvedLeaderPid: resolved.election.leaderInfo.pid,
-          resolvedLeaderSessionId: resolved.election.leaderInfo.sessionId,
-          replacementReason: resolved.replacement?.preference?.reason ?? null,
-          forcedClaim: resolved.forcedClaim,
-        });
-
-        queueMicrotask(() => {
-          promotionMgr.promote(forwardingSink, sessionHeartbeat)
-            .catch((err) => logger.error('[UnifiedConsole] Authority-based promotion crashed', {
-              error: String(err),
-            }));
-        });
-      })
-      .catch((err) => {
-        logger.debug('[UnifiedConsole] Follower authority re-evaluation failed', {
-          error: err instanceof Error ? err.message : String(err),
-          sessionId: options.sessionId,
-          port: consolePort,
-        });
-      })
+      .then(handleResolvedAuthority)
+      .catch(handleAuthorityFailure)
       .finally(() => {
         checkInProgress = false;
       });
-  }, FOLLOWER_AUTHORITY_RECHECK_MS);
+  }, recheckIntervalMs);
   authorityTimer.unref();
 
   return () => {

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -64,8 +64,12 @@ const DEFAULT_CONSOLE_PORT = env.DOLLHOUSE_WEB_CONSOLE_PORT;
 const LEGACY_CONSOLE_FALLBACK_PORT = 3939;
 const SYNTHETIC_PORT_OWNER_SESSION_PREFIX = 'port-owner-';
 const LEADER_DISCOVERY_TIMEOUT_MS = 2_000;
-const FOLLOWER_AUTHORITY_RECHECK_MS = 15_000;
-const FOLLOWER_AUTHORITY_RECHECK_JITTER_MS = 5_000;
+const FOLLOWER_AUTHORITY_MONITOR_CONFIG = {
+  intervalMs: env.DOLLHOUSE_CONSOLE_AUTHORITY_RECHECK_MS,
+  jitterMs: env.DOLLHOUSE_CONSOLE_AUTHORITY_RECHECK_JITTER_MS,
+  failureThreshold: env.DOLLHOUSE_CONSOLE_AUTHORITY_RECHECK_FAILURE_THRESHOLD,
+  failureCooldownMs: env.DOLLHOUSE_CONSOLE_AUTHORITY_RECHECK_FAILURE_COOLDOWN_MS,
+} as const;
 
 function currentTimestamp(): string {
   return new Date().toISOString();
@@ -75,9 +79,13 @@ function computeFollowerAuthorityRecheckInterval(sessionId: string): number {
   const normalizedSessionId = UnicodeValidator.normalize(sessionId).normalizedContent;
   let hash = 0;
   for (let index = 0; index < normalizedSessionId.length; index += 1) {
-    hash = (hash * 31 + normalizedSessionId.charCodeAt(index)) >>> 0;
+    const codePoint = normalizedSessionId.codePointAt(index) ?? 0;
+    hash = (hash * 31 + codePoint) >>> 0;
+    if (codePoint > 0xffff) {
+      index += 1;
+    }
   }
-  return FOLLOWER_AUTHORITY_RECHECK_MS + (hash % (FOLLOWER_AUTHORITY_RECHECK_JITTER_MS + 1));
+  return FOLLOWER_AUTHORITY_MONITOR_CONFIG.intervalMs + (hash % (FOLLOWER_AUTHORITY_MONITOR_CONFIG.jitterMs + 1));
 }
 
 /**
@@ -222,6 +230,7 @@ interface FollowerAuthorityMonitorDependencies extends FollowerAuthorityDependen
   resolveFollowerAuthorityImpl?: typeof resolveFollowerAuthority;
   setIntervalImpl?: typeof setInterval;
   clearIntervalImpl?: typeof clearInterval;
+  nowImpl?: () => number;
 }
 
 interface DiscoveryDependencies {
@@ -572,9 +581,12 @@ export function startFollowerAuthorityMonitor(
   const resolveFollowerAuthorityImpl = deps.resolveFollowerAuthorityImpl ?? resolveFollowerAuthority;
   const setIntervalImpl = deps.setIntervalImpl ?? setInterval;
   const clearIntervalImpl = deps.clearIntervalImpl ?? clearInterval;
+  const nowImpl = deps.nowImpl ?? Date.now;
   let currentElection = election;
   let checkInProgress = false;
   let promotionQueued = false;
+  let consecutiveFailures = 0;
+  let circuitOpenUntilMs = 0;
   let authorityTimer: ReturnType<typeof setInterval> | null = null;
   const recheckIntervalMs = computeFollowerAuthorityRecheckInterval(options.sessionId);
 
@@ -589,6 +601,8 @@ export function startFollowerAuthorityMonitor(
 
   const handleResolvedAuthority = (resolved: FollowerAuthorityResolution) => {
     currentElection = resolved.election;
+    consecutiveFailures = 0;
+    circuitOpenUntilMs = 0;
 
     if (resolved.election.role !== 'leader') {
       return;
@@ -617,17 +631,44 @@ export function startFollowerAuthorityMonitor(
   };
 
   const handleAuthorityFailure = (err: unknown) => {
+    consecutiveFailures += 1;
+    if (consecutiveFailures >= FOLLOWER_AUTHORITY_MONITOR_CONFIG.failureThreshold) {
+      circuitOpenUntilMs = nowImpl() + FOLLOWER_AUTHORITY_MONITOR_CONFIG.failureCooldownMs;
+      logger.warn('[UnifiedConsole] Follower authority re-evaluation circuit opened after repeated failures', {
+        sessionId: options.sessionId,
+        port: consolePort,
+        recheckIntervalMs,
+        consecutiveFailures,
+        circuitOpenUntilMs: new Date(circuitOpenUntilMs).toISOString(),
+      });
+      consecutiveFailures = 0;
+    }
+
     logger.debug('[UnifiedConsole] Follower authority re-evaluation failed', {
       error: err instanceof Error ? err.message : String(err),
       sessionId: options.sessionId,
       port: consolePort,
       recheckIntervalMs,
+      circuitOpenUntilMs: circuitOpenUntilMs ? new Date(circuitOpenUntilMs).toISOString() : null,
     });
   };
 
   authorityTimer = setIntervalImpl(() => {
     if (checkInProgress || promotionQueued) {
       return;
+    }
+
+    if (circuitOpenUntilMs > nowImpl()) {
+      return;
+    }
+
+    if (circuitOpenUntilMs !== 0) {
+      logger.info('[UnifiedConsole] Follower authority re-evaluation circuit closed; resuming checks', {
+        sessionId: options.sessionId,
+        port: consolePort,
+        recheckIntervalMs,
+      });
+      circuitOpenUntilMs = 0;
     }
 
     checkInProgress = true;

--- a/tests/unit/web/console/UnifiedConsole.test.ts
+++ b/tests/unit/web/console/UnifiedConsole.test.ts
@@ -25,6 +25,7 @@ import {
   recoverLeaderBindFailure,
   evaluatePortOwnerReplacement,
   resolveFollowerAuthority,
+  startFollowerAuthorityMonitor,
 } from '../../../../src/web/console/UnifiedConsole.js';
 import type { LegacyLeaderInfo, ConsoleLeaderInfo } from '../../../../src/web/console/LeaderElection.js';
 
@@ -580,5 +581,141 @@ describe('resolveFollowerAuthority', () => {
         reason: 'same-version',
       }),
     });
+  });
+});
+
+describe('startFollowerAuthorityMonitor', () => {
+  function makeOptions() {
+    return {
+      sessionId: 'session-newest',
+      stableSessionId: 'stable-session-newest',
+      portfolioDir: '/sonar-fixture/unused-portfolio',
+      memorySink: {} as any,
+      registerLogSink: jest.fn(),
+      wireSSEBroadcasts: jest.fn(),
+    };
+  }
+
+  function makeFollowerElection(): { role: 'follower'; leaderInfo: ConsoleLeaderInfo } {
+    return {
+      role: 'follower',
+      leaderInfo: {
+        version: 1,
+        pid: 57117,
+        port: 41715,
+        sessionId: 'current-leader',
+        startedAt: '2026-04-16T16:29:44.000Z',
+        heartbeat: '2026-04-16T16:29:44.000Z',
+        serverVersion: '2.0.26',
+        consoleProtocolVersion: 1,
+      },
+    };
+  }
+
+  it('queues promotion when a periodic authority recheck prefers the local follower', async () => {
+    const promotionMgr = {
+      promote: jest.fn().mockResolvedValue(undefined),
+    } as unknown as import('../../../../src/web/console/PromotionManager.js').PromotionManager;
+    const forwardingSink = {} as import('../../../../src/web/console/LeaderForwardingSink.js').LeaderForwardingLogSink;
+    const sessionHeartbeat = {} as import('../../../../src/web/console/LeaderForwardingSink.js').SessionHeartbeat;
+    const timerHandle = { unref: jest.fn() } as unknown as ReturnType<typeof setInterval>;
+    let intervalCallback: (() => void) | null = null;
+    const setIntervalImpl = jest.fn<typeof setInterval>((callback) => {
+      intervalCallback = callback as () => void;
+      return timerHandle;
+    });
+    const clearIntervalImpl = jest.fn<typeof clearInterval>();
+
+    const stopMonitor = startFollowerAuthorityMonitor(
+      makeOptions(),
+      41715,
+      makeFollowerElection(),
+      promotionMgr,
+      forwardingSink,
+      sessionHeartbeat,
+      {
+        resolveFollowerAuthorityImpl: jest.fn().mockResolvedValue({
+          election: {
+            role: 'leader',
+            leaderInfo: {
+              version: 1,
+              pid: process.pid,
+              port: 41715,
+              sessionId: 'session-newest',
+              startedAt: '2026-04-19T16:00:00.000Z',
+              heartbeat: '2026-04-19T16:00:00.000Z',
+              serverVersion: PACKAGE_VERSION,
+              consoleProtocolVersion: 1,
+            },
+          },
+          discovery: null,
+          replacement: {
+            shouldEvict: true,
+            ownerPid: 57117,
+            preference: {
+              shouldReplace: true,
+              reason: 'newer-compatible-version',
+              candidateVersion: PACKAGE_VERSION,
+              existingVersion: '2.0.26',
+              candidateProtocolVersion: 1,
+              existingProtocolVersion: 1,
+            },
+          },
+          forcedClaim: false,
+        }),
+        setIntervalImpl,
+        clearIntervalImpl,
+      },
+    );
+
+    expect(setIntervalImpl).toHaveBeenCalledTimes(1);
+    expect(timerHandle.unref).toHaveBeenCalledTimes(1);
+    expect(intervalCallback).not.toBeNull();
+
+    intervalCallback?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(clearIntervalImpl).toHaveBeenCalledWith(timerHandle);
+    expect(promotionMgr.promote).toHaveBeenCalledWith(forwardingSink, sessionHeartbeat);
+
+    stopMonitor();
+  });
+
+  it('stays idle when the periodic authority recheck still prefers following', async () => {
+    const promotionMgr = {
+      promote: jest.fn().mockResolvedValue(undefined),
+    } as unknown as import('../../../../src/web/console/PromotionManager.js').PromotionManager;
+    const forwardingSink = {} as import('../../../../src/web/console/LeaderForwardingSink.js').LeaderForwardingLogSink;
+    const sessionHeartbeat = {} as import('../../../../src/web/console/LeaderForwardingSink.js').SessionHeartbeat;
+    const timerHandle = { unref: jest.fn() } as unknown as ReturnType<typeof setInterval>;
+    let intervalCallback: (() => void) | null = null;
+
+    startFollowerAuthorityMonitor(
+      makeOptions(),
+      41715,
+      makeFollowerElection(),
+      promotionMgr,
+      forwardingSink,
+      sessionHeartbeat,
+      {
+        resolveFollowerAuthorityImpl: jest.fn().mockResolvedValue({
+          election: makeFollowerElection(),
+          discovery: null,
+          replacement: null,
+          forcedClaim: false,
+        }),
+        setIntervalImpl: jest.fn<typeof setInterval>((callback) => {
+          intervalCallback = callback as () => void;
+          return timerHandle;
+        }),
+        clearIntervalImpl: jest.fn<typeof clearInterval>(),
+      },
+    );
+
+    intervalCallback?.();
+    await Promise.resolve();
+
+    expect(promotionMgr.promote).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/web/console/UnifiedConsole.test.ts
+++ b/tests/unit/web/console/UnifiedConsole.test.ts
@@ -64,6 +64,33 @@ function makeLoggerStub() {
   } as unknown as typeof import('../../../../src/utils/logger.js').logger;
 }
 
+function makeAuthorityMonitorOptions() {
+  return {
+    sessionId: 'session-newest',
+    stableSessionId: 'stable-session-newest',
+    portfolioDir: '/sonar-fixture/unused-portfolio',
+    memorySink: {} as any,
+    registerLogSink: jest.fn(),
+    wireSSEBroadcasts: jest.fn(),
+  };
+}
+
+function makeAuthorityMonitorFollowerElection(): { role: 'follower'; leaderInfo: ConsoleLeaderInfo } {
+  return {
+    role: 'follower',
+    leaderInfo: {
+      version: 1,
+      pid: 57117,
+      port: 41715,
+      sessionId: 'current-leader',
+      startedAt: '2026-04-16T16:29:44.000Z',
+      heartbeat: '2026-04-16T16:29:44.000Z',
+      serverVersion: '2.0.26',
+      consoleProtocolVersion: 1,
+    },
+  };
+}
+
 describe('warnIfLegacyConsolePresent', () => {
   it('logs a WARN when the legacy console is running, with pid/port in the message', async () => {
     const logStub = makeLoggerStub();
@@ -585,33 +612,6 @@ describe('resolveFollowerAuthority', () => {
 });
 
 describe('startFollowerAuthorityMonitor', () => {
-  function makeOptions() {
-    return {
-      sessionId: 'session-newest',
-      stableSessionId: 'stable-session-newest',
-      portfolioDir: '/sonar-fixture/unused-portfolio',
-      memorySink: {} as any,
-      registerLogSink: jest.fn(),
-      wireSSEBroadcasts: jest.fn(),
-    };
-  }
-
-  function makeFollowerElection(): { role: 'follower'; leaderInfo: ConsoleLeaderInfo } {
-    return {
-      role: 'follower',
-      leaderInfo: {
-        version: 1,
-        pid: 57117,
-        port: 41715,
-        sessionId: 'current-leader',
-        startedAt: '2026-04-16T16:29:44.000Z',
-        heartbeat: '2026-04-16T16:29:44.000Z',
-        serverVersion: '2.0.26',
-        consoleProtocolVersion: 1,
-      },
-    };
-  }
-
   it('queues promotion when a periodic authority recheck prefers the local follower', async () => {
     const promotionMgr = {
       promote: jest.fn().mockResolvedValue(undefined),
@@ -627,9 +627,9 @@ describe('startFollowerAuthorityMonitor', () => {
     const clearIntervalImpl = jest.fn<typeof clearInterval>();
 
     const stopMonitor = startFollowerAuthorityMonitor(
-      makeOptions(),
+      makeAuthorityMonitorOptions(),
       41715,
-      makeFollowerElection(),
+      makeAuthorityMonitorFollowerElection(),
       promotionMgr,
       forwardingSink,
       sessionHeartbeat,
@@ -692,15 +692,15 @@ describe('startFollowerAuthorityMonitor', () => {
     let intervalCallback: (() => void) | null = null;
 
     startFollowerAuthorityMonitor(
-      makeOptions(),
+      makeAuthorityMonitorOptions(),
       41715,
-      makeFollowerElection(),
+      makeAuthorityMonitorFollowerElection(),
       promotionMgr,
       forwardingSink,
       sessionHeartbeat,
       {
         resolveFollowerAuthorityImpl: jest.fn().mockResolvedValue({
-          election: makeFollowerElection(),
+          election: makeAuthorityMonitorFollowerElection(),
           discovery: null,
           replacement: null,
           forcedClaim: false,

--- a/tests/unit/web/console/UnifiedConsole.test.ts
+++ b/tests/unit/web/console/UnifiedConsole.test.ts
@@ -19,6 +19,7 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { PACKAGE_VERSION } from '../../../../src/generated/version.js';
 import { LEGACY_SERVER_VERSION } from '../../../../src/web/console/LeaderElection.js';
+import { logger } from '../../../../src/utils/logger.js';
 import {
   warnIfLegacyConsolePresent,
   discoverLeaderServingPort,
@@ -89,6 +90,11 @@ function makeAuthorityMonitorFollowerElection(): { role: 'follower'; leaderInfo:
       consoleProtocolVersion: 1,
     },
   };
+}
+
+async function flushAuthorityMonitorTick(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 describe('warnIfLegacyConsolePresent', () => {
@@ -717,5 +723,82 @@ describe('startFollowerAuthorityMonitor', () => {
     await Promise.resolve();
 
     expect(promotionMgr.promote).not.toHaveBeenCalled();
+  });
+
+  it('opens a circuit breaker after repeated authority failures and resumes after cooldown', async () => {
+    const promotionMgr = {
+      promote: jest.fn().mockResolvedValue(undefined),
+    } as unknown as import('../../../../src/web/console/PromotionManager.js').PromotionManager;
+    const forwardingSink = {} as import('../../../../src/web/console/LeaderForwardingSink.js').LeaderForwardingLogSink;
+    const sessionHeartbeat = {} as import('../../../../src/web/console/LeaderForwardingSink.js').SessionHeartbeat;
+    const timerHandle = { unref: jest.fn() } as unknown as ReturnType<typeof setInterval>;
+    let intervalCallback: (() => void) | null = null;
+    let nowMs = 1_000;
+    const resolveFollowerAuthorityImpl = jest.fn<typeof resolveFollowerAuthority>()
+      .mockRejectedValue(new Error('authority lookup failed'));
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => {});
+    const debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
+
+    try {
+      const stopMonitor = startFollowerAuthorityMonitor(
+        makeAuthorityMonitorOptions(),
+        41715,
+        makeAuthorityMonitorFollowerElection(),
+        promotionMgr,
+        forwardingSink,
+        sessionHeartbeat,
+        {
+          resolveFollowerAuthorityImpl,
+          setIntervalImpl: jest.fn<typeof setInterval>((callback) => {
+            intervalCallback = callback as () => void;
+            return timerHandle;
+          }),
+          clearIntervalImpl: jest.fn<typeof clearInterval>(),
+          nowImpl: () => nowMs,
+        },
+      );
+
+      expect(intervalCallback).not.toBeNull();
+
+      intervalCallback?.();
+      await flushAuthorityMonitorTick();
+      intervalCallback?.();
+      await flushAuthorityMonitorTick();
+      intervalCallback?.();
+      await flushAuthorityMonitorTick();
+
+      expect(resolveFollowerAuthorityImpl).toHaveBeenCalledTimes(3);
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[UnifiedConsole] Follower authority re-evaluation circuit opened after repeated failures',
+        expect.objectContaining({
+          sessionId: 'session-newest',
+          consecutiveFailures: 3,
+        }),
+      );
+
+      intervalCallback?.();
+      await flushAuthorityMonitorTick();
+      expect(resolveFollowerAuthorityImpl).toHaveBeenCalledTimes(3);
+
+      nowMs += 60_001;
+      intervalCallback?.();
+      await flushAuthorityMonitorTick();
+
+      expect(infoSpy).toHaveBeenCalledWith(
+        '[UnifiedConsole] Follower authority re-evaluation circuit closed; resuming checks',
+        expect.objectContaining({
+          sessionId: 'session-newest',
+        }),
+      );
+      expect(resolveFollowerAuthorityImpl).toHaveBeenCalledTimes(4);
+      expect(promotionMgr.promote).not.toHaveBeenCalled();
+
+      stopMonitor();
+    } finally {
+      warnSpy.mockRestore();
+      infoSpy.mockRestore();
+      debugSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add periodic follower-side authority re-evaluation in heterogeneous environments
- queue a leader promotion when a running follower becomes the preferred newer console leader
- cover the new monitor behavior with focused console unit tests

Fixes #2092

## Testing
- npm test -- --runInBand tests/unit/web/console/UnifiedConsole.test.ts tests/unit/web/console/LeaderElection.test.ts
- npx eslint src/web/console/UnifiedConsole.ts tests/unit/web/console/UnifiedConsole.test.ts tests/unit/web/console/LeaderElection.test.ts