### PR TITLE
fix: preserve follower sessions across leader takeover

### DIFF
--- a/src/web/console/IngestRoutes.ts
+++ b/src/web/console/IngestRoutes.ts
@@ -42,6 +42,7 @@ const REAPER_INTERVAL_MS = 5_000;
 
 /** How long since last heartbeat before a session is considered dead (ms) */
 const SESSION_STALE_MS = 15_000;
+const TAKEOVER_IMPORTED_SESSION_GRACE_MS = 60_000;
 
 /** Timeout for legacy port federation/proxy requests (ms) */
 const LEGACY_FETCH_TIMEOUT_MS = 2_000;
@@ -125,6 +126,8 @@ export interface IngestRoutesResult {
   router: Router;
   /** Get all tracked sessions */
   getSessions: () => SessionInfo[];
+  /** Import active follower sessions from a displaced leader during takeover. */
+  importSessions: (sessions: SessionInfo[]) => void;
   /** Register the leader as a session */
   registerLeaderSession: (sessionId: string, pid: number) => void;
   /** Register the web console as a session so the indicator is never empty (#1805) */
@@ -170,6 +173,7 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
   // When the user dismisses a pid=0 orphan, we add it here. The next heartbeat
   // (every 10s) carries the PID — we SIGTERM immediately and move to killedSessions.
   const pendingKills = new Set<string>();
+  const importedSessionGraceUntil = new Map<string, number>();
 
   /** Execute a deferred kill if we now have a PID. */
   function tryExecutePendingKill(sessionId: string, pid?: number): void {
@@ -245,6 +249,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     if (!existing) {
       return autoRegister(sessionId, pid, authenticated, serverVersion, consoleProtocolVersion);
     }
+
+    importedSessionGraceUntil.delete(sessionId);
 
     if (existing.status === 'ended') {
       existing.status = 'active';
@@ -532,6 +538,11 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       if (session.status !== 'active') continue;
       if (session.isLeader || session.kind === 'console') continue;
       const age = now - new Date(session.lastHeartbeat).getTime();
+      const graceUntil = importedSessionGraceUntil.get(id) ?? 0;
+      if (graceUntil > now) continue;
+      if (graceUntil !== 0) {
+        importedSessionGraceUntil.delete(id);
+      }
       if (age <= SESSION_STALE_MS) continue;
       session.status = 'ended';
       namePool.release(id);
@@ -548,6 +559,7 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
   function purgeStaleEntries(now: number): void {
     for (const [id, session] of sessions) {
       if (session.status === 'ended' && now - new Date(session.lastHeartbeat).getTime() > ENDED_PURGE_MS) {
+        importedSessionGraceUntil.delete(id);
         sessions.delete(id);
       }
     }
@@ -562,6 +574,46 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
 
   function getSessions(): SessionInfo[] {
     return Array.from(sessions.values()).filter(s => s.status === 'active');
+  }
+
+  function importSessions(importedSessions: SessionInfo[]): void {
+    const now = Date.now();
+    for (const imported of importedSessions) {
+      if (imported.status !== 'active') continue;
+      if (imported.isLeader || imported.kind === 'console') continue;
+      if (killedSessions.has(imported.sessionId) || pendingKills.has(imported.sessionId)) continue;
+
+      const normalizedSessionId = normalizeInput(imported.sessionId);
+      const existing = sessions.get(normalizedSessionId);
+      if (existing?.isLeader || existing?.kind === 'console') {
+        continue;
+      }
+
+      const displayName = imported.displayName
+        ? namePool.adopt(normalizedSessionId, imported.displayName)
+        : namePool.assign(normalizedSessionId);
+      const color = imported.color || namePool.getColor(normalizedSessionId) || '#3b82f6';
+      const merged: SessionInfo = {
+        sessionId: normalizedSessionId,
+        displayName,
+        color,
+        pid: imported.pid || existing?.pid || 0,
+        startedAt: imported.startedAt || existing?.startedAt || new Date(now).toISOString(),
+        lastHeartbeat: imported.lastHeartbeat || existing?.lastHeartbeat || new Date(now).toISOString(),
+        status: 'active',
+        isLeader: false,
+        authenticated: imported.authenticated ?? existing?.authenticated ?? false,
+        kind: 'mcp',
+        serverVersion: normalizeServerVersion(imported.serverVersion || existing?.serverVersion),
+        consoleProtocolVersion: normalizeConsoleProtocolVersion(
+          imported.consoleProtocolVersion ?? existing?.consoleProtocolVersion,
+        ),
+      };
+
+      sessions.set(normalizedSessionId, merged);
+      importedSessionGraceUntil.set(normalizedSessionId, now + TAKEOVER_IMPORTED_SESSION_GRACE_MS);
+      broadcasts.sessionBroadcast?.(merged);
+    }
   }
 
   function registerLeaderSession(sessionId: string, pid: number): void {
@@ -610,5 +662,5 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     logger.info('[IngestRoutes] Console session registered', { sessionId: consoleId, pid: process.pid });
   }
 
-  return { router, getSessions, registerLeaderSession, registerConsoleSession };
+  return { router, getSessions, importSessions, registerLeaderSession, registerConsoleSession };
 }

--- a/src/web/console/SessionNames.ts
+++ b/src/web/console/SessionNames.ts
@@ -321,6 +321,28 @@ export class SessionNamePool {
   }
 
   /**
+   * Preserve an existing human-facing assignment during leadership handoff.
+   * If the requested name is already taken by another live session, the pool
+   * falls back to normal assignment logic rather than creating a duplicate.
+   */
+  adopt(sessionId: string, name: string, isLeader = false): string {
+    const existing = this.assigned.get(sessionId);
+    if (existing) return existing;
+
+    this.flushCooldowns();
+
+    if (!this.nameToSession.has(name) && !(isLeader && FOLLOWER_ONLY_NAMES.has(name))) {
+      this.assigned.set(sessionId, name);
+      this.nameToSession.set(name, sessionId);
+      this.cooldown = this.cooldown.filter(entry => entry.name !== name);
+      logger.debug(`[SessionNames] Adopted '${name}' for ${sessionId}`);
+      return name;
+    }
+
+    return this.assign(sessionId, isLeader);
+  }
+
+  /**
    * Release a name back to the pool with a cooldown period.
    */
   release(sessionId: string): void {

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -52,6 +52,7 @@ import {
   type KillStaleProcessOutcome,
 } from './StaleProcessRecovery.js';
 import { env } from '../../config/env.js';
+import type { SessionInfo } from './IngestRoutes.js';
 
 /**
  * Default console port from the env var. Used as fallback when no port
@@ -207,6 +208,7 @@ interface ForceTakeoverAttemptResult {
   election: ElectionResult;
   fallback: PortLeaderDiscovery;
   replacement: PortOwnerReplacementDecision;
+  recoveredSessions: SessionInfo[];
   forcedKill: KillStaleProcessOutcome | null;
   takeoverAttempted: boolean;
   reboundLockClaimed: boolean;
@@ -241,6 +243,31 @@ interface DiscoveryDependencies {
 
 function buildDiscoveryHeaders(authToken: string | null): Record<string, string> {
   return authToken ? { Authorization: `Bearer ${authToken}` } : {};
+}
+
+export async function fetchLeaderSessionsSnapshot(
+  port: number,
+  authToken: string | null,
+  fetchImpl: typeof fetch = fetch,
+): Promise<SessionInfo[]> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), LEADER_DISCOVERY_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(`http://127.0.0.1:${port}/api/sessions`, {
+      headers: buildDiscoveryHeaders(authToken),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return [];
+    }
+
+    const data = await response.json() as { sessions?: SessionInfo[] };
+    return Array.isArray(data.sessions) ? data.sessions : [];
+  } catch {
+    return [];
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 function buildLeaderInfoFromSession(port: number, ownerPid: number, leaderSession: SessionApiRecord): ConsoleLeaderInfo {
@@ -706,6 +733,7 @@ async function attemptForceTakeover(
       election: currentElection,
       fallback: initialFallback,
       replacement: initialReplacement,
+      recoveredSessions: [],
       forcedKill: null,
       takeoverAttempted: false,
       reboundLockClaimed: false,
@@ -713,6 +741,7 @@ async function attemptForceTakeover(
   }
 
   const latestFallback = await discoverLeaderServingPort(consolePort, primaryToken);
+  const recoveredSessions = await fetchLeaderSessionsSnapshot(consolePort, primaryToken);
   const latestReplacement = evaluatePortOwnerReplacement(currentElection.leaderInfo, latestFallback);
   if (!latestReplacement.shouldEvict || latestReplacement.ownerPid === null) {
     logger.warn('[UnifiedConsole] Forced takeover target changed before eviction; skipping forced kill', {
@@ -730,6 +759,7 @@ async function attemptForceTakeover(
       election: currentElection,
       fallback: latestFallback,
       replacement: latestReplacement,
+      recoveredSessions,
       forcedKill: null,
       takeoverAttempted: false,
       reboundLockClaimed: false,
@@ -765,6 +795,7 @@ async function attemptForceTakeover(
       election: currentElection,
       fallback: latestFallback,
       replacement: latestReplacement,
+      recoveredSessions,
       forcedKill,
       takeoverAttempted: true,
       reboundLockClaimed: false,
@@ -809,6 +840,7 @@ async function attemptForceTakeover(
     election: reboundElection,
     fallback: latestFallback,
     replacement: latestReplacement,
+    recoveredSessions,
     forcedKill,
     takeoverAttempted: true,
     reboundLockClaimed,
@@ -902,6 +934,7 @@ async function startAsLeader(
   // bindAndListen now handles EADDRINUSE by finding and killing the stale
   // process on the port, then retrying. No external retry loop needed.
   let webResult = await startWebServer(serverOpts);
+  let recoveredFollowerSessions: SessionInfo[] = [];
 
   if (webResult.bindResult && !webResult.bindResult.success) {
     const forceTakeover = await attemptForceTakeover(
@@ -914,6 +947,7 @@ async function startAsLeader(
     );
     webResult = forceTakeover.webResult;
     election = forceTakeover.election;
+    recoveredFollowerSessions = forceTakeover.recoveredSessions;
 
     if (webResult.bindResult && !webResult.bindResult.success) {
       if (forceTakeover.fallback.leaderInfo) {
@@ -955,6 +989,14 @@ async function startAsLeader(
 
   // Register the web console itself so the session indicator is never empty (#1805)
   ingestResult.registerConsoleSession();
+
+  if (recoveredFollowerSessions.length > 0) {
+    ingestResult.importSessions(recoveredFollowerSessions);
+    logger.info('[UnifiedConsole] Recovered follower session snapshot from displaced leader', {
+      sessionId: options.sessionId,
+      recoveredSessions: recoveredFollowerSessions.length,
+    });
+  }
 
   // Wire SSE broadcasts for this leader's own events
   options.wireSSEBroadcasts(webResult, options.metricsSink);

--- a/tests/unit/web/console/SessionNames.test.ts
+++ b/tests/unit/web/console/SessionNames.test.ts
@@ -162,6 +162,13 @@ describe('SessionNamePool', () => {
     expect(pool.getName('session-rel')).toBeUndefined();
   });
 
+  it('adopt() preserves an imported puppet name across leader handoff', () => {
+    const pool = new SessionNamePool();
+    const adopted = pool.adopt('session-imported', 'Kermit');
+    expect(adopted).toBe('Kermit');
+    expect(pool.getName('session-imported')).toBe('Kermit');
+  });
+
   it('falls back to session-ID segment when pool is exhausted', () => {
     const pool = new SessionNamePool();
     // Assign all names in the puppet pool

--- a/tests/unit/web/console/UnifiedConsole.test.ts
+++ b/tests/unit/web/console/UnifiedConsole.test.ts
@@ -23,6 +23,7 @@ import { logger } from '../../../../src/utils/logger.js';
 import {
   warnIfLegacyConsolePresent,
   discoverLeaderServingPort,
+  fetchLeaderSessionsSnapshot,
   recoverLeaderBindFailure,
   evaluatePortOwnerReplacement,
   resolveFollowerAuthority,
@@ -318,6 +319,45 @@ describe('discoverLeaderServingPort', () => {
       pid: 81234,
       port: 41715,
     });
+  });
+});
+
+describe('fetchLeaderSessionsSnapshot', () => {
+  it('reads the predecessor session snapshot with bearer auth when available', async () => {
+    const fetchStub = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        sessions: [
+          {
+            sessionId: 'older-follower',
+            displayName: 'Kermit',
+            color: '#00ff00',
+            pid: 4567,
+            startedAt: '2026-04-19T16:00:00.000Z',
+            lastHeartbeat: '2026-04-19T16:00:05.000Z',
+            status: 'active',
+            isLeader: false,
+            authenticated: true,
+            kind: 'mcp',
+            serverVersion: '2.0.18',
+            consoleProtocolVersion: 1,
+          },
+        ],
+      }),
+    } as Response);
+
+    const result = await fetchLeaderSessionsSnapshot(41715, 'token-123', fetchStub);
+
+    expect(fetchStub).toHaveBeenCalledWith('http://127.0.0.1:41715/api/sessions', expect.objectContaining({
+      headers: { Authorization: 'Bearer token-123' },
+      signal: expect.any(AbortSignal),
+    }));
+    expect(result).toEqual([
+      expect.objectContaining({
+        sessionId: 'older-follower',
+        displayName: 'Kermit',
+      }),
+    ]);
   });
 });
 

--- a/tests/unit/web/console/sessionRegistry.test.ts
+++ b/tests/unit/web/console/sessionRegistry.test.ts
@@ -128,6 +128,64 @@ describe('Session registry (#1805)', () => {
       expect(kinds).toContain('mcp');
       expect(kinds).toContain('console');
     });
+
+    it('imports displaced follower sessions without importing the old leader or console', () => {
+      ingestResult.importSessions([
+        {
+          sessionId: 'old-leader',
+          displayName: 'Leader',
+          color: '#111111',
+          pid: 11,
+          startedAt: new Date().toISOString(),
+          lastHeartbeat: new Date().toISOString(),
+          status: 'active',
+          isLeader: true,
+          authenticated: true,
+          kind: 'mcp',
+          serverVersion: '2.0.26',
+          consoleProtocolVersion: 1,
+        },
+        {
+          sessionId: 'old-console',
+          displayName: 'Web Console',
+          color: '#222222',
+          pid: 12,
+          startedAt: new Date().toISOString(),
+          lastHeartbeat: new Date().toISOString(),
+          status: 'active',
+          isLeader: false,
+          authenticated: true,
+          kind: 'console',
+          serverVersion: '2.0.26',
+          consoleProtocolVersion: 1,
+        },
+        {
+          sessionId: 'older-follower',
+          displayName: 'Kermit',
+          color: '#00ff00',
+          pid: 13,
+          startedAt: new Date().toISOString(),
+          lastHeartbeat: new Date().toISOString(),
+          status: 'active',
+          isLeader: false,
+          authenticated: true,
+          kind: 'mcp',
+          serverVersion: '2.0.18',
+          consoleProtocolVersion: 1,
+        },
+      ]);
+
+      expect(ingestResult.getSessions()).toEqual([
+        expect.objectContaining({
+          sessionId: 'older-follower',
+          displayName: 'Kermit',
+          pid: 13,
+          kind: 'mcp',
+          isLeader: false,
+          serverVersion: '2.0.18',
+        }),
+      ]);
+    });
   });
 
   describe('GET /api/sessions endpoint', () => {
@@ -207,6 +265,42 @@ describe('Session registry (#1805)', () => {
         expect(sessions).toHaveLength(1);
         expect(sessions[0].isLeader).toBe(true);
         expect(sessions[0].status).toBe('active');
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('keeps imported takeover sessions alive long enough to reconnect', () => {
+      jest.useFakeTimers();
+      try {
+        ingestResult = createIngestRoutes({
+          logBroadcast: () => {},
+        });
+
+        ingestResult.importSessions([
+          {
+            sessionId: 'imported-follower',
+            displayName: 'Bunraku',
+            color: '#123456',
+            pid: 77,
+            startedAt: new Date().toISOString(),
+            lastHeartbeat: new Date().toISOString(),
+            status: 'active',
+            isLeader: false,
+            authenticated: true,
+            kind: 'mcp',
+            serverVersion: '2.0.18',
+            consoleProtocolVersion: 1,
+          },
+        ]);
+
+        jest.advanceTimersByTime(20_000);
+        expect(ingestResult.getSessions()).toEqual([
+          expect.objectContaining({ sessionId: 'imported-follower', status: 'active' }),
+        ]);
+
+        jest.advanceTimersByTime(50_000);
+        expect(ingestResult.getSessions()).toHaveLength(0);
       } finally {
         jest.useRealTimers();
       }


### PR DESCRIPTION
## Summary
- import active follower sessions from the displaced leader during version-aware takeover
- preserve imported puppet-name assignments and give takeover sessions time to reconnect
- add coverage for snapshot fetch and imported-session grace behavior

## Testing
- npm test -- --runInBand tests/unit/web/console/UnifiedConsole.test.ts tests/unit/web/console/sessionRegistry.test.ts tests/unit/web/console/ghostSession.test.ts tests/unit/web/console/SessionNames.test.ts
- npx eslint src/web/console/UnifiedConsole.ts src/web/console/IngestRoutes.ts src/web/console/SessionNames.ts tests/unit/web/console/UnifiedConsole.test.ts tests/unit/web/console/sessionRegistry.test.ts tests/unit/web/console/ghostSession.test.ts tests/unit/web/console/SessionNames.test.ts