### PR TITLE
Fix split-brain leader lock lease after takeover

### DIFF
--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -66,6 +66,7 @@ const LEGACY_CONSOLE_FALLBACK_PORT = 3939;
 const SYNTHETIC_PORT_OWNER_SESSION_PREFIX = 'port-owner-';
 const LEADER_DISCOVERY_TIMEOUT_MS = 2_000;
 const LEADER_LEASE_RECONCILE_INTERVAL_MS = 2_000;
+const LEADER_LEASE_RECONCILE_MAX_INTERVAL_MS = 30_000;
 const FOLLOWER_AUTHORITY_MONITOR_CONFIG = {
   intervalMs: env.DOLLHOUSE_CONSOLE_AUTHORITY_RECHECK_MS,
   jitterMs: env.DOLLHOUSE_CONSOLE_AUTHORITY_RECHECK_JITTER_MS,
@@ -231,8 +232,8 @@ interface FollowerAuthorityDependencies {
 
 interface FollowerAuthorityMonitorDependencies extends FollowerAuthorityDependencies {
   resolveFollowerAuthorityImpl?: typeof resolveFollowerAuthority;
-  setIntervalImpl?: typeof setInterval;
-  clearIntervalImpl?: typeof clearInterval;
+  setTimeoutImpl?: typeof setTimeout;
+  clearTimeoutImpl?: typeof clearTimeout;
   nowImpl?: () => number;
 }
 
@@ -241,8 +242,8 @@ interface LeaderLeaseReconciliationDependencies {
   findPidOnPortImpl?: typeof findPidOnPort;
   claimLeadershipImpl?: typeof claimLeadership;
   killStaleProcessDetailedImpl?: typeof killStaleProcessDetailed;
-  setIntervalImpl?: typeof setInterval;
-  clearIntervalImpl?: typeof clearInterval;
+  setTimeoutImpl?: typeof setTimeout;
+  clearTimeoutImpl?: typeof clearTimeout;
 }
 
 interface DiscoveryDependencies {
@@ -616,15 +617,15 @@ export function startFollowerAuthorityMonitor(
   deps: FollowerAuthorityMonitorDependencies = {},
 ): () => void {
   const resolveFollowerAuthorityImpl = deps.resolveFollowerAuthorityImpl ?? resolveFollowerAuthority;
-  const setIntervalImpl = deps.setIntervalImpl ?? setInterval;
-  const clearIntervalImpl = deps.clearIntervalImpl ?? clearInterval;
+  const setTimeoutImpl = deps.setTimeoutImpl ?? setTimeout;
+  const clearTimeoutImpl = deps.clearTimeoutImpl ?? clearTimeout;
   const nowImpl = deps.nowImpl ?? Date.now;
   let currentElection = election;
-  let checkInProgress = false;
   let promotionQueued = false;
   let consecutiveFailures = 0;
   let circuitOpenUntilMs = 0;
-  let authorityTimer: ReturnType<typeof setInterval> | null = null;
+  let authorityTimer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
   const recheckIntervalMs = computeFollowerAuthorityRecheckInterval(options.sessionId);
 
   const queueAuthorityPromotion = () => {
@@ -647,7 +648,7 @@ export function startFollowerAuthorityMonitor(
 
     promotionQueued = true;
     if (authorityTimer) {
-      clearIntervalImpl(authorityTimer);
+      clearTimeoutImpl(authorityTimer);
       authorityTimer = null;
     }
 
@@ -690,12 +691,21 @@ export function startFollowerAuthorityMonitor(
     });
   };
 
-  authorityTimer = setIntervalImpl(() => {
-    if (checkInProgress || promotionQueued) {
+  const scheduleNextCheck = (delayMs: number) => {
+    if (stopped || promotionQueued) {
       return;
     }
+    authorityTimer = setTimeoutImpl(runAuthorityCheck, delayMs);
+    authorityTimer.unref();
+  };
 
+  const runAuthorityCheck = () => {
+    authorityTimer = null;
+    if (stopped || promotionQueued) {
+      return;
+    }
     if (circuitOpenUntilMs > nowImpl()) {
+      scheduleNextCheck(recheckIntervalMs);
       return;
     }
 
@@ -708,21 +718,22 @@ export function startFollowerAuthorityMonitor(
       circuitOpenUntilMs = 0;
     }
 
-    checkInProgress = true;
     resolveFollowerAuthorityImpl(options.sessionId, consolePort, currentElection)
       .then(handleResolvedAuthority)
       .catch(handleAuthorityFailure)
       .finally(() => {
-        checkInProgress = false;
+        scheduleNextCheck(recheckIntervalMs);
       });
-  }, recheckIntervalMs);
-  authorityTimer.unref();
+  };
+
+  scheduleNextCheck(recheckIntervalMs);
 
   return () => {
     if (authorityTimer) {
-      clearIntervalImpl(authorityTimer);
+      clearTimeoutImpl(authorityTimer);
       authorityTimer = null;
     }
+    stopped = true;
   };
 }
 
@@ -730,7 +741,7 @@ export async function reconcileLeaderLease(
   sessionId: string,
   consolePort: number,
   deps: LeaderLeaseReconciliationDependencies = {},
-): Promise<void> {
+): Promise<'not-port-owner' | 'already-owned' | 'reconciled'> {
   const readLeaderLockImpl = deps.readLeaderLockImpl ?? readLeaderLock;
   const findPidOnPortImpl = deps.findPidOnPortImpl ?? findPidOnPort;
   const claimLeadershipImpl = deps.claimLeadershipImpl ?? claimLeadership;
@@ -738,12 +749,12 @@ export async function reconcileLeaderLease(
 
   const portOwnerPid = await findPidOnPortImpl(consolePort);
   if (portOwnerPid !== process.pid) {
-    return;
+    return 'not-port-owner';
   }
 
   const currentLock = await readLeaderLockImpl();
   if (!currentLock || currentLock.pid === process.pid) {
-    return;
+    return 'already-owned';
   }
 
   const expectedLeader = createLeaderInfo(sessionId, consolePort);
@@ -779,6 +790,7 @@ export async function reconcileLeaderLease(
     killed: killOutcome.killed,
     lockClaimed,
   });
+  return 'reconciled';
 }
 
 export function startLeaderLeaseMonitor(
@@ -786,28 +798,49 @@ export function startLeaderLeaseMonitor(
   consolePort: number,
   deps: LeaderLeaseReconciliationDependencies = {},
 ): () => void {
-  const setIntervalImpl = deps.setIntervalImpl ?? setInterval;
-  const clearIntervalImpl = deps.clearIntervalImpl ?? clearInterval;
-  let reconcileInProgress = false;
-  const timer = setIntervalImpl(() => {
-    if (reconcileInProgress) {
+  const setTimeoutImpl = deps.setTimeoutImpl ?? setTimeout;
+  const clearTimeoutImpl = deps.clearTimeoutImpl ?? clearTimeout;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+  let delayMs = LEADER_LEASE_RECONCILE_INTERVAL_MS;
+
+  const scheduleNext = () => {
+    if (stopped) {
       return;
     }
-    reconcileInProgress = true;
+    timer = setTimeoutImpl(runCheck, delayMs);
+    timer.unref();
+  };
+
+  const runCheck = () => {
+    timer = null;
+    if (stopped) {
+      return;
+    }
     reconcileLeaderLease(sessionId, consolePort, deps)
+      .then((result) => {
+        delayMs = result === 'reconciled'
+          ? LEADER_LEASE_RECONCILE_INTERVAL_MS
+          : Math.min(delayMs * 2, LEADER_LEASE_RECONCILE_MAX_INTERVAL_MS);
+      })
       .catch((err) => logger.debug('[UnifiedConsole] Leader lease reconciliation failed', {
         error: err instanceof Error ? err.message : String(err),
         sessionId,
         port: consolePort,
       }))
       .finally(() => {
-        reconcileInProgress = false;
+        scheduleNext();
       });
-  }, LEADER_LEASE_RECONCILE_INTERVAL_MS);
-  timer.unref();
+  };
+
+  scheduleNext();
 
   return () => {
-    clearIntervalImpl(timer);
+    stopped = true;
+    if (timer) {
+      clearTimeoutImpl(timer);
+      timer = null;
+    }
   };
 }
 

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -65,6 +65,7 @@ const DEFAULT_CONSOLE_PORT = env.DOLLHOUSE_WEB_CONSOLE_PORT;
 const LEGACY_CONSOLE_FALLBACK_PORT = 3939;
 const SYNTHETIC_PORT_OWNER_SESSION_PREFIX = 'port-owner-';
 const LEADER_DISCOVERY_TIMEOUT_MS = 2_000;
+const LEADER_LEASE_RECONCILE_INTERVAL_MS = 2_000;
 const FOLLOWER_AUTHORITY_MONITOR_CONFIG = {
   intervalMs: env.DOLLHOUSE_CONSOLE_AUTHORITY_RECHECK_MS,
   jitterMs: env.DOLLHOUSE_CONSOLE_AUTHORITY_RECHECK_JITTER_MS,
@@ -233,6 +234,15 @@ interface FollowerAuthorityMonitorDependencies extends FollowerAuthorityDependen
   setIntervalImpl?: typeof setInterval;
   clearIntervalImpl?: typeof clearInterval;
   nowImpl?: () => number;
+}
+
+interface LeaderLeaseReconciliationDependencies {
+  readLeaderLockImpl?: typeof readLeaderLock;
+  findPidOnPortImpl?: typeof findPidOnPort;
+  claimLeadershipImpl?: typeof claimLeadership;
+  killStaleProcessDetailedImpl?: typeof killStaleProcessDetailed;
+  setIntervalImpl?: typeof setInterval;
+  clearIntervalImpl?: typeof clearInterval;
 }
 
 interface DiscoveryDependencies {
@@ -716,6 +726,91 @@ export function startFollowerAuthorityMonitor(
   };
 }
 
+export async function reconcileLeaderLease(
+  sessionId: string,
+  consolePort: number,
+  deps: LeaderLeaseReconciliationDependencies = {},
+): Promise<void> {
+  const readLeaderLockImpl = deps.readLeaderLockImpl ?? readLeaderLock;
+  const findPidOnPortImpl = deps.findPidOnPortImpl ?? findPidOnPort;
+  const claimLeadershipImpl = deps.claimLeadershipImpl ?? claimLeadership;
+  const killStaleProcessDetailedImpl = deps.killStaleProcessDetailedImpl ?? killStaleProcessDetailed;
+
+  const portOwnerPid = await findPidOnPortImpl(consolePort);
+  if (portOwnerPid !== process.pid) {
+    return;
+  }
+
+  const currentLock = await readLeaderLockImpl();
+  if (!currentLock || currentLock.pid === process.pid) {
+    return;
+  }
+
+  const expectedLeader = createLeaderInfo(sessionId, consolePort);
+  const replacement = evaluatePortOwnerReplacement(expectedLeader, {
+    ownerPid: currentLock.pid,
+    source: 'lock',
+    leaderInfo: currentLock,
+  });
+
+  logger.warn('[UnifiedConsole] Port-owning leader detected a displaced lock writer; reconciling leader lease', {
+    sessionId,
+    port: consolePort,
+    lockOwnerPid: currentLock.pid,
+    lockOwnerSessionId: currentLock.sessionId,
+    lockOwnerVersion: currentLock.serverVersion ?? LEGACY_SERVER_VERSION,
+    actualPortOwnerPid: portOwnerPid,
+    replacementReason: replacement.preference?.reason ?? null,
+  });
+
+  const killOutcome = await killStaleProcessDetailedImpl(currentLock.pid, consolePort, {
+    allowActiveHostParent: true,
+  });
+  const lockClaimed = await claimLeadershipImpl(expectedLeader);
+
+  logger.info('[UnifiedConsole] Leader lease reconciliation completed', {
+    sessionId,
+    port: consolePort,
+    displacedPid: currentLock.pid,
+    displacedSessionId: currentLock.sessionId,
+    displacedVersion: currentLock.serverVersion ?? LEGACY_SERVER_VERSION,
+    killAttempted: true,
+    killResult: killOutcome.reason,
+    killed: killOutcome.killed,
+    lockClaimed,
+  });
+}
+
+export function startLeaderLeaseMonitor(
+  sessionId: string,
+  consolePort: number,
+  deps: LeaderLeaseReconciliationDependencies = {},
+): () => void {
+  const setIntervalImpl = deps.setIntervalImpl ?? setInterval;
+  const clearIntervalImpl = deps.clearIntervalImpl ?? clearInterval;
+  let reconcileInProgress = false;
+  const timer = setIntervalImpl(() => {
+    if (reconcileInProgress) {
+      return;
+    }
+    reconcileInProgress = true;
+    reconcileLeaderLease(sessionId, consolePort, deps)
+      .catch((err) => logger.debug('[UnifiedConsole] Leader lease reconciliation failed', {
+        error: err instanceof Error ? err.message : String(err),
+        sessionId,
+        port: consolePort,
+      }))
+      .finally(() => {
+        reconcileInProgress = false;
+      });
+  }, LEADER_LEASE_RECONCILE_INTERVAL_MS);
+  timer.unref();
+
+  return () => {
+    clearIntervalImpl(timer);
+  };
+}
+
 async function attemptForceTakeover(
   options: UnifiedConsoleOptions,
   currentElection: ElectionResult,
@@ -1019,6 +1114,7 @@ async function startAsLeader(
 
   // Start heartbeat and register cleanup
   const stopHeartbeat = startHeartbeat(election.leaderInfo);
+  const stopLeaseMonitor = startLeaderLeaseMonitor(options.sessionId, consolePort);
   registerLeaderCleanup();
 
   logger.info('[UnifiedConsole] Leader started', {
@@ -1032,6 +1128,7 @@ async function startAsLeader(
     port: consolePort,
     cleanup: async () => {
       stopHeartbeat();
+      stopLeaseMonitor();
     },
   };
 }

--- a/tests/unit/web/console/UnifiedConsole.test.ts
+++ b/tests/unit/web/console/UnifiedConsole.test.ts
@@ -28,6 +28,8 @@ import {
   evaluatePortOwnerReplacement,
   resolveFollowerAuthority,
   startFollowerAuthorityMonitor,
+  reconcileLeaderLease,
+  startLeaderLeaseMonitor,
 } from '../../../../src/web/console/UnifiedConsole.js';
 import type { LegacyLeaderInfo, ConsoleLeaderInfo } from '../../../../src/web/console/LeaderElection.js';
 
@@ -840,5 +842,115 @@ describe('startFollowerAuthorityMonitor', () => {
       infoSpy.mockRestore();
       debugSpy.mockRestore();
     }
+  });
+});
+
+describe('reconcileLeaderLease', () => {
+  it('reclaims the lock and evicts the displaced lock writer when this process owns the console port', async () => {
+    const claimLeadershipImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').claimLeadership>()
+      .mockResolvedValue(true);
+    const killStaleProcessDetailedImpl = jest.fn<typeof import('../../../../src/web/console/StaleProcessRecovery.js').killStaleProcessDetailed>()
+      .mockResolvedValue({
+        killed: true,
+        reason: 'terminated',
+        pid: 3877,
+      });
+
+    await reconcileLeaderLease('session-newest', 41715, {
+      findPidOnPortImpl: async () => process.pid,
+      readLeaderLockImpl: async () => ({
+        version: 1,
+        pid: 3877,
+        port: 41715,
+        sessionId: 'session-old',
+        startedAt: '2026-04-16T20:40:19.500Z',
+        heartbeat: '2026-04-19T18:13:34.914Z',
+        serverVersion: '2.0.25',
+        consoleProtocolVersion: 1,
+      }),
+      claimLeadershipImpl,
+      killStaleProcessDetailedImpl,
+    });
+
+    expect(killStaleProcessDetailedImpl).toHaveBeenCalledWith(3877, 41715, {
+      allowActiveHostParent: true,
+    });
+    expect(claimLeadershipImpl).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session-newest',
+      port: 41715,
+    }));
+  });
+
+  it('does nothing when this process does not own the console port', async () => {
+    const claimLeadershipImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').claimLeadership>();
+    const killStaleProcessDetailedImpl = jest.fn<typeof import('../../../../src/web/console/StaleProcessRecovery.js').killStaleProcessDetailed>();
+
+    await reconcileLeaderLease('session-newest', 41715, {
+      findPidOnPortImpl: async () => 3877,
+      readLeaderLockImpl: async () => ({
+        version: 1,
+        pid: 3877,
+        port: 41715,
+        sessionId: 'session-old',
+        startedAt: '2026-04-16T20:40:19.500Z',
+        heartbeat: '2026-04-19T18:13:34.914Z',
+        serverVersion: '2.0.25',
+        consoleProtocolVersion: 1,
+      }),
+      claimLeadershipImpl,
+      killStaleProcessDetailedImpl,
+    });
+
+    expect(killStaleProcessDetailedImpl).not.toHaveBeenCalled();
+    expect(claimLeadershipImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe('startLeaderLeaseMonitor', () => {
+  it('schedules periodic lease reconciliation and cleans up the timer', async () => {
+    const timerHandle = { unref: jest.fn() } as unknown as ReturnType<typeof setInterval>;
+    let intervalCallback: (() => void) | null = null;
+    const claimLeadershipImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').claimLeadership>()
+      .mockResolvedValue(true);
+    const killStaleProcessDetailedImpl = jest.fn<typeof import('../../../../src/web/console/StaleProcessRecovery.js').killStaleProcessDetailed>()
+      .mockResolvedValue({
+        killed: true,
+        reason: 'terminated',
+        pid: 3877,
+      });
+    const clearIntervalImpl = jest.fn<typeof clearInterval>();
+
+    const stopMonitor = startLeaderLeaseMonitor('session-newest', 41715, {
+      setIntervalImpl: jest.fn<typeof setInterval>((callback) => {
+        intervalCallback = callback as () => void;
+        return timerHandle;
+      }),
+      clearIntervalImpl,
+      findPidOnPortImpl: async () => process.pid,
+      readLeaderLockImpl: async () => ({
+        version: 1,
+        pid: 3877,
+        port: 41715,
+        sessionId: 'session-old',
+        startedAt: '2026-04-16T20:40:19.500Z',
+        heartbeat: '2026-04-19T18:13:34.914Z',
+        serverVersion: '2.0.25',
+        consoleProtocolVersion: 1,
+      }),
+      claimLeadershipImpl,
+      killStaleProcessDetailedImpl,
+    });
+
+    expect(intervalCallback).not.toBeNull();
+    expect(timerHandle.unref).toHaveBeenCalledTimes(1);
+
+    intervalCallback?.();
+    await flushAuthorityMonitorTick();
+
+    expect(killStaleProcessDetailedImpl).toHaveBeenCalled();
+    expect(claimLeadershipImpl).toHaveBeenCalled();
+
+    stopMonitor();
+    expect(clearIntervalImpl).toHaveBeenCalledWith(timerHandle);
   });
 });

--- a/tests/unit/web/console/UnifiedConsole.test.ts
+++ b/tests/unit/web/console/UnifiedConsole.test.ts
@@ -666,13 +666,13 @@ describe('startFollowerAuthorityMonitor', () => {
     } as unknown as import('../../../../src/web/console/PromotionManager.js').PromotionManager;
     const forwardingSink = {} as import('../../../../src/web/console/LeaderForwardingSink.js').LeaderForwardingLogSink;
     const sessionHeartbeat = {} as import('../../../../src/web/console/LeaderForwardingSink.js').SessionHeartbeat;
-    const timerHandle = { unref: jest.fn() } as unknown as ReturnType<typeof setInterval>;
-    let intervalCallback: (() => void) | null = null;
-    const setIntervalImpl = jest.fn<typeof setInterval>((callback) => {
-      intervalCallback = callback as () => void;
+    const timerHandle = { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+    let timeoutCallback: (() => void) | null = null;
+    const setTimeoutImpl = jest.fn<typeof setTimeout>((callback) => {
+      timeoutCallback = callback as () => void;
       return timerHandle;
     });
-    const clearIntervalImpl = jest.fn<typeof clearInterval>();
+    const clearTimeoutImpl = jest.fn<typeof clearTimeout>();
 
     const stopMonitor = startFollowerAuthorityMonitor(
       makeAuthorityMonitorOptions(),
@@ -711,23 +711,23 @@ describe('startFollowerAuthorityMonitor', () => {
           },
           forcedClaim: false,
         }),
-        setIntervalImpl,
-        clearIntervalImpl,
+        setTimeoutImpl,
+        clearTimeoutImpl,
       },
     );
 
-    expect(setIntervalImpl).toHaveBeenCalledTimes(1);
+    expect(setTimeoutImpl).toHaveBeenCalledTimes(1);
     expect(timerHandle.unref).toHaveBeenCalledTimes(1);
-    expect(intervalCallback).not.toBeNull();
+    expect(timeoutCallback).not.toBeNull();
 
-    intervalCallback?.();
+    timeoutCallback?.();
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(clearIntervalImpl).toHaveBeenCalledWith(timerHandle);
     expect(promotionMgr.promote).toHaveBeenCalledWith(forwardingSink, sessionHeartbeat);
 
     stopMonitor();
+    expect(clearTimeoutImpl).not.toHaveBeenCalled();
   });
 
   it('stays idle when the periodic authority recheck still prefers following', async () => {
@@ -736,8 +736,8 @@ describe('startFollowerAuthorityMonitor', () => {
     } as unknown as import('../../../../src/web/console/PromotionManager.js').PromotionManager;
     const forwardingSink = {} as import('../../../../src/web/console/LeaderForwardingSink.js').LeaderForwardingLogSink;
     const sessionHeartbeat = {} as import('../../../../src/web/console/LeaderForwardingSink.js').SessionHeartbeat;
-    const timerHandle = { unref: jest.fn() } as unknown as ReturnType<typeof setInterval>;
-    let intervalCallback: (() => void) | null = null;
+    const timerHandle = { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+    let timeoutCallback: (() => void) | null = null;
 
     startFollowerAuthorityMonitor(
       makeAuthorityMonitorOptions(),
@@ -753,15 +753,15 @@ describe('startFollowerAuthorityMonitor', () => {
           replacement: null,
           forcedClaim: false,
         }),
-        setIntervalImpl: jest.fn<typeof setInterval>((callback) => {
-          intervalCallback = callback as () => void;
+        setTimeoutImpl: jest.fn<typeof setTimeout>((callback) => {
+          timeoutCallback = callback as () => void;
           return timerHandle;
         }),
-        clearIntervalImpl: jest.fn<typeof clearInterval>(),
+        clearTimeoutImpl: jest.fn<typeof clearTimeout>(),
       },
     );
 
-    intervalCallback?.();
+    timeoutCallback?.();
     await Promise.resolve();
 
     expect(promotionMgr.promote).not.toHaveBeenCalled();
@@ -773,8 +773,8 @@ describe('startFollowerAuthorityMonitor', () => {
     } as unknown as import('../../../../src/web/console/PromotionManager.js').PromotionManager;
     const forwardingSink = {} as import('../../../../src/web/console/LeaderForwardingSink.js').LeaderForwardingLogSink;
     const sessionHeartbeat = {} as import('../../../../src/web/console/LeaderForwardingSink.js').SessionHeartbeat;
-    const timerHandle = { unref: jest.fn() } as unknown as ReturnType<typeof setInterval>;
-    let intervalCallback: (() => void) | null = null;
+    const timerHandle = { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+    let timeoutCallback: (() => void) | null = null;
     let nowMs = 1_000;
     const resolveFollowerAuthorityImpl = jest.fn<typeof resolveFollowerAuthority>()
       .mockRejectedValue(new Error('authority lookup failed'));
@@ -792,22 +792,22 @@ describe('startFollowerAuthorityMonitor', () => {
         sessionHeartbeat,
         {
           resolveFollowerAuthorityImpl,
-          setIntervalImpl: jest.fn<typeof setInterval>((callback) => {
-            intervalCallback = callback as () => void;
+          setTimeoutImpl: jest.fn<typeof setTimeout>((callback) => {
+            timeoutCallback = callback as () => void;
             return timerHandle;
           }),
-          clearIntervalImpl: jest.fn<typeof clearInterval>(),
+          clearTimeoutImpl: jest.fn<typeof clearTimeout>(),
           nowImpl: () => nowMs,
         },
       );
 
-      expect(intervalCallback).not.toBeNull();
+      expect(timeoutCallback).not.toBeNull();
 
-      intervalCallback?.();
+      timeoutCallback?.();
       await flushAuthorityMonitorTick();
-      intervalCallback?.();
+      timeoutCallback?.();
       await flushAuthorityMonitorTick();
-      intervalCallback?.();
+      timeoutCallback?.();
       await flushAuthorityMonitorTick();
 
       expect(resolveFollowerAuthorityImpl).toHaveBeenCalledTimes(3);
@@ -819,12 +819,12 @@ describe('startFollowerAuthorityMonitor', () => {
         }),
       );
 
-      intervalCallback?.();
+      timeoutCallback?.();
       await flushAuthorityMonitorTick();
       expect(resolveFollowerAuthorityImpl).toHaveBeenCalledTimes(3);
 
       nowMs += 60_001;
-      intervalCallback?.();
+      timeoutCallback?.();
       await flushAuthorityMonitorTick();
 
       expect(infoSpy).toHaveBeenCalledWith(
@@ -856,7 +856,7 @@ describe('reconcileLeaderLease', () => {
         pid: 3877,
       });
 
-    await reconcileLeaderLease('session-newest', 41715, {
+    const result = await reconcileLeaderLease('session-newest', 41715, {
       findPidOnPortImpl: async () => process.pid,
       readLeaderLockImpl: async () => ({
         version: 1,
@@ -872,6 +872,7 @@ describe('reconcileLeaderLease', () => {
       killStaleProcessDetailedImpl,
     });
 
+    expect(result).toBe('reconciled');
     expect(killStaleProcessDetailedImpl).toHaveBeenCalledWith(3877, 41715, {
       allowActiveHostParent: true,
     });
@@ -885,7 +886,7 @@ describe('reconcileLeaderLease', () => {
     const claimLeadershipImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').claimLeadership>();
     const killStaleProcessDetailedImpl = jest.fn<typeof import('../../../../src/web/console/StaleProcessRecovery.js').killStaleProcessDetailed>();
 
-    await reconcileLeaderLease('session-newest', 41715, {
+    const result = await reconcileLeaderLease('session-newest', 41715, {
       findPidOnPortImpl: async () => 3877,
       readLeaderLockImpl: async () => ({
         version: 1,
@@ -901,15 +902,16 @@ describe('reconcileLeaderLease', () => {
       killStaleProcessDetailedImpl,
     });
 
+    expect(result).toBe('not-port-owner');
     expect(killStaleProcessDetailedImpl).not.toHaveBeenCalled();
     expect(claimLeadershipImpl).not.toHaveBeenCalled();
   });
 });
 
 describe('startLeaderLeaseMonitor', () => {
-  it('schedules periodic lease reconciliation and cleans up the timer', async () => {
-    const timerHandle = { unref: jest.fn() } as unknown as ReturnType<typeof setInterval>;
-    let intervalCallback: (() => void) | null = null;
+  it('schedules lease reconciliation, backs off when stable, and cleans up the timer', async () => {
+    const timerHandle = { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+    let timeoutCallback: (() => void) | null = null;
     const claimLeadershipImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').claimLeadership>()
       .mockResolvedValue(true);
     const killStaleProcessDetailedImpl = jest.fn<typeof import('../../../../src/web/console/StaleProcessRecovery.js').killStaleProcessDetailed>()
@@ -918,16 +920,9 @@ describe('startLeaderLeaseMonitor', () => {
         reason: 'terminated',
         pid: 3877,
       });
-    const clearIntervalImpl = jest.fn<typeof clearInterval>();
-
-    const stopMonitor = startLeaderLeaseMonitor('session-newest', 41715, {
-      setIntervalImpl: jest.fn<typeof setInterval>((callback) => {
-        intervalCallback = callback as () => void;
-        return timerHandle;
-      }),
-      clearIntervalImpl,
-      findPidOnPortImpl: async () => process.pid,
-      readLeaderLockImpl: async () => ({
+    const clearTimeoutImpl = jest.fn<typeof clearTimeout>();
+    const readLeaderLockImpl = jest.fn()
+      .mockResolvedValueOnce({
         version: 1,
         pid: 3877,
         port: 41715,
@@ -936,21 +931,50 @@ describe('startLeaderLeaseMonitor', () => {
         heartbeat: '2026-04-19T18:13:34.914Z',
         serverVersion: '2.0.25',
         consoleProtocolVersion: 1,
+      })
+      .mockResolvedValueOnce({
+        version: 1,
+        pid: process.pid,
+        port: 41715,
+        sessionId: 'session-newest',
+        startedAt: '2026-04-19T19:00:00.000Z',
+        heartbeat: '2026-04-19T19:00:00.000Z',
+        serverVersion: PACKAGE_VERSION,
+        consoleProtocolVersion: 1,
+      });
+
+    const stopMonitor = startLeaderLeaseMonitor('session-newest', 41715, {
+      setTimeoutImpl: jest.fn<typeof setTimeout>((callback, delay) => {
+        timeoutCallback = callback as () => void;
+        if (claimLeadershipImpl.mock.calls.length === 0) {
+          expect(delay).toBe(2_000);
+        } else {
+          expect(delay).toBe(4_000);
+        }
+        return timerHandle;
       }),
+      clearTimeoutImpl,
+      findPidOnPortImpl: async () => process.pid,
+      readLeaderLockImpl,
       claimLeadershipImpl,
       killStaleProcessDetailedImpl,
     });
 
-    expect(intervalCallback).not.toBeNull();
+    expect(timeoutCallback).not.toBeNull();
     expect(timerHandle.unref).toHaveBeenCalledTimes(1);
 
-    intervalCallback?.();
+    timeoutCallback?.();
+    await flushAuthorityMonitorTick();
+    expect(killStaleProcessDetailedImpl).toHaveBeenCalledTimes(1);
+    expect(claimLeadershipImpl).toHaveBeenCalledTimes(1);
+
+    timeoutCallback?.();
     await flushAuthorityMonitorTick();
 
-    expect(killStaleProcessDetailedImpl).toHaveBeenCalled();
-    expect(claimLeadershipImpl).toHaveBeenCalled();
+    expect(killStaleProcessDetailedImpl).toHaveBeenCalledTimes(1);
+    expect(claimLeadershipImpl).toHaveBeenCalledTimes(1);
 
     stopMonitor();
-    expect(clearIntervalImpl).toHaveBeenCalledWith(timerHandle);
+    expect(clearTimeoutImpl).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- reconcile the leader lock when the active console port owner detects another process still heartbeating the lease
- evict displaced older lock writers so mixed-version environments converge on the actual newest-compatible leader
- add regression coverage for lease reconciliation and the periodic monitor

## Testing
- npm test -- --runInBand tests/unit/web/console/UnifiedConsole.test.ts tests/unit/web/console/LeaderElection.test.ts
- npx eslint src/web/console/UnifiedConsole.ts tests/unit/web/console/UnifiedConsole.test.ts tests/unit/web/console/LeaderElection.test.ts
- npm run build
