### PR TITLE
test: add mixed-version console harness

### DIFF
--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -647,6 +647,17 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Install shellcheck
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Validate mixed-version harness shell scripts
+        shell: bash
+        run: |
+          shellcheck docker/mixed-version/*.sh
+
       - name: Test MINIMAL Docker Compose (hello world test)
         shell: bash
         run: |
@@ -698,6 +709,12 @@ jobs:
             exit 1
           fi
 
+      - name: Test mixed-version harness smoke flow
+        shell: bash
+        run: |
+          chmod +x docker/mixed-version/*.sh
+          ./docker/mixed-version/smoke-test.sh
+
       - name: Cleanup Docker Compose
         if: always()
         shell: bash
@@ -719,6 +736,7 @@ jobs:
           fi
 
           docker compose --project-name "$COMPOSE_PROJECT_NAME" --file docker/docker-compose.yml rm -f || true
+          docker compose -f docker/docker-compose.mixed-version.yml down --remove-orphans || true
 
       - name: Docker Compose testing complete
         shell: bash

--- a/docker/docker-compose.mixed-version.yml
+++ b/docker/docker-compose.mixed-version.yml
@@ -1,0 +1,107 @@
+name: dollhouse-mixed-version
+
+x-session-env: &session-env
+  NODE_ENV: production
+  DOLLHOUSE_WEB_CONSOLE: "true"
+  DOLLHOUSE_PERMISSION_SERVER: "true"
+  DOLLHOUSE_DISABLE_UPDATES: "true"
+  DOLLHOUSE_SECURITY_MODE: strict
+  DOLLHOUSE_WEB_CONSOLE_PORT: "41715"
+  HOME: /dollhouse-home
+  DOLLHOUSE_HOME_DIR: /dollhouse-home
+  DOLLHOUSE_PORTFOLIO_DIR: /dollhouse-home/.dollhouse/portfolio
+  DOLLHOUSE_CACHE_DIR: /dollhouse-home/.dollhouse/cache
+  HARNESS_LOG_DIR: /logs
+
+services:
+  netns:
+    image: alpine:3.20
+    container_name: dollhouse-mixed-version-netns
+    command: ["sh", "-lc", "mkdir -p /dollhouse-home/.dollhouse/run /dollhouse-home/.dollhouse/portfolio /dollhouse-home/.dollhouse/cache /dollhouse-home/.dollhouse/logs /logs && sleep infinity"]
+    ports:
+      - "${MIXED_VERSION_HOST_PORT:-42715}:41715"
+    volumes:
+      - ../tmp/mixed-version/home:/dollhouse-home
+      - ../tmp/mixed-version/logs:/logs
+
+  current-local:
+    build:
+      context: ..
+      dockerfile: docker/mixed-version/Dockerfile.current
+    image: dollhouse-mixed-version-current:local
+    container_name: dollhouse-mixed-version-current
+    init: true
+    depends_on:
+      - netns
+    network_mode: "service:netns"
+    working_dir: /workspace
+    entrypoint: ["/bin/bash", "/harness/run-session.sh"]
+    environment:
+      <<: *session-env
+      SESSION_NAME: current-local
+      DOLLHOUSE_SESSION_ID: current-local
+      MCP_SERVER_TARGET: image-worktree
+    volumes:
+      - ../docker/mixed-version:/harness:ro
+      - ../tmp/mixed-version/home:/dollhouse-home
+      - ../tmp/mixed-version/logs:/logs
+
+  stable-226:
+    image: node:22-bookworm-slim
+    container_name: dollhouse-mixed-version-stable-226
+    init: true
+    depends_on:
+      - netns
+    network_mode: "service:netns"
+    entrypoint: ["/bin/bash", "/harness/run-session.sh"]
+    environment:
+      <<: *session-env
+      SESSION_NAME: stable-226
+      DOLLHOUSE_SESSION_ID: stable-226
+      MCP_SERVER_TARGET: "${MIXED_VERSION_STABLE_SPEC:-@dollhousemcp/mcp-server@2.0.26}"
+    volumes:
+      - npm-cache:/root/.npm
+      - ../docker/mixed-version:/harness:ro
+      - ../tmp/mixed-version/home:/dollhouse-home
+      - ../tmp/mixed-version/logs:/logs
+
+  legacy-225:
+    image: node:22-bookworm-slim
+    container_name: dollhouse-mixed-version-legacy-225
+    init: true
+    depends_on:
+      - netns
+    network_mode: "service:netns"
+    entrypoint: ["/bin/bash", "/harness/run-session.sh"]
+    environment:
+      <<: *session-env
+      SESSION_NAME: legacy-225
+      DOLLHOUSE_SESSION_ID: legacy-225
+      MCP_SERVER_TARGET: "${MIXED_VERSION_LEGACY_ONE_SPEC:-@dollhousemcp/mcp-server@2.0.25}"
+    volumes:
+      - npm-cache:/root/.npm
+      - ../docker/mixed-version:/harness:ro
+      - ../tmp/mixed-version/home:/dollhouse-home
+      - ../tmp/mixed-version/logs:/logs
+
+  legacy-219:
+    image: node:22-bookworm-slim
+    container_name: dollhouse-mixed-version-legacy-219
+    init: true
+    depends_on:
+      - netns
+    network_mode: "service:netns"
+    entrypoint: ["/bin/bash", "/harness/run-session.sh"]
+    environment:
+      <<: *session-env
+      SESSION_NAME: legacy-219
+      DOLLHOUSE_SESSION_ID: legacy-219
+      MCP_SERVER_TARGET: "${MIXED_VERSION_LEGACY_TWO_SPEC:-@dollhousemcp/mcp-server@2.0.19}"
+    volumes:
+      - npm-cache:/root/.npm
+      - ../docker/mixed-version:/harness:ro
+      - ../tmp/mixed-version/home:/dollhouse-home
+      - ../tmp/mixed-version/logs:/logs
+
+volumes:
+  npm-cache:

--- a/docker/docker-compose.mixed-version.yml
+++ b/docker/docker-compose.mixed-version.yml
@@ -17,7 +17,8 @@ services:
   netns:
     image: alpine:3.20
     container_name: dollhouse-mixed-version-netns
-    command: ["sh", "-lc", "mkdir -p /dollhouse-home/.dollhouse/run /dollhouse-home/.dollhouse/portfolio /dollhouse-home/.dollhouse/cache /dollhouse-home/.dollhouse/logs /logs && sleep infinity"]
+    init: true
+    command: ["sh", "-lc", "mkdir -p /dollhouse-home/.dollhouse/run /dollhouse-home/.dollhouse/portfolio /dollhouse-home/.dollhouse/cache /dollhouse-home/.dollhouse/logs /logs && exec tail -f /dev/null"]
     ports:
       - "${MIXED_VERSION_HOST_PORT:-42715}:41715"
     volumes:

--- a/docker/mixed-version/Dockerfile.current
+++ b/docker/mixed-version/Dockerfile.current
@@ -9,6 +9,15 @@ COPY packages/safety/package-lock.json packages/safety/package-lock.json
 
 RUN npm ci --include=dev --no-audit --no-fund
 
-COPY . .
+COPY tsconfig.json tsconfig.scripts.json ./
+COPY manifest.json server.json oauth-helper.mjs ./
+COPY data ./data
+COPY scripts ./scripts
+COPY src ./src
+COPY workers ./workers
+COPY packages/safety/src ./packages/safety/src
+COPY packages/safety/tsconfig.json ./packages/safety/tsconfig.json
 
 RUN npm run build
+
+USER node

--- a/docker/mixed-version/Dockerfile.current
+++ b/docker/mixed-version/Dockerfile.current
@@ -1,0 +1,14 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /workspace
+
+# Copy manifests first so dependency installation benefits from layer caching.
+COPY package.json package-lock.json ./
+COPY packages/safety/package.json packages/safety/package.json
+COPY packages/safety/package-lock.json packages/safety/package-lock.json
+
+RUN npm ci --include=dev --no-audit --no-fund
+
+COPY . .
+
+RUN npm run build

--- a/docker/mixed-version/README.md
+++ b/docker/mixed-version/README.md
@@ -57,6 +57,10 @@ If you want to try the host-facing port anyway, the default mapping is:
 
 but treat that as best-effort rather than the source of truth.
 
+The default host port `42715` is intentionally different from Dollhouse's
+internal `41715` so the harness can run alongside a local machine install
+without colliding with the real console.
+
 To capture a shareable snapshot instead of a live watch:
 
 ```bash

--- a/docker/mixed-version/README.md
+++ b/docker/mixed-version/README.md
@@ -1,0 +1,145 @@
+# Mixed-Version Console Harness
+
+This harness reproduces the exact class of bugs where multiple `mcp-server`
+versions share one Dollhouse home directory, fight over the authenticated web
+console lock file, and fail to converge on a single leader plus follower list.
+
+It is intentionally different from the existing Docker test setups:
+
+- all sessions share the same `HOME`
+- all sessions share the same `~/.dollhouse/run` lock and port files
+- all sessions share the same localhost network namespace
+- one service runs the current local worktree while others run pinned published
+  versions from npm
+
+That makes it useful for debugging heterogeneous mixed-version environments
+before cutting another release candidate.
+
+## Services
+
+- `current-local`
+  - builds and runs the current checked-out worktree
+- `stable-226`
+  - runs `@dollhousemcp/mcp-server@2.0.26`
+- `legacy-225`
+  - runs `@dollhousemcp/mcp-server@2.0.25`
+- `legacy-219`
+  - runs `@dollhousemcp/mcp-server@2.0.19`
+
+All of them share the same host-mounted state:
+
+- `tmp/mixed-version/home`
+- `tmp/mixed-version/logs`
+
+## Quick Start
+
+From the repo root:
+
+```bash
+./docker/mixed-version/reset-state.sh
+docker compose -f docker/docker-compose.mixed-version.yml up -d --build
+./docker/mixed-version/observe-state.sh
+```
+
+That gives you a live view of:
+
+- the active lock file writer
+- the number of `permission-server-*.port` files
+- the current `/api/sessions` summary
+
+The observer queries the console from *inside* the shared Docker namespace, so
+it still works even when the web console is only bound to `127.0.0.1` inside
+the harness.
+
+If you want to try the host-facing port anyway, the default mapping is:
+
+- [http://127.0.0.1:42715](http://127.0.0.1:42715)
+
+but treat that as best-effort rather than the source of truth.
+
+To capture a shareable snapshot instead of a live watch:
+
+```bash
+./docker/mixed-version/report-state.sh
+```
+
+That writes a timestamped markdown report under `tmp/mixed-version/reports/`.
+
+## Useful Commands
+
+Follow container logs:
+
+```bash
+docker compose -f docker/docker-compose.mixed-version.yml logs -f current-local stable-226 legacy-225 legacy-219
+```
+
+Rebuild the current local worktree image after changing code:
+
+```bash
+docker compose -f docker/docker-compose.mixed-version.yml up -d --build current-local
+```
+
+Rebuild via the injection helper:
+
+```bash
+./docker/mixed-version/inject-service.sh current-local --rebuild
+```
+
+Swap one published service to a different package version:
+
+```bash
+./docker/mixed-version/inject-service.sh legacy-225 @dollhousemcp/mcp-server@2.0.24
+```
+
+Stop the harness:
+
+```bash
+docker compose -f docker/docker-compose.mixed-version.yml down
+```
+
+Stop and remove state:
+
+```bash
+docker compose -f docker/docker-compose.mixed-version.yml down
+./docker/mixed-version/reset-state.sh
+```
+
+Inspect the shared lock file directly:
+
+```bash
+cat tmp/mixed-version/home/.dollhouse/run/console-leader.auth.lock
+```
+
+Inspect the pid-specific port files:
+
+```bash
+ls -1 tmp/mixed-version/home/.dollhouse/run/permission-server-*.port
+```
+
+## Overriding Versions
+
+You can swap the published package versions without editing the compose file:
+
+```bash
+MIXED_VERSION_STABLE_SPEC=@dollhousemcp/mcp-server@2.0.26 \
+MIXED_VERSION_LEGACY_ONE_SPEC=@dollhousemcp/mcp-server@2.0.24 \
+MIXED_VERSION_LEGACY_TWO_SPEC=@dollhousemcp/mcp-server@2.0.18 \
+docker compose -f docker/docker-compose.mixed-version.yml up -d
+```
+
+If `42715` is already in use, move the host-facing console port:
+
+```bash
+MIXED_VERSION_HOST_PORT=43715 docker compose -f docker/docker-compose.mixed-version.yml up -d
+```
+
+## Why The Shared `netns` Service Exists
+
+Separate containers normally get separate network namespaces, which would let
+every version bind its own internal `41715` without a real conflict. The `netns`
+sidecar exposes container port `41715` through host port `42715` by default, and
+the session services all join that same namespace via `network_mode: service:netns`,
+so they genuinely fight over the same localhost port inside the harness.
+
+That is essential for reproducing the same “port owner vs lock writer” failures
+we have been seeing on real heterogeneous machines.

--- a/docker/mixed-version/inject-service.sh
+++ b/docker/mixed-version/inject-service.sh
@@ -17,6 +17,8 @@ validate_package_spec() {
     echo "Expected format: @dollhousemcp/mcp-server@2.0.26 or @dollhousemcp/mcp-server@2.0.27-rc.6" >&2
     exit 1
   fi
+
+  return 0
 }
 
 if [[ $# -lt 1 ]]; then

--- a/docker/mixed-version/inject-service.sh
+++ b/docker/mixed-version/inject-service.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+COMPOSE_FILE="${REPO_ROOT}/docker/docker-compose.mixed-version.yml"
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage:" >&2
+  echo "  $0 current-local --rebuild" >&2
+  echo "  $0 <stable-226|legacy-225|legacy-219> <npm-spec>" >&2
+  exit 1
+fi
+
+SERVICE="$1"
+shift
+
+case "${SERVICE}" in
+  current-local)
+    if [[ "${1:-}" != "--rebuild" ]]; then
+      echo "current-local only supports --rebuild" >&2
+      exit 1
+    fi
+    docker compose -f "${COMPOSE_FILE}" up -d --build --force-recreate current-local
+    ;;
+  stable-226)
+    SPEC="${1:?Provide an npm package spec such as @dollhousemcp/mcp-server@2.0.26}"
+    MIXED_VERSION_STABLE_SPEC="${SPEC}" docker compose -f "${COMPOSE_FILE}" up -d --force-recreate stable-226
+    ;;
+  legacy-225)
+    SPEC="${1:?Provide an npm package spec such as @dollhousemcp/mcp-server@2.0.25}"
+    MIXED_VERSION_LEGACY_ONE_SPEC="${SPEC}" docker compose -f "${COMPOSE_FILE}" up -d --force-recreate legacy-225
+    ;;
+  legacy-219)
+    SPEC="${1:?Provide an npm package spec such as @dollhousemcp/mcp-server@2.0.19}"
+    MIXED_VERSION_LEGACY_TWO_SPEC="${SPEC}" docker compose -f "${COMPOSE_FILE}" up -d --force-recreate legacy-219
+    ;;
+  *)
+    echo "Unknown service: ${SERVICE}" >&2
+    exit 1
+    ;;
+esac

--- a/docker/mixed-version/inject-service.sh
+++ b/docker/mixed-version/inject-service.sh
@@ -6,6 +6,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 COMPOSE_FILE="${REPO_ROOT}/docker/docker-compose.mixed-version.yml"
 
+validate_package_spec() {
+  local spec="$1"
+
+  # Keep the harness narrow on purpose: it only swaps published mcp-server
+  # package versions. Reject anything else rather than passing arbitrary
+  # environment content through to docker compose.
+  if [[ ! "${spec}" =~ ^@dollhousemcp/mcp-server@[0-9]+\.[0-9]+\.[0-9]+([-a-zA-Z0-9.]+)?$ ]]; then
+    echo "Invalid package spec: ${spec}" >&2
+    echo "Expected format: @dollhousemcp/mcp-server@2.0.26 or @dollhousemcp/mcp-server@2.0.27-rc.6" >&2
+    exit 1
+  fi
+}
+
 if [[ $# -lt 1 ]]; then
   echo "Usage:" >&2
   echo "  $0 current-local --rebuild" >&2
@@ -19,21 +32,25 @@ shift
 case "${SERVICE}" in
   current-local)
     if [[ "${1:-}" != "--rebuild" ]]; then
-      echo "current-local only supports --rebuild" >&2
+      echo "current-local only supports --rebuild because it uses the local worktree image." >&2
+      echo "Use one of stable-226, legacy-225, or legacy-219 to inject a published npm version." >&2
       exit 1
     fi
     docker compose -f "${COMPOSE_FILE}" up -d --build --force-recreate current-local
     ;;
   stable-226)
     SPEC="${1:?Provide an npm package spec such as @dollhousemcp/mcp-server@2.0.26}"
+    validate_package_spec "${SPEC}"
     MIXED_VERSION_STABLE_SPEC="${SPEC}" docker compose -f "${COMPOSE_FILE}" up -d --force-recreate stable-226
     ;;
   legacy-225)
     SPEC="${1:?Provide an npm package spec such as @dollhousemcp/mcp-server@2.0.25}"
+    validate_package_spec "${SPEC}"
     MIXED_VERSION_LEGACY_ONE_SPEC="${SPEC}" docker compose -f "${COMPOSE_FILE}" up -d --force-recreate legacy-225
     ;;
   legacy-219)
     SPEC="${1:?Provide an npm package spec such as @dollhousemcp/mcp-server@2.0.19}"
+    validate_package_spec "${SPEC}"
     MIXED_VERSION_LEGACY_TWO_SPEC="${SPEC}" docker compose -f "${COMPOSE_FILE}" up -d --force-recreate legacy-219
     ;;
   *)

--- a/docker/mixed-version/observe-state.sh
+++ b/docker/mixed-version/observe-state.sh
@@ -8,6 +8,7 @@ STATE_HOME="${REPO_ROOT}/tmp/mixed-version/home/.dollhouse"
 RUN_DIR="${STATE_HOME}/run"
 LOCK_FILE="${RUN_DIR}/console-leader.auth.lock"
 COMPOSE_FILE="${REPO_ROOT}/docker/docker-compose.mixed-version.yml"
+INTERNAL_CONSOLE_PORT="${DOLLHOUSE_WEB_CONSOLE_PORT:-41715}"
 CONSOLE_URL="${MIXED_VERSION_CONSOLE_URL:-http://127.0.0.1:${MIXED_VERSION_HOST_PORT:-42715}}"
 INTERVAL=2
 MAX_ITERATIONS=0
@@ -16,10 +17,18 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --interval)
       INTERVAL="${2:?--interval requires a value}"
+      if ! [[ "${INTERVAL}" =~ ^[0-9]+$ ]] || (( INTERVAL < 1 )); then
+        echo "--interval must be a positive integer" >&2
+        exit 1
+      fi
       shift 2
       ;;
     --count)
       MAX_ITERATIONS="${2:?--count requires a value}"
+      if ! [[ "${MAX_ITERATIONS}" =~ ^[0-9]+$ ]]; then
+        echo "--count must be a non-negative integer" >&2
+        exit 1
+      fi
       shift 2
       ;;
     --once)
@@ -67,30 +76,17 @@ print_port_files() {
 
 print_sessions_summary() {
   local response
+  local fallback_error=""
   if ! response="$(curl -fsS "${CONSOLE_URL}/api/sessions" 2>/dev/null)"; then
-    response="$(
-      docker compose -f "${COMPOSE_FILE}" exec -T stable-226 node - <<'NODE'
-const http = require('node:http');
-
-const request = http.get('http://127.0.0.1:41715/api/sessions', (response) => {
-  let body = '';
-  response.setEncoding('utf8');
-  response.on('data', (chunk) => { body += chunk; });
-  response.on('end', () => {
-    process.stdout.write(body);
-  });
-});
-
-request.on('error', (error) => {
-  process.stderr.write(String(error));
-  process.exit(1);
-});
-NODE
-    )" || true
+    response="$(docker compose -f "${COMPOSE_FILE}" exec -T -e DOLLHOUSE_WEB_CONSOLE_PORT="${INTERNAL_CONSOLE_PORT}" stable-226 node /harness/query-sessions.mjs 2>/tmp/mixed-version-observe.err)" || fallback_error="$(cat /tmp/mixed-version-observe.err 2>/dev/null || true)"
   fi
 
   if [[ -z "${response}" ]]; then
-    echo "sessions: console unavailable at ${CONSOLE_URL} and inside shared namespace"
+    if [[ -n "${fallback_error}" ]]; then
+      echo "sessions: console unavailable at ${CONSOLE_URL}; fallback query failed: ${fallback_error}"
+    else
+      echo "sessions: console unavailable at ${CONSOLE_URL} and inside shared namespace"
+    fi
     return
   fi
 

--- a/docker/mixed-version/observe-state.sh
+++ b/docker/mixed-version/observe-state.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+STATE_HOME="${REPO_ROOT}/tmp/mixed-version/home/.dollhouse"
+RUN_DIR="${STATE_HOME}/run"
+LOCK_FILE="${RUN_DIR}/console-leader.auth.lock"
+COMPOSE_FILE="${REPO_ROOT}/docker/docker-compose.mixed-version.yml"
+CONSOLE_URL="${MIXED_VERSION_CONSOLE_URL:-http://127.0.0.1:${MIXED_VERSION_HOST_PORT:-42715}}"
+INTERVAL=2
+MAX_ITERATIONS=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --interval)
+      INTERVAL="${2:?--interval requires a value}"
+      shift 2
+      ;;
+    --count)
+      MAX_ITERATIONS="${2:?--count requires a value}"
+      shift 2
+      ;;
+    --once)
+      MAX_ITERATIONS=1
+      shift
+      ;;
+    *)
+      # Backwards-compatible shorthand: first positional argument is the interval.
+      if [[ "${INTERVAL}" == "2" ]]; then
+        INTERVAL="$1"
+        shift
+      else
+        echo "Unknown argument: $1" >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+print_lock_summary() {
+  if [[ ! -f "${LOCK_FILE}" ]]; then
+    echo "lock: missing (${LOCK_FILE})"
+    return
+  fi
+
+  node - "${LOCK_FILE}" <<'NODE'
+const fs = require('node:fs');
+const lockPath = process.argv[2];
+const raw = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+const version = raw.serverVersion ?? 'unknown';
+console.log(`lock: pid=${raw.pid} version=${version} heartbeat=${raw.heartbeat} session=${raw.sessionId}`);
+NODE
+}
+
+print_port_files() {
+  if [[ ! -d "${RUN_DIR}" ]]; then
+    echo "port files: run dir missing (${RUN_DIR})"
+    return
+  fi
+
+  local count
+  count="$(find "${RUN_DIR}" -maxdepth 1 -name 'permission-server-*.port' | wc -l | tr -d ' ')"
+  echo "port files: ${count} pid-specific files"
+}
+
+print_sessions_summary() {
+  local response
+  if ! response="$(curl -fsS "${CONSOLE_URL}/api/sessions" 2>/dev/null)"; then
+    response="$(
+      docker compose -f "${COMPOSE_FILE}" exec -T stable-226 node - <<'NODE'
+const http = require('node:http');
+
+const request = http.get('http://127.0.0.1:41715/api/sessions', (response) => {
+  let body = '';
+  response.setEncoding('utf8');
+  response.on('data', (chunk) => { body += chunk; });
+  response.on('end', () => {
+    process.stdout.write(body);
+  });
+});
+
+request.on('error', (error) => {
+  process.stderr.write(String(error));
+  process.exit(1);
+});
+NODE
+    )" || true
+  fi
+
+  if [[ -z "${response}" ]]; then
+    echo "sessions: console unavailable at ${CONSOLE_URL} and inside shared namespace"
+    return
+  fi
+
+  node - "${response}" <<'NODE'
+const payload = JSON.parse(process.argv[2]);
+const sessions = Array.isArray(payload.sessions) ? payload.sessions : [];
+const summary = sessions.map((session) => {
+  const role = session.isLeader ? 'leader' : 'follower';
+  const version = session.serverVersion ?? 'unknown';
+  const name = session.displayName ?? session.sessionId ?? 'unknown';
+  return `${name}:${role}:${version}`;
+}).join(', ');
+console.log(`sessions: count=${sessions.length}${summary ? ` -> ${summary}` : ''}`);
+NODE
+}
+
+iteration=0
+while true; do
+  printf '\n[%s]\n' "$(date '+%Y-%m-%d %H:%M:%S')"
+  print_lock_summary
+  print_port_files
+  print_sessions_summary
+
+  iteration=$((iteration + 1))
+  if (( MAX_ITERATIONS > 0 && iteration >= MAX_ITERATIONS )); then
+    break
+  fi
+
+  sleep "${INTERVAL}"
+done

--- a/docker/mixed-version/query-sessions.mjs
+++ b/docker/mixed-version/query-sessions.mjs
@@ -1,0 +1,47 @@
+import http from 'node:http';
+
+const port = process.env.DOLLHOUSE_WEB_CONSOLE_PORT ?? '41715';
+
+if (!/^\d+$/.test(port)) {
+  console.error(`invalid DOLLHOUSE_WEB_CONSOLE_PORT: ${port}`);
+  process.exit(1);
+}
+
+const numericPort = Number(port);
+if (numericPort < 1 || numericPort > 65535) {
+  console.error(`invalid DOLLHOUSE_WEB_CONSOLE_PORT: ${port}`);
+  process.exit(1);
+}
+
+const request = http.get(
+  {
+    host: '127.0.0.1',
+    port: numericPort,
+    path: '/api/sessions',
+    timeout: 5000,
+  },
+  (response) => {
+    let body = '';
+    response.setEncoding('utf8');
+    response.on('data', (chunk) => {
+      body += chunk;
+    });
+    response.on('end', () => {
+      if (response.statusCode !== 200) {
+        console.error(`session query failed with status ${response.statusCode ?? 'unknown'}`);
+        process.exit(1);
+      }
+
+      process.stdout.write(body);
+    });
+  },
+);
+
+request.on('timeout', () => {
+  request.destroy(new Error('session query timed out'));
+});
+
+request.on('error', (error) => {
+  console.error(String(error));
+  process.exit(1);
+});

--- a/docker/mixed-version/report-state.sh
+++ b/docker/mixed-version/report-state.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+COMPOSE_FILE="${REPO_ROOT}/docker/docker-compose.mixed-version.yml"
+STATE_ROOT="${REPO_ROOT}/tmp/mixed-version"
+RUN_DIR="${STATE_ROOT}/home/.dollhouse/run"
+REPORT_DIR="${STATE_ROOT}/reports"
+TIMESTAMP="$(date '+%Y%m%d-%H%M%S')"
+REPORT_PATH="${REPORT_DIR}/mixed-version-report-${TIMESTAMP}.md"
+
+mkdir -p "${REPORT_DIR}"
+
+{
+  echo "# Mixed-Version Harness Report"
+  echo
+  echo "- Generated: $(date '+%Y-%m-%d %H:%M:%S %Z')"
+  echo "- Worktree: ${REPO_ROOT}"
+  echo "- Host port: ${MIXED_VERSION_HOST_PORT:-42715}"
+  echo
+  echo "## Compose Status"
+  echo
+  echo '```text'
+  docker compose -f "${COMPOSE_FILE}" ps
+  echo '```'
+  echo
+  echo "## Live Observer Snapshot"
+  echo
+  echo '```text'
+  "${SCRIPT_DIR}/observe-state.sh" --once
+  echo '```'
+  echo
+  echo "## Lock File"
+  echo
+  if [[ -f "${RUN_DIR}/console-leader.auth.lock" ]]; then
+    echo '```json'
+    cat "${RUN_DIR}/console-leader.auth.lock"
+    echo '```'
+  else
+    echo "_No lock file present_"
+  fi
+  echo
+  echo "## Port Files"
+  echo
+  echo '```text'
+  if [[ -d "${RUN_DIR}" ]]; then
+    find "${RUN_DIR}" -maxdepth 1 \( -name 'permission-server*.port' -o -name 'console-leader*.lock' \) | sort
+  else
+    echo "Run directory missing: ${RUN_DIR}"
+  fi
+  echo '```'
+  echo
+  echo "## Recent Container Logs"
+  echo
+  echo '```text'
+  docker compose -f "${COMPOSE_FILE}" logs --tail=80 current-local stable-226 legacy-225 legacy-219
+  echo '```'
+} > "${REPORT_PATH}"
+
+echo "${REPORT_PATH}"

--- a/docker/mixed-version/report-state.sh
+++ b/docker/mixed-version/report-state.sh
@@ -10,6 +10,7 @@ RUN_DIR="${STATE_ROOT}/home/.dollhouse/run"
 REPORT_DIR="${STATE_ROOT}/reports"
 TIMESTAMP="$(date '+%Y%m%d-%H%M%S')"
 REPORT_PATH="${REPORT_DIR}/mixed-version-report-${TIMESTAMP}.md"
+TEXT_CODE_FENCE='```text'
 
 mkdir -p "${REPORT_DIR}"
 
@@ -22,13 +23,13 @@ mkdir -p "${REPORT_DIR}"
   echo
   echo "## Compose Status"
   echo
-  echo '```text'
+  echo "${TEXT_CODE_FENCE}"
   docker compose -f "${COMPOSE_FILE}" ps
   echo '```'
   echo
   echo "## Live Observer Snapshot"
   echo
-  echo '```text'
+  echo "${TEXT_CODE_FENCE}"
   "${SCRIPT_DIR}/observe-state.sh" --once
   echo '```'
   echo
@@ -44,7 +45,7 @@ mkdir -p "${REPORT_DIR}"
   echo
   echo "## Port Files"
   echo
-  echo '```text'
+  echo "${TEXT_CODE_FENCE}"
   if [[ -d "${RUN_DIR}" ]]; then
     find "${RUN_DIR}" -maxdepth 1 \( -name 'permission-server*.port' -o -name 'console-leader*.lock' \) | sort
   else
@@ -54,7 +55,7 @@ mkdir -p "${REPORT_DIR}"
   echo
   echo "## Recent Container Logs"
   echo
-  echo '```text'
+  echo "${TEXT_CODE_FENCE}"
   docker compose -f "${COMPOSE_FILE}" logs --tail=80 current-local stable-226 legacy-225 legacy-219
   echo '```'
 } > "${REPORT_PATH}"

--- a/docker/mixed-version/reset-state.sh
+++ b/docker/mixed-version/reset-state.sh
@@ -8,5 +8,6 @@ STATE_ROOT="${REPO_ROOT}/tmp/mixed-version"
 
 rm -rf "${STATE_ROOT}"
 mkdir -p "${STATE_ROOT}/home" "${STATE_ROOT}/logs"
+chmod 0777 "${STATE_ROOT}/home" "${STATE_ROOT}/logs"
 
 echo "Reset mixed-version harness state under ${STATE_ROOT}"

--- a/docker/mixed-version/reset-state.sh
+++ b/docker/mixed-version/reset-state.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+STATE_ROOT="${REPO_ROOT}/tmp/mixed-version"
+
+rm -rf "${STATE_ROOT}"
+mkdir -p "${STATE_ROOT}/home" "${STATE_ROOT}/logs"
+
+echo "Reset mixed-version harness state under ${STATE_ROOT}"

--- a/docker/mixed-version/run-session.sh
+++ b/docker/mixed-version/run-session.sh
@@ -24,6 +24,7 @@ run_local_worktree() {
   cd /workspace
 
   local lock_hash_file="/workspace/node_modules/.mixed-version-package-lock.sha256"
+  local install_lock_dir="/workspace/.mixed-version-npm-ci.lock"
   local current_hash
   local original_node_env="${NODE_ENV:-}"
   current_hash="$(sha256sum package-lock.json | awk '{print $1}')"
@@ -34,9 +35,22 @@ run_local_worktree() {
   export NODE_ENV=development
 
   if [[ ! -d /workspace/node_modules ]] || [[ ! -f "${lock_hash_file}" ]] || [[ "$(cat "${lock_hash_file}" 2>/dev/null || true)" != "${current_hash}" ]]; then
-    echo "[mixed-version] installing local workspace dependencies"
-    npm ci --include=dev --no-audit --no-fund
-    echo "${current_hash}" > "${lock_hash_file}"
+    # Multiple harness containers can share the same mounted workspace. Use a
+    # simple mkdir lock so only one of them runs npm ci at a time.
+    until mkdir "${install_lock_dir}" 2>/dev/null; do
+      echo "[mixed-version] waiting for dependency install lock"
+      sleep 1
+    done
+
+    trap 'rmdir "'"${install_lock_dir}"'" 2>/dev/null || true' RETURN
+
+    if [[ ! -d /workspace/node_modules ]] || [[ ! -f "${lock_hash_file}" ]] || [[ "$(cat "${lock_hash_file}" 2>/dev/null || true)" != "${current_hash}" ]]; then
+      echo "[mixed-version] installing local workspace dependencies"
+      npm ci --include=dev --no-audit --no-fund
+      echo "${current_hash}" > "${lock_hash_file}"
+    else
+      echo "[mixed-version] dependencies already installed by another container"
+    fi
   fi
 
   echo "[mixed-version] building local workspace"
@@ -51,6 +65,9 @@ run_local_worktree() {
   else
     unset NODE_ENV
   fi
+
+  rmdir "${install_lock_dir}" 2>/dev/null || true
+  trap - RETURN
 
   # Keep stdin open forever so the stdio MCP server remains connected long enough
   # to exercise deferred console setup, leader election, and follower forwarding.

--- a/docker/mixed-version/run-session.sh
+++ b/docker/mixed-version/run-session.sh
@@ -72,6 +72,7 @@ run_local_worktree() {
   # Keep stdin open forever so the stdio MCP server remains connected long enough
   # to exercise deferred console setup, leader election, and follower forwarding.
   tail -f /dev/null | node dist/index.js
+  return 0
 }
 
 run_built_worktree() {
@@ -82,6 +83,7 @@ run_built_worktree() {
   echo "[mixed-version] image worktree version=${version}"
 
   tail -f /dev/null | node dist/index.js
+  return 0
 }
 
 run_published_package() {
@@ -90,6 +92,7 @@ run_published_package() {
   # npx installs the requested version into the shared npm cache volume after the
   # first run, which keeps subsequent reproductions much faster.
   tail -f /dev/null | npx -y "${MCP_SERVER_TARGET}"
+  return 0
 }
 
 case "${MCP_SERVER_TARGET}" in

--- a/docker/mixed-version/run-session.sh
+++ b/docker/mixed-version/run-session.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SESSION_NAME="${SESSION_NAME:?SESSION_NAME is required}"
+MCP_SERVER_TARGET="${MCP_SERVER_TARGET:?MCP_SERVER_TARGET is required}"
+LOG_DIR="${HARNESS_LOG_DIR:-/logs}"
+HOME_DIR="${HOME:-/dollhouse-home}"
+APP_HOME="${DOLLHOUSE_HOME_DIR:-$HOME_DIR}"
+RUN_DIR="${APP_HOME}/.dollhouse/run"
+PORTFOLIO_DIR="${DOLLHOUSE_PORTFOLIO_DIR:-${APP_HOME}/.dollhouse/portfolio}"
+CACHE_DIR="${DOLLHOUSE_CACHE_DIR:-${APP_HOME}/.dollhouse/cache}"
+FILE_LOG_DIR="${APP_HOME}/.dollhouse/logs"
+LOG_FILE="${LOG_DIR}/${SESSION_NAME}.log"
+
+mkdir -p "${RUN_DIR}" "${PORTFOLIO_DIR}" "${CACHE_DIR}" "${FILE_LOG_DIR}" "${LOG_DIR}"
+touch "${LOG_FILE}"
+exec > >(tee -a "${LOG_FILE}") 2>&1
+
+echo "[mixed-version] session=${SESSION_NAME} target=${MCP_SERVER_TARGET}"
+echo "[mixed-version] home=${APP_HOME} port=${DOLLHOUSE_WEB_CONSOLE_PORT:-41715}"
+
+run_local_worktree() {
+  cd /workspace
+
+  local lock_hash_file="/workspace/node_modules/.mixed-version-package-lock.sha256"
+  local current_hash
+  local original_node_env="${NODE_ENV:-}"
+  current_hash="$(sha256sum package-lock.json | awk '{print $1}')"
+
+  # The local-worktree harness needs the full dev toolchain to build the current
+  # branch inside the container. The production default is still useful for the
+  # published-package services, so only override it in this local path.
+  export NODE_ENV=development
+
+  if [[ ! -d /workspace/node_modules ]] || [[ ! -f "${lock_hash_file}" ]] || [[ "$(cat "${lock_hash_file}" 2>/dev/null || true)" != "${current_hash}" ]]; then
+    echo "[mixed-version] installing local workspace dependencies"
+    npm ci --include=dev --no-audit --no-fund
+    echo "${current_hash}" > "${lock_hash_file}"
+  fi
+
+  echo "[mixed-version] building local workspace"
+  npm run build
+
+  local version
+  version="$(node -p "require('./package.json').version")"
+  echo "[mixed-version] local workspace version=${version}"
+
+  if [[ -n "${original_node_env}" ]]; then
+    export NODE_ENV="${original_node_env}"
+  else
+    unset NODE_ENV
+  fi
+
+  # Keep stdin open forever so the stdio MCP server remains connected long enough
+  # to exercise deferred console setup, leader election, and follower forwarding.
+  tail -f /dev/null | node dist/index.js
+}
+
+run_built_worktree() {
+  cd /workspace
+
+  local version
+  version="$(node -p "require('./package.json').version")"
+  echo "[mixed-version] image worktree version=${version}"
+
+  tail -f /dev/null | node dist/index.js
+}
+
+run_published_package() {
+  echo "[mixed-version] starting published package ${MCP_SERVER_TARGET}"
+
+  # npx installs the requested version into the shared npm cache volume after the
+  # first run, which keeps subsequent reproductions much faster.
+  tail -f /dev/null | npx -y "${MCP_SERVER_TARGET}"
+}
+
+case "${MCP_SERVER_TARGET}" in
+  local-worktree)
+    run_local_worktree
+    ;;
+  image-worktree)
+    run_built_worktree
+    ;;
+  *)
+    run_published_package
+    ;;
+esac

--- a/docker/mixed-version/smoke-test.sh
+++ b/docker/mixed-version/smoke-test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+COMPOSE_FILE="${REPO_ROOT}/docker/docker-compose.mixed-version.yml"
+TARGET_INJECT_SPEC="${TARGET_INJECT_SPEC:-@dollhousemcp/mcp-server@2.0.24}"
+
+cleanup() {
+  docker compose -f "${COMPOSE_FILE}" down >/dev/null 2>&1 || true
+}
+
+wait_for_sessions() {
+  local description="$1"
+  local expected_pattern="$2"
+  local output=""
+
+  for _ in $(seq 1 15); do
+    output="$("${SCRIPT_DIR}/observe-state.sh" --once)"
+    if [[ "${output}" =~ sessions:\ count=([0-9]+) ]] && [[ "${output}" =~ ${expected_pattern} ]]; then
+      printf '%s\n' "${output}"
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "Timed out waiting for ${description}" >&2
+  printf '%s\n' "${output}" >&2
+  return 1
+}
+
+trap cleanup EXIT
+
+"${SCRIPT_DIR}/reset-state.sh"
+docker compose -f "${COMPOSE_FILE}" up -d --build
+
+wait_for_sessions "initial mixed-version leader election" "count=([2-9]|[1-9][0-9]+)"
+
+"${SCRIPT_DIR}/inject-service.sh" legacy-225 "${TARGET_INJECT_SPEC}"
+
+wait_for_sessions "legacy injection to appear in sessions" "2\\.0\\.24"

--- a/docker/mixed-version/smoke-test.sh
+++ b/docker/mixed-version/smoke-test.sh
@@ -9,6 +9,7 @@ TARGET_INJECT_SPEC="${TARGET_INJECT_SPEC:-@dollhousemcp/mcp-server@2.0.24}"
 
 cleanup() {
   docker compose -f "${COMPOSE_FILE}" down >/dev/null 2>&1 || true
+  return 0
 }
 
 wait_for_sessions() {
@@ -18,7 +19,7 @@ wait_for_sessions() {
 
   for _ in $(seq 1 15); do
     output="$("${SCRIPT_DIR}/observe-state.sh" --once)"
-    if [[ "${output}" =~ sessions:\ count=([0-9]+) ]] && [[ "${output}" =~ ${expected_pattern} ]]; then
+    if [[ "${output}" =~ sessions:\ count=([0-9]+) ]] && printf '%s\n' "${output}" | grep -Eq "${expected_pattern}"; then
       printf '%s\n' "${output}"
       return 0
     fi

--- a/docker/mixed-version/smoke-test.sh
+++ b/docker/mixed-version/smoke-test.sh
@@ -6,6 +6,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 COMPOSE_FILE="${REPO_ROOT}/docker/docker-compose.mixed-version.yml"
 TARGET_INJECT_SPEC="${TARGET_INJECT_SPEC:-@dollhousemcp/mcp-server@2.0.24}"
+SESSION_WAIT_RETRIES="${SESSION_WAIT_RETRIES:-30}"
+SESSION_WAIT_SLEEP_SECONDS="${SESSION_WAIT_SLEEP_SECONDS:-2}"
 
 cleanup() {
   docker compose -f "${COMPOSE_FILE}" down >/dev/null 2>&1 || true
@@ -17,17 +19,19 @@ wait_for_sessions() {
   local expected_pattern="$2"
   local output=""
 
-  for _ in $(seq 1 15); do
+  for _ in $(seq 1 "${SESSION_WAIT_RETRIES}"); do
     output="$("${SCRIPT_DIR}/observe-state.sh" --once)"
     if [[ "${output}" =~ sessions:\ count=([0-9]+) ]] && printf '%s\n' "${output}" | grep -Eq "${expected_pattern}"; then
       printf '%s\n' "${output}"
       return 0
     fi
-    sleep 2
+    sleep "${SESSION_WAIT_SLEEP_SECONDS}"
   done
 
   echo "Timed out waiting for ${description}" >&2
   printf '%s\n' "${output}" >&2
+  echo "Recent container logs:" >&2
+  docker compose -f "${COMPOSE_FILE}" logs --tail=40 current-local stable-226 legacy-225 legacy-219 >&2 || true
   return 1
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated Docker harness for mixed-version console leader-election debugging
- include live observer and markdown report generation for lock/session state
- add an injection helper so one running service can be swapped to a different package version without editing compose files

## What I validated
- brought up the full harness with current-local plus historical published versions
- captured live mixed-version state with `observe-state.sh`
- generated timestamped reports with `report-state.sh`
- injected a version change with `inject-service.sh legacy-225 @dollhousemcp/mcp-server@2.0.24`
- confirmed the shared session view updated to show the injected follower on `2.0.24`

## Notes
- the observer is the source of truth because it queries `/api/sessions` from inside the shared Docker namespace
- the host-facing published port is best-effort only because the console binds loopback inside that namespace
