### PR TITLE
Fix false-success mixed-version console takeover

### DIFF
--- a/src/web/console/LeaderElection.ts
+++ b/src/web/console/LeaderElection.ts
@@ -19,8 +19,8 @@
  */
 
 import { homedir } from 'node:os';
-import { join } from 'node:path';
-import { mkdir, readFile, writeFile, rename, unlink } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { mkdir, open, readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { env } from '../../config/env.js';
 import { PACKAGE_VERSION } from '../../generated/version.js';
@@ -278,9 +278,9 @@ export async function detectLegacyLeader(lockPath: string = LEGACY_LOCK_FILE): P
  * Read and parse the leader lock file.
  * Returns null if the file doesn't exist, is unreadable, or has invalid content.
  */
-export async function readLeaderLock(): Promise<ConsoleLeaderInfo | null> {
+export async function readLeaderLock(lockPath: string = LOCK_FILE): Promise<ConsoleLeaderInfo | null> {
   try {
-    const content = await readFile(LOCK_FILE, 'utf-8');
+    const content = await readFile(lockPath, 'utf-8');
     const data = JSON.parse(content) as ConsoleLeaderInfo;
     if (data.version !== LOCK_VERSION || !data.pid || !data.port || !data.sessionId) {
       return null;
@@ -289,7 +289,7 @@ export async function readLeaderLock(): Promise<ConsoleLeaderInfo | null> {
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
       logger.debug('[LeaderElection] Ignoring unreadable or invalid leader lock', {
-        lockFile: LOCK_FILE,
+        lockFile: lockPath,
         error: error instanceof Error ? error.message : String(error),
       });
     }
@@ -311,25 +311,33 @@ export function isLockStale(info: ConsoleLeaderInfo): boolean {
 /**
  * Attempt to atomically claim leadership.
  *
- * Writes to a temp file then renames to the lock path. On POSIX systems
- * rename is atomic, so only one writer wins. After renaming, re-reads the
- * lock to verify our PID won.
+ * Creates the lock file with exclusive-write semantics so only one process
+ * can win the initial claim. This avoids startup races where multiple
+ * contenders overwrite the lock in quick succession and each briefly believe
+ * they are leader.
  *
  * @returns true if this process successfully claimed leadership
  */
-export async function claimLeadership(info: ConsoleLeaderInfo): Promise<boolean> {
-  await mkdir(RUN_DIR, { recursive: true });
-  const tmpFile = join(RUN_DIR, `console-leader.lock.${process.pid}.tmp`);
+export async function claimLeadership(
+  info: ConsoleLeaderInfo,
+  lockPath: string = LOCK_FILE,
+): Promise<boolean> {
+  await mkdir(dirname(lockPath), { recursive: true });
   try {
-    await writeFile(tmpFile, JSON.stringify(info, null, 2), 'utf-8');
-    await rename(tmpFile, LOCK_FILE);
+    const handle = await open(lockPath, 'wx', 0o600);
+    try {
+      await handle.writeFile(JSON.stringify(info, null, 2), 'utf-8');
+    } finally {
+      await handle.close();
+    }
 
-    // Verify we won the race
-    const written = await readLeaderLock();
+    // Verify we won the race.
+    const written = await readLeaderLock(lockPath);
     return written !== null && written.pid === info.pid;
-  } catch {
-    // Clean up temp file on failure
-    try { await unlink(tmpFile); } catch { /* ignore */ }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      return false;
+    }
     return false;
   }
 }

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -241,6 +241,7 @@ interface LeaderLeaseReconciliationDependencies {
   readLeaderLockImpl?: typeof readLeaderLock;
   findPidOnPortImpl?: typeof findPidOnPort;
   claimLeadershipImpl?: typeof claimLeadership;
+  deleteLeaderLockImpl?: typeof deleteLeaderLock;
   killStaleProcessDetailedImpl?: typeof killStaleProcessDetailed;
   setTimeoutImpl?: typeof setTimeout;
   clearTimeoutImpl?: typeof clearTimeout;
@@ -741,10 +742,11 @@ export async function reconcileLeaderLease(
   sessionId: string,
   consolePort: number,
   deps: LeaderLeaseReconciliationDependencies = {},
-): Promise<'not-port-owner' | 'already-owned' | 'reconciled'> {
+): Promise<'not-port-owner' | 'already-owned' | 'reconciled' | 'reclaim-failed'> {
   const readLeaderLockImpl = deps.readLeaderLockImpl ?? readLeaderLock;
   const findPidOnPortImpl = deps.findPidOnPortImpl ?? findPidOnPort;
   const claimLeadershipImpl = deps.claimLeadershipImpl ?? claimLeadership;
+  const deleteLeaderLockImpl = deps.deleteLeaderLockImpl ?? deleteLeaderLock;
   const killStaleProcessDetailedImpl = deps.killStaleProcessDetailedImpl ?? killStaleProcessDetailed;
 
   const portOwnerPid = await findPidOnPortImpl(consolePort);
@@ -777,7 +779,22 @@ export async function reconcileLeaderLease(
   const killOutcome = await killStaleProcessDetailedImpl(currentLock.pid, consolePort, {
     allowActiveHostParent: true,
   });
-  const lockClaimed = await claimLeadershipImpl(expectedLeader);
+  const lockAfterKill = await readLeaderLockImpl();
+  let lockDeleted = false;
+  let lockClaimAttempted = false;
+  let lockClaimed = false;
+
+  if (lockAfterKill?.pid !== process.pid) {
+    if (lockAfterKill) {
+      await deleteLeaderLockImpl();
+      lockDeleted = true;
+    }
+    lockClaimAttempted = true;
+    lockClaimed = await claimLeadershipImpl(expectedLeader);
+  }
+
+  const finalLock = await readLeaderLockImpl();
+  const reconciled = finalLock?.pid === process.pid;
 
   logger.info('[UnifiedConsole] Leader lease reconciliation completed', {
     sessionId,
@@ -788,8 +805,32 @@ export async function reconcileLeaderLease(
     killAttempted: true,
     killResult: killOutcome.reason,
     killed: killOutcome.killed,
+    lockDeleted,
+    lockClaimAttempted,
     lockClaimed,
+    finalLockOwnerPid: finalLock?.pid ?? null,
+    finalLockOwnerSessionId: finalLock?.sessionId ?? null,
+    finalLockOwnerVersion: finalLock?.serverVersion ?? null,
+    reconciled,
   });
+
+  if (!reconciled) {
+    logger.warn('[UnifiedConsole] Port-owning leader could not reclaim the displaced leader lock', {
+      sessionId,
+      port: consolePort,
+      displacedPid: currentLock.pid,
+      displacedSessionId: currentLock.sessionId,
+      finalLockOwnerPid: finalLock?.pid ?? null,
+      finalLockOwnerSessionId: finalLock?.sessionId ?? null,
+      finalLockOwnerVersion: finalLock?.serverVersion ?? null,
+      killResult: killOutcome.reason,
+      lockDeleted,
+      lockClaimAttempted,
+      lockClaimed,
+    });
+    return 'reclaim-failed';
+  }
+
   return 'reconciled';
 }
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -162,6 +162,11 @@ export interface BindResult {
   detail?: string;
 }
 
+export interface PortOwnershipVerificationResult {
+  matches: boolean;
+  ownerPid: number | null;
+}
+
 /**
  * Result of starting the web server, including hooks for DI wiring.
  */
@@ -546,8 +551,20 @@ function printStartupBanner(port: number, tokenStore: ConsoleTokenStore | undefi
 }
 
 // Stale process recovery — extracted to StaleProcessRecovery.ts for independent testing (#1850).
-import { recoverStalePort } from './console/StaleProcessRecovery.js';
+import { findPidOnPort, recoverStalePort } from './console/StaleProcessRecovery.js';
 export { findPidOnPort, killStaleProcess, recoverStalePort } from './console/StaleProcessRecovery.js';
+
+export async function verifyBoundPortOwnership(
+  port: number,
+  expectedPid: number,
+  findPidOnPortImpl: typeof findPidOnPort = findPidOnPort,
+): Promise<PortOwnershipVerificationResult> {
+  const ownerPid = await findPidOnPortImpl(port);
+  return {
+    matches: ownerPid === null || ownerPid === expectedPid,
+    ownerPid,
+  };
+}
 
 /**
  * Attempt a single port bind. Returns a BindResult without any recovery logic.
@@ -558,22 +575,55 @@ function attemptBind(
   options: WebServerOptions,
 ): Promise<BindResult> {
   return new Promise<BindResult>((resolve) => {
-    const httpServer = app.listen(port, '127.0.0.1', () => {
-      serverRunning = true;
-      serverPort = port;
-      activeHttpServer = httpServer;
-      printStartupBanner(port, options.tokenStore);
-      if (options.openBrowser) {
-        openInBrowser(`http://${CONSOLE_HOST}:${port}`);
+    let settled = false;
+    const settle = (result: BindResult) => {
+      if (!settled) {
+        settled = true;
+        resolve(result);
       }
-      resolve({ success: true });
+    };
+
+    const httpServer = app.listen(port, '127.0.0.1', () => {
+      void (async () => {
+        const ownership = await verifyBoundPortOwnership(port, process.pid);
+        if (!ownership.matches) {
+          httpServer.close();
+          logger.warn('[WebUI] Port ownership verification failed after bind callback', {
+            port,
+            expectedPid: process.pid,
+            observedPid: ownership.ownerPid,
+          });
+          settle({
+            success: false,
+            error: 'EADDRINUSE',
+            detail: `Port ${port} already in use by pid ${ownership.ownerPid ?? 'unknown'}`,
+          });
+          return;
+        }
+
+        serverRunning = true;
+        serverPort = port;
+        activeHttpServer = httpServer;
+        printStartupBanner(port, options.tokenStore);
+        if (options.openBrowser) {
+          openInBrowser(`http://${CONSOLE_HOST}:${port}`);
+        }
+        settle({ success: true });
+      })().catch((err) => {
+        logger.error(`[WebUI] Failed to verify bound port ${port}: ${err instanceof Error ? err.message : String(err)}`);
+        settle({
+          success: false,
+          error: 'OTHER',
+          detail: err instanceof Error ? err.message : String(err),
+        });
+      });
     });
     httpServer.on('error', (err: NodeJS.ErrnoException) => {
       if (err.code === 'EADDRINUSE') {
-        resolve({ success: false, error: 'EADDRINUSE', detail: `Port ${port} already in use` });
+        settle({ success: false, error: 'EADDRINUSE', detail: `Port ${port} already in use` });
       } else {
         logger.error(`[WebUI] Failed to bind port ${port}: ${err.message}`);
-        resolve({ success: false, error: 'OTHER', detail: err.message });
+        settle({ success: false, error: 'OTHER', detail: err.message });
       }
     });
   });

--- a/tests/unit/config/consolePort.test.ts
+++ b/tests/unit/config/consolePort.test.ts
@@ -284,12 +284,12 @@ describe('Console port configuration (#1840)', () => {
 
     it('resolves promise on conflict (does not throw)', async () => {
       const source = await readFile(join(SRC, 'src/web/server.ts'), 'utf8');
-      // The error handler calls resolve(handleListenError(...)), not reject()
+      // The bind error handler settles the promise instead of rejecting it.
       const errorSection = source.slice(
         source.indexOf("httpServer.on('error'"),
         source.indexOf('});', source.indexOf("httpServer.on('error'")) + 10,
       );
-      expect(errorSection).toContain('resolve(');
+      expect(errorSection).toContain('settle(');
       expect(errorSection).not.toContain('reject(');
     });
   });

--- a/tests/unit/web/console/LeaderElection.test.ts
+++ b/tests/unit/web/console/LeaderElection.test.ts
@@ -99,6 +99,52 @@ describe('LeaderElection', () => {
     });
   });
 
+  describe('claimLeadership', () => {
+    let tempDir: string;
+    let tempLockPath: string;
+
+    beforeEach(async () => {
+      const { mkdtemp } = await import('node:fs/promises');
+      const { tmpdir } = await import('node:os');
+      const { join } = await import('node:path');
+      tempDir = await mkdtemp(join(tmpdir(), 'dh-leader-claim-test-'));
+      tempLockPath = join(tempDir, 'console-leader.auth.lock');
+    });
+
+    afterEach(async () => {
+      const { rm } = await import('node:fs/promises');
+      await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it('creates a new lock when none exists', async () => {
+      const claimed = await LeaderElection.claimLeadership(
+        makeLeaderInfo({ sessionId: 'fresh-claim' }),
+        tempLockPath,
+      );
+
+      expect(claimed).toBe(true);
+      await expect(LeaderElection.readLeaderLock(tempLockPath)).resolves.toMatchObject({
+        sessionId: 'fresh-claim',
+        pid: process.pid,
+      });
+    });
+
+    it('does not overwrite an existing lock', async () => {
+      const { writeFile } = await import('node:fs/promises');
+      await writeFile(tempLockPath, JSON.stringify(makeLeaderInfo({ sessionId: 'existing-leader' })), 'utf-8');
+
+      const claimed = await LeaderElection.claimLeadership(
+        makeLeaderInfo({ sessionId: 'late-joiner' }),
+        tempLockPath,
+      );
+
+      expect(claimed).toBe(false);
+      await expect(LeaderElection.readLeaderLock(tempLockPath)).resolves.toMatchObject({
+        sessionId: 'existing-leader',
+      });
+    });
+  });
+
   describe('ConsoleLeaderInfo interface', () => {
     it('should have the expected shape', () => {
       const info: import('../../../../src/web/console/LeaderElection.js').ConsoleLeaderInfo = {

--- a/tests/unit/web/console/UnifiedConsole.test.ts
+++ b/tests/unit/web/console/UnifiedConsole.test.ts
@@ -849,26 +849,45 @@ describe('reconcileLeaderLease', () => {
   it('reclaims the lock and evicts the displaced lock writer when this process owns the console port', async () => {
     const claimLeadershipImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').claimLeadership>()
       .mockResolvedValue(true);
+    const deleteLeaderLockImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').deleteLeaderLock>()
+      .mockResolvedValue();
     const killStaleProcessDetailedImpl = jest.fn<typeof import('../../../../src/web/console/StaleProcessRecovery.js').killStaleProcessDetailed>()
       .mockResolvedValue({
         killed: true,
         reason: 'terminated',
         pid: 3877,
       });
+    const displacedLock = {
+      version: 1,
+      pid: 3877,
+      port: 41715,
+      sessionId: 'session-old',
+      startedAt: '2026-04-16T20:40:19.500Z',
+      heartbeat: '2026-04-19T18:13:34.914Z',
+      serverVersion: '2.0.25',
+      consoleProtocolVersion: 1,
+    } as const;
+    const reclaimedLock = {
+      version: 1,
+      pid: process.pid,
+      port: 41715,
+      sessionId: 'session-newest',
+      startedAt: '2026-04-19T19:00:00.000Z',
+      heartbeat: '2026-04-19T19:00:00.000Z',
+      serverVersion: PACKAGE_VERSION,
+      consoleProtocolVersion: 1,
+    } as const;
+    let readCount = 0;
+    const readLeaderLockImpl = jest.fn(async () => {
+      readCount += 1;
+      return readCount < 3 ? displacedLock : reclaimedLock;
+    });
 
     const result = await reconcileLeaderLease('session-newest', 41715, {
       findPidOnPortImpl: async () => process.pid,
-      readLeaderLockImpl: async () => ({
-        version: 1,
-        pid: 3877,
-        port: 41715,
-        sessionId: 'session-old',
-        startedAt: '2026-04-16T20:40:19.500Z',
-        heartbeat: '2026-04-19T18:13:34.914Z',
-        serverVersion: '2.0.25',
-        consoleProtocolVersion: 1,
-      }),
+      readLeaderLockImpl,
       claimLeadershipImpl,
+      deleteLeaderLockImpl,
       killStaleProcessDetailedImpl,
     });
 
@@ -876,6 +895,7 @@ describe('reconcileLeaderLease', () => {
     expect(killStaleProcessDetailedImpl).toHaveBeenCalledWith(3877, 41715, {
       allowActiveHostParent: true,
     });
+    expect(deleteLeaderLockImpl).toHaveBeenCalledTimes(1);
     expect(claimLeadershipImpl).toHaveBeenCalledWith(expect.objectContaining({
       sessionId: 'session-newest',
       port: 41715,
@@ -906,75 +926,115 @@ describe('reconcileLeaderLease', () => {
     expect(killStaleProcessDetailedImpl).not.toHaveBeenCalled();
     expect(claimLeadershipImpl).not.toHaveBeenCalled();
   });
-});
 
-describe('startLeaderLeaseMonitor', () => {
-  it('schedules lease reconciliation, backs off when stable, and cleans up the timer', async () => {
-    const timerHandle = { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
-    let timeoutCallback: (() => void) | null = null;
+  it('returns reclaim-failed when the displaced lock cannot be reclaimed after eviction', async () => {
     const claimLeadershipImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').claimLeadership>()
-      .mockResolvedValue(true);
+      .mockResolvedValue(false);
+    const deleteLeaderLockImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').deleteLeaderLock>()
+      .mockResolvedValue();
     const killStaleProcessDetailedImpl = jest.fn<typeof import('../../../../src/web/console/StaleProcessRecovery.js').killStaleProcessDetailed>()
       .mockResolvedValue({
         killed: true,
         reason: 'terminated',
         pid: 3877,
       });
+    const displacedLock = {
+      version: 1,
+      pid: 3877,
+      port: 41715,
+      sessionId: 'session-old',
+      startedAt: '2026-04-16T20:40:19.500Z',
+      heartbeat: '2026-04-19T18:13:34.914Z',
+      serverVersion: '2.0.25',
+      consoleProtocolVersion: 1,
+    } as const;
+    const racerLock = {
+      version: 1,
+      pid: 4988,
+      port: 41715,
+      sessionId: 'session-racer',
+      startedAt: '2026-04-19T19:00:02.000Z',
+      heartbeat: '2026-04-19T19:00:02.000Z',
+      serverVersion: '2.0.26',
+      consoleProtocolVersion: 1,
+    } as const;
+    let readCount = 0;
+    const readLeaderLockImpl = jest.fn(async () => {
+      readCount += 1;
+      return readCount < 3 ? displacedLock : racerLock;
+    });
+
+    const result = await reconcileLeaderLease('session-newest', 41715, {
+      findPidOnPortImpl: async () => process.pid,
+      readLeaderLockImpl,
+      claimLeadershipImpl,
+      deleteLeaderLockImpl,
+      killStaleProcessDetailedImpl,
+    });
+
+    expect(result).toBe('reclaim-failed');
+    expect(deleteLeaderLockImpl).toHaveBeenCalledTimes(1);
+    expect(claimLeadershipImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('startLeaderLeaseMonitor', () => {
+  it('schedules lease reconciliation, backs off when stable, and cleans up the timer', async () => {
+    const timerHandle = { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+    let timeoutCallback: (() => void) | null = null;
+    const scheduledDelays: number[] = [];
+    const claimLeadershipImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').claimLeadership>();
+    const deleteLeaderLockImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').deleteLeaderLock>()
+      .mockResolvedValue();
+    const killStaleProcessDetailedImpl = jest.fn<typeof import('../../../../src/web/console/StaleProcessRecovery.js').killStaleProcessDetailed>();
     const clearTimeoutImpl = jest.fn<typeof clearTimeout>();
-    const readLeaderLockImpl = jest.fn()
-      .mockResolvedValueOnce({
-        version: 1,
-        pid: 3877,
-        port: 41715,
-        sessionId: 'session-old',
-        startedAt: '2026-04-16T20:40:19.500Z',
-        heartbeat: '2026-04-19T18:13:34.914Z',
-        serverVersion: '2.0.25',
-        consoleProtocolVersion: 1,
-      })
-      .mockResolvedValueOnce({
-        version: 1,
-        pid: process.pid,
-        port: 41715,
-        sessionId: 'session-newest',
-        startedAt: '2026-04-19T19:00:00.000Z',
-        heartbeat: '2026-04-19T19:00:00.000Z',
-        serverVersion: PACKAGE_VERSION,
-        consoleProtocolVersion: 1,
-      });
+    const reclaimedLock = {
+      version: 1,
+      pid: process.pid,
+      port: 41715,
+      sessionId: 'session-newest',
+      startedAt: '2026-04-19T19:00:00.000Z',
+      heartbeat: '2026-04-19T19:00:00.000Z',
+      serverVersion: PACKAGE_VERSION,
+      consoleProtocolVersion: 1,
+    } as const;
+    const readLeaderLockImpl = jest.fn(async () => reclaimedLock);
 
     const stopMonitor = startLeaderLeaseMonitor('session-newest', 41715, {
       setTimeoutImpl: jest.fn<typeof setTimeout>((callback, delay) => {
         timeoutCallback = callback as () => void;
-        if (claimLeadershipImpl.mock.calls.length === 0) {
-          expect(delay).toBe(2_000);
-        } else {
-          expect(delay).toBe(4_000);
-        }
+        scheduledDelays.push(delay as number);
         return timerHandle;
       }),
       clearTimeoutImpl,
       findPidOnPortImpl: async () => process.pid,
       readLeaderLockImpl,
       claimLeadershipImpl,
+      deleteLeaderLockImpl,
       killStaleProcessDetailedImpl,
     });
 
     expect(timeoutCallback).not.toBeNull();
     expect(timerHandle.unref).toHaveBeenCalledTimes(1);
+    expect(scheduledDelays).toEqual([2_000]);
 
     timeoutCallback?.();
     await flushAuthorityMonitorTick();
-    expect(killStaleProcessDetailedImpl).toHaveBeenCalledTimes(1);
-    expect(claimLeadershipImpl).toHaveBeenCalledTimes(1);
+    await flushAuthorityMonitorTick();
+    expect(killStaleProcessDetailedImpl).not.toHaveBeenCalled();
+    expect(claimLeadershipImpl).not.toHaveBeenCalled();
+    expect(deleteLeaderLockImpl).not.toHaveBeenCalled();
+    expect(scheduledDelays).toEqual([2_000, 4_000]);
 
     timeoutCallback?.();
     await flushAuthorityMonitorTick();
+    await flushAuthorityMonitorTick();
 
-    expect(killStaleProcessDetailedImpl).toHaveBeenCalledTimes(1);
-    expect(claimLeadershipImpl).toHaveBeenCalledTimes(1);
+    expect(killStaleProcessDetailedImpl).not.toHaveBeenCalled();
+    expect(claimLeadershipImpl).not.toHaveBeenCalled();
+    expect(scheduledDelays).toEqual([2_000, 4_000, 8_000]);
 
     stopMonitor();
-    expect(clearTimeoutImpl).not.toHaveBeenCalled();
+    expect(clearTimeoutImpl).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/web/console/lifecycle-cleanup.test.ts
+++ b/tests/unit/web/console/lifecycle-cleanup.test.ts
@@ -101,6 +101,22 @@ describe('Process Lifecycle Cleanup (#1856)', () => {
       expect(typeof shutdownWebServer).toBe('function');
     });
 
+    it('verifyBoundPortOwnership accepts the current listener and reports mismatches', async () => {
+      const { verifyBoundPortOwnership } = await import('../../../../src/web/server.js');
+
+      await expect(
+        verifyBoundPortOwnership(41715, 1234, async () => 1234),
+      ).resolves.toEqual({ matches: true, ownerPid: 1234 });
+
+      await expect(
+        verifyBoundPortOwnership(41715, 1234, async () => 9999),
+      ).resolves.toEqual({ matches: false, ownerPid: 9999 });
+
+      await expect(
+        verifyBoundPortOwnership(41715, 1234, async () => null),
+      ).resolves.toEqual({ matches: true, ownerPid: null });
+    });
+
     it('registerPortCleanup is exported from portDiscovery.ts', async () => {
       const { registerPortCleanup } = await import('../../../../src/web/portDiscovery.js');
       expect(typeof registerPortCleanup).toBe('function');


### PR DESCRIPTION
## Summary
- stop leader election from overwriting an existing lock during startup races
- verify that a would-be leader actually owns the console port before treating bind success as real
- make lease reconciliation delete and re-claim displaced locks, and only report success when the active port owner truly owns the lock again

## Testing
- npm test -- --runInBand tests/unit/web/console/UnifiedConsole.test.ts tests/unit/web/console/LeaderElection.test.ts tests/unit/web/console/lifecycle-cleanup.test.ts
- npx eslint src/web/console/UnifiedConsole.ts src/web/console/LeaderElection.ts src/web/server.ts tests/unit/web/console/UnifiedConsole.test.ts tests/unit/web/console/LeaderElection.test.ts tests/unit/web/console/lifecycle-cleanup.test.ts

## Notes
- This fixes the false-success takeover path where a newer process believed it became leader without actually owning the console port and lease.
- The separate mixed-version follower re-registration problem still remains and should be handled in a follow-up PR.
