### PR TITLE
Fix same-version console takeover from stale lock writers

### DIFF
--- a/docker/docker-compose.mixed-version.yml
+++ b/docker/docker-compose.mixed-version.yml
@@ -32,6 +32,12 @@ services:
     image: dollhouse-mixed-version-current:local
     container_name: dollhouse-mixed-version-current
     init: true
+    # The production image runs as the non-root `node` user, but the harness
+    # intentionally shares one bind-mounted Dollhouse home with historical npm
+    # packages that still start as root. Run the current image as root here so
+    # it exercises the same shared-state semantics in CI instead of failing on
+    # chmod/chown during startup.
+    user: "0:0"
     depends_on:
       - netns
     network_mode: "service:netns"

--- a/docker/mixed-version/observe-state.sh
+++ b/docker/mixed-version/observe-state.sh
@@ -97,7 +97,8 @@ const summary = sessions.map((session) => {
   const role = session.isLeader ? 'leader' : 'follower';
   const version = session.serverVersion ?? 'unknown';
   const name = session.displayName ?? session.sessionId ?? 'unknown';
-  return `${name}:${role}:${version}`;
+  const sessionId = session.sessionId ?? 'unknown-session';
+  return `${name}[${sessionId}]:${role}:${version}`;
 }).join(', ');
 console.log(`sessions: count=${sessions.length}${summary ? ` -> ${summary}` : ''}`);
 NODE

--- a/docker/mixed-version/smoke-test.sh
+++ b/docker/mixed-version/smoke-test.sh
@@ -16,12 +16,21 @@ cleanup() {
 
 wait_for_sessions() {
   local description="$1"
-  local expected_pattern="$2"
+  shift
   local output=""
+  local pattern=""
 
   for _ in $(seq 1 "${SESSION_WAIT_RETRIES}"); do
     output="$("${SCRIPT_DIR}/observe-state.sh" --once)"
-    if [[ "${output}" =~ sessions:\ count=([0-9]+) ]] && printf '%s\n' "${output}" | grep -Eq "${expected_pattern}"; then
+    local matched_all=true
+    for pattern in "$@"; do
+      if ! printf '%s\n' "${output}" | grep -Eq "${pattern}"; then
+        matched_all=false
+        break
+      fi
+    done
+
+    if [[ "${output}" =~ sessions:\ count=([0-9]+) ]] && [[ "${matched_all}" == "true" ]]; then
       printf '%s\n' "${output}"
       return 0
     fi
@@ -40,8 +49,14 @@ trap cleanup EXIT
 "${SCRIPT_DIR}/reset-state.sh"
 docker compose -f "${COMPOSE_FILE}" up -d --build
 
-wait_for_sessions "initial mixed-version leader election" "count=([2-9]|[1-9][0-9]+)"
+wait_for_sessions \
+  "initial mixed-version leader election" \
+  "count=([2-9]|[1-9][0-9]+)" \
+  "\\[current-local\\]"
 
 "${SCRIPT_DIR}/inject-service.sh" legacy-225 "${TARGET_INJECT_SPEC}"
 
-wait_for_sessions "legacy injection to appear in sessions" "2\\.0\\.24"
+wait_for_sessions \
+  "legacy injection to appear in sessions" \
+  "\\[legacy-225\\]" \
+  "2\\.0\\.24"

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -245,6 +245,13 @@ const envSchema = z.object({
   DOLLHOUSE_CONSOLE_AUTHORITY_RECHECK_FAILURE_COOLDOWN_MS: z.coerce.number().int().min(1_000).max(900_000).default(60_000),
 
   /**
+   * Timeout for leader-discovery HTTP probes against /api/sessions before the
+   * caller falls back to lock-file or synthetic-owner heuristics.
+   * Default: 2000ms.
+   */
+  DOLLHOUSE_CONSOLE_LEADER_DISCOVERY_TIMEOUT_MS: z.coerce.number().int().min(250).max(30_000).default(2_000),
+
+  /**
    * Issue #1780: Phase 2 — require a confirmation code (OS dialog or TOTP)
    * for privileged actions like token rotation. Default is true for safety;
    * set to false for headless CI and scripted deployments that need to rotate

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -223,10 +223,23 @@ interface FollowerAuthorityResolution {
   forcedClaim: boolean;
 }
 
+interface LeaderPreflightResolution {
+  election: ElectionResult;
+  discovery: PortLeaderDiscovery | null;
+  replacement: PortOwnerReplacementDecision | null;
+  demotedToFollower: boolean;
+}
+
 interface FollowerAuthorityDependencies {
   isLeaderWebConsoleReachableImpl?: typeof isLeaderWebConsoleReachable;
   discoverLeaderServingPortImpl?: typeof discoverLeaderServingPort;
   forceClaimLeadershipImpl?: typeof forceClaimLeadership;
+  deleteLeaderLockImpl?: typeof deleteLeaderLock;
+}
+
+interface LeaderPreflightDependencies extends DiscoveryDependencies {
+  discoverLeaderServingPortImpl?: typeof discoverLeaderServingPort;
+  readLeaderLockImpl?: typeof readLeaderLock;
   deleteLeaderLockImpl?: typeof deleteLeaderLock;
 }
 
@@ -473,6 +486,13 @@ export function evaluatePortOwnerReplacement(
   };
 }
 
+export function shouldEvictDiscoveredOwner(
+  discovery: PortLeaderDiscovery,
+  replacement: PortOwnerReplacementDecision,
+): boolean {
+  return discovery.source !== 'synthetic' && replacement.shouldEvict && replacement.ownerPid !== null;
+}
+
 function buildBindFailureLogContext(
   consolePort: number,
   provisionalLeader: ConsoleLeaderInfo,
@@ -564,7 +584,7 @@ export async function resolveFollowerAuthority(
   }
 
   const replacement = evaluatePortOwnerReplacement(candidateLeader, discovery);
-  if (replacement.shouldEvict) {
+  if (shouldEvictDiscoveredOwner(discovery, replacement)) {
     await deleteLeaderLockImpl();
     logger.warn(
       discovery.ownerPid === election.leaderInfo.pid
@@ -605,6 +625,66 @@ export async function resolveFollowerAuthority(
     discovery,
     replacement,
     forcedClaim: false,
+  };
+}
+
+export async function resolveLeaderPreflightAuthority(
+  sessionId: string,
+  consolePort: number,
+  election: ElectionResult,
+  authToken: string | null,
+  deps: LeaderPreflightDependencies = {},
+): Promise<LeaderPreflightResolution> {
+  const discoverLeaderServingPortImpl = deps.discoverLeaderServingPortImpl ?? discoverLeaderServingPort;
+  const readLeaderLockImpl = deps.readLeaderLockImpl ?? readLeaderLock;
+  const deleteLeaderLockImpl = deps.deleteLeaderLockImpl ?? deleteLeaderLock;
+
+  const discovery = await discoverLeaderServingPortImpl(consolePort, authToken, deps);
+  if (!discovery.leaderInfo || discovery.ownerPid === null || discovery.ownerPid === election.leaderInfo.pid) {
+    return {
+      election,
+      discovery,
+      replacement: discovery.leaderInfo ? evaluatePortOwnerReplacement(election.leaderInfo, discovery) : null,
+      demotedToFollower: false,
+    };
+  }
+
+  const replacement = evaluatePortOwnerReplacement(election.leaderInfo, discovery);
+  if (shouldEvictDiscoveredOwner(discovery, replacement)) {
+    return {
+      election,
+      discovery,
+      replacement,
+      demotedToFollower: false,
+    };
+  }
+
+  const provisionalLock = await readLeaderLockImpl();
+  const provisionalLockMatches = (
+    provisionalLock?.pid === election.leaderInfo.pid &&
+    provisionalLock.port === election.leaderInfo.port &&
+    provisionalLock.sessionId === election.leaderInfo.sessionId
+  );
+
+  if (provisionalLockMatches) {
+    await deleteLeaderLockImpl();
+  }
+
+  logger.warn(
+    discovery.source === 'synthetic'
+      ? '[UnifiedConsole] Provisional leader detected an unknown active console owner before bind; following the existing port owner instead of forcing eviction'
+      : '[UnifiedConsole] Provisional leader detected a healthy console owner before bind; following the existing leader instead of forcing takeover',
+    {
+      ...buildAuthorityResolutionLogContext(consolePort, election.leaderInfo, discovery, replacement),
+      provisionalLockCleared: provisionalLockMatches,
+    },
+  );
+
+  return {
+    election: { role: 'follower', leaderInfo: discovery.leaderInfo },
+    discovery,
+    replacement,
+    demotedToFollower: true,
   };
 }
 
@@ -896,7 +976,7 @@ async function attemptForceTakeover(
   const initialFallback = await recoverLeaderBindFailure(currentElection.leaderInfo, consolePort, primaryToken);
   const initialReplacement = evaluatePortOwnerReplacement(currentElection.leaderInfo, initialFallback);
 
-  if (!initialReplacement.shouldEvict || initialReplacement.ownerPid === null) {
+  if (!shouldEvictDiscoveredOwner(initialFallback, initialReplacement)) {
     return {
       webResult: { bindResult: { success: false, error: 'EADDRINUSE', detail: `Port ${consolePort} already in use` } },
       election: currentElection,
@@ -912,7 +992,7 @@ async function attemptForceTakeover(
   const latestFallback = await discoverLeaderServingPort(consolePort, primaryToken);
   const recoveredSessions = await fetchLeaderSessionsSnapshot(consolePort, primaryToken);
   const latestReplacement = evaluatePortOwnerReplacement(currentElection.leaderInfo, latestFallback);
-  if (!latestReplacement.shouldEvict || latestReplacement.ownerPid === null) {
+  if (!shouldEvictDiscoveredOwner(latestFallback, latestReplacement)) {
     logger.warn('[UnifiedConsole] Forced takeover target changed before eviction; skipping forced kill', {
       ...buildBindFailureLogContext(
         consolePort,
@@ -945,7 +1025,21 @@ async function attemptForceTakeover(
     ),
   });
 
-  const forcedKill = await killStaleProcessDetailed(latestReplacement.ownerPid, consolePort, {
+  const ownerPid = latestReplacement.ownerPid;
+  if (ownerPid === null) {
+    return {
+      webResult: { bindResult: { success: false, error: 'EADDRINUSE', detail: `Port ${consolePort} already in use` } },
+      election: currentElection,
+      fallback: latestFallback,
+      replacement: latestReplacement,
+      recoveredSessions,
+      forcedKill: null,
+      takeoverAttempted: false,
+      reboundLockClaimed: false,
+    };
+  }
+
+  const forcedKill = await killStaleProcessDetailed(ownerPid, consolePort, {
     allowActiveHostParent: true,
   });
   if (!forcedKill.killed) {
@@ -1039,6 +1133,11 @@ export async function startUnifiedConsole(options: UnifiedConsoleOptions): Promi
 
   if (election.role === 'follower') {
     const resolved = await resolveFollowerAuthority(options.sessionId, consolePort, election);
+    election = resolved.election;
+  } else {
+    const { getPrimaryTokenFromFile } = await import('./consoleToken.js');
+    const authToken = await getPrimaryTokenFromFile(env.DOLLHOUSE_CONSOLE_TOKEN_FILE);
+    const resolved = await resolveLeaderPreflightAuthority(options.sessionId, consolePort, election, authToken);
     election = resolved.election;
   }
 

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -64,7 +64,7 @@ import type { SessionInfo } from './IngestRoutes.js';
 const DEFAULT_CONSOLE_PORT = env.DOLLHOUSE_WEB_CONSOLE_PORT;
 const LEGACY_CONSOLE_FALLBACK_PORT = 3939;
 const SYNTHETIC_PORT_OWNER_SESSION_PREFIX = 'port-owner-';
-const LEADER_DISCOVERY_TIMEOUT_MS = 2_000;
+const LEADER_DISCOVERY_TIMEOUT_MS = env.DOLLHOUSE_CONSOLE_LEADER_DISCOVERY_TIMEOUT_MS;
 const LEADER_LEASE_RECONCILE_INTERVAL_MS = 2_000;
 const LEADER_LEASE_RECONCILE_MAX_INTERVAL_MS = 30_000;
 const FOLLOWER_AUTHORITY_MONITOR_CONFIG = {
@@ -288,7 +288,11 @@ export async function fetchLeaderSessionsSnapshot(
 
     const data = await response.json() as { sessions?: SessionInfo[] };
     return Array.isArray(data.sessions) ? data.sessions : [];
-  } catch {
+  } catch (err) {
+    logger.debug('[UnifiedConsole] Failed to fetch leader session snapshot', {
+      port,
+      error: err instanceof Error ? err.message : String(err),
+    });
     return [];
   } finally {
     clearTimeout(timeout);

--- a/tests/unit/web/console/UnifiedConsole.test.ts
+++ b/tests/unit/web/console/UnifiedConsole.test.ts
@@ -26,7 +26,9 @@ import {
   fetchLeaderSessionsSnapshot,
   recoverLeaderBindFailure,
   evaluatePortOwnerReplacement,
+  shouldEvictDiscoveredOwner,
   resolveFollowerAuthority,
+  resolveLeaderPreflightAuthority,
   startFollowerAuthorityMonitor,
   reconcileLeaderLease,
   startLeaderLeaseMonitor,
@@ -477,6 +479,181 @@ describe('evaluatePortOwnerReplacement', () => {
     expect(decision.shouldEvict).toBe(false);
     expect(decision.preference).toMatchObject({
       reason: 'same-version',
+    });
+  });
+});
+
+describe('shouldEvictDiscoveredOwner', () => {
+  it('does not evict a synthetic port owner when the owner identity is unknown', () => {
+    const decision = {
+      shouldEvict: true,
+      ownerPid: 57117,
+      preference: {
+        shouldReplace: true,
+        reason: 'newer-compatible-version' as const,
+        candidateVersion: PACKAGE_VERSION,
+        existingVersion: LEGACY_SERVER_VERSION,
+        candidateProtocolVersion: 1,
+        existingProtocolVersion: 0,
+      },
+    };
+
+    expect(shouldEvictDiscoveredOwner({
+      ownerPid: 57117,
+      source: 'synthetic',
+      leaderInfo: {
+        version: 1,
+        pid: 57117,
+        port: 41715,
+        sessionId: 'port-owner-57117',
+        startedAt: '2026-04-19T18:00:00.000Z',
+        heartbeat: '2026-04-19T18:00:00.000Z',
+        serverVersion: LEGACY_SERVER_VERSION,
+        consoleProtocolVersion: 1,
+      },
+    }, decision)).toBe(false);
+  });
+
+  it('evicts an older API-confirmed port owner when replacement is preferred', () => {
+    const decision = {
+      shouldEvict: true,
+      ownerPid: 57117,
+      preference: {
+        shouldReplace: true,
+        reason: 'newer-compatible-version' as const,
+        candidateVersion: PACKAGE_VERSION,
+        existingVersion: LEGACY_SERVER_VERSION,
+        candidateProtocolVersion: 1,
+        existingProtocolVersion: 0,
+      },
+    };
+
+    expect(shouldEvictDiscoveredOwner({
+      ownerPid: 57117,
+      source: 'api',
+      leaderInfo: {
+        version: 1,
+        pid: 57117,
+        port: 41715,
+        sessionId: 'legacy-console',
+        startedAt: '2026-04-19T18:00:00.000Z',
+        heartbeat: '2026-04-19T18:00:00.000Z',
+        serverVersion: LEGACY_SERVER_VERSION,
+        consoleProtocolVersion: 1,
+      },
+    }, decision)).toBe(true);
+  });
+});
+
+describe('resolveLeaderPreflightAuthority', () => {
+  it('demotes a provisional leader when the actual port owner is already healthy on the same version', async () => {
+    const deleteLeaderLockImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').deleteLeaderLock>().mockResolvedValue();
+    const provisionalElection = {
+      role: 'leader' as const,
+      leaderInfo: {
+        version: 1,
+        pid: 99991,
+        port: 41715,
+        sessionId: 'session-newest',
+        startedAt: '2026-04-19T18:00:00.000Z',
+        heartbeat: '2026-04-19T18:00:00.000Z',
+        serverVersion: PACKAGE_VERSION,
+        consoleProtocolVersion: 1,
+      },
+    };
+
+    const result = await resolveLeaderPreflightAuthority(
+      'session-newest',
+      41715,
+      provisionalElection,
+      'token-123',
+      {
+        discoverLeaderServingPortImpl: async () => ({
+          ownerPid: 60525,
+          source: 'api',
+          leaderInfo: {
+            version: 1,
+            pid: 60525,
+            port: 41715,
+            sessionId: 'current-leader',
+            startedAt: '2026-04-19T17:55:00.000Z',
+            heartbeat: '2026-04-19T18:00:00.000Z',
+            serverVersion: PACKAGE_VERSION,
+            consoleProtocolVersion: 1,
+          },
+        }),
+        readLeaderLockImpl: async () => provisionalElection.leaderInfo,
+        deleteLeaderLockImpl,
+      },
+    );
+
+    expect(deleteLeaderLockImpl).toHaveBeenCalledTimes(1);
+    expect(result.demotedToFollower).toBe(true);
+    expect(result.election).toEqual({
+      role: 'follower',
+      leaderInfo: {
+        version: 1,
+        pid: 60525,
+        port: 41715,
+        sessionId: 'current-leader',
+        startedAt: '2026-04-19T17:55:00.000Z',
+        heartbeat: '2026-04-19T18:00:00.000Z',
+        serverVersion: PACKAGE_VERSION,
+        consoleProtocolVersion: 1,
+      },
+    });
+  });
+
+  it('demotes a provisional leader instead of evicting a synthetic unknown owner', async () => {
+    const deleteLeaderLockImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').deleteLeaderLock>().mockResolvedValue();
+    const provisionalElection = {
+      role: 'leader' as const,
+      leaderInfo: {
+        version: 1,
+        pid: 99991,
+        port: 41715,
+        sessionId: 'session-newest',
+        startedAt: '2026-04-19T18:00:00.000Z',
+        heartbeat: '2026-04-19T18:00:00.000Z',
+        serverVersion: PACKAGE_VERSION,
+        consoleProtocolVersion: 1,
+      },
+    };
+
+    const result = await resolveLeaderPreflightAuthority(
+      'session-newest',
+      41715,
+      provisionalElection,
+      'token-123',
+      {
+        discoverLeaderServingPortImpl: async () => ({
+          ownerPid: 60525,
+          source: 'synthetic',
+          leaderInfo: {
+            version: 1,
+            pid: 60525,
+            port: 41715,
+            sessionId: 'port-owner-60525',
+            startedAt: '2026-04-19T17:55:00.000Z',
+            heartbeat: '2026-04-19T18:00:00.000Z',
+            serverVersion: LEGACY_SERVER_VERSION,
+            consoleProtocolVersion: 1,
+          },
+        }),
+        readLeaderLockImpl: async () => provisionalElection.leaderInfo,
+        deleteLeaderLockImpl,
+      },
+    );
+
+    expect(deleteLeaderLockImpl).toHaveBeenCalledTimes(1);
+    expect(result.demotedToFollower).toBe(true);
+    expect(result.election.role).toBe('follower');
+    expect(result.election.leaderInfo.sessionId).toBe('port-owner-60525');
+    expect(result.replacement).toMatchObject({
+      shouldEvict: true,
+      preference: expect.objectContaining({
+        reason: 'newer-compatible-version',
+      }),
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a leader preflight that trusts the healthy port owner before takeover/bind
- treat synthetic/unknown port owners as non-evictable so we fail safe instead of killing a healthy leader
- add regressions for same-version split-brain and synthetic-owner scenarios

## Root cause
On the live machine, `rc.7` could still see a stale older lock writer even while a healthy current leader already owned `:41715`.

A new session would:
1. treat the stale lock writer as replaceable
2. provisionally claim leadership
3. hit bind conflict with the healthy current leader
4. sometimes force-evict the actual port owner during takeover recovery

That let a second latest-RC session kick the first one offline, which is exactly the public-facing failure we need to avoid.

## Fix
- preflight leader authority against the actual port owner before bind/takeover
- demote provisional leaders to follower when the existing port owner is healthy on the same/newer version
- never evict a synthetic/unknown owner just because the lock metadata looked old

## Validation
- `npm test -- --runInBand tests/unit/web/console/UnifiedConsole.test.ts tests/unit/web/console/LeaderElection.test.ts tests/unit/web/console/lifecycle-cleanup.test.ts`
- `npm run build`
- `npx eslint src/web/console/UnifiedConsole.ts tests/unit/web/console/UnifiedConsole.test.ts`
