### PR TITLE
Sync follower session names with console leader

### DIFF
--- a/src/web/console/IngestRoutes.ts
+++ b/src/web/console/IngestRoutes.ts
@@ -21,7 +21,11 @@ import type { UnifiedLogEntry } from '../../logging/types.js';
 import type { MetricSnapshot } from '../../metrics/types.js';
 import { SlidingWindowRateLimiter } from '../../utils/SlidingWindowRateLimiter.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
-import { SessionNamePool } from './SessionNames.js';
+import {
+  SessionNamePool,
+  derivePreferredSessionName,
+  getPuppetColor,
+} from './SessionNames.js';
 import { logger } from '../../utils/logger.js';
 import { env } from '../../config/env.js';
 import { PACKAGE_VERSION } from '../../generated/version.js';
@@ -56,6 +60,8 @@ const ENDED_PURGE_MS = 5 * 60_000; // 5 minutes
 export interface SessionInfo {
   /** Unique identifier for this session (UUID or `console-<pid>`). */
   sessionId: string;
+  /** Stable cross-restart/session identity when the host provides one. */
+  stableSessionId: string | null;
   /** Friendly puppet name (e.g., "Kermit", "Punch") or "Web Console". */
   displayName: string;
   /** Canonical hex color for this puppet character. */
@@ -85,6 +91,8 @@ export interface SessionInfo {
  */
 export interface IngestLogPayload {
   sessionId: string;
+  stableSessionId?: string;
+  displayName?: string;
   entries: UnifiedLogEntry[];
 }
 
@@ -93,6 +101,8 @@ export interface IngestLogPayload {
  */
 export interface IngestMetricsPayload {
   sessionId: string;
+  stableSessionId?: string;
+  displayName?: string;
   snapshot: MetricSnapshot;
 }
 
@@ -101,6 +111,8 @@ export interface IngestMetricsPayload {
  */
 export interface SessionEventPayload {
   sessionId: string;
+  stableSessionId?: string;
+  displayName?: string;
   event: 'started' | 'stopped' | 'heartbeat';
   pid: number;
   startedAt: string;
@@ -129,7 +141,12 @@ export interface IngestRoutesResult {
   /** Import active follower sessions from a displaced leader during takeover. */
   importSessions: (sessions: SessionInfo[]) => void;
   /** Register the leader as a session */
-  registerLeaderSession: (sessionId: string, pid: number) => void;
+  registerLeaderSession: (
+    sessionId: string,
+    pid: number,
+    displayName?: string,
+    stableSessionId?: string,
+  ) => void;
   /** Register the web console as a session so the indicator is never empty (#1805) */
   registerConsoleSession: () => void;
 }
@@ -137,6 +154,14 @@ export interface IngestRoutesResult {
 /** Normalize a string via UnicodeValidator (DMCP-SEC-004) */
 function normalizeInput(s: string): string {
   return UnicodeValidator.normalize(s).normalizedContent;
+}
+
+function normalizeOptionalInput(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const normalized = normalizeInput(value).trim();
+  return normalized || undefined;
 }
 
 function normalizeServerVersion(version?: string): string {
@@ -201,13 +226,21 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     authenticated = false,
     serverVersion?: string,
     consoleProtocolVersion?: number,
+    displayName?: string,
+    stableSessionId?: string,
   ): SessionInfo | null {
     try {
-      const displayName = namePool.assign(sessionId);
-      const color = namePool.getColor(sessionId) ?? '#3b82f6';
+      const preferredDisplayName = normalizeOptionalInput(displayName);
+      const resolvedDisplayName = preferredDisplayName
+        ? namePool.adopt(sessionId, preferredDisplayName)
+        : namePool.assign(sessionId);
+      const color = namePool.getColor(sessionId) ?? getPuppetColor(resolvedDisplayName) ?? '#3b82f6';
       const now = new Date().toISOString();
       const info: SessionInfo = {
-        sessionId, displayName, color,
+        sessionId,
+        stableSessionId: normalizeOptionalInput(stableSessionId) ?? null,
+        displayName: resolvedDisplayName,
+        color,
         pid: pid || 0,
         startedAt: now, lastHeartbeat: now,
         status: 'active', isLeader: false, authenticated, kind: 'mcp',
@@ -216,7 +249,7 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       };
       sessions.set(sessionId, info);
       logger.info('[IngestRoutes] Auto-registered orphaned session', {
-        displayName, sessionId, source: pid ? 'heartbeat' : 'ingestion',
+        displayName: resolvedDisplayName, sessionId, source: pid ? 'heartbeat' : 'ingestion',
       });
       broadcasts.sessionBroadcast?.(info);
       return info;
@@ -238,6 +271,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     authenticated = false,
     serverVersion?: string,
     consoleProtocolVersion?: number,
+    displayName?: string,
+    stableSessionId?: string,
   ): SessionInfo | null {
     if (killedSessions.has(sessionId)) return null;
     if (pendingKills.has(sessionId)) {
@@ -247,7 +282,15 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
 
     const existing = sessions.get(sessionId);
     if (!existing) {
-      return autoRegister(sessionId, pid, authenticated, serverVersion, consoleProtocolVersion);
+      return autoRegister(
+        sessionId,
+        pid,
+        authenticated,
+        serverVersion,
+        consoleProtocolVersion,
+        displayName,
+        stableSessionId,
+      );
     }
 
     importedSessionGraceUntil.delete(sessionId);
@@ -270,6 +313,18 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     }
     if (consoleProtocolVersion !== undefined) {
       existing.consoleProtocolVersion = normalizeConsoleProtocolVersion(consoleProtocolVersion);
+    }
+    const preferredDisplayName = normalizeOptionalInput(displayName);
+    if (preferredDisplayName) {
+      const resolvedDisplayName = namePool.reassign(sessionId, preferredDisplayName, existing.isLeader);
+      if (resolvedDisplayName !== existing.displayName) {
+        existing.displayName = resolvedDisplayName;
+        existing.color = getPuppetColor(resolvedDisplayName) ?? existing.color;
+      }
+    }
+    const normalizedStableSessionId = normalizeOptionalInput(stableSessionId);
+    if (normalizedStableSessionId) {
+      existing.stableSessionId = normalizedStableSessionId;
     }
     return existing;
   }
@@ -294,6 +349,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       return;
     }
     payload.sessionId = normalizeInput(payload.sessionId);
+    const payloadDisplayName = normalizeOptionalInput(payload.displayName);
+    const payloadStableSessionId = normalizeOptionalInput(payload.stableSessionId);
 
     let count = 0;
     let skipped = 0;
@@ -308,7 +365,15 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     }
 
     // Update heartbeat, revive ended sessions, or auto-register orphans (#1870)
-    const session = ensureSession(payload.sessionId);
+    const session = ensureSession(
+      payload.sessionId,
+      undefined,
+      false,
+      undefined,
+      undefined,
+      payloadDisplayName,
+      payloadStableSessionId,
+    );
 
     if (skipped > 0) {
       logger.debug(`[IngestRoutes] Log ingest from ${session?.displayName ?? payload.sessionId}: accepted=${count}, skipped=${skipped}`);
@@ -334,6 +399,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       return;
     }
     payload.sessionId = normalizeInput(payload.sessionId);
+    const payloadDisplayName = normalizeOptionalInput(payload.displayName);
+    const payloadStableSessionId = normalizeOptionalInput(payload.stableSessionId);
 
     if (broadcasts.metricsOnSnapshot) {
       broadcasts.metricsOnSnapshot(payload.snapshot);
@@ -343,7 +410,15 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     }
 
     // Update heartbeat, revive ended sessions, or auto-register orphans (#1870)
-    const session = ensureSession(payload.sessionId);
+    const session = ensureSession(
+      payload.sessionId,
+      undefined,
+      false,
+      undefined,
+      undefined,
+      payloadDisplayName,
+      payloadStableSessionId,
+    );
     logger.debug(`[IngestRoutes] Metrics ingested from ${session?.displayName ?? payload.sessionId}`);
     res.status(200).json({ accepted: true });
   });
@@ -360,6 +435,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       return;
     }
     payload.sessionId = normalizeInput(payload.sessionId);
+    const payloadDisplayName = normalizeOptionalInput(payload.displayName);
+    const payloadStableSessionId = normalizeOptionalInput(payload.stableSessionId);
 
     const now = new Date().toISOString();
 
@@ -369,11 +446,15 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
         if (killedSessions.has(payload.sessionId)) break;
         if (pendingKills.has(payload.sessionId)) { finalizePendingKill(payload.sessionId, payload.pid); break; }
 
-        const displayName = namePool.assign(payload.sessionId);
-        const color = namePool.getColor(payload.sessionId) ?? '#3b82f6';
+        const preferredDisplayName = payloadDisplayName ?? derivePreferredSessionName(payload.sessionId);
+        const displayName = namePool.adopt(payload.sessionId, preferredDisplayName);
+        const color = namePool.getColor(payload.sessionId) ?? getPuppetColor(displayName) ?? '#3b82f6';
         const isAuthenticated = Boolean((res as any).locals?.tokenEntry);
         sessions.set(payload.sessionId, {
-          sessionId: payload.sessionId, displayName, color,
+          sessionId: payload.sessionId,
+          stableSessionId: payloadStableSessionId ?? null,
+          displayName,
+          color,
           pid: payload.pid, startedAt: payload.startedAt || now, lastHeartbeat: now,
           status: 'active', isLeader: false, authenticated: isAuthenticated, kind: 'mcp',
           serverVersion: normalizeServerVersion(payload.serverVersion),
@@ -408,6 +489,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
           false,
           payload.serverVersion,
           payload.consoleProtocolVersion,
+          payloadDisplayName,
+          payloadStableSessionId,
         );
         break;
       }
@@ -595,6 +678,7 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       const color = imported.color || namePool.getColor(normalizedSessionId) || '#3b82f6';
       const merged: SessionInfo = {
         sessionId: normalizedSessionId,
+        stableSessionId: imported.stableSessionId ?? existing?.stableSessionId ?? null,
         displayName,
         color,
         pid: imported.pid || existing?.pid || 0,
@@ -616,12 +700,19 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     }
   }
 
-  function registerLeaderSession(sessionId: string, pid: number): void {
-    const displayName = namePool.assign(sessionId, true);
-    const color = namePool.getColor(sessionId) ?? '#3b82f6';
+  function registerLeaderSession(
+    sessionId: string,
+    pid: number,
+    displayName?: string,
+    stableSessionId?: string,
+  ): void {
+    const preferredDisplayName = normalizeOptionalInput(displayName) ?? derivePreferredSessionName(sessionId, true);
+    const resolvedDisplayName = namePool.adopt(sessionId, preferredDisplayName, true);
+    const color = namePool.getColor(sessionId) ?? getPuppetColor(resolvedDisplayName) ?? '#3b82f6';
     sessions.set(sessionId, {
       sessionId,
-      displayName,
+      stableSessionId: normalizeOptionalInput(stableSessionId) ?? null,
+      displayName: resolvedDisplayName,
       color,
       pid,
       startedAt: new Date().toISOString(),
@@ -633,7 +724,13 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       serverVersion: PACKAGE_VERSION,
       consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
     });
-    logger.info('[IngestRoutes] Leader session registered', { displayName, sessionId, pid, color });
+    logger.info('[IngestRoutes] Leader session registered', {
+      displayName: resolvedDisplayName,
+      sessionId,
+      stableSessionId: normalizeOptionalInput(stableSessionId) ?? null,
+      pid,
+      color,
+    });
   }
 
   /**
@@ -647,6 +744,7 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     const displayName = 'Web Console';
     sessions.set(consoleId, {
       sessionId: consoleId,
+      stableSessionId: null,
       displayName,
       color: '#6366f1', // indigo — distinct from puppet greens/blues
       pid: process.pid,

--- a/src/web/console/IngestRoutes.ts
+++ b/src/web/console/IngestRoutes.ts
@@ -23,7 +23,8 @@ import { SlidingWindowRateLimiter } from '../../utils/SlidingWindowRateLimiter.j
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import {
   SessionNamePool,
-  derivePreferredSessionName,
+  derivePreferredFollowerSessionName,
+  derivePreferredLeaderSessionName,
   getPuppetColor,
 } from './SessionNames.js';
 import { logger } from '../../utils/logger.js';
@@ -90,9 +91,13 @@ export interface SessionInfo {
  * Payload for POST /api/ingest/logs
  */
 export interface IngestLogPayload {
+  /** Runtime-unique session identity for the follower sending the logs. */
   sessionId: string;
+  /** Stable cross-restart/session identity when the host provides one. */
   stableSessionId?: string;
+  /** Follower-provided canonical display name preference for this runtime session. */
   displayName?: string;
+  /** Batched log entries already stamped with follower-local metadata. */
   entries: UnifiedLogEntry[];
 }
 
@@ -100,9 +105,13 @@ export interface IngestLogPayload {
  * Payload for POST /api/ingest/metrics
  */
 export interface IngestMetricsPayload {
+  /** Runtime-unique session identity for the follower sending the snapshot. */
   sessionId: string;
+  /** Stable cross-restart/session identity when the host provides one. */
   stableSessionId?: string;
+  /** Follower-provided canonical display name preference for this runtime session. */
   displayName?: string;
+  /** Metric snapshot captured on the follower. */
   snapshot: MetricSnapshot;
 }
 
@@ -110,13 +119,21 @@ export interface IngestMetricsPayload {
  * Payload for POST /api/ingest/session
  */
 export interface SessionEventPayload {
+  /** Runtime-unique session identity for the follower emitting the event. */
   sessionId: string;
+  /** Stable cross-restart/session identity when the host provides one. */
   stableSessionId?: string;
+  /** Follower-provided canonical display name preference for this runtime session. */
   displayName?: string;
+  /** Lifecycle event that should renew, create, or retire the session lease. */
   event: 'started' | 'stopped' | 'heartbeat';
+  /** PID of the follower runtime emitting the event. */
   pid: number;
+  /** Original startup time reported by the follower runtime. */
   startedAt: string;
+  /** Package version reported by the follower runtime. */
   serverVersion?: string;
+  /** Console/session protocol version reported by the follower runtime. */
   consoleProtocolVersion?: number;
 }
 
@@ -199,6 +216,21 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
   // (every 10s) carries the PID — we SIGTERM immediately and move to killedSessions.
   const pendingKills = new Set<string>();
   const importedSessionGraceUntil = new Map<string, number>();
+  const metadataSyncCounters = {
+    displayNameAdoptions: 0,
+    displayNameReassignments: 0,
+    stableSessionBindings: 0,
+  };
+
+  function recordMetadataSync(event: keyof typeof metadataSyncCounters, sessionId: string, details: Record<string, unknown> = {}): void {
+    metadataSyncCounters[event] += 1;
+    logger.debug('[IngestRoutes] Session metadata synchronized', {
+      event,
+      sessionId,
+      total: metadataSyncCounters[event],
+      ...details,
+    });
+  }
 
   /** Execute a deferred kill if we now have a PID. */
   function tryExecutePendingKill(sessionId: string, pid?: number): void {
@@ -234,11 +266,18 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       const resolvedDisplayName = preferredDisplayName
         ? namePool.adopt(sessionId, preferredDisplayName)
         : namePool.assign(sessionId);
+      if (preferredDisplayName && resolvedDisplayName === preferredDisplayName) {
+        recordMetadataSync('displayNameAdoptions', sessionId, { displayName: resolvedDisplayName });
+      }
       const color = namePool.getColor(sessionId) ?? getPuppetColor(resolvedDisplayName) ?? '#3b82f6';
+      const normalizedStableSessionId = normalizeOptionalInput(stableSessionId) ?? null;
+      if (normalizedStableSessionId) {
+        recordMetadataSync('stableSessionBindings', sessionId, { stableSessionId: normalizedStableSessionId });
+      }
       const now = new Date().toISOString();
       const info: SessionInfo = {
         sessionId,
-        stableSessionId: normalizeOptionalInput(stableSessionId) ?? null,
+        stableSessionId: normalizedStableSessionId,
         displayName: resolvedDisplayName,
         color,
         pid: pid || 0,
@@ -316,14 +355,21 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     }
     const preferredDisplayName = normalizeOptionalInput(displayName);
     if (preferredDisplayName) {
-      const resolvedDisplayName = namePool.reassign(sessionId, preferredDisplayName, existing.isLeader);
+      const resolvedDisplayName = existing.isLeader
+        ? namePool.reassignLeader(sessionId, preferredDisplayName)
+        : namePool.reassign(sessionId, preferredDisplayName);
       if (resolvedDisplayName !== existing.displayName) {
+        recordMetadataSync('displayNameReassignments', sessionId, {
+          previousDisplayName: existing.displayName,
+          nextDisplayName: resolvedDisplayName,
+        });
         existing.displayName = resolvedDisplayName;
         existing.color = getPuppetColor(resolvedDisplayName) ?? existing.color;
       }
     }
     const normalizedStableSessionId = normalizeOptionalInput(stableSessionId);
-    if (normalizedStableSessionId) {
+    if (normalizedStableSessionId && normalizedStableSessionId !== existing.stableSessionId) {
+      recordMetadataSync('stableSessionBindings', sessionId, { stableSessionId: normalizedStableSessionId });
       existing.stableSessionId = normalizedStableSessionId;
     }
     return existing;
@@ -446,13 +492,20 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
         if (killedSessions.has(payload.sessionId)) break;
         if (pendingKills.has(payload.sessionId)) { finalizePendingKill(payload.sessionId, payload.pid); break; }
 
-        const preferredDisplayName = payloadDisplayName ?? derivePreferredSessionName(payload.sessionId);
+        const preferredDisplayName = payloadDisplayName ?? derivePreferredFollowerSessionName(payload.sessionId);
         const displayName = namePool.adopt(payload.sessionId, preferredDisplayName);
+        if (displayName === preferredDisplayName) {
+          recordMetadataSync('displayNameAdoptions', payload.sessionId, { displayName });
+        }
         const color = namePool.getColor(payload.sessionId) ?? getPuppetColor(displayName) ?? '#3b82f6';
         const isAuthenticated = Boolean((res as any).locals?.tokenEntry);
+        const normalizedStableSessionId = payloadStableSessionId ?? null;
+        if (normalizedStableSessionId) {
+          recordMetadataSync('stableSessionBindings', payload.sessionId, { stableSessionId: normalizedStableSessionId });
+        }
         sessions.set(payload.sessionId, {
           sessionId: payload.sessionId,
-          stableSessionId: payloadStableSessionId ?? null,
+          stableSessionId: normalizedStableSessionId,
           displayName,
           color,
           pid: payload.pid, startedAt: payload.startedAt || now, lastHeartbeat: now,
@@ -675,10 +728,23 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       const displayName = imported.displayName
         ? namePool.adopt(normalizedSessionId, imported.displayName)
         : namePool.assign(normalizedSessionId);
+      if (imported.displayName && displayName === imported.displayName) {
+        recordMetadataSync('displayNameAdoptions', normalizedSessionId, {
+          displayName,
+          source: 'takeover-import',
+        });
+      }
       const color = imported.color || namePool.getColor(normalizedSessionId) || '#3b82f6';
+      const normalizedStableSessionId = imported.stableSessionId ?? existing?.stableSessionId ?? null;
+      if (normalizedStableSessionId) {
+        recordMetadataSync('stableSessionBindings', normalizedSessionId, {
+          stableSessionId: normalizedStableSessionId,
+          source: 'takeover-import',
+        });
+      }
       const merged: SessionInfo = {
         sessionId: normalizedSessionId,
-        stableSessionId: imported.stableSessionId ?? existing?.stableSessionId ?? null,
+        stableSessionId: normalizedStableSessionId,
         displayName,
         color,
         pid: imported.pid || existing?.pid || 0,
@@ -706,12 +772,25 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     displayName?: string,
     stableSessionId?: string,
   ): void {
-    const preferredDisplayName = normalizeOptionalInput(displayName) ?? derivePreferredSessionName(sessionId, true);
-    const resolvedDisplayName = namePool.adopt(sessionId, preferredDisplayName, true);
+    const preferredDisplayName = normalizeOptionalInput(displayName) ?? derivePreferredLeaderSessionName(sessionId);
+    const resolvedDisplayName = namePool.adoptLeader(sessionId, preferredDisplayName);
+    if (resolvedDisplayName === preferredDisplayName) {
+      recordMetadataSync('displayNameAdoptions', sessionId, {
+        displayName: resolvedDisplayName,
+        source: 'leader-registration',
+      });
+    }
     const color = namePool.getColor(sessionId) ?? getPuppetColor(resolvedDisplayName) ?? '#3b82f6';
+    const normalizedStableSessionId = normalizeOptionalInput(stableSessionId) ?? null;
+    if (normalizedStableSessionId) {
+      recordMetadataSync('stableSessionBindings', sessionId, {
+        stableSessionId: normalizedStableSessionId,
+        source: 'leader-registration',
+      });
+    }
     sessions.set(sessionId, {
       sessionId,
-      stableSessionId: normalizeOptionalInput(stableSessionId) ?? null,
+      stableSessionId: normalizedStableSessionId,
       displayName: resolvedDisplayName,
       color,
       pid,
@@ -727,7 +806,7 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     logger.info('[IngestRoutes] Leader session registered', {
       displayName: resolvedDisplayName,
       sessionId,
-      stableSessionId: normalizeOptionalInput(stableSessionId) ?? null,
+      stableSessionId: normalizedStableSessionId,
       pid,
       color,
     });

--- a/src/web/console/LeaderForwardingSink.ts
+++ b/src/web/console/LeaderForwardingSink.ts
@@ -76,6 +76,10 @@ export class LeaderForwardingLogSink implements ILogSink {
     private readonly authToken: string | null = null,
     /** Callback invoked when the leader is presumed dead after MAX_CONSECUTIVE_FAILURES (#1850). */
     private readonly onLeaderDeath?: () => void,
+    /** Canonical local display name for this runtime session. */
+    private readonly sessionDisplayName: string | null = null,
+    /** Stable session identity shared across restarts when available. */
+    private readonly stableSessionId: string | null = null,
   ) {
     this.sessionId = UnicodeValidator.normalize(sessionId).normalizedContent;
     this.flushTimer = setInterval(() => this.flushBuffer(), FLUSH_INTERVAL_MS);
@@ -124,7 +128,12 @@ export class LeaderForwardingLogSink implements ILogSink {
       const response = await fetch(`${this.leaderUrl}/api/ingest/logs`, {
         method: 'POST',
         headers: buildIngestHeaders(this.authToken),
-        body: JSON.stringify({ sessionId: this.sessionId, entries: batch }),
+        body: JSON.stringify({
+          sessionId: this.sessionId,
+          ...(this.stableSessionId ? { stableSessionId: this.stableSessionId } : {}),
+          ...(this.sessionDisplayName ? { displayName: this.sessionDisplayName } : {}),
+          entries: batch,
+        }),
         signal: controller.signal,
       });
       clearTimeout(timeout);
@@ -189,6 +198,10 @@ export class LeaderForwardingMetricsSink {
     private readonly sessionId: string,
     /** Optional console auth token (#1780). Included as Bearer header on ingest POSTs. */
     private readonly authToken: string | null = null,
+    /** Canonical local display name for this runtime session. */
+    private readonly sessionDisplayName: string | null = null,
+    /** Stable session identity shared across restarts when available. */
+    private readonly stableSessionId: string | null = null,
   ) {}
 
   async onSnapshot(snapshot: MetricSnapshot): Promise<void> {
@@ -199,7 +212,12 @@ export class LeaderForwardingMetricsSink {
       await fetch(`${this.leaderUrl}/api/ingest/metrics`, {
         method: 'POST',
         headers: buildIngestHeaders(this.authToken),
-        body: JSON.stringify({ sessionId: this.sessionId, snapshot }),
+        body: JSON.stringify({
+          sessionId: this.sessionId,
+          ...(this.stableSessionId ? { stableSessionId: this.stableSessionId } : {}),
+          ...(this.sessionDisplayName ? { displayName: this.sessionDisplayName } : {}),
+          snapshot,
+        }),
         signal: controller.signal,
       });
       clearTimeout(timeout);
@@ -221,6 +239,10 @@ export class SessionHeartbeat {
     private readonly pid: number,
     /** Optional console auth token (#1780). Included as Bearer header on ingest POSTs. */
     private readonly authToken: string | null = null,
+    /** Canonical local display name for this runtime session. */
+    private readonly sessionDisplayName: string | null = null,
+    /** Stable session identity shared across restarts when available. */
+    private readonly stableSessionId: string | null = null,
   ) {}
 
   /** Notify the leader that this session has started */
@@ -252,6 +274,8 @@ export class SessionHeartbeat {
         headers: buildIngestHeaders(this.authToken),
         body: JSON.stringify({
           sessionId: this.sessionId,
+          ...(this.stableSessionId ? { stableSessionId: this.stableSessionId } : {}),
+          ...(this.sessionDisplayName ? { displayName: this.sessionDisplayName } : {}),
           event,
           pid: this.pid,
           startedAt: new Date().toISOString(),

--- a/src/web/console/SessionNames.ts
+++ b/src/web/console/SessionNames.ts
@@ -9,7 +9,7 @@
  * @since v2.1.0 — Issue #1700
  */
 
-import { randomInt } from 'node:crypto';
+import { createHash, randomInt } from 'node:crypto';
 import { logger } from '../../utils/logger.js';
 
 /**
@@ -116,6 +116,12 @@ function shuffleArray<T>(arr: T[]): T[] {
 /** Shuffled copy of the name pool — randomized on each process start */
 const PUPPET_NAMES: string[] = shuffleArray([...ALL_PUPPET_NAMES]);
 
+function getAssignablePuppetNames(isLeader = false): readonly string[] {
+  return isLeader
+    ? ALL_PUPPET_NAMES.filter(name => !FOLLOWER_ONLY_NAMES.has(name))
+    : ALL_PUPPET_NAMES;
+}
+
 /**
  * Iconic attire and accessories drawn from famous dolls, puppets, and
  * theatrical characters throughout history. Used to name console tokens
@@ -189,6 +195,20 @@ export function pickRandomTokenName(): string {
 }
 
 /**
+ * Derive a stable preferred puppet name for a runtime session.
+ *
+ * This lets followers and leaders agree on a canonical human-facing name for
+ * the same runtime session before the leader decides whether it can reserve
+ * that name in the active pool.
+ */
+export function derivePreferredSessionName(sessionId: string, isLeader = false): string {
+  const candidates = getAssignablePuppetNames(isLeader);
+  const digest = createHash('sha256').update(sessionId, 'utf8').digest();
+  const index = digest.readUInt32BE(0) % candidates.length;
+  return candidates[index];
+}
+
+/**
  * Canonical colors for each puppet character.
  * Adjusted from true canonical colors for UI readability in both light/dark themes.
  */
@@ -255,6 +275,10 @@ const PUPPET_COLORS: Record<string, string> = {
   'Betsy':        '#DD7694', // rose pink
   'Madeline':     '#FFD700', // yellow hat
 };
+
+export function getPuppetColor(name: string): string | undefined {
+  return PUPPET_COLORS[name] ?? undefined;
+}
 
 /** Cooldown period before a released name can be reused (ms) */
 const NAME_COOLDOWN_MS = 5 * 60_000; // 5 minutes
@@ -331,7 +355,11 @@ export class SessionNamePool {
 
     this.flushCooldowns();
 
-    if (!this.nameToSession.has(name) && !(isLeader && FOLLOWER_ONLY_NAMES.has(name))) {
+    if (
+      ALL_PUPPET_NAMES.includes(name) &&
+      !this.nameToSession.has(name) &&
+      !(isLeader && FOLLOWER_ONLY_NAMES.has(name))
+    ) {
       this.assigned.set(sessionId, name);
       this.nameToSession.set(name, sessionId);
       this.cooldown = this.cooldown.filter(entry => entry.name !== name);
@@ -340,6 +368,35 @@ export class SessionNamePool {
     }
 
     return this.assign(sessionId, isLeader);
+  }
+
+  /**
+   * Update an existing session to a canonical preferred name when the new name
+   * is available. If another live session already owns that name, the current
+   * assignment is preserved to avoid churn.
+   */
+  reassign(sessionId: string, name: string, isLeader = false): string {
+    const existing = this.assigned.get(sessionId);
+    if (!existing) {
+      return this.adopt(sessionId, name, isLeader);
+    }
+
+    if (existing === name) {
+      return existing;
+    }
+
+    const currentOwner = this.nameToSession.get(name);
+    if (currentOwner && currentOwner !== sessionId) {
+      return existing;
+    }
+
+    this.assigned.delete(sessionId);
+    this.nameToSession.delete(existing);
+    if (ALL_PUPPET_NAMES.includes(existing)) {
+      this.cooldown.push({ name: existing, releasedAt: Date.now() });
+    }
+
+    return this.adopt(sessionId, name, isLeader);
   }
 
   /**
@@ -372,7 +429,7 @@ export class SessionNamePool {
    */
   getColor(sessionId: string): string | undefined {
     const name = this.assigned.get(sessionId);
-    return name ? (PUPPET_COLORS[name] ?? undefined) : undefined;
+    return name ? getPuppetColor(name) : undefined;
   }
 
   /**

--- a/src/web/console/SessionNames.ts
+++ b/src/web/console/SessionNames.ts
@@ -116,10 +116,22 @@ function shuffleArray<T>(arr: T[]): T[] {
 /** Shuffled copy of the name pool — randomized on each process start */
 const PUPPET_NAMES: string[] = shuffleArray([...ALL_PUPPET_NAMES]);
 
-function getAssignablePuppetNames(isLeader = false): readonly string[] {
-  return isLeader
-    ? ALL_PUPPET_NAMES.filter(name => !FOLLOWER_ONLY_NAMES.has(name))
-    : ALL_PUPPET_NAMES;
+const LEADER_ASSIGNABLE_PUPPET_NAMES = ALL_PUPPET_NAMES.filter(
+  name => !FOLLOWER_ONLY_NAMES.has(name),
+);
+
+function getFollowerAssignablePuppetNames(): readonly string[] {
+  return ALL_PUPPET_NAMES;
+}
+
+function getLeaderAssignablePuppetNames(): readonly string[] {
+  return LEADER_ASSIGNABLE_PUPPET_NAMES;
+}
+
+function derivePreferredNameFromCandidates(sessionId: string, candidates: readonly string[]): string {
+  const digest = createHash('sha256').update(sessionId, 'utf8').digest();
+  const index = digest.readUInt32BE(0) % candidates.length;
+  return candidates[index];
 }
 
 /**
@@ -197,15 +209,21 @@ export function pickRandomTokenName(): string {
 /**
  * Derive a stable preferred puppet name for a runtime session.
  *
- * This lets followers and leaders agree on a canonical human-facing name for
- * the same runtime session before the leader decides whether it can reserve
- * that name in the active pool.
+ * This gives followers a deterministic local preference before the active
+ * leader grants the authoritative leased display name.
  */
-export function derivePreferredSessionName(sessionId: string, isLeader = false): string {
-  const candidates = getAssignablePuppetNames(isLeader);
-  const digest = createHash('sha256').update(sessionId, 'utf8').digest();
-  const index = digest.readUInt32BE(0) % candidates.length;
-  return candidates[index];
+export function derivePreferredFollowerSessionName(sessionId: string): string {
+  return derivePreferredNameFromCandidates(sessionId, getFollowerAssignablePuppetNames());
+}
+
+/**
+ * Derive a stable preferred puppet name for a leader runtime session.
+ *
+ * Leader sessions use the same deterministic derivation as followers, but
+ * they exclude follower-only names such as `Punch`.
+ */
+export function derivePreferredLeaderSessionName(sessionId: string): string {
+  return derivePreferredNameFromCandidates(sessionId, getLeaderAssignablePuppetNames());
 }
 
 /**
@@ -299,13 +317,19 @@ export class SessionNamePool {
   /** Names in cooldown after session end */
   private cooldown: CooldownEntry[] = [];
 
+  assign(sessionId: string): string {
+    return this.assignFromCandidates(sessionId, getFollowerAssignablePuppetNames());
+  }
+
   /**
-   * Assign a friendly name to a session.
-   * Returns an existing assignment if the session already has one.
-   *
-   * @param isLeader - If true, follower-only names (e.g., Punch) are excluded
+   * Assign a friendly name to a leader session.
+   * Leader sessions exclude follower-only names such as `Punch`.
    */
-  assign(sessionId: string, isLeader = false): string {
+  assignLeader(sessionId: string): string {
+    return this.assignFromCandidates(sessionId, getLeaderAssignablePuppetNames());
+  }
+
+  private assignFromCandidates(sessionId: string, candidates: readonly string[]): string {
     // Already assigned?
     const existing = this.assigned.get(sessionId);
     if (existing) return existing;
@@ -313,12 +337,12 @@ export class SessionNamePool {
     // Flush expired cooldowns
     this.flushCooldowns();
 
-    // Find an available name, respecting leader restrictions
+    // Find an available name within the allowed candidate set.
     const cooldownNames = new Set(this.cooldown.map(c => c.name));
     const availableName = PUPPET_NAMES.find(
-      name => !this.nameToSession.has(name) &&
-              !cooldownNames.has(name) &&
-              !(isLeader && FOLLOWER_ONLY_NAMES.has(name))
+      name => candidates.includes(name) &&
+        !this.nameToSession.has(name) &&
+        !cooldownNames.has(name),
     );
 
     if (availableName) {
@@ -349,17 +373,24 @@ export class SessionNamePool {
    * If the requested name is already taken by another live session, the pool
    * falls back to normal assignment logic rather than creating a duplicate.
    */
-  adopt(sessionId: string, name: string, isLeader = false): string {
+  adopt(sessionId: string, name: string): string {
+    return this.adoptFromCandidates(sessionId, name, getFollowerAssignablePuppetNames());
+  }
+
+  /**
+   * Preserve an existing leader-facing assignment while excluding follower-only names.
+   */
+  adoptLeader(sessionId: string, name: string): string {
+    return this.adoptFromCandidates(sessionId, name, getLeaderAssignablePuppetNames());
+  }
+
+  private adoptFromCandidates(sessionId: string, name: string, candidates: readonly string[]): string {
     const existing = this.assigned.get(sessionId);
     if (existing) return existing;
 
     this.flushCooldowns();
 
-    if (
-      ALL_PUPPET_NAMES.includes(name) &&
-      !this.nameToSession.has(name) &&
-      !(isLeader && FOLLOWER_ONLY_NAMES.has(name))
-    ) {
+    if (candidates.includes(name) && !this.nameToSession.has(name)) {
       this.assigned.set(sessionId, name);
       this.nameToSession.set(name, sessionId);
       this.cooldown = this.cooldown.filter(entry => entry.name !== name);
@@ -367,7 +398,7 @@ export class SessionNamePool {
       return name;
     }
 
-    return this.assign(sessionId, isLeader);
+    return this.assignFromCandidates(sessionId, candidates);
   }
 
   /**
@@ -375,10 +406,22 @@ export class SessionNamePool {
    * is available. If another live session already owns that name, the current
    * assignment is preserved to avoid churn.
    */
-  reassign(sessionId: string, name: string, isLeader = false): string {
+  reassign(sessionId: string, name: string): string {
+    return this.reassignFromCandidates(sessionId, name, getFollowerAssignablePuppetNames());
+  }
+
+  /**
+   * Reassign a leader session to a preferred name while preserving the
+   * leader-only exclusion rules.
+   */
+  reassignLeader(sessionId: string, name: string): string {
+    return this.reassignFromCandidates(sessionId, name, getLeaderAssignablePuppetNames());
+  }
+
+  private reassignFromCandidates(sessionId: string, name: string, candidates: readonly string[]): string {
     const existing = this.assigned.get(sessionId);
     if (!existing) {
-      return this.adopt(sessionId, name, isLeader);
+      return this.adoptFromCandidates(sessionId, name, candidates);
     }
 
     if (existing === name) {
@@ -396,7 +439,7 @@ export class SessionNamePool {
       this.cooldown.push({ name: existing, releasedAt: Date.now() });
     }
 
-    return this.adopt(sessionId, name, isLeader);
+    return this.adoptFromCandidates(sessionId, name, candidates);
   }
 
   /**

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -1163,7 +1163,7 @@ async function startAsLeader(
   consolePort: number = DEFAULT_CONSOLE_PORT,
 ): Promise<UnifiedConsoleResult> {
   const { startWebServer } = await import('../server.js');
-  const { pickRandomTokenName } = await import('./SessionNames.js');
+  const { derivePreferredSessionName, pickRandomTokenName } = await import('./SessionNames.js');
 
   // Initialize the console token store (#1780). Creates the token file on
   // first run, reads the existing tokens on subsequent runs. The token is
@@ -1257,7 +1257,12 @@ async function startAsLeader(
   }
 
   // Register the leader only after the HTTP listener is actually serving the port.
-  ingestResult.registerLeaderSession(options.sessionId, process.pid);
+  ingestResult.registerLeaderSession(
+    options.sessionId,
+    process.pid,
+    derivePreferredSessionName(options.sessionId, true),
+    options.stableSessionId,
+  );
 
   // Register the web console itself so the session indicator is never empty (#1805)
   ingestResult.registerConsoleSession();
@@ -1336,6 +1341,9 @@ async function startAsFollower(
     logger.debug('[UnifiedConsole] No console auth token file found; follower will POST without Bearer header');
   }
 
+  const { derivePreferredSessionName } = await import('./SessionNames.js');
+  const preferredSessionName = derivePreferredSessionName(options.sessionId);
+
   // Per-instance promotion manager — tracks its own attempt counter so
   // multiple followers don't interfere with each other's promotion budgets.
   const promotionMgr = new PromotionManager(options, consolePort, startAsLeader, startAsFollower);
@@ -1345,14 +1353,28 @@ async function startAsFollower(
   let sessionHeartbeat: SessionHeartbeat;
 
   // Register a forwarding log sink with leader-death callback (#1850).
-  const forwardingSink = new LeaderForwardingLogSink(leaderUrl, options.sessionId, authToken, () => {
+  const forwardingSink = new LeaderForwardingLogSink(
+    leaderUrl,
+    options.sessionId,
+    authToken,
+    () => {
     promotionMgr.promote(forwardingSink, sessionHeartbeat)
       .catch(err => logger.error('[UnifiedConsole] Promotion crashed', { error: String(err) }));
-  });
+    },
+    preferredSessionName,
+    options.stableSessionId,
+  );
   options.registerLogSink(forwardingSink);
 
   // Start session heartbeat to the leader
-  sessionHeartbeat = new SessionHeartbeat(leaderUrl, options.sessionId, process.pid, authToken);
+  sessionHeartbeat = new SessionHeartbeat(
+    leaderUrl,
+    options.sessionId,
+    process.pid,
+    authToken,
+    preferredSessionName,
+    options.stableSessionId,
+  );
   await sessionHeartbeat.start();
 
   const stopAuthorityMonitor = startFollowerAuthorityMonitor(

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -20,6 +20,7 @@ import type { MemoryMetricsSink } from '../../metrics/sinks/MemoryMetricsSink.js
 import type { WebServerOptions, WebServerResult } from '../server.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { logger } from '../../utils/logger.js';
+import type { MCPAQLHandler } from '../../handlers/mcp-aql/MCPAQLHandler.js';
 import {
   electLeader,
   isLeaderWebConsoleReachable,
@@ -105,8 +106,8 @@ export interface UnifiedConsoleOptions {
   memorySink: MemoryLogSink;
   /** Metrics memory sink */
   metricsSink?: MemoryMetricsSink;
-  /** MCP-AQL handler for permission routes (typed as any to avoid circular imports) */
-  mcpAqlHandler?: any;
+  /** MCP-AQL handler for permission and gateway routes when the console is leader. */
+  mcpAqlHandler?: MCPAQLHandler;
   /** Callback to register a log sink with the LogManager */
   registerLogSink: (sink: { write(entry: UnifiedLogEntry): void; flush(): Promise<void>; close(): Promise<void> }) => void;
   /** Callback to wire SSE broadcasts after web server starts */
@@ -283,14 +284,34 @@ export async function fetchLeaderSessionsSnapshot(
       signal: controller.signal,
     });
     if (!response.ok) {
+      logger.debug('[UnifiedConsole] Leader session snapshot request returned non-OK response', {
+        port,
+        status: response.status,
+        statusText: response.statusText,
+      });
       return [];
     }
 
     const data = await response.json() as { sessions?: SessionInfo[] };
-    return Array.isArray(data.sessions) ? data.sessions : [];
-  } catch (err) {
-    logger.debug('[UnifiedConsole] Failed to fetch leader session snapshot', {
+    if (!Array.isArray(data.sessions)) {
+      logger.debug('[UnifiedConsole] Leader session snapshot response missing sessions array', { port });
+      return [];
+    }
+
+    logger.debug('[UnifiedConsole] Leader session snapshot fetched', {
       port,
+      sessions: data.sessions.length,
+      authMode: authToken ? 'bearer' : 'anonymous',
+    });
+    return data.sessions;
+  } catch (err) {
+    const errorName = err instanceof Error ? err.name : 'UnknownError';
+    const debugMessage = errorName === 'AbortError'
+      ? '[UnifiedConsole] Leader session snapshot request timed out'
+      : '[UnifiedConsole] Failed to fetch leader session snapshot';
+    logger.debug(debugMessage, {
+      port,
+      errorName,
       error: err instanceof Error ? err.message : String(err),
     });
     return [];
@@ -1163,7 +1184,7 @@ async function startAsLeader(
   consolePort: number = DEFAULT_CONSOLE_PORT,
 ): Promise<UnifiedConsoleResult> {
   const { startWebServer } = await import('../server.js');
-  const { derivePreferredSessionName, pickRandomTokenName } = await import('./SessionNames.js');
+  const { derivePreferredLeaderSessionName, pickRandomTokenName } = await import('./SessionNames.js');
 
   // Initialize the console token store (#1780). Creates the token file on
   // first run, reads the existing tokens on subsequent runs. The token is
@@ -1260,7 +1281,7 @@ async function startAsLeader(
   ingestResult.registerLeaderSession(
     options.sessionId,
     process.pid,
-    derivePreferredSessionName(options.sessionId, true),
+    derivePreferredLeaderSessionName(options.sessionId),
     options.stableSessionId,
   );
 
@@ -1341,8 +1362,8 @@ async function startAsFollower(
     logger.debug('[UnifiedConsole] No console auth token file found; follower will POST without Bearer header');
   }
 
-  const { derivePreferredSessionName } = await import('./SessionNames.js');
-  const preferredSessionName = derivePreferredSessionName(options.sessionId);
+  const { derivePreferredFollowerSessionName } = await import('./SessionNames.js');
+  const preferredSessionName = derivePreferredFollowerSessionName(options.sessionId);
 
   // Per-instance promotion manager — tracks its own attempt counter so
   // multiple followers don't interfere with each other's promotion budgets.

--- a/tests/unit/web/console/SessionNames.test.ts
+++ b/tests/unit/web/console/SessionNames.test.ts
@@ -11,6 +11,8 @@ import { describe, it, expect, jest } from '@jest/globals';
 import {
   ALL_PUPPET_NAMES,
   ALL_TOKEN_NAMES,
+  derivePreferredSessionName,
+  getPuppetColor,
   pickRandomTokenName,
   SessionNamePool,
 } from '../../../../src/web/console/SessionNames.js';
@@ -79,6 +81,17 @@ describe('pickRandomTokenName()', () => {
 // ─── SessionNamePool ─────────────────────────────────────────────────────────
 
 describe('SessionNamePool', () => {
+  it('derives a stable preferred name for the same runtime session', () => {
+    expect(derivePreferredSessionName('local-test-session')).toBe(
+      derivePreferredSessionName('local-test-session'),
+    );
+  });
+
+  it('derives different leader and follower preferences when Punch would be excluded', () => {
+    const leaderName = derivePreferredSessionName('leader-test-session', true);
+    expect(leaderName).not.toBe('Punch');
+  });
+
   it('assigns a name from the puppet pool', () => {
     const pool = new SessionNamePool();
     const name = pool.assign('session-1');
@@ -160,6 +173,26 @@ describe('SessionNamePool', () => {
     pool.assign('session-rel');
     pool.release('session-rel');
     expect(pool.getName('session-rel')).toBeUndefined();
+  });
+
+  it('reassigns a session to a preferred puppet name when that name is free', () => {
+    const pool = new SessionNamePool();
+    pool.assign('session-a');
+
+    const reassigned = pool.reassign('session-a', 'Bunraku');
+    expect(reassigned).toBe('Bunraku');
+    expect(pool.getName('session-a')).toBe('Bunraku');
+    expect(pool.getColor('session-a')).toBe(getPuppetColor('Bunraku'));
+  });
+
+  it('keeps the current assignment when another session already owns the requested name', () => {
+    const pool = new SessionNamePool();
+    pool.adopt('session-a', 'Bunraku');
+    const original = pool.assign('session-b');
+
+    const reassigned = pool.reassign('session-b', 'Bunraku');
+    expect(reassigned).toBe(original);
+    expect(pool.getName('session-b')).toBe(original);
   });
 
   it('adopt() preserves an imported puppet name across leader handoff', () => {

--- a/tests/unit/web/console/SessionNames.test.ts
+++ b/tests/unit/web/console/SessionNames.test.ts
@@ -11,7 +11,8 @@ import { describe, it, expect, jest } from '@jest/globals';
 import {
   ALL_PUPPET_NAMES,
   ALL_TOKEN_NAMES,
-  derivePreferredSessionName,
+  derivePreferredFollowerSessionName,
+  derivePreferredLeaderSessionName,
   getPuppetColor,
   pickRandomTokenName,
   SessionNamePool,
@@ -82,13 +83,13 @@ describe('pickRandomTokenName()', () => {
 
 describe('SessionNamePool', () => {
   it('derives a stable preferred name for the same runtime session', () => {
-    expect(derivePreferredSessionName('local-test-session')).toBe(
-      derivePreferredSessionName('local-test-session'),
+    expect(derivePreferredFollowerSessionName('local-test-session')).toBe(
+      derivePreferredFollowerSessionName('local-test-session'),
     );
   });
 
   it('derives different leader and follower preferences when Punch would be excluded', () => {
-    const leaderName = derivePreferredSessionName('leader-test-session', true);
+    const leaderName = derivePreferredLeaderSessionName('leader-test-session');
     expect(leaderName).not.toBe('Punch');
   });
 
@@ -125,7 +126,7 @@ describe('SessionNamePool', () => {
     const names = new Set<string>();
     // Assign enough sessions to exercise most of the pool
     for (let i = 0; i < 30; i++) {
-      names.add(pool.assign(`leader-${i}`, /* isLeader= */ true));
+      names.add(pool.assignLeader(`leader-${i}`));
     }
     expect(names.has('Punch')).toBe(false);
   });

--- a/tests/unit/web/console/UnifiedConsole.test.ts
+++ b/tests/unit/web/console/UnifiedConsole.test.ts
@@ -334,6 +334,7 @@ describe('fetchLeaderSessionsSnapshot', () => {
         sessions: [
           {
             sessionId: 'older-follower',
+            stableSessionId: null,
             displayName: 'Kermit',
             color: '#00ff00',
             pid: 4567,
@@ -356,12 +357,13 @@ describe('fetchLeaderSessionsSnapshot', () => {
       headers: { Authorization: 'Bearer token-123' },
       signal: expect.any(AbortSignal),
     }));
-    expect(result).toEqual([
-      expect.objectContaining({
-        sessionId: 'older-follower',
-        displayName: 'Kermit',
-      }),
-    ]);
+      expect(result).toEqual([
+        expect.objectContaining({
+          sessionId: 'older-follower',
+          stableSessionId: null,
+          displayName: 'Kermit',
+        }),
+      ]);
   });
 });
 

--- a/tests/unit/web/console/UnifiedConsole.test.ts
+++ b/tests/unit/web/console/UnifiedConsole.test.ts
@@ -365,6 +365,49 @@ describe('fetchLeaderSessionsSnapshot', () => {
         }),
       ]);
   });
+
+  it('logs non-ok responses and returns an empty snapshot', async () => {
+    const debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
+    const fetchStub = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+    } as Response);
+
+    try {
+      const result = await fetchLeaderSessionsSnapshot(41715, null, fetchStub);
+      expect(result).toEqual([]);
+      expect(debugSpy).toHaveBeenCalledWith(
+        '[UnifiedConsole] Leader session snapshot request returned non-OK response',
+        expect.objectContaining({
+          port: 41715,
+          status: 503,
+          statusText: 'Service Unavailable',
+        }),
+      );
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+
+  it('logs malformed snapshot payloads and returns an empty list', async () => {
+    const debugSpy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
+    const fetchStub = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({ nope: [] }),
+    } as Response);
+
+    try {
+      const result = await fetchLeaderSessionsSnapshot(41715, null, fetchStub);
+      expect(result).toEqual([]);
+      expect(debugSpy).toHaveBeenCalledWith(
+        '[UnifiedConsole] Leader session snapshot response missing sessions array',
+        expect.objectContaining({ port: 41715 }),
+      );
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
 });
 
 describe('recoverLeaderBindFailure', () => {

--- a/tests/unit/web/console/console-failure-modes.test.ts
+++ b/tests/unit/web/console/console-failure-modes.test.ts
@@ -476,6 +476,8 @@ describe('Console Failure Modes', () => {
           'test-session',
           process.pid,
           null,
+          'Bunraku',
+          'claude-code-main',
         );
 
         await heartbeat.start();
@@ -485,6 +487,8 @@ describe('Console Failure Modes', () => {
         const body = parseRequestBody((firstCall?.[1] as RequestInit | undefined)?.body);
         expect(body.serverVersion).toBe(PACKAGE_VERSION);
         expect(body.consoleProtocolVersion).toBe(CONSOLE_PROTOCOL_VERSION);
+        expect(body.displayName).toBe('Bunraku');
+        expect(body.stableSessionId).toBe('claude-code-main');
       } finally {
         fetchSpy.mockRestore();
       }

--- a/tests/unit/web/console/ghostSession.test.ts
+++ b/tests/unit/web/console/ghostSession.test.ts
@@ -72,6 +72,22 @@ describe('Ghost session cleanup (#1870)', () => {
       expect(s.color).toMatch(/^#[0-9a-fA-F]{6}$/);
     });
 
+    it('uses the follower-provided display name and stable identity when auto-registering from logs', async () => {
+      const app = buildApp(ir);
+      await request(app)
+        .post('/api/ingest/logs')
+        .send({
+          sessionId: 'orphan-identity',
+          stableSessionId: 'claude-code-main',
+          displayName: 'Skipper',
+          entries: [makeEntry()],
+        });
+
+      const session = ir.getSessions()[0];
+      expect(session.displayName).toBe('Skipper');
+      expect(session.stableSessionId).toBe('claude-code-main');
+    });
+
     it('broadcasts the new session', async () => {
       const app = buildApp(ir);
       await request(app)

--- a/tests/unit/web/console/sessionRegistry.test.ts
+++ b/tests/unit/web/console/sessionRegistry.test.ts
@@ -133,6 +133,7 @@ describe('Session registry (#1805)', () => {
       ingestResult.importSessions([
         {
           sessionId: 'old-leader',
+          stableSessionId: null,
           displayName: 'Leader',
           color: '#111111',
           pid: 11,
@@ -147,6 +148,7 @@ describe('Session registry (#1805)', () => {
         },
         {
           sessionId: 'old-console',
+          stableSessionId: null,
           displayName: 'Web Console',
           color: '#222222',
           pid: 12,
@@ -161,6 +163,7 @@ describe('Session registry (#1805)', () => {
         },
         {
           sessionId: 'older-follower',
+          stableSessionId: null,
           displayName: 'Kermit',
           color: '#00ff00',
           pid: 13,
@@ -236,6 +239,28 @@ describe('Session registry (#1805)', () => {
       expect(follower.serverVersion).toBe('2.0.99');
       expect(follower.consoleProtocolVersion).toBe(1);
     });
+
+    it('preserves follower-provided display names and stable session identity', async () => {
+      const app = buildApp(ingestResult);
+
+      await request(app)
+        .post('/api/ingest/session')
+        .send({
+          sessionId: 'follower-identity-001',
+          stableSessionId: 'claude-code-main',
+          displayName: 'Bunraku',
+          event: 'started',
+          pid: 12345,
+          startedAt: new Date().toISOString(),
+        });
+
+      const res = await request(app).get('/api/sessions');
+      expect(res.status).toBe(200);
+      const follower = res.body.sessions.find((s: SessionInfo) => s.sessionId === 'follower-identity-001');
+      expect(follower).toBeDefined();
+      expect(follower.displayName).toBe('Bunraku');
+      expect(follower.stableSessionId).toBe('claude-code-main');
+    });
   });
 
   describe('stale session reaper', () => {
@@ -280,6 +305,7 @@ describe('Session registry (#1805)', () => {
         ingestResult.importSessions([
           {
             sessionId: 'imported-follower',
+            stableSessionId: 'claude-code-main',
             displayName: 'Bunraku',
             color: '#123456',
             pid: 77,
@@ -313,6 +339,7 @@ describe('Session registry (#1805)', () => {
       const session = ingestResult.getSessions()[0];
       expect(session).toEqual(expect.objectContaining({
         sessionId: 'leader-001',
+        stableSessionId: null,
         pid: process.pid,
         status: 'active',
         isLeader: true,
@@ -331,6 +358,7 @@ describe('Session registry (#1805)', () => {
       ingestResult.registerConsoleSession();
       const session = ingestResult.getSessions()[0];
       expect(session).toEqual(expect.objectContaining({
+        stableSessionId: null,
         displayName: 'Web Console',
         pid: process.pid,
         status: 'active',


### PR DESCRIPTION
## Summary
- send canonical follower display names and stable session ids to the leader during log, metrics, and heartbeat forwarding
- converge auto-registered sessions to the follower-provided canonical puppet name instead of inventing a new one on the leader
- add regression coverage for deterministic naming, heartbeat metadata propagation, and registry/ghost-session preservation

## Testing
- npm test -- --runInBand tests/unit/web/console/SessionNames.test.ts tests/unit/web/console/sessionRegistry.test.ts tests/unit/web/console/ghostSession.test.ts tests/unit/web/console/console-failure-modes.test.ts tests/unit/web/console/UnifiedConsole.test.ts
- npx eslint src/web/console/SessionNames.ts src/web/console/IngestRoutes.ts src/web/console/LeaderForwardingSink.ts src/web/console/UnifiedConsole.ts tests/unit/web/console/SessionNames.test.ts tests/unit/web/console/sessionRegistry.test.ts tests/unit/web/console/ghostSession.test.ts tests/unit/web/console/console-failure-modes.test.ts tests/unit/web/console/UnifiedConsole.test.ts
- npm run build