### PR TITLE
Implement leader-authoritative session display-name leasing

### DIFF
--- a/src/web/console/IngestRoutes.ts
+++ b/src/web/console/IngestRoutes.ts
@@ -34,6 +34,7 @@ import {
   CONSOLE_PROTOCOL_VERSION,
   LEGACY_CONSOLE_PROTOCOL_VERSION,
 } from './LeaderElection.js';
+import type { ConsoleTokenEntry } from './consoleToken.js';
 
 /** Maximum payload size for ingestion requests */
 const MAX_PAYLOAD_SIZE = '1mb';
@@ -209,6 +210,10 @@ interface SessionLeaseResolution {
   resolution: 'runtime-renewal' | 'stable-resume' | 'new-allocation';
 }
 
+interface IngestRouteLocals {
+  tokenEntry?: ConsoleTokenEntry;
+}
+
 interface SessionDisplayNameHints {
   displayName?: string;
   preferredDisplayName?: string;
@@ -269,6 +274,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
   // (every 10s) carries the PID — we SIGTERM immediately and move to killedSessions.
   const pendingKills = new Set<string>();
   const importedSessionGraceUntil = new Map<string, number>();
+  // Bounded observability counters for lease-flow debugging. This object keeps a
+  // fixed set of numeric totals and does not grow with session count.
   const metadataSyncCounters = {
     displayNameAdoptions: 0,
     stableSessionBindings: 0,
@@ -643,7 +650,7 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
   /**
    * POST /api/ingest/session — Session lifecycle events.
    */
-  router.post('/api/ingest/session', (req: Request, res: Response) => {
+  router.post('/api/ingest/session', (req: Request, res: Response<unknown, IngestRouteLocals>) => {
     const payload = req.body as SessionEventPayload;
     if (!payload?.sessionId || !payload.event) {
       const received = payload ? Object.keys(payload) : [];
@@ -672,7 +679,7 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
           lastAssignedDisplayName: payloadLastAssignedDisplayName,
           pid: payload.pid,
           startedAt: payload.startedAt || now,
-          authenticated: Boolean((res as any).locals?.tokenEntry),
+          authenticated: Boolean(res.locals.tokenEntry),
           kind: 'mcp',
           isLeader: false,
           serverVersion: payload.serverVersion,

--- a/src/web/console/IngestRoutes.ts
+++ b/src/web/console/IngestRoutes.ts
@@ -209,6 +209,12 @@ interface SessionLeaseResolution {
   resolution: 'runtime-renewal' | 'stable-resume' | 'new-allocation';
 }
 
+interface SessionDisplayNameHints {
+  displayName?: string;
+  preferredDisplayName?: string;
+  lastAssignedDisplayName?: string;
+}
+
 /** Normalize a string via UnicodeValidator (DMCP-SEC-004) */
 function normalizeInput(s: string): string {
   return UnicodeValidator.normalize(s).normalizedContent;
@@ -234,6 +240,12 @@ function normalizeConsoleProtocolVersion(version?: number): number {
     return version;
   }
   return LEGACY_CONSOLE_PROTOCOL_VERSION;
+}
+
+function chooseRequestedDisplayName(hints: SessionDisplayNameHints): string | undefined {
+  return normalizeOptionalInput(hints.lastAssignedDisplayName)
+    ?? normalizeOptionalInput(hints.displayName)
+    ?? normalizeOptionalInput(hints.preferredDisplayName);
 }
 
 /**
@@ -291,12 +303,6 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     };
   }
 
-  function chooseRequestedDisplayName(request: SessionLeaseRequest): string | undefined {
-    return normalizeOptionalInput(request.lastAssignedDisplayName)
-      ?? normalizeOptionalInput(request.displayName)
-      ?? normalizeOptionalInput(request.preferredDisplayName);
-  }
-
   function assignDisplayNameForRequest(sessionId: string, request: SessionLeaseRequest): string {
     const requestedDisplayName = chooseRequestedDisplayName(request);
     if (requestedDisplayName) {
@@ -335,6 +341,114 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     return null;
   }
 
+  function renewRuntimeLease(
+    runtimeMatch: SessionInfo,
+    request: SessionLeaseRequest,
+    now: string,
+  ): SessionLeaseResolution {
+    importedSessionGraceUntil.delete(request.sessionId);
+    if (runtimeMatch.status === 'ended') {
+      runtimeMatch.status = 'active';
+      logger.info('[IngestRoutes] Revived ended session still sending data', {
+        displayName: runtimeMatch.displayName,
+        sessionId: request.sessionId,
+      });
+    }
+
+    runtimeMatch.lastHeartbeat = now;
+    if (request.pid && !runtimeMatch.pid) {
+      runtimeMatch.pid = request.pid;
+      logger.info('[IngestRoutes] Recovered PID for orphaned session', {
+        displayName: runtimeMatch.displayName,
+        sessionId: request.sessionId,
+        pid: request.pid,
+      });
+    }
+    if (request.serverVersion) {
+      runtimeMatch.serverVersion = normalizeServerVersion(request.serverVersion);
+    }
+    if (request.consoleProtocolVersion !== undefined) {
+      runtimeMatch.consoleProtocolVersion = normalizeConsoleProtocolVersion(request.consoleProtocolVersion);
+    }
+    const normalizedStableSessionId = normalizeOptionalInput(request.stableSessionId);
+    if (normalizedStableSessionId && normalizedStableSessionId !== runtimeMatch.stableSessionId) {
+      runtimeMatch.stableSessionId = normalizedStableSessionId;
+      recordMetadataSync('stableSessionBindings', request.sessionId, {
+        stableSessionId: normalizedStableSessionId,
+        source: request.source,
+      });
+    }
+
+    return { session: runtimeMatch, resolution: 'runtime-renewal' };
+  }
+
+  function resumeStableLease(
+    resumable: SessionInfo,
+    request: SessionLeaseRequest,
+    now: string,
+  ): SessionLeaseResolution {
+    const requestedDisplayName = chooseRequestedDisplayName(request) ?? resumable.displayName;
+    const resumedDisplayName = request.isLeader
+      ? namePool.adoptLeader(request.sessionId, requestedDisplayName)
+      : namePool.adopt(request.sessionId, requestedDisplayName);
+    const resumedColor = getPuppetColor(resumedDisplayName) ?? resumable.color ?? '#3b82f6';
+    const resumedSession = buildSessionInfo(
+      {
+        ...request,
+        startedAt: request.startedAt || resumable.startedAt,
+        authenticated: request.authenticated ?? resumable.authenticated,
+        kind: request.kind ?? resumable.kind,
+        isLeader: request.isLeader ?? resumable.isLeader,
+        serverVersion: request.serverVersion ?? resumable.serverVersion,
+        consoleProtocolVersion: request.consoleProtocolVersion ?? resumable.consoleProtocolVersion,
+        stableSessionId: request.stableSessionId ?? resumable.stableSessionId ?? undefined,
+      },
+      resumedDisplayName,
+      resumedColor,
+      now,
+    );
+
+    sessions.delete(resumable.sessionId);
+    importedSessionGraceUntil.delete(resumable.sessionId);
+    sessions.set(request.sessionId, resumedSession);
+    recordMetadataSync('leaseResumptions', request.sessionId, {
+      previousSessionId: resumable.sessionId,
+      stableSessionId: resumedSession.stableSessionId,
+      displayName: resumedDisplayName,
+      source: request.source,
+    });
+    broadcasts.sessionBroadcast?.(resumedSession);
+    return { session: resumedSession, resolution: 'stable-resume' };
+  }
+
+  function allocateSessionLease(request: SessionLeaseRequest, now: string): SessionLeaseResolution {
+    const allocatedDisplayName = assignDisplayNameForRequest(request.sessionId, request);
+    const color = namePool.getColor(request.sessionId) ?? getPuppetColor(allocatedDisplayName) ?? '#3b82f6';
+    const info = buildSessionInfo(request, allocatedDisplayName, color, now);
+    sessions.set(request.sessionId, info);
+
+    const normalizedStableSessionId = normalizeOptionalInput(request.stableSessionId);
+    if (normalizedStableSessionId) {
+      recordMetadataSync('stableSessionBindings', request.sessionId, {
+        stableSessionId: normalizedStableSessionId,
+        source: request.source,
+      });
+    }
+    if (allocatedDisplayName === chooseRequestedDisplayName(request)) {
+      recordMetadataSync('displayNameAdoptions', request.sessionId, {
+        displayName: allocatedDisplayName,
+        source: request.source,
+      });
+    }
+    logger.info('[IngestRoutes] Session lease allocated', {
+      displayName: allocatedDisplayName,
+      sessionId: request.sessionId,
+      source: request.source,
+    });
+    broadcasts.sessionBroadcast?.(info);
+    return { session: info, resolution: 'new-allocation' };
+  }
+
   /** Execute a deferred kill if we now have a PID. */
   function tryExecutePendingKill(sessionId: string, pid?: number): void {
     const killPid = pid || sessions.get(sessionId)?.pid;
@@ -367,103 +481,15 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       const now = new Date().toISOString();
       const runtimeMatch = sessions.get(request.sessionId);
       if (runtimeMatch) {
-        importedSessionGraceUntil.delete(request.sessionId);
-        if (runtimeMatch.status === 'ended') {
-          runtimeMatch.status = 'active';
-          logger.info('[IngestRoutes] Revived ended session still sending data', {
-            displayName: runtimeMatch.displayName,
-            sessionId: request.sessionId,
-          });
-        }
-
-        runtimeMatch.lastHeartbeat = now;
-        if (request.pid && !runtimeMatch.pid) {
-          runtimeMatch.pid = request.pid;
-          logger.info('[IngestRoutes] Recovered PID for orphaned session', {
-            displayName: runtimeMatch.displayName,
-            sessionId: request.sessionId,
-            pid: request.pid,
-          });
-        }
-        if (request.serverVersion) {
-          runtimeMatch.serverVersion = normalizeServerVersion(request.serverVersion);
-        }
-        if (request.consoleProtocolVersion !== undefined) {
-          runtimeMatch.consoleProtocolVersion = normalizeConsoleProtocolVersion(request.consoleProtocolVersion);
-        }
-        const normalizedStableSessionId = normalizeOptionalInput(request.stableSessionId);
-        if (normalizedStableSessionId && normalizedStableSessionId !== runtimeMatch.stableSessionId) {
-          runtimeMatch.stableSessionId = normalizedStableSessionId;
-          recordMetadataSync('stableSessionBindings', request.sessionId, {
-            stableSessionId: normalizedStableSessionId,
-            source: request.source,
-          });
-        }
-
-        return { session: runtimeMatch, resolution: 'runtime-renewal' };
+        return renewRuntimeLease(runtimeMatch, request, now);
       }
 
       const resumable = findResumableSessionByStableId(request.stableSessionId, request.sessionId);
       if (resumable) {
-        const requestedDisplayName = chooseRequestedDisplayName(request) ?? resumable.displayName;
-        const resumedDisplayName = request.isLeader
-          ? namePool.adoptLeader(request.sessionId, requestedDisplayName)
-          : namePool.adopt(request.sessionId, requestedDisplayName);
-        const resumedColor = getPuppetColor(resumedDisplayName) ?? resumable.color ?? '#3b82f6';
-        const resumedSession = buildSessionInfo(
-          {
-            ...request,
-            startedAt: request.startedAt || resumable.startedAt,
-            authenticated: request.authenticated ?? resumable.authenticated,
-            kind: request.kind ?? resumable.kind,
-            isLeader: request.isLeader ?? resumable.isLeader,
-            serverVersion: request.serverVersion ?? resumable.serverVersion,
-            consoleProtocolVersion: request.consoleProtocolVersion ?? resumable.consoleProtocolVersion,
-            stableSessionId: request.stableSessionId ?? resumable.stableSessionId ?? undefined,
-          },
-          resumedDisplayName,
-          resumedColor,
-          now,
-        );
-
-        sessions.delete(resumable.sessionId);
-        importedSessionGraceUntil.delete(resumable.sessionId);
-        sessions.set(request.sessionId, resumedSession);
-        recordMetadataSync('leaseResumptions', request.sessionId, {
-          previousSessionId: resumable.sessionId,
-          stableSessionId: resumedSession.stableSessionId,
-          displayName: resumedDisplayName,
-          source: request.source,
-        });
-        broadcasts.sessionBroadcast?.(resumedSession);
-        return { session: resumedSession, resolution: 'stable-resume' };
+        return resumeStableLease(resumable, request, now);
       }
 
-      const allocatedDisplayName = assignDisplayNameForRequest(request.sessionId, request);
-      const color = namePool.getColor(request.sessionId) ?? getPuppetColor(allocatedDisplayName) ?? '#3b82f6';
-      const info = buildSessionInfo(request, allocatedDisplayName, color, now);
-      sessions.set(request.sessionId, info);
-
-      const normalizedStableSessionId = normalizeOptionalInput(request.stableSessionId);
-      if (normalizedStableSessionId) {
-        recordMetadataSync('stableSessionBindings', request.sessionId, {
-          stableSessionId: normalizedStableSessionId,
-          source: request.source,
-        });
-      }
-      if (allocatedDisplayName === chooseRequestedDisplayName(request)) {
-        recordMetadataSync('displayNameAdoptions', request.sessionId, {
-          displayName: allocatedDisplayName,
-          source: request.source,
-        });
-      }
-      logger.info('[IngestRoutes] Session lease allocated', {
-        displayName: allocatedDisplayName,
-        sessionId: request.sessionId,
-        source: request.source,
-      });
-      broadcasts.sessionBroadcast?.(info);
-      return { session: info, resolution: 'new-allocation' };
+      return allocateSessionLease(request, now);
     } catch (err) {
       logger.debug('[IngestRoutes] Failed to register or resume session lease', {
         sessionId: request.sessionId,

--- a/src/web/console/IngestRoutes.ts
+++ b/src/web/console/IngestRoutes.ts
@@ -95,8 +95,12 @@ export interface IngestLogPayload {
   sessionId: string;
   /** Stable cross-restart/session identity when the host provides one. */
   stableSessionId?: string;
-  /** Follower-provided canonical display name preference for this runtime session. */
+  /** Current follower-visible display name for this runtime session. */
   displayName?: string;
+  /** Follower-provided canonical display name preference for this runtime session. */
+  preferredDisplayName?: string;
+  /** Last leader-assigned display name known to the follower. */
+  lastAssignedDisplayName?: string;
   /** Batched log entries already stamped with follower-local metadata. */
   entries: UnifiedLogEntry[];
 }
@@ -109,8 +113,12 @@ export interface IngestMetricsPayload {
   sessionId: string;
   /** Stable cross-restart/session identity when the host provides one. */
   stableSessionId?: string;
-  /** Follower-provided canonical display name preference for this runtime session. */
+  /** Current follower-visible display name for this runtime session. */
   displayName?: string;
+  /** Follower-provided canonical display name preference for this runtime session. */
+  preferredDisplayName?: string;
+  /** Last leader-assigned display name known to the follower. */
+  lastAssignedDisplayName?: string;
   /** Metric snapshot captured on the follower. */
   snapshot: MetricSnapshot;
 }
@@ -123,8 +131,12 @@ export interface SessionEventPayload {
   sessionId: string;
   /** Stable cross-restart/session identity when the host provides one. */
   stableSessionId?: string;
-  /** Follower-provided canonical display name preference for this runtime session. */
+  /** Current follower-visible display name for this runtime session. */
   displayName?: string;
+  /** Follower-provided canonical display name preference for this runtime session. */
+  preferredDisplayName?: string;
+  /** Last leader-assigned display name known to the follower. */
+  lastAssignedDisplayName?: string;
   /** Lifecycle event that should renew, create, or retire the session lease. */
   event: 'started' | 'stopped' | 'heartbeat';
   /** PID of the follower runtime emitting the event. */
@@ -166,6 +178,35 @@ export interface IngestRoutesResult {
   ) => void;
   /** Register the web console as a session so the indicator is never empty (#1805) */
   registerConsoleSession: () => void;
+}
+
+type SessionLeaseSource =
+  | 'log-ingest'
+  | 'metrics-ingest'
+  | 'session-started'
+  | 'session-heartbeat'
+  | 'takeover-import'
+  | 'leader-registration';
+
+interface SessionLeaseRequest {
+  sessionId: string;
+  stableSessionId?: string;
+  displayName?: string;
+  preferredDisplayName?: string;
+  lastAssignedDisplayName?: string;
+  pid?: number;
+  startedAt?: string;
+  authenticated?: boolean;
+  kind?: 'mcp' | 'console';
+  isLeader?: boolean;
+  serverVersion?: string;
+  consoleProtocolVersion?: number;
+  source: SessionLeaseSource;
+}
+
+interface SessionLeaseResolution {
+  session: SessionInfo;
+  resolution: 'runtime-renewal' | 'stable-resume' | 'new-allocation';
 }
 
 /** Normalize a string via UnicodeValidator (DMCP-SEC-004) */
@@ -218,8 +259,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
   const importedSessionGraceUntil = new Map<string, number>();
   const metadataSyncCounters = {
     displayNameAdoptions: 0,
-    displayNameReassignments: 0,
     stableSessionBindings: 0,
+    leaseResumptions: 0,
   };
 
   function recordMetadataSync(event: keyof typeof metadataSyncCounters, sessionId: string, details: Record<string, unknown> = {}): void {
@@ -230,6 +271,68 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       total: metadataSyncCounters[event],
       ...details,
     });
+  }
+
+  function buildSessionInfo(request: SessionLeaseRequest, displayName: string, color: string, now: string): SessionInfo {
+    return {
+      sessionId: request.sessionId,
+      stableSessionId: normalizeOptionalInput(request.stableSessionId) ?? null,
+      displayName,
+      color,
+      pid: request.pid || 0,
+      startedAt: request.startedAt || now,
+      lastHeartbeat: now,
+      status: 'active',
+      isLeader: request.isLeader ?? false,
+      authenticated: request.authenticated ?? false,
+      kind: request.kind ?? 'mcp',
+      serverVersion: normalizeServerVersion(request.serverVersion),
+      consoleProtocolVersion: normalizeConsoleProtocolVersion(request.consoleProtocolVersion),
+    };
+  }
+
+  function chooseRequestedDisplayName(request: SessionLeaseRequest): string | undefined {
+    return normalizeOptionalInput(request.lastAssignedDisplayName)
+      ?? normalizeOptionalInput(request.displayName)
+      ?? normalizeOptionalInput(request.preferredDisplayName);
+  }
+
+  function assignDisplayNameForRequest(sessionId: string, request: SessionLeaseRequest): string {
+    const requestedDisplayName = chooseRequestedDisplayName(request);
+    if (requestedDisplayName) {
+      return request.isLeader
+        ? namePool.adoptLeader(sessionId, requestedDisplayName)
+        : namePool.adopt(sessionId, requestedDisplayName);
+    }
+
+    return request.isLeader
+      ? namePool.assignLeader(sessionId)
+      : namePool.assign(sessionId);
+  }
+
+  function findResumableSessionByStableId(stableSessionId: string | undefined, incomingSessionId: string): SessionInfo | null {
+    const normalizedStableSessionId = normalizeOptionalInput(stableSessionId);
+    if (!normalizedStableSessionId) {
+      return null;
+    }
+
+    for (const session of sessions.values()) {
+      if (session.sessionId === incomingSessionId) {
+        continue;
+      }
+      if (session.stableSessionId !== normalizedStableSessionId) {
+        continue;
+      }
+      if (session.kind === 'console' || session.isLeader) {
+        continue;
+      }
+      if (session.status === 'active') {
+        continue;
+      }
+      return session;
+    }
+
+    return null;
   }
 
   /** Execute a deferred kill if we now have a PID. */
@@ -251,50 +354,121 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     killedSessions.add(sessionId);
   }
 
-  /** Create a new session entry for an orphan. Returns null on failure. */
-  function autoRegister(
-    sessionId: string,
-    pid?: number,
-    authenticated = false,
-    serverVersion?: string,
-    consoleProtocolVersion?: number,
-    displayName?: string,
-    stableSessionId?: string,
-  ): SessionInfo | null {
+  /**
+   * Create or resume the authoritative display-name lease for one runtime.
+   *
+   * Resolution order matches the documented #2111 architecture:
+   * 1. Renew the active lease for the exact runtime session id.
+   * 2. Otherwise resume a compatible recently-ended lease for the same stable session id.
+   * 3. Otherwise allocate a new display name through the leader-owned pool.
+   */
+  function registerOrResumeSessionLease(request: SessionLeaseRequest): SessionLeaseResolution | null {
     try {
-      const preferredDisplayName = normalizeOptionalInput(displayName);
-      const resolvedDisplayName = preferredDisplayName
-        ? namePool.adopt(sessionId, preferredDisplayName)
-        : namePool.assign(sessionId);
-      if (preferredDisplayName && resolvedDisplayName === preferredDisplayName) {
-        recordMetadataSync('displayNameAdoptions', sessionId, { displayName: resolvedDisplayName });
-      }
-      const color = namePool.getColor(sessionId) ?? getPuppetColor(resolvedDisplayName) ?? '#3b82f6';
-      const normalizedStableSessionId = normalizeOptionalInput(stableSessionId) ?? null;
-      if (normalizedStableSessionId) {
-        recordMetadataSync('stableSessionBindings', sessionId, { stableSessionId: normalizedStableSessionId });
-      }
       const now = new Date().toISOString();
-      const info: SessionInfo = {
-        sessionId,
-        stableSessionId: normalizedStableSessionId,
-        displayName: resolvedDisplayName,
-        color,
-        pid: pid || 0,
-        startedAt: now, lastHeartbeat: now,
-        status: 'active', isLeader: false, authenticated, kind: 'mcp',
-        serverVersion: normalizeServerVersion(serverVersion),
-        consoleProtocolVersion: normalizeConsoleProtocolVersion(consoleProtocolVersion),
-      };
-      sessions.set(sessionId, info);
-      logger.info('[IngestRoutes] Auto-registered orphaned session', {
-        displayName: resolvedDisplayName, sessionId, source: pid ? 'heartbeat' : 'ingestion',
+      const runtimeMatch = sessions.get(request.sessionId);
+      if (runtimeMatch) {
+        importedSessionGraceUntil.delete(request.sessionId);
+        if (runtimeMatch.status === 'ended') {
+          runtimeMatch.status = 'active';
+          logger.info('[IngestRoutes] Revived ended session still sending data', {
+            displayName: runtimeMatch.displayName,
+            sessionId: request.sessionId,
+          });
+        }
+
+        runtimeMatch.lastHeartbeat = now;
+        if (request.pid && !runtimeMatch.pid) {
+          runtimeMatch.pid = request.pid;
+          logger.info('[IngestRoutes] Recovered PID for orphaned session', {
+            displayName: runtimeMatch.displayName,
+            sessionId: request.sessionId,
+            pid: request.pid,
+          });
+        }
+        if (request.serverVersion) {
+          runtimeMatch.serverVersion = normalizeServerVersion(request.serverVersion);
+        }
+        if (request.consoleProtocolVersion !== undefined) {
+          runtimeMatch.consoleProtocolVersion = normalizeConsoleProtocolVersion(request.consoleProtocolVersion);
+        }
+        const normalizedStableSessionId = normalizeOptionalInput(request.stableSessionId);
+        if (normalizedStableSessionId && normalizedStableSessionId !== runtimeMatch.stableSessionId) {
+          runtimeMatch.stableSessionId = normalizedStableSessionId;
+          recordMetadataSync('stableSessionBindings', request.sessionId, {
+            stableSessionId: normalizedStableSessionId,
+            source: request.source,
+          });
+        }
+
+        return { session: runtimeMatch, resolution: 'runtime-renewal' };
+      }
+
+      const resumable = findResumableSessionByStableId(request.stableSessionId, request.sessionId);
+      if (resumable) {
+        const requestedDisplayName = chooseRequestedDisplayName(request) ?? resumable.displayName;
+        const resumedDisplayName = request.isLeader
+          ? namePool.adoptLeader(request.sessionId, requestedDisplayName)
+          : namePool.adopt(request.sessionId, requestedDisplayName);
+        const resumedColor = getPuppetColor(resumedDisplayName) ?? resumable.color ?? '#3b82f6';
+        const resumedSession = buildSessionInfo(
+          {
+            ...request,
+            startedAt: request.startedAt || resumable.startedAt,
+            authenticated: request.authenticated ?? resumable.authenticated,
+            kind: request.kind ?? resumable.kind,
+            isLeader: request.isLeader ?? resumable.isLeader,
+            serverVersion: request.serverVersion ?? resumable.serverVersion,
+            consoleProtocolVersion: request.consoleProtocolVersion ?? resumable.consoleProtocolVersion,
+            stableSessionId: request.stableSessionId ?? resumable.stableSessionId ?? undefined,
+          },
+          resumedDisplayName,
+          resumedColor,
+          now,
+        );
+
+        sessions.delete(resumable.sessionId);
+        importedSessionGraceUntil.delete(resumable.sessionId);
+        sessions.set(request.sessionId, resumedSession);
+        recordMetadataSync('leaseResumptions', request.sessionId, {
+          previousSessionId: resumable.sessionId,
+          stableSessionId: resumedSession.stableSessionId,
+          displayName: resumedDisplayName,
+          source: request.source,
+        });
+        broadcasts.sessionBroadcast?.(resumedSession);
+        return { session: resumedSession, resolution: 'stable-resume' };
+      }
+
+      const allocatedDisplayName = assignDisplayNameForRequest(request.sessionId, request);
+      const color = namePool.getColor(request.sessionId) ?? getPuppetColor(allocatedDisplayName) ?? '#3b82f6';
+      const info = buildSessionInfo(request, allocatedDisplayName, color, now);
+      sessions.set(request.sessionId, info);
+
+      const normalizedStableSessionId = normalizeOptionalInput(request.stableSessionId);
+      if (normalizedStableSessionId) {
+        recordMetadataSync('stableSessionBindings', request.sessionId, {
+          stableSessionId: normalizedStableSessionId,
+          source: request.source,
+        });
+      }
+      if (allocatedDisplayName === chooseRequestedDisplayName(request)) {
+        recordMetadataSync('displayNameAdoptions', request.sessionId, {
+          displayName: allocatedDisplayName,
+          source: request.source,
+        });
+      }
+      logger.info('[IngestRoutes] Session lease allocated', {
+        displayName: allocatedDisplayName,
+        sessionId: request.sessionId,
+        source: request.source,
       });
       broadcasts.sessionBroadcast?.(info);
-      return info;
+      return { session: info, resolution: 'new-allocation' };
     } catch (err) {
-      logger.debug('[IngestRoutes] Failed to auto-register orphaned session', {
-        sessionId, error: (err as Error).message,
+      logger.debug('[IngestRoutes] Failed to register or resume session lease', {
+        sessionId: request.sessionId,
+        source: request.source,
+        error: (err as Error).message,
       });
       return null;
     }
@@ -311,7 +485,10 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     serverVersion?: string,
     consoleProtocolVersion?: number,
     displayName?: string,
+    preferredDisplayName?: string,
+    lastAssignedDisplayName?: string,
     stableSessionId?: string,
+    source: SessionLeaseSource = 'log-ingest',
   ): SessionInfo | null {
     if (killedSessions.has(sessionId)) return null;
     if (pendingKills.has(sessionId)) {
@@ -319,60 +496,18 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       return null;
     }
 
-    const existing = sessions.get(sessionId);
-    if (!existing) {
-      return autoRegister(
-        sessionId,
-        pid,
-        authenticated,
-        serverVersion,
-        consoleProtocolVersion,
-        displayName,
-        stableSessionId,
-      );
-    }
-
-    importedSessionGraceUntil.delete(sessionId);
-
-    if (existing.status === 'ended') {
-      existing.status = 'active';
-      logger.info('[IngestRoutes] Revived ended session still sending data', {
-        displayName: existing.displayName, sessionId,
-      });
-    }
-    existing.lastHeartbeat = new Date().toISOString();
-    if (pid && !existing.pid) {
-      existing.pid = pid;
-      logger.info('[IngestRoutes] Recovered PID for orphaned session', {
-        displayName: existing.displayName, sessionId, pid,
-      });
-    }
-    if (serverVersion) {
-      existing.serverVersion = normalizeServerVersion(serverVersion);
-    }
-    if (consoleProtocolVersion !== undefined) {
-      existing.consoleProtocolVersion = normalizeConsoleProtocolVersion(consoleProtocolVersion);
-    }
-    const preferredDisplayName = normalizeOptionalInput(displayName);
-    if (preferredDisplayName) {
-      const resolvedDisplayName = existing.isLeader
-        ? namePool.reassignLeader(sessionId, preferredDisplayName)
-        : namePool.reassign(sessionId, preferredDisplayName);
-      if (resolvedDisplayName !== existing.displayName) {
-        recordMetadataSync('displayNameReassignments', sessionId, {
-          previousDisplayName: existing.displayName,
-          nextDisplayName: resolvedDisplayName,
-        });
-        existing.displayName = resolvedDisplayName;
-        existing.color = getPuppetColor(resolvedDisplayName) ?? existing.color;
-      }
-    }
-    const normalizedStableSessionId = normalizeOptionalInput(stableSessionId);
-    if (normalizedStableSessionId && normalizedStableSessionId !== existing.stableSessionId) {
-      recordMetadataSync('stableSessionBindings', sessionId, { stableSessionId: normalizedStableSessionId });
-      existing.stableSessionId = normalizedStableSessionId;
-    }
-    return existing;
+    return registerOrResumeSessionLease({
+      sessionId,
+      pid,
+      authenticated,
+      serverVersion,
+      consoleProtocolVersion,
+      displayName,
+      preferredDisplayName,
+      lastAssignedDisplayName,
+      stableSessionId,
+      source,
+    })?.session ?? null;
   }
 
   // JSON body parsing with size limit
@@ -396,6 +531,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     }
     payload.sessionId = normalizeInput(payload.sessionId);
     const payloadDisplayName = normalizeOptionalInput(payload.displayName);
+    const payloadPreferredDisplayName = normalizeOptionalInput(payload.preferredDisplayName);
+    const payloadLastAssignedDisplayName = normalizeOptionalInput(payload.lastAssignedDisplayName);
     const payloadStableSessionId = normalizeOptionalInput(payload.stableSessionId);
 
     let count = 0;
@@ -418,7 +555,10 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       undefined,
       undefined,
       payloadDisplayName,
+      payloadPreferredDisplayName,
+      payloadLastAssignedDisplayName,
       payloadStableSessionId,
+      'log-ingest',
     );
 
     if (skipped > 0) {
@@ -446,6 +586,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     }
     payload.sessionId = normalizeInput(payload.sessionId);
     const payloadDisplayName = normalizeOptionalInput(payload.displayName);
+    const payloadPreferredDisplayName = normalizeOptionalInput(payload.preferredDisplayName);
+    const payloadLastAssignedDisplayName = normalizeOptionalInput(payload.lastAssignedDisplayName);
     const payloadStableSessionId = normalizeOptionalInput(payload.stableSessionId);
 
     if (broadcasts.metricsOnSnapshot) {
@@ -463,7 +605,10 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       undefined,
       undefined,
       payloadDisplayName,
+      payloadPreferredDisplayName,
+      payloadLastAssignedDisplayName,
       payloadStableSessionId,
+      'metrics-ingest',
     );
     logger.debug(`[IngestRoutes] Metrics ingested from ${session?.displayName ?? payload.sessionId}`);
     res.status(200).json({ accepted: true });
@@ -482,6 +627,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     }
     payload.sessionId = normalizeInput(payload.sessionId);
     const payloadDisplayName = normalizeOptionalInput(payload.displayName);
+    const payloadPreferredDisplayName = normalizeOptionalInput(payload.preferredDisplayName);
+    const payloadLastAssignedDisplayName = normalizeOptionalInput(payload.lastAssignedDisplayName);
     const payloadStableSessionId = normalizeOptionalInput(payload.stableSessionId);
 
     const now = new Date().toISOString();
@@ -491,33 +638,30 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
         // Killed sessions stay dead; pending kills get finalized (#1870)
         if (killedSessions.has(payload.sessionId)) break;
         if (pendingKills.has(payload.sessionId)) { finalizePendingKill(payload.sessionId, payload.pid); break; }
-
-        const preferredDisplayName = payloadDisplayName ?? derivePreferredFollowerSessionName(payload.sessionId);
-        const displayName = namePool.adopt(payload.sessionId, preferredDisplayName);
-        if (displayName === preferredDisplayName) {
-          recordMetadataSync('displayNameAdoptions', payload.sessionId, { displayName });
-        }
-        const color = namePool.getColor(payload.sessionId) ?? getPuppetColor(displayName) ?? '#3b82f6';
-        const isAuthenticated = Boolean((res as any).locals?.tokenEntry);
-        const normalizedStableSessionId = payloadStableSessionId ?? null;
-        if (normalizedStableSessionId) {
-          recordMetadataSync('stableSessionBindings', payload.sessionId, { stableSessionId: normalizedStableSessionId });
-        }
-        sessions.set(payload.sessionId, {
+        const leaseResolution = registerOrResumeSessionLease({
           sessionId: payload.sessionId,
-          stableSessionId: normalizedStableSessionId,
-          displayName,
-          color,
-          pid: payload.pid, startedAt: payload.startedAt || now, lastHeartbeat: now,
-          status: 'active', isLeader: false, authenticated: isAuthenticated, kind: 'mcp',
-          serverVersion: normalizeServerVersion(payload.serverVersion),
-          consoleProtocolVersion: normalizeConsoleProtocolVersion(payload.consoleProtocolVersion),
+          stableSessionId: payloadStableSessionId,
+          displayName: payloadDisplayName,
+          preferredDisplayName: payloadPreferredDisplayName ?? derivePreferredFollowerSessionName(payload.sessionId),
+          lastAssignedDisplayName: payloadLastAssignedDisplayName,
+          pid: payload.pid,
+          startedAt: payload.startedAt || now,
+          authenticated: Boolean((res as any).locals?.tokenEntry),
+          kind: 'mcp',
+          isLeader: false,
+          serverVersion: payload.serverVersion,
+          consoleProtocolVersion: payload.consoleProtocolVersion,
+          source: 'session-started',
         });
-        logger.info('[IngestRoutes] Session registered', {
-          displayName, sessionId: payload.sessionId, pid: payload.pid, color,
-          activeSessions: Array.from(sessions.values()).filter(s => s.status === 'active').length,
-        });
-        broadcasts.sessionBroadcast?.(sessions.get(payload.sessionId)!);
+        if (leaseResolution) {
+          logger.info('[IngestRoutes] Session registered', {
+            displayName: leaseResolution.session.displayName,
+            sessionId: payload.sessionId,
+            pid: payload.pid,
+            resolution: leaseResolution.resolution,
+            activeSessions: Array.from(sessions.values()).filter(s => s.status === 'active').length,
+          });
+        }
         break;
       }
       case 'stopped': {
@@ -543,13 +687,28 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
           payload.serverVersion,
           payload.consoleProtocolVersion,
           payloadDisplayName,
+          payloadPreferredDisplayName,
+          payloadLastAssignedDisplayName,
           payloadStableSessionId,
+          'session-heartbeat',
         );
         break;
       }
     }
 
-    res.status(200).json({ ok: true });
+    const session = sessions.get(payload.sessionId);
+    res.status(200).json({
+      ok: true,
+      ...(session?.status === 'active'
+        ? {
+            lease: {
+              sessionId: session.sessionId,
+              stableSessionId: session.stableSessionId,
+              displayName: session.displayName,
+            },
+          }
+        : {}),
+    });
   });
 
   /**
@@ -713,56 +872,31 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
   }
 
   function importSessions(importedSessions: SessionInfo[]): void {
-    const now = Date.now();
     for (const imported of importedSessions) {
       if (imported.status !== 'active') continue;
       if (imported.isLeader || imported.kind === 'console') continue;
       if (killedSessions.has(imported.sessionId) || pendingKills.has(imported.sessionId)) continue;
-
       const normalizedSessionId = normalizeInput(imported.sessionId);
-      const existing = sessions.get(normalizedSessionId);
-      if (existing?.isLeader || existing?.kind === 'console') {
-        continue;
-      }
-
-      const displayName = imported.displayName
-        ? namePool.adopt(normalizedSessionId, imported.displayName)
-        : namePool.assign(normalizedSessionId);
-      if (imported.displayName && displayName === imported.displayName) {
-        recordMetadataSync('displayNameAdoptions', normalizedSessionId, {
-          displayName,
-          source: 'takeover-import',
-        });
-      }
-      const color = imported.color || namePool.getColor(normalizedSessionId) || '#3b82f6';
-      const normalizedStableSessionId = imported.stableSessionId ?? existing?.stableSessionId ?? null;
-      if (normalizedStableSessionId) {
-        recordMetadataSync('stableSessionBindings', normalizedSessionId, {
-          stableSessionId: normalizedStableSessionId,
-          source: 'takeover-import',
-        });
-      }
-      const merged: SessionInfo = {
+      const leaseResolution = registerOrResumeSessionLease({
         sessionId: normalizedSessionId,
-        stableSessionId: normalizedStableSessionId,
-        displayName,
-        color,
-        pid: imported.pid || existing?.pid || 0,
-        startedAt: imported.startedAt || existing?.startedAt || new Date(now).toISOString(),
-        lastHeartbeat: imported.lastHeartbeat || existing?.lastHeartbeat || new Date(now).toISOString(),
-        status: 'active',
-        isLeader: false,
-        authenticated: imported.authenticated ?? existing?.authenticated ?? false,
+        stableSessionId: imported.stableSessionId ?? undefined,
+        displayName: imported.displayName,
+        lastAssignedDisplayName: imported.displayName,
+        pid: imported.pid,
+        startedAt: imported.startedAt,
+        authenticated: imported.authenticated,
         kind: 'mcp',
-        serverVersion: normalizeServerVersion(imported.serverVersion || existing?.serverVersion),
-        consoleProtocolVersion: normalizeConsoleProtocolVersion(
-          imported.consoleProtocolVersion ?? existing?.consoleProtocolVersion,
-        ),
-      };
-
-      sessions.set(normalizedSessionId, merged);
-      importedSessionGraceUntil.set(normalizedSessionId, now + TAKEOVER_IMPORTED_SESSION_GRACE_MS);
-      broadcasts.sessionBroadcast?.(merged);
+        isLeader: false,
+        serverVersion: imported.serverVersion,
+        consoleProtocolVersion: imported.consoleProtocolVersion,
+        source: 'takeover-import',
+      });
+      if (leaseResolution) {
+        importedSessionGraceUntil.set(
+          normalizedSessionId,
+          Date.now() + TAKEOVER_IMPORTED_SESSION_GRACE_MS,
+        );
+      }
     }
   }
 
@@ -772,44 +906,29 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     displayName?: string,
     stableSessionId?: string,
   ): void {
-    const preferredDisplayName = normalizeOptionalInput(displayName) ?? derivePreferredLeaderSessionName(sessionId);
-    const resolvedDisplayName = namePool.adoptLeader(sessionId, preferredDisplayName);
-    if (resolvedDisplayName === preferredDisplayName) {
-      recordMetadataSync('displayNameAdoptions', sessionId, {
-        displayName: resolvedDisplayName,
-        source: 'leader-registration',
-      });
-    }
-    const color = namePool.getColor(sessionId) ?? getPuppetColor(resolvedDisplayName) ?? '#3b82f6';
-    const normalizedStableSessionId = normalizeOptionalInput(stableSessionId) ?? null;
-    if (normalizedStableSessionId) {
-      recordMetadataSync('stableSessionBindings', sessionId, {
-        stableSessionId: normalizedStableSessionId,
-        source: 'leader-registration',
-      });
-    }
-    sessions.set(sessionId, {
+    const leaseResolution = registerOrResumeSessionLease({
       sessionId,
-      stableSessionId: normalizedStableSessionId,
-      displayName: resolvedDisplayName,
-      color,
+      stableSessionId,
+      displayName,
+      preferredDisplayName: displayName ?? derivePreferredLeaderSessionName(sessionId),
+      lastAssignedDisplayName: displayName,
       pid,
-      startedAt: new Date().toISOString(),
-      lastHeartbeat: new Date().toISOString(),
-      status: 'active',
-      isLeader: true,
       authenticated: true,
       kind: 'mcp',
+      isLeader: true,
       serverVersion: PACKAGE_VERSION,
       consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+      source: 'leader-registration',
     });
-    logger.info('[IngestRoutes] Leader session registered', {
-      displayName: resolvedDisplayName,
-      sessionId,
-      stableSessionId: normalizedStableSessionId,
-      pid,
-      color,
-    });
+    if (leaseResolution) {
+      logger.info('[IngestRoutes] Leader session registered', {
+        displayName: leaseResolution.session.displayName,
+        sessionId,
+        stableSessionId: leaseResolution.session.stableSessionId,
+        pid,
+        resolution: leaseResolution.resolution,
+      });
+    }
   }
 
   /**

--- a/src/web/console/LeaderForwardingSink.ts
+++ b/src/web/console/LeaderForwardingSink.ts
@@ -44,6 +44,101 @@ const MAX_CONSECUTIVE_FAILURES = env.DOLLHOUSE_CONSOLE_MAX_FORWARD_FAILURES;
 /** HTTP request timeout (ms) */
 const REQUEST_TIMEOUT_MS = 5_000;
 
+interface LeaseBearingPayload {
+  displayName?: string;
+  preferredDisplayName?: string;
+  lastAssignedDisplayName?: string;
+  stableSessionId?: string;
+}
+
+interface SessionLeaseSnapshot {
+  displayName: string;
+  stableSessionId: string | null;
+  sessionId: string;
+}
+
+interface SessionLeaseResponse {
+  ok: boolean;
+  lease?: SessionLeaseSnapshot;
+}
+
+/**
+ * Mutable local view of the display-name lease for one runtime session.
+ *
+ * Followers start with a deterministic preferred name, then replace it with
+ * the leader-assigned authoritative display name once the leader responds.
+ */
+export class SessionLeaseState {
+  private assignedDisplayName: string | null = null;
+
+  constructor(
+    private readonly preferredDisplayName: string,
+    private readonly stableSessionId: string | null = null,
+  ) {}
+
+  getDisplayName(): string {
+    return this.assignedDisplayName ?? this.preferredDisplayName;
+  }
+
+  getPreferredDisplayName(): string {
+    return this.preferredDisplayName;
+  }
+
+  getLastAssignedDisplayName(): string | null {
+    return this.assignedDisplayName;
+  }
+
+  getStableSessionId(): string | null {
+    return this.stableSessionId;
+  }
+
+  applyLease(lease: SessionLeaseSnapshot | null | undefined): void {
+    if (!lease?.displayName) {
+      return;
+    }
+
+    const normalizedDisplayName = UnicodeValidator.normalize(lease.displayName).normalizedContent.trim();
+    if (!normalizedDisplayName) {
+      return;
+    }
+
+    this.assignedDisplayName = normalizedDisplayName;
+  }
+}
+
+function buildLeasePayload(leaseState: SessionLeaseState): LeaseBearingPayload {
+  const currentDisplayName = leaseState.getDisplayName();
+  const preferredDisplayName = leaseState.getPreferredDisplayName();
+  const lastAssignedDisplayName = leaseState.getLastAssignedDisplayName();
+  const stableSessionId = leaseState.getStableSessionId();
+
+  return {
+    ...(currentDisplayName ? { displayName: currentDisplayName } : {}),
+    ...(preferredDisplayName ? { preferredDisplayName } : {}),
+    ...(lastAssignedDisplayName ? { lastAssignedDisplayName } : {}),
+    ...(stableSessionId ? { stableSessionId } : {}),
+  };
+}
+
+function isSessionLeaseResponse(payload: unknown): payload is SessionLeaseResponse {
+  return Boolean(payload) && typeof payload === 'object';
+}
+
+function resolveLeaseState(
+  leaseStateOrDisplayName: SessionLeaseState | string | null | undefined,
+  stableSessionId: string | null | undefined,
+): SessionLeaseState | undefined {
+  if (leaseStateOrDisplayName instanceof SessionLeaseState) {
+    return leaseStateOrDisplayName;
+  }
+
+  if (typeof leaseStateOrDisplayName === 'string' && leaseStateOrDisplayName.trim().length > 0) {
+    return new SessionLeaseState(leaseStateOrDisplayName, stableSessionId ?? null);
+  }
+
+  return undefined;
+}
+
 /**
  * Build the HTTP headers for ingest POSTs, including the console auth token
  * if one was provided (#1780). Followers read the token from the shared token
@@ -68,6 +163,7 @@ export class LeaderForwardingLogSink implements ILogSink {
   private flushing = false;
   private consecutiveFailures = 0;
   private gaveUp = false;
+  private readonly leaseState?: SessionLeaseState;
 
   constructor(
     private readonly leaderUrl: string,
@@ -76,12 +172,12 @@ export class LeaderForwardingLogSink implements ILogSink {
     private readonly authToken: string | null = null,
     /** Callback invoked when the leader is presumed dead after MAX_CONSECUTIVE_FAILURES (#1850). */
     private readonly onLeaderDeath?: () => void,
-    /** Canonical local display name for this runtime session. */
-    private readonly sessionDisplayName: string | null = null,
-    /** Stable session identity shared across restarts when available. */
-    private readonly stableSessionId: string | null = null,
+    /** Local mutable lease state for this runtime session. */
+    leaseStateOrDisplayName: SessionLeaseState | string | null = null,
+    stableSessionId: string | null = null,
   ) {
     this.sessionId = UnicodeValidator.normalize(sessionId).normalizedContent;
+    this.leaseState = resolveLeaseState(leaseStateOrDisplayName, stableSessionId);
     this.flushTimer = setInterval(() => this.flushBuffer(), FLUSH_INTERVAL_MS);
     this.flushTimer.unref();
   }
@@ -130,8 +226,7 @@ export class LeaderForwardingLogSink implements ILogSink {
         headers: buildIngestHeaders(this.authToken),
         body: JSON.stringify({
           sessionId: this.sessionId,
-          ...(this.stableSessionId ? { stableSessionId: this.stableSessionId } : {}),
-          ...(this.sessionDisplayName ? { displayName: this.sessionDisplayName } : {}),
+          ...(this.leaseState ? buildLeasePayload(this.leaseState) : {}),
           entries: batch,
         }),
         signal: controller.signal,
@@ -193,16 +288,19 @@ export class LeaderForwardingLogSink implements ILogSink {
  * Forwards metric snapshots to the leader's /api/ingest/metrics.
  */
 export class LeaderForwardingMetricsSink {
+  private readonly leaseState?: SessionLeaseState;
+
   constructor(
     private readonly leaderUrl: string,
     private readonly sessionId: string,
     /** Optional console auth token (#1780). Included as Bearer header on ingest POSTs. */
     private readonly authToken: string | null = null,
-    /** Canonical local display name for this runtime session. */
-    private readonly sessionDisplayName: string | null = null,
-    /** Stable session identity shared across restarts when available. */
-    private readonly stableSessionId: string | null = null,
-  ) {}
+    /** Local mutable lease state for this runtime session. */
+    leaseStateOrDisplayName: SessionLeaseState | string | null = null,
+    stableSessionId: string | null = null,
+  ) {
+    this.leaseState = resolveLeaseState(leaseStateOrDisplayName, stableSessionId);
+  }
 
   async onSnapshot(snapshot: MetricSnapshot): Promise<void> {
     try {
@@ -214,8 +312,7 @@ export class LeaderForwardingMetricsSink {
         headers: buildIngestHeaders(this.authToken),
         body: JSON.stringify({
           sessionId: this.sessionId,
-          ...(this.stableSessionId ? { stableSessionId: this.stableSessionId } : {}),
-          ...(this.sessionDisplayName ? { displayName: this.sessionDisplayName } : {}),
+          ...(this.leaseState ? buildLeasePayload(this.leaseState) : {}),
           snapshot,
         }),
         signal: controller.signal,
@@ -232,6 +329,7 @@ export class LeaderForwardingMetricsSink {
  */
 export class SessionHeartbeat {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly leaseState?: SessionLeaseState;
 
   constructor(
     private readonly leaderUrl: string,
@@ -239,11 +337,12 @@ export class SessionHeartbeat {
     private readonly pid: number,
     /** Optional console auth token (#1780). Included as Bearer header on ingest POSTs. */
     private readonly authToken: string | null = null,
-    /** Canonical local display name for this runtime session. */
-    private readonly sessionDisplayName: string | null = null,
-    /** Stable session identity shared across restarts when available. */
-    private readonly stableSessionId: string | null = null,
-  ) {}
+    /** Local mutable lease state for this runtime session. */
+    leaseStateOrDisplayName: SessionLeaseState | string | null = null,
+    stableSessionId: string | null = null,
+  ) {
+    this.leaseState = resolveLeaseState(leaseStateOrDisplayName, stableSessionId);
+  }
 
   /** Notify the leader that this session has started */
   async start(): Promise<void> {
@@ -269,13 +368,12 @@ export class SessionHeartbeat {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 
-      await fetch(`${this.leaderUrl}/api/ingest/session`, {
+      const response = await fetch(`${this.leaderUrl}/api/ingest/session`, {
         method: 'POST',
         headers: buildIngestHeaders(this.authToken),
         body: JSON.stringify({
           sessionId: this.sessionId,
-          ...(this.stableSessionId ? { stableSessionId: this.stableSessionId } : {}),
-          ...(this.sessionDisplayName ? { displayName: this.sessionDisplayName } : {}),
+          ...(this.leaseState ? buildLeasePayload(this.leaseState) : {}),
           event,
           pid: this.pid,
           startedAt: new Date().toISOString(),
@@ -285,6 +383,12 @@ export class SessionHeartbeat {
         signal: controller.signal,
       });
       clearTimeout(timeout);
+      if (this.leaseState && response.ok) {
+        const payload = await response.json().catch(() => null);
+        if (isSessionLeaseResponse(payload)) {
+          this.leaseState.applyLease(payload.lease);
+        }
+      }
     } catch {
       logger.debug(`[SessionHeartbeat] Failed to send ${event} event`);
     }

--- a/src/web/console/LeaderForwardingSink.ts
+++ b/src/web/console/LeaderForwardingSink.ts
@@ -62,6 +62,8 @@ interface SessionLeaseResponse {
   lease?: SessionLeaseSnapshot;
 }
 
+type SessionLeaseInput = SessionLeaseState | string | null;
+
 /**
  * Mutable local view of the display-name lease for one runtime session.
  *
@@ -125,7 +127,7 @@ function isSessionLeaseResponse(payload: unknown): payload is SessionLeaseRespon
 }
 
 function resolveLeaseState(
-  leaseStateOrDisplayName: SessionLeaseState | string | null | undefined,
+  leaseStateOrDisplayName: SessionLeaseInput | undefined,
   stableSessionId: string | null | undefined,
 ): SessionLeaseState | undefined {
   if (leaseStateOrDisplayName instanceof SessionLeaseState) {
@@ -173,7 +175,7 @@ export class LeaderForwardingLogSink implements ILogSink {
     /** Callback invoked when the leader is presumed dead after MAX_CONSECUTIVE_FAILURES (#1850). */
     private readonly onLeaderDeath?: () => void,
     /** Local mutable lease state for this runtime session. */
-    leaseStateOrDisplayName: SessionLeaseState | string | null = null,
+    leaseStateOrDisplayName: SessionLeaseInput = null,
     stableSessionId: string | null = null,
   ) {
     this.sessionId = UnicodeValidator.normalize(sessionId).normalizedContent;
@@ -296,7 +298,7 @@ export class LeaderForwardingMetricsSink {
     /** Optional console auth token (#1780). Included as Bearer header on ingest POSTs. */
     private readonly authToken: string | null = null,
     /** Local mutable lease state for this runtime session. */
-    leaseStateOrDisplayName: SessionLeaseState | string | null = null,
+    leaseStateOrDisplayName: SessionLeaseInput = null,
     stableSessionId: string | null = null,
   ) {
     this.leaseState = resolveLeaseState(leaseStateOrDisplayName, stableSessionId);
@@ -338,7 +340,7 @@ export class SessionHeartbeat {
     /** Optional console auth token (#1780). Included as Bearer header on ingest POSTs. */
     private readonly authToken: string | null = null,
     /** Local mutable lease state for this runtime session. */
-    leaseStateOrDisplayName: SessionLeaseState | string | null = null,
+    leaseStateOrDisplayName: SessionLeaseInput = null,
     stableSessionId: string | null = null,
   ) {
     this.leaseState = resolveLeaseState(leaseStateOrDisplayName, stableSessionId);

--- a/src/web/console/LeaderForwardingSink.ts
+++ b/src/web/console/LeaderForwardingSink.ts
@@ -57,6 +57,13 @@ interface SessionLeaseSnapshot {
   sessionId: string;
 }
 
+/**
+ * Minimal leader response for session lifecycle events.
+ *
+ * `lease` is present when the leader has an active authoritative assignment
+ * for the runtime session. Older leaders or non-active sessions may return
+ * only `{ ok: true }`, which followers treat as "keep the current local view".
+ */
 interface SessionLeaseResponse {
   ok: boolean;
   lease?: SessionLeaseSnapshot;

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -43,6 +43,7 @@ import {
 import { createIngestRoutes } from './IngestRoutes.js';
 import {
   LeaderForwardingLogSink,
+  SessionLeaseState,
   SessionHeartbeat,
 } from './LeaderForwardingSink.js';
 import { PromotionManager } from './PromotionManager.js';
@@ -1363,7 +1364,10 @@ async function startAsFollower(
   }
 
   const { derivePreferredFollowerSessionName } = await import('./SessionNames.js');
-  const preferredSessionName = derivePreferredFollowerSessionName(options.sessionId);
+  const leaseState = new SessionLeaseState(
+    derivePreferredFollowerSessionName(options.sessionId),
+    options.stableSessionId,
+  );
 
   // Per-instance promotion manager — tracks its own attempt counter so
   // multiple followers don't interfere with each other's promotion budgets.
@@ -1382,8 +1386,7 @@ async function startAsFollower(
     promotionMgr.promote(forwardingSink, sessionHeartbeat)
       .catch(err => logger.error('[UnifiedConsole] Promotion crashed', { error: String(err) }));
     },
-    preferredSessionName,
-    options.stableSessionId,
+    leaseState,
   );
   options.registerLogSink(forwardingSink);
 
@@ -1393,8 +1396,7 @@ async function startAsFollower(
     options.sessionId,
     process.pid,
     authToken,
-    preferredSessionName,
-    options.stableSessionId,
+    leaseState,
   );
   await sessionHeartbeat.start();
 

--- a/tests/unit/web/console/console-failure-modes.test.ts
+++ b/tests/unit/web/console/console-failure-modes.test.ts
@@ -460,6 +460,14 @@ describe('Console Failure Modes', () => {
     it('sends server version metadata with session events', async () => {
       const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
         ok: true,
+        json: async () => ({
+          ok: true,
+          lease: {
+            sessionId: 'test-session',
+            stableSessionId: 'claude-code-main',
+            displayName: 'Bunraku',
+          },
+        }),
       } as Response);
 
       try {
@@ -488,6 +496,94 @@ describe('Console Failure Modes', () => {
         expect(body.serverVersion).toBe(PACKAGE_VERSION);
         expect(body.consoleProtocolVersion).toBe(CONSOLE_PROTOCOL_VERSION);
         expect(body.displayName).toBe('Bunraku');
+        expect(body.preferredDisplayName).toBe('Bunraku');
+        expect(body.stableSessionId).toBe('claude-code-main');
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it('applies the leader-assigned lease name to subsequent heartbeats', async () => {
+      const fetchSpy = jest.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            lease: {
+              sessionId: 'test-session',
+              stableSessionId: 'claude-code-main',
+              displayName: 'Mortimer',
+            },
+          }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ ok: true }),
+        } as Response);
+
+      try {
+        const { SessionHeartbeat } = await import(
+          '../../../../src/web/console/LeaderForwardingSink.js'
+        );
+
+        const heartbeat = new SessionHeartbeat(
+          'http://127.0.0.1:41715',
+          'test-session',
+          process.pid,
+          null,
+          'Bunraku',
+          'claude-code-main',
+        );
+
+        await heartbeat.start();
+        await heartbeat.stop();
+
+        const secondCall = fetchSpy.mock.calls[1];
+        const body = parseRequestBody((secondCall?.[1] as RequestInit | undefined)?.body);
+        expect(body.displayName).toBe('Mortimer');
+        expect(body.lastAssignedDisplayName).toBe('Mortimer');
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it('reuses the leader-assigned lease name across other forwarding channels', async () => {
+      const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true }),
+      } as Response);
+
+      try {
+        const {
+          LeaderForwardingMetricsSink,
+          SessionLeaseState,
+        } = await import('../../../../src/web/console/LeaderForwardingSink.js');
+
+        const leaseState = new SessionLeaseState('Bunraku', 'claude-code-main');
+        leaseState.applyLease({
+          sessionId: 'test-session',
+          stableSessionId: 'claude-code-main',
+          displayName: 'Mortimer',
+        });
+
+        const sink = new LeaderForwardingMetricsSink(
+          'http://127.0.0.1:41715',
+          'test-session',
+          null,
+          leaseState,
+        );
+
+        await sink.onSnapshot({
+          totals: { total: 1, allowed: 1, denied: 0, asked: 0 },
+          rates: { allowRate: 1, denyRate: 0, askRate: 0 },
+          topTools: [],
+          timeWindow: { start: 0, end: 1 },
+        });
+
+        const body = parseRequestBody((fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined)?.body);
+        expect(body.displayName).toBe('Mortimer');
+        expect(body.preferredDisplayName).toBe('Bunraku');
+        expect(body.lastAssignedDisplayName).toBe('Mortimer');
         expect(body.stableSessionId).toBe('claude-code-main');
       } finally {
         fetchSpy.mockRestore();

--- a/tests/unit/web/console/sessionRegistry.test.ts
+++ b/tests/unit/web/console/sessionRegistry.test.ts
@@ -243,7 +243,7 @@ describe('Session registry (#1805)', () => {
     it('preserves follower-provided display names and stable session identity', async () => {
       const app = buildApp(ingestResult);
 
-      await request(app)
+      const startResponse = await request(app)
         .post('/api/ingest/session')
         .send({
           sessionId: 'follower-identity-001',
@@ -254,12 +254,102 @@ describe('Session registry (#1805)', () => {
           startedAt: new Date().toISOString(),
         });
 
+      expect(startResponse.status).toBe(200);
+      expect(startResponse.body.lease).toEqual(expect.objectContaining({
+        sessionId: 'follower-identity-001',
+        stableSessionId: 'claude-code-main',
+        displayName: 'Bunraku',
+      }));
+
       const res = await request(app).get('/api/sessions');
       expect(res.status).toBe(200);
       const follower = res.body.sessions.find((s: SessionInfo) => s.sessionId === 'follower-identity-001');
       expect(follower).toBeDefined();
       expect(follower.displayName).toBe('Bunraku');
       expect(follower.stableSessionId).toBe('claude-code-main');
+    });
+
+    it('keeps the leader-assigned name on heartbeat even if the follower proposes a different one later', async () => {
+      const app = buildApp(ingestResult);
+
+      const started = await request(app)
+        .post('/api/ingest/session')
+        .send({
+          sessionId: 'follower-same-runtime',
+          stableSessionId: 'claude-main',
+          displayName: 'Bunraku',
+          event: 'started',
+          pid: 12345,
+          startedAt: new Date().toISOString(),
+        });
+
+      expect(started.body.lease.displayName).toBe('Bunraku');
+
+      const heartbeat = await request(app)
+        .post('/api/ingest/session')
+        .send({
+          sessionId: 'follower-same-runtime',
+          stableSessionId: 'claude-main',
+          displayName: 'Skipper',
+          preferredDisplayName: 'Skipper',
+          lastAssignedDisplayName: 'Bunraku',
+          event: 'heartbeat',
+          pid: 12345,
+          startedAt: new Date().toISOString(),
+        });
+
+      expect(heartbeat.body.lease.displayName).toBe('Bunraku');
+
+      const res = await request(app).get('/api/sessions');
+      const follower = res.body.sessions.find((s: SessionInfo) => s.sessionId === 'follower-same-runtime');
+      expect(follower.displayName).toBe('Bunraku');
+    });
+
+    it('resumes an ended stable session with the prior leader-assigned display name', async () => {
+      const app = buildApp(ingestResult);
+
+      await request(app)
+        .post('/api/ingest/session')
+        .send({
+          sessionId: 'runtime-old',
+          stableSessionId: 'claude-shared',
+          displayName: 'Bunraku',
+          event: 'started',
+          pid: 111,
+          startedAt: '2026-04-20T03:00:00.000Z',
+        });
+
+      await request(app)
+        .post('/api/ingest/session')
+        .send({
+          sessionId: 'runtime-old',
+          event: 'stopped',
+          pid: 111,
+          startedAt: '2026-04-20T03:00:00.000Z',
+        });
+
+      const resumed = await request(app)
+        .post('/api/ingest/session')
+        .send({
+          sessionId: 'runtime-new',
+          stableSessionId: 'claude-shared',
+          preferredDisplayName: 'Skipper',
+          lastAssignedDisplayName: 'Bunraku',
+          event: 'started',
+          pid: 222,
+          startedAt: '2026-04-20T03:05:00.000Z',
+        });
+
+      expect(resumed.body.lease).toEqual(expect.objectContaining({
+        sessionId: 'runtime-new',
+        stableSessionId: 'claude-shared',
+        displayName: 'Bunraku',
+      }));
+
+      const res = await request(app).get('/api/sessions');
+      const follower = res.body.sessions.find((s: SessionInfo) => s.sessionId === 'runtime-new');
+      expect(follower.displayName).toBe('Bunraku');
+      expect(follower.stableSessionId).toBe('claude-shared');
     });
   });
 


### PR DESCRIPTION
## Summary
- add leader-authoritative session lease registration/resume flow for runtime and stable session identities
- let followers keep a local preferred name until the leader returns an authoritative lease, then reuse that assignment for heartbeat and forwarding
- add regression coverage for lease responses, stable-session resume, and leader-assigned name reuse across forwarding

Closes #2111

## Verification
- npm test -- --runInBand tests/unit/web/console/sessionRegistry.test.ts tests/unit/web/console/console-failure-modes.test.ts tests/unit/web/console/ghostSession.test.ts tests/unit/web/console/UnifiedConsole.test.ts tests/unit/web/console/SessionNames.test.ts
- npx eslint src/web/console/IngestRoutes.ts src/web/console/LeaderForwardingSink.ts src/web/console/UnifiedConsole.ts tests/unit/web/console/sessionRegistry.test.ts tests/unit/web/console/console-failure-modes.test.ts tests/unit/web/console/ghostSession.test.ts tests/unit/web/console/UnifiedConsole.test.ts tests/unit/web/console/SessionNames.test.ts
- npm run build