### PR TITLE
fix: stop stale leaders from rewriting console lock

### DIFF
--- a/docker/mixed-version/report-state.sh
+++ b/docker/mixed-version/report-state.sh
@@ -11,8 +11,31 @@ REPORT_DIR="${STATE_ROOT}/reports"
 TIMESTAMP="$(date '+%Y%m%d-%H%M%S')"
 REPORT_PATH="${REPORT_DIR}/mixed-version-report-${TIMESTAMP}.md"
 TEXT_CODE_FENCE='```text'
+REPORT_LABEL="manual"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --label)
+      REPORT_LABEL="${2:-manual}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
 
 mkdir -p "${REPORT_DIR}"
+
+compose_status="$(docker compose -f "${COMPOSE_FILE}" ps || true)"
+running_services="$(docker compose -f "${COMPOSE_FILE}" ps --status running --services || true)"
+stack_state="inactive"
+if [[ -n "${running_services}" ]]; then
+  stack_state="active"
+fi
+
+observer_output="$("${SCRIPT_DIR}/observe-state.sh" --once || true)"
 
 {
   echo "# Mixed-Version Harness Report"
@@ -20,17 +43,22 @@ mkdir -p "${REPORT_DIR}"
   echo "- Generated: $(date '+%Y-%m-%d %H:%M:%S %Z')"
   echo "- Worktree: ${REPO_ROOT}"
   echo "- Host port: ${MIXED_VERSION_HOST_PORT:-42715}"
+  echo "- Label: ${REPORT_LABEL}"
+  echo "- Stack state: ${stack_state}"
+  if [[ "${stack_state}" != "active" ]]; then
+    echo "- Warning: this report was captured after the mixed-version stack had already stopped, so compose status and observer output may reflect teardown instead of live convergence"
+  fi
   echo
   echo "## Compose Status"
   echo
   echo "${TEXT_CODE_FENCE}"
-  docker compose -f "${COMPOSE_FILE}" ps
+  printf '%s\n' "${compose_status}"
   echo '```'
   echo
   echo "## Live Observer Snapshot"
   echo
   echo "${TEXT_CODE_FENCE}"
-  "${SCRIPT_DIR}/observe-state.sh" --once
+  printf '%s\n' "${observer_output}"
   echo '```'
   echo
   echo "## Lock File"

--- a/docker/mixed-version/smoke-test.sh
+++ b/docker/mixed-version/smoke-test.sh
@@ -14,6 +14,7 @@ capture_report() {
   local label="$1"
   LAST_REPORT_PATH="$("${SCRIPT_DIR}/report-state.sh" --label "${label}")"
   echo "State report (${label}): ${LAST_REPORT_PATH}"
+  return 0
 }
 
 cleanup() {

--- a/docker/mixed-version/smoke-test.sh
+++ b/docker/mixed-version/smoke-test.sh
@@ -8,8 +8,18 @@ COMPOSE_FILE="${REPO_ROOT}/docker/docker-compose.mixed-version.yml"
 TARGET_INJECT_SPEC="${TARGET_INJECT_SPEC:-@dollhousemcp/mcp-server@2.0.24}"
 SESSION_WAIT_RETRIES="${SESSION_WAIT_RETRIES:-30}"
 SESSION_WAIT_SLEEP_SECONDS="${SESSION_WAIT_SLEEP_SECONDS:-2}"
+LAST_REPORT_PATH=""
+
+capture_report() {
+  local label="$1"
+  LAST_REPORT_PATH="$("${SCRIPT_DIR}/report-state.sh" --label "${label}")"
+  echo "State report (${label}): ${LAST_REPORT_PATH}"
+}
 
 cleanup() {
+  if [[ -n "$(docker compose -f "${COMPOSE_FILE}" ps --status running --services 2>/dev/null)" ]]; then
+    capture_report "pre-cleanup"
+  fi
   docker compose -f "${COMPOSE_FILE}" down >/dev/null 2>&1 || true
   return 0
 }
@@ -39,6 +49,7 @@ wait_for_sessions() {
 
   echo "Timed out waiting for ${description}" >&2
   printf '%s\n' "${output}" >&2
+  capture_report "timeout-${description// /-}" >&2
   echo "Recent container logs:" >&2
   docker compose -f "${COMPOSE_FILE}" logs --tail=40 current-local stable-226 legacy-225 legacy-219 >&2 || true
   return 1
@@ -60,3 +71,5 @@ wait_for_sessions \
   "legacy injection to appear in sessions" \
   "\\[legacy-225\\]" \
   "2\\.0\\.24"
+
+capture_report "success"

--- a/src/web/console/LeaderElection.ts
+++ b/src/web/console/LeaderElection.ts
@@ -26,6 +26,7 @@ import { env } from '../../config/env.js';
 import { PACKAGE_VERSION } from '../../generated/version.js';
 import { logger } from '../../utils/logger.js';
 import { compareVersions } from '../../utils/version.js';
+import { findPidOnPort } from './StaleProcessRecovery.js';
 
 /** Directory for runtime state files */
 const RUN_DIR = join(homedir(), '.dollhouse', 'run');
@@ -100,6 +101,14 @@ export interface ElectionResult {
   /** Leader info — for followers, this is the existing leader's info */
   leaderInfo: ConsoleLeaderInfo;
 }
+
+export interface HeartbeatDependencies {
+  lockPath?: string;
+  readLeaderLockImpl?: typeof readLeaderLock;
+  findPidOnPortImpl?: typeof findPidOnPort;
+}
+
+export type HeartbeatRenewalResult = 'updated' | 'lost-lock' | 'lost-port' | 'failed';
 
 export interface LeaderPreferenceDecision {
   shouldReplace: boolean;
@@ -473,21 +482,60 @@ export async function forceClaimLeadership(sessionId: string, port: number): Pro
   return { role: 'follower', leaderInfo: winner ?? myInfo };
 }
 
+export async function renewLeaderHeartbeat(
+  info: ConsoleLeaderInfo,
+  deps: HeartbeatDependencies = {},
+): Promise<HeartbeatRenewalResult> {
+  const lockPath = deps.lockPath ?? LOCK_FILE;
+  const readLeaderLockImpl = deps.readLeaderLockImpl ?? readLeaderLock;
+  const findPidOnPortImpl = deps.findPidOnPortImpl ?? findPidOnPort;
+
+  try {
+    const currentLock = await readLeaderLockImpl(lockPath);
+    if (currentLock && currentLock.pid !== info.pid) {
+      logger.info('[LeaderElection] Heartbeat stopping after leadership was lost to another lock owner', {
+        sessionId: info.sessionId,
+        pid: info.pid,
+        port: info.port,
+        currentLockPid: currentLock.pid,
+        currentLockSessionId: currentLock.sessionId,
+      });
+      return 'lost-lock';
+    }
+
+    const competingPortOwnerPid = await findPidOnPortImpl(info.port);
+    if (competingPortOwnerPid !== null && competingPortOwnerPid !== info.pid) {
+      logger.info('[LeaderElection] Heartbeat stopping because another process owns the console port', {
+        sessionId: info.sessionId,
+        pid: info.pid,
+        port: info.port,
+        competingPortOwnerPid,
+      });
+      return 'lost-port';
+    }
+
+    const updated: ConsoleLeaderInfo = { ...info, heartbeat: new Date().toISOString() };
+    const tmpFile = join(RUN_DIR, `console-leader.lock.${process.pid}.tmp`);
+    await writeFile(tmpFile, JSON.stringify(updated, null, 2), 'utf-8');
+    await rename(tmpFile, lockPath);
+    return 'updated';
+  } catch (err) {
+    logger.debug('[LeaderElection] Heartbeat write failed:', err);
+    return 'failed';
+  }
+}
+
 /**
  * Start the leader heartbeat loop.
  * Updates the lock file every HEARTBEAT_INTERVAL_MS so followers know the leader is alive.
  *
  * @returns A stop function to clear the interval
  */
-export function startHeartbeat(info: ConsoleLeaderInfo): () => void {
+export function startHeartbeat(info: ConsoleLeaderInfo, deps: HeartbeatDependencies = {}): () => void {
   const interval = setInterval(async () => {
-    try {
-      const updated: ConsoleLeaderInfo = { ...info, heartbeat: new Date().toISOString() };
-      const tmpFile = join(RUN_DIR, `console-leader.lock.${process.pid}.tmp`);
-      await writeFile(tmpFile, JSON.stringify(updated, null, 2), 'utf-8');
-      await rename(tmpFile, LOCK_FILE);
-    } catch (err) {
-      logger.debug('[LeaderElection] Heartbeat write failed:', err);
+    const result = await renewLeaderHeartbeat(info, deps);
+    if (result === 'lost-lock' || result === 'lost-port') {
+      clearInterval(interval);
     }
   }, HEARTBEAT_INTERVAL_MS);
 

--- a/tests/unit/web/console/LeaderElection.test.ts
+++ b/tests/unit/web/console/LeaderElection.test.ts
@@ -5,7 +5,7 @@
  * stale detection, PID liveness checks, and claim mechanics.
  */
 
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
 
 // We test the exported utility functions directly rather than mocking fs,
 // using a real temp directory for isolation.
@@ -244,6 +244,14 @@ describe('LeaderElection', () => {
   });
 
   describe('startHeartbeat', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('should return a stop function', () => {
       const info = {
         version: 1,
@@ -256,6 +264,59 @@ describe('LeaderElection', () => {
       const stop = LeaderElection.startHeartbeat(info);
       expect(typeof stop).toBe('function');
       stop(); // clean up immediately
+    });
+  });
+
+  describe('renewLeaderHeartbeat', () => {
+    let tempDir: string;
+    let tempLockPath: string;
+
+    beforeEach(async () => {
+      const { mkdtemp } = await import('node:fs/promises');
+      const { tmpdir } = await import('node:os');
+      const { join } = await import('node:path');
+      tempDir = await mkdtemp(join(tmpdir(), 'dh-heartbeat-renew-test-'));
+      tempLockPath = join(tempDir, 'console-leader.auth.lock');
+    });
+
+    afterEach(async () => {
+      const { rm } = await import('node:fs/promises');
+      await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it('returns lost-lock instead of overwriting another leader lock', async () => {
+      const { writeFile, readFile } = await import('node:fs/promises');
+      const existingLock = makeLeaderInfo({
+        pid: 424242,
+        sessionId: 'newer-leader',
+      });
+      await writeFile(tempLockPath, JSON.stringify(existingLock), 'utf-8');
+
+      const result = await LeaderElection.renewLeaderHeartbeat(
+        makeLeaderInfo({ sessionId: 'former-leader' }),
+        {
+          lockPath: tempLockPath,
+          readLeaderLockImpl: LeaderElection.readLeaderLock,
+          findPidOnPortImpl: async () => null,
+        },
+      );
+
+      expect(result).toBe('lost-lock');
+      await expect(readFile(tempLockPath, 'utf-8')).resolves.toEqual(JSON.stringify(existingLock));
+    });
+
+    it('returns lost-port instead of reclaiming the lock when another pid owns the port', async () => {
+      const result = await LeaderElection.renewLeaderHeartbeat(
+        makeLeaderInfo({ sessionId: 'former-leader' }),
+        {
+          lockPath: tempLockPath,
+          readLeaderLockImpl: async () => null,
+          findPidOnPortImpl: async () => 424242,
+        },
+      );
+
+      expect(result).toBe('lost-port');
+      await expect(LeaderElection.readLeaderLock(tempLockPath)).resolves.toBeNull();
     });
   });
 

--- a/tests/unit/web/console/LeaderElection.test.ts
+++ b/tests/unit/web/console/LeaderElection.test.ts
@@ -302,7 +302,8 @@ describe('LeaderElection', () => {
       );
 
       expect(result).toBe('lost-lock');
-      await expect(readFile(tempLockPath, 'utf-8')).resolves.toEqual(JSON.stringify(existingLock));
+      const persistedLock = JSON.parse(await readFile(tempLockPath, 'utf-8')) as typeof existingLock;
+      expect(persistedLock).toMatchObject(existingLock);
     });
 
     it('returns lost-port instead of reclaiming the lock when another pid owns the port', async () => {


### PR DESCRIPTION
## Summary
- stop leader heartbeats from rewriting the shared lock after leadership has already been lost
- refuse heartbeat renewal when another process owns the lock or the console port
- add regressions for displaced leaders that stay alive after losing authority

## Testing
- npm test -- --runInBand tests/unit/web/console/LeaderElection.test.ts tests/unit/web/console/UnifiedConsole.test.ts tests/unit/web/console/sessionRegistry.test.ts tests/unit/web/console/SessionNames.test.ts tests/unit/web/console/ghostSession.test.ts tests/unit/web/console/console-failure-modes.test.ts tests/unit/web/console/lifecycle-cleanup.test.ts
- npx eslint src/web/console/LeaderElection.ts tests/unit/web/console/LeaderElection.test.ts
- npm run build
- ./docker/mixed-version/smoke-test.sh