### PR TITLE
Make console port recovery non-destructive

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -848,12 +848,14 @@ if ((isDirectExecution || isNpxExecution || isCliExecution) && (!isTest || isTes
       const cliPort = portArg ? Number.parseInt(portArg.split('=')[1], 10) : undefined;
       const noBrowser = process.argv.includes('--no-open');
 
-      // Pre-flight: kill any stale DollhouseMCP process squatting on our port
-      // BEFORE any container/server setup. This is the definitive fix for #1850 —
-      // clear the port first, then start cleanly.
-      // Race condition note: a new process could grab the port between kill and
-      // our bind, but recoverStalePort's TOCTOU mitigation (500ms lock file
-      // re-read) and bindAndListen's own recovery handle that edge case.
+      // Pre-flight: inspect any existing DollhouseMCP process on our port
+      // BEFORE any container/server setup. Recovery is intentionally
+      // non-destructive for verified Dollhouse sessions; operators can use the
+      // session UI to dismiss proven orphans explicitly.
+      // Race condition note: a new process could grab the port between inspect
+      // and bind, but recoverStalePort's TOCTOU mitigation (500ms lock file
+      // re-read) and bindAndListen's own conflict handling keep that edge case
+      // visible instead of silently terminating another session.
       const targetPort = cliPort || env.DOLLHOUSE_WEB_CONSOLE_PORT;
       try {
         const { recoverStalePort } = await import('./web/console/StaleProcessRecovery.js');

--- a/src/web/console/StaleProcessRecovery.ts
+++ b/src/web/console/StaleProcessRecovery.ts
@@ -1,9 +1,11 @@
 /**
- * Stale process detection and recovery (#1850).
+ * Non-destructive stale process inspection (#1850).
  *
- * Finds and kills zombie DollhouseMCP processes that squat on the console
- * port after their session has ended. Used by bindAndListen in server.ts
- * when EADDRINUSE occurs.
+ * Detects when another process is already holding the console port and
+ * classifies whether it looks like DollhouseMCP. Startup recovery is
+ * intentionally non-destructive for verified Dollhouse sessions: authority
+ * issues should demote/follow existing sessions rather than killing them.
+ * Operators can still explicitly dismiss true orphans from the web console.
  *
  * Extracted to a standalone module so it can be tested without importing
  * the full Express server and its dependency chain.
@@ -75,6 +77,7 @@ export interface KillStaleProcessOutcome {
     | 'inspect_failed'
     | 'different_user'
     | 'not_dollhouse_process'
+    | 'requires_orphan_proof'
     | 'active_host_parent'
     | 'terminated'
     | 'already_dead'
@@ -88,6 +91,7 @@ export interface KillStaleProcessOutcome {
 }
 
 export interface KillStaleProcessOptions {
+  allowVerifiedDollhouseKill?: boolean;
   allowActiveHostParent?: boolean;
 }
 
@@ -161,11 +165,23 @@ async function getKillGuardFailure(
     return buildKillOutcome(false, 'not_dollhouse_process', processInfo);
   }
 
+  const parentCommand = processInfo.parentPid > ROOT_PARENT_PID
+    ? (await getProcessCommand(processInfo.parentPid)) ?? undefined
+    : undefined;
+
+  if (!options.allowVerifiedDollhouseKill) {
+    await logger.warn(`[WebUI] Port ${port} held by another DollhouseMCP session (pid ${processInfo.pid}) — not auto-killing`, {
+      cmdLine: processInfo.command,
+      parentPid: processInfo.parentPid,
+      parentCommand,
+    });
+    return buildKillOutcome(false, 'requires_orphan_proof', processInfo, parentCommand);
+  }
+
   if (processInfo.parentPid <= ROOT_PARENT_PID || !isPidAlive(processInfo.parentPid)) {
     return null;
   }
 
-  const parentCommand = (await getProcessCommand(processInfo.parentPid)) ?? undefined;
   if (!options.allowActiveHostParent && parentCommand && isRecognizedMcpHostParent(parentCommand)) {
     await logger.warn(`[WebUI] Port ${port} held by active client-backed DollhouseMCP process (pid ${processInfo.pid}) — not killing`, {
       cmdLine: processInfo.command,
@@ -336,9 +352,11 @@ export async function findPidOnPort(port: number): Promise<number | null> {
 }
 
 /**
- * Kill a stale process holding a port. Sends SIGTERM, waits briefly,
- * then SIGKILL if still alive. Only kills DollhouseMCP processes
- * (verified by checking the command line and user ownership).
+ * Kill a process holding a port.
+ *
+ * This helper is intentionally conservative. By default it refuses to signal
+ * verified DollhouseMCP sessions unless the caller opts in with explicit
+ * orphan proof via `allowVerifiedDollhouseKill`.
  *
  * Timeout: 1s for ps verification. Kill wait: 300ms × 10 polls = 3s
  * before escalating to SIGKILL. Total worst case: ~4s.
@@ -380,9 +398,11 @@ export async function killStaleProcessDetailed(
 }
 
 /**
- * Detect and recover from a stale process squatting on the port.
+ * Inspect the process squatting on the port.
  * Compares the port holder's PID against the leader lock file to determine
- * if it's a squatter. Returns true if the squatter was killed.
+ * if it's a fresh leader, but refuses to auto-kill verified DollhouseMCP
+ * sessions. Returns true only when a future caller provides orphan proof and
+ * the occupant is actually terminated.
  *
  * Timeouts: lsof 1s, ps 1s, SIGTERM wait 3s — max ~5s total.
  */

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -630,8 +630,9 @@ function attemptBind(
 }
 
 /**
- * Bind the Express app to 127.0.0.1:port. On EADDRINUSE, attempt to find
- * and kill the stale DollhouseMCP process holding the port, then retry once.
+ * Bind the Express app to 127.0.0.1:port. On EADDRINUSE, inspect the current
+ * port holder and retry only if a future recovery path proves it is safe to
+ * terminate.
  */
 async function bindAndListen(
   app: import('express').Express,
@@ -641,7 +642,8 @@ async function bindAndListen(
   const result = await attemptBind(app, port, options);
   if (result.success || result.error !== 'EADDRINUSE') return result;
 
-  // Port occupied — attempt stale process recovery and retry
+  // Port occupied — inspect the port holder. Recovery is intentionally
+  // non-destructive for verified DollhouseMCP sessions.
   if (await recoverStalePort(port)) {
     const retryResult = await attemptBind(app, port, options);
     if (retryResult.success) return retryResult;

--- a/tests/integration/web-standalone-mode.test.ts
+++ b/tests/integration/web-standalone-mode.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for standalone --web mode (#1850).
  *
  * Verifies the --web startup path has the correct structure:
- * 1. Pre-flight zombie kill runs BEFORE container setup
+ * 1. Pre-flight port inspection runs BEFORE container setup
  * 2. completeDeferredSetup() is NOT called (prevents leader election conflict)
  * 3. Port file sweep runs independently
  * 4. startWebServer is called with full sinks
@@ -28,7 +28,7 @@ describe('Standalone --web mode (#1850)', () => {
     webModeSource = await readFile(path.join(PROJECT_ROOT, 'src/index.ts'), 'utf8');
   });
 
-  describe('Pre-flight zombie kill', () => {
+  describe('Pre-flight port inspection', () => {
     it('calls recoverStalePort before container bootstrap', () => {
       const webBlock = getWebModeBlock(webModeSource);
       const recoverIdx = webBlock.indexOf('recoverStalePort(targetPort)');
@@ -40,7 +40,7 @@ describe('Standalone --web mode (#1850)', () => {
 
     it('logs recovery failures instead of swallowing them', () => {
       const preflightSection = webModeSource.slice(
-        webModeSource.indexOf('Pre-flight: kill any stale'),
+        webModeSource.indexOf('Pre-flight: inspect any existing'),
         webModeSource.indexOf('let mcpAqlHandler'),
       );
       expect(preflightSection).toContain('console.error');
@@ -102,7 +102,7 @@ describe('Standalone --web mode (#1850)', () => {
   describe('Race condition documentation', () => {
     it('documents the TOCTOU mitigation in the pre-flight comment', () => {
       const preflightSection = webModeSource.slice(
-        webModeSource.indexOf('Pre-flight: kill any stale'),
+        webModeSource.indexOf('Pre-flight: inspect any existing'),
         webModeSource.indexOf('const targetPort'),
       );
       expect(preflightSection).toContain('TOCTOU');

--- a/tests/unit/config/consolePort.test.ts
+++ b/tests/unit/config/consolePort.test.ts
@@ -274,12 +274,14 @@ describe('Console port configuration (#1840)', () => {
       expect(source).toContain('another process holds this port');
     });
 
-    it('only kills verified DollhouseMCP processes on port conflict', async () => {
+    it('never auto-kills verified DollhouseMCP processes on port conflict', async () => {
       const source = await readFile(join(SRC, 'src/web/console/StaleProcessRecovery.ts'), 'utf8');
-      // killStaleProcess verifies the process is DollhouseMCP before sending signals
+      // Startup recovery inspects DollhouseMCP occupants but requires explicit
+      // orphan proof before it can send signals.
       expect(source).toContain('dollhousemcp');
       expect(source).toContain('mcp-server');
-      expect(source).toContain('SIGTERM');
+      expect(source).toContain('allowVerifiedDollhouseKill');
+      expect(source).toContain('requires_orphan_proof');
     });
 
     it('resolves promise on conflict (does not throw)', async () => {

--- a/tests/unit/web/console/stale-process-recovery.test.ts
+++ b/tests/unit/web/console/stale-process-recovery.test.ts
@@ -179,12 +179,15 @@ describe('Stale Process Recovery (#1850)', () => {
       it('refuses to auto-kill a verified DollhouseMCP process without orphan proof', async () => {
         const port = await getFreePort();
         const { child, tempDir } = await spawnFakeDollhouseServer(port);
+        const childPid = child.pid;
+        expect(childPid).toBeDefined();
+        if (!childPid) return;
 
         try {
-          const outcome = await Recovery.killStaleProcessDetailed(child.pid!, port);
+          const outcome = await Recovery.killStaleProcessDetailed(childPid, port);
           expect(outcome.killed).toBe(false);
           expect(outcome.reason).toBe('requires_orphan_proof');
-          expect(() => process.kill(child.pid!, 0)).not.toThrow();
+          expect(() => process.kill(childPid, 0)).not.toThrow();
         } finally {
           await cleanupFakeDollhouseServer(child, tempDir);
         }
@@ -215,11 +218,14 @@ describe('Stale Process Recovery (#1850)', () => {
       it('does not auto-kill a verified DollhouseMCP server on the port', async () => {
         const port = await getFreePort();
         const { child, tempDir } = await spawnFakeDollhouseServer(port);
+        const childPid = child.pid;
+        expect(childPid).toBeDefined();
+        if (!childPid) return;
 
         try {
           expect(await Recovery.recoverStalePort(port)).toBe(false);
-          expect(() => process.kill(child.pid!, 0)).not.toThrow();
-          expect(await Recovery.findPidOnPort(port)).toBe(child.pid);
+          expect(() => process.kill(childPid, 0)).not.toThrow();
+          expect(await Recovery.findPidOnPort(port)).toBe(childPid);
         } finally {
           await cleanupFakeDollhouseServer(child, tempDir);
         }

--- a/tests/unit/web/console/stale-process-recovery.test.ts
+++ b/tests/unit/web/console/stale-process-recovery.test.ts
@@ -16,6 +16,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import type { ChildProcess } from 'node:child_process';
 
 const execAsync = promisify(execFile);
 
@@ -47,6 +48,65 @@ function listenOnPort(): Promise<{ server: net.Server; port: number }> {
 
 function closeServer(server: net.Server): Promise<void> {
   return new Promise((resolve) => server.close(() => resolve()));
+}
+
+async function waitFor<T>(
+  description: string,
+  fn: () => Promise<T | null>,
+  timeoutMs = 5_000,
+  intervalMs = 100,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = await fn();
+    if (result !== null) {
+      return result;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+async function spawnFakeDollhouseServer(port: number): Promise<{ child: ChildProcess; tempDir: string }> {
+  const { spawn } = await import('node:child_process');
+  const tempDir = await mkdtemp(join(tmpdir(), 'fake-dollhouse-port-holder-'));
+  const scriptDir = join(tempDir, 'node_modules', '.bin');
+  const scriptPath = join(scriptDir, 'mcp-server');
+  await mkdir(scriptDir, { recursive: true });
+  await writeFile(
+    scriptPath,
+    [
+      "const net = require('node:net');",
+      'const port = Number(process.argv[2]);',
+      "const server = net.createServer();",
+      "server.listen(port, '127.0.0.1');",
+      "process.on('SIGTERM', () => server.close(() => process.exit(0)));",
+      "process.on('SIGINT', () => server.close(() => process.exit(0)));",
+      'setInterval(() => {}, 1000);',
+    ].join('\n'),
+  );
+
+  const child = spawn(process.execPath, [scriptPath, String(port)], {
+    stdio: 'ignore',
+  });
+
+  await waitFor(
+    `fake Dollhouse server on port ${port}`,
+    async () => ((await Recovery.findPidOnPort(port)) === child.pid ? child.pid ?? null : null),
+  );
+
+  return { child, tempDir };
+}
+
+async function cleanupFakeDollhouseServer(child: ChildProcess, tempDir: string): Promise<void> {
+  if (child.pid) {
+    try {
+      process.kill(child.pid, 'SIGKILL');
+    } catch {
+      // already dead
+    }
+  }
+  await rm(tempDir, { recursive: true, force: true });
 }
 
 /** Helper matching the same logic as StaleProcessRecovery.ts binary detection. */
@@ -115,6 +175,20 @@ describe('Stale Process Recovery (#1850)', () => {
           try { process.kill(childPid, 'SIGKILL'); } catch { /* dead */ }
         }
       }, 10000);
+
+      it('refuses to auto-kill a verified DollhouseMCP process without orphan proof', async () => {
+        const port = await getFreePort();
+        const { child, tempDir } = await spawnFakeDollhouseServer(port);
+
+        try {
+          const outcome = await Recovery.killStaleProcessDetailed(child.pid!, port);
+          expect(outcome.killed).toBe(false);
+          expect(outcome.reason).toBe('requires_orphan_proof');
+          expect(() => process.kill(child.pid!, 0)).not.toThrow();
+        } finally {
+          await cleanupFakeDollhouseServer(child, tempDir);
+        }
+      }, 15000);
     }
   });
 
@@ -136,6 +210,21 @@ describe('Stale Process Recovery (#1850)', () => {
         await closeServer(server);
       }
     }, 10000);
+
+    if (process.platform !== 'win32') {
+      it('does not auto-kill a verified DollhouseMCP server on the port', async () => {
+        const port = await getFreePort();
+        const { child, tempDir } = await spawnFakeDollhouseServer(port);
+
+        try {
+          expect(await Recovery.recoverStalePort(port)).toBe(false);
+          expect(() => process.kill(child.pid!, 0)).not.toThrow();
+          expect(await Recovery.findPidOnPort(port)).toBe(child.pid);
+        } finally {
+          await cleanupFakeDollhouseServer(child, tempDir);
+        }
+      }, 15000);
+    }
   });
 
   // ── Lock file mismatch scenarios ──────────────────────────────────────


### PR DESCRIPTION
## Summary
- stop startup port recovery from auto-killing verified DollhouseMCP sessions
- document the pre-flight path as inspection-only and preserve explicit session UI kill as the destructive path
- add regressions proving fake \.bin/mcp-server occupants are left alive unless a future caller provides orphan proof

## Testing
- npm test -- --runInBand tests/unit/web/console/stale-process-recovery.test.ts tests/unit/config/consolePort.test.ts
- npx eslint src/web/console/StaleProcessRecovery.ts src/web/server.ts src/index.ts tests/unit/web/console/stale-process-recovery.test.ts tests/integration/web-standalone-mode.test.ts tests/unit/config/consolePort.test.ts
- npm run build
- node - <<'NODE'
const fs = require('node:fs');
const src = fs.readFileSync('src/index.ts','utf8');
if (!src.includes('Pre-flight: inspect any existing DollhouseMCP process on our port')) process.exit(1);
if (!src.includes('non-destructive for verified Dollhouse sessions')) process.exit(2);
console.log('source-check ok');
NODE