### PR TITLE
Show session host and version metadata in the console picker

### DIFF
--- a/src/web/public/sessions.css
+++ b/src/web/public/sessions.css
@@ -236,6 +236,21 @@
   white-space: nowrap;
 }
 
+.session-dropdown-name-group {
+  min-width: 0;
+  display: grid;
+  gap: 0.1rem;
+}
+
+.session-dropdown-version {
+  font-size: 0.68rem;
+  font-family: var(--font-mono, monospace);
+  color: var(--ink-500, #677893);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .session-dropdown-uptime {
   font-size: 0.7rem;
   font-family: var(--font-mono, monospace);
@@ -286,6 +301,10 @@
 
 [data-theme="dark"] .session-dropdown-name {
   color: var(--ink-900, #e0e8f0);
+}
+
+[data-theme="dark"] .session-dropdown-version {
+  color: var(--ink-500, #8899bb);
 }
 
 [data-theme="dark"] .session-dropdown-toggle-label {

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -187,6 +187,52 @@
     return parts.length >= 2 ? parts[1] : id.slice(0, 8);
   }
 
+  function displayVersion(session) {
+    if (!session || typeof session !== 'object' || typeof session.serverVersion !== 'string') return '';
+    var raw = nfc(session.serverVersion).trim();
+    if (!raw) return '';
+    var normalized = normalizeSemver(raw);
+    return normalized ? 'v' + normalized : raw;
+  }
+
+  function sessionIdentitySource(session) {
+    if (!session || typeof session !== 'object') return '';
+    if (typeof session.stableSessionId === 'string' && session.stableSessionId.trim()) {
+      return nfc(session.stableSessionId).trim().toLowerCase();
+    }
+    if (typeof session.sessionId === 'string' && session.sessionId.trim()) {
+      return nfc(session.sessionId).trim().toLowerCase();
+    }
+    return '';
+  }
+
+  function displayPlatform(session) {
+    if (!session || typeof session !== 'object') return '';
+    if (session.kind === 'console') return 'Web Console';
+
+    var identity = sessionIdentitySource(session);
+    if (!identity) return '';
+
+    var platformMap = [
+      ['claude-code', 'Claude Code'],
+      ['codex', 'Codex'],
+      ['cursor', 'Cursor'],
+      ['vscode', 'VS Code'],
+      ['windsurf', 'Windsurf'],
+      ['gemini', 'Gemini'],
+      ['cline', 'Cline'],
+      ['lmstudio', 'LM Studio'],
+    ];
+
+    for (var i = 0; i < platformMap.length; i++) {
+      if (identity.indexOf(platformMap[i][0]) === 0) {
+        return platformMap[i][1];
+      }
+    }
+
+    return '';
+  }
+
   function getLiveSessions() {
     return sessions.filter(function(s) { return s.status === 'active'; });
   }
@@ -254,7 +300,15 @@
   // Build a key from current sessions to detect changes
   function sessionListKey(list) {
     return list.map(function(s) {
-      return s.sessionId + ':' + s.status + ':' + (isPolicyOnlySession(s) ? 'policy' : 'live');
+      return [
+        s.sessionId,
+        s.status,
+        isPolicyOnlySession(s) ? 'policy' : 'live',
+        displayName(s),
+        displayPlatform(s),
+        displayVersion(s),
+        s.isLeader ? 'leader' : 'follower',
+      ].join(':');
     }).join(',')
       + '|policyDebug:' + (showPolicySessions ? 'on' : 'off')
       + '|knownPolicy:' + policySessions.map(function(session) { return session.sessionId; }).join(',');
@@ -529,11 +583,33 @@
       if (s.color) dot.style.background = s.color;
       item.appendChild(dot);
 
+      var nameGroup = document.createElement('span');
+      nameGroup.className = 'session-dropdown-name-group';
+
       var nameEl = document.createElement('span');
       nameEl.className = 'session-dropdown-name';
       nameEl.textContent = displayName(s);
       if (s.color) nameEl.style.color = s.color;
-      item.appendChild(nameEl);
+      nameGroup.appendChild(nameEl);
+
+      var metaParts = [];
+      var platform = displayPlatform(s);
+      if (platform) {
+        metaParts.push(platform);
+      }
+      var version = displayVersion(s);
+      if (version) {
+        metaParts.push(version);
+      }
+      if (metaParts.length) {
+        var versionEl = document.createElement('span');
+        versionEl.className = 'session-dropdown-version';
+        versionEl.textContent = metaParts.join(' \u2022 ');
+        versionEl.title = metaParts.join(' • ');
+        nameGroup.appendChild(versionEl);
+      }
+
+      item.appendChild(nameGroup);
 
       // Session status badges (#1805) — for persisted policy sessions we
       // switch from "live/authenticated" semantics to "saved/no client".

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -387,6 +387,69 @@ describe('Web console cleanup regressions', () => {
     cleanup();
   });
 
+  it('shows session versions in the dropdown and refreshes them when a session upgrades', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="session-indicator"></div>
+      <div id="tab-logs"><div class="log-controls"></div></div>
+    `);
+
+    let currentVersion = '2.0.27-rc.9';
+    win.DollhouseAuth.apiFetch = jest.fn().mockImplementation((url: string) => {
+      if (url !== '/api/sessions') {
+        return Promise.reject(new Error(`unexpected url ${url}`));
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          sessions: [
+            {
+              sessionId: 'session-1',
+              stableSessionId: 'claude-code-main',
+              status: 'active',
+              displayName: 'Bunraku',
+              startedAt: '2026-04-20T10:00:00.000Z',
+              isLeader: true,
+              authenticated: true,
+              kind: 'mcp',
+              color: '#ff00ff',
+              serverVersion: currentVersion,
+            },
+          ],
+        }),
+      });
+    });
+    win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+    win.DollhouseConsoleConfig = {
+      sessionPollIntervalMs: 10,
+      sessionFilterInjectionRetryIntervalMs: TEST_SESSION_FILTER_INJECTION_RETRY_INTERVAL_MS,
+      sessionFilterInjectionMaxRetries: 5,
+    };
+
+    win.eval(sessionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    await wait(SESSION_FILTER_INJECTION_WAIT_MS);
+
+    const sessionBox = win.document.querySelector('.session-box') as HTMLButtonElement | null;
+    expect(sessionBox).not.toBeNull();
+    sessionBox?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    const initialVersion = win.document.querySelector('.session-dropdown-item[data-session-id="session-1"] .session-dropdown-version');
+    expect(initialVersion?.textContent).toBe('Claude Code • v2.0.27-rc.9');
+
+    currentVersion = '2.0.27-rc.10';
+    await wait(30);
+
+    const refreshedSessionBox = win.document.querySelector('.session-box') as HTMLButtonElement | null;
+    refreshedSessionBox?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    const refreshedVersion = win.document.querySelector('.session-dropdown-item[data-session-id="session-1"] .session-dropdown-version');
+    expect(refreshedVersion?.textContent).toBe('Claude Code • v2.0.27-rc.10');
+
+    cleanup();
+  });
+
   it('keeps aggregate policy sources visible when selecting a persisted policy session', async () => {
     const { window: win, cleanup } = createDom(`
       <div id="session-indicator"></div>


### PR DESCRIPTION
## Summary
- show each live session's host/platform and server version in the session dropdown
- refresh the dropdown when a session keeps the same identity but reports a new version
- cover the host/version rendering and refresh path with a web-console regression test

## Verification
- npm test -- --runInBand tests/unit/web/console-ui-regressions.test.ts
- npx eslint src/web/public/sessions.js tests/unit/web/console-ui-regressions.test.ts