### PR TITLE
Implement non-destructive console leadership handoff

### DIFF
--- a/src/web/console/IngestRoutes.ts
+++ b/src/web/console/IngestRoutes.ts
@@ -31,6 +31,8 @@ import { logger } from '../../utils/logger.js';
 import { env } from '../../config/env.js';
 import { PACKAGE_VERSION } from '../../generated/version.js';
 import {
+  type ConsoleLeaderInfo,
+  type LeaderPreferenceDecision,
   CONSOLE_PROTOCOL_VERSION,
   LEGACY_CONSOLE_PROTOCOL_VERSION,
 } from './LeaderElection.js';
@@ -159,6 +161,7 @@ export interface IngestBroadcasts {
   metricsOnSnapshot?: (snapshot: MetricSnapshot) => void;
   storeMetricsSnapshot?: (snapshot: MetricSnapshot, sessionId: string) => void;
   sessionBroadcast?: (event: SessionInfo) => void;
+  requestLeaderHandoff?: (candidateLeader: ConsoleLeaderInfo) => Promise<ConsoleLeadershipHandoffDecision>;
 }
 
 /**
@@ -179,6 +182,16 @@ export interface IngestRoutesResult {
   ) => void;
   /** Register the web console as a session so the indicator is never empty (#1805) */
   registerConsoleSession: () => void;
+}
+
+export type ConsoleLeadershipHandoffReason =
+  | LeaderPreferenceDecision['reason']
+  | 'handoff-in-progress';
+
+export interface ConsoleLeadershipHandoffDecision {
+  accepted: boolean;
+  reason: ConsoleLeadershipHandoffReason;
+  leaderInfo: ConsoleLeaderInfo;
 }
 
 type SessionLeaseSource =
@@ -245,6 +258,33 @@ function normalizeConsoleProtocolVersion(version?: number): number {
     return version;
   }
   return LEGACY_CONSOLE_PROTOCOL_VERSION;
+}
+
+function normalizeCandidateLeaderInfo(value: unknown): ConsoleLeaderInfo | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const candidate = value as Partial<ConsoleLeaderInfo>;
+  const sessionId = normalizeOptionalInput(candidate.sessionId);
+  if (!sessionId || typeof candidate.pid !== 'number' || !Number.isInteger(candidate.pid) || candidate.pid <= 0) {
+    return null;
+  }
+  if (typeof candidate.port !== 'number' || !Number.isInteger(candidate.port) || candidate.port <= 0) {
+    return null;
+  }
+
+  const now = new Date().toISOString();
+  return {
+    version: Number.isInteger(candidate.version) ? candidate.version as number : 1,
+    pid: candidate.pid,
+    port: candidate.port,
+    sessionId,
+    startedAt: normalizeOptionalInput(candidate.startedAt) ?? now,
+    heartbeat: normalizeOptionalInput(candidate.heartbeat) ?? now,
+    serverVersion: normalizeServerVersion(candidate.serverVersion),
+    consoleProtocolVersion: normalizeConsoleProtocolVersion(candidate.consoleProtocolVersion),
+  };
 }
 
 function chooseRequestedDisplayName(hints: SessionDisplayNameHints): string | undefined {
@@ -742,6 +782,22 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
           }
         : {}),
     });
+  });
+
+  router.post('/api/console/handoff', async (req: Request, res: Response) => {
+    if (!broadcasts.requestLeaderHandoff) {
+      res.status(501).json({ error: 'Leader handoff unsupported' });
+      return;
+    }
+
+    const candidateLeader = normalizeCandidateLeaderInfo((req.body as { candidateLeader?: unknown } | undefined)?.candidateLeader);
+    if (!candidateLeader) {
+      res.status(400).json({ error: 'Invalid candidate leader info' });
+      return;
+    }
+
+    const decision = await broadcasts.requestLeaderHandoff(candidateLeader);
+    res.status(decision.accepted ? 202 : 409).json(decision);
   });
 
   /**

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -50,11 +50,12 @@ import { PromotionManager } from './PromotionManager.js';
 import { ConsoleTokenStore } from './consoleToken.js';
 import {
   findPidOnPort,
-  killStaleProcessDetailed,
-  type KillStaleProcessOutcome,
 } from './StaleProcessRecovery.js';
 import { env } from '../../config/env.js';
-import type { SessionInfo } from './IngestRoutes.js';
+import type {
+  ConsoleLeadershipHandoffDecision,
+  SessionInfo,
+} from './IngestRoutes.js';
 
 /**
  * Default console port from the env var. Used as fallback when no port
@@ -69,6 +70,9 @@ const SYNTHETIC_PORT_OWNER_SESSION_PREFIX = 'port-owner-';
 const LEADER_DISCOVERY_TIMEOUT_MS = env.DOLLHOUSE_CONSOLE_LEADER_DISCOVERY_TIMEOUT_MS;
 const LEADER_LEASE_RECONCILE_INTERVAL_MS = 2_000;
 const LEADER_LEASE_RECONCILE_MAX_INTERVAL_MS = 30_000;
+const LEADER_HANDOFF_REQUEST_TIMEOUT_MS = 2_000;
+const LEADER_HANDOFF_RELEASE_WAIT_MS = 5_000;
+const LEADER_HANDOFF_RELEASE_POLL_MS = 100;
 const FOLLOWER_AUTHORITY_MONITOR_CONFIG = {
   intervalMs: env.DOLLHOUSE_CONSOLE_AUTHORITY_RECHECK_MS,
   jitterMs: env.DOLLHOUSE_CONSOLE_AUTHORITY_RECHECK_JITTER_MS,
@@ -213,7 +217,7 @@ interface ForceTakeoverAttemptResult {
   fallback: PortLeaderDiscovery;
   replacement: PortOwnerReplacementDecision;
   recoveredSessions: SessionInfo[];
-  forcedKill: KillStaleProcessOutcome | null;
+  handoff: ConsoleLeadershipHandoffDecision | null;
   takeoverAttempted: boolean;
   reboundLockClaimed: boolean;
 }
@@ -257,7 +261,6 @@ interface LeaderLeaseReconciliationDependencies {
   findPidOnPortImpl?: typeof findPidOnPort;
   claimLeadershipImpl?: typeof claimLeadership;
   deleteLeaderLockImpl?: typeof deleteLeaderLock;
-  killStaleProcessDetailedImpl?: typeof killStaleProcessDetailed;
   setTimeoutImpl?: typeof setTimeout;
   clearTimeoutImpl?: typeof clearTimeout;
 }
@@ -270,6 +273,83 @@ interface DiscoveryDependencies {
 
 function buildDiscoveryHeaders(authToken: string | null): Record<string, string> {
   return authToken ? { Authorization: `Bearer ${authToken}` } : {};
+}
+
+export interface LeaderHandoffDependencies {
+  fetchImpl?: typeof fetch;
+  findPidOnPortImpl?: typeof findPidOnPort;
+  setTimeoutImpl?: typeof setTimeout;
+}
+
+export async function requestLeaderHandoff(
+  port: number,
+  authToken: string | null,
+  candidateLeader: ConsoleLeaderInfo,
+  deps: LeaderHandoffDependencies = {},
+): Promise<ConsoleLeadershipHandoffDecision | null> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), LEADER_HANDOFF_REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetchImpl(`http://127.0.0.1:${port}/api/console/handoff`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...buildDiscoveryHeaders(authToken),
+      },
+      body: JSON.stringify({ candidateLeader }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok && response.status !== 409) {
+      return null;
+    }
+
+    const payload = await response.json() as Partial<ConsoleLeadershipHandoffDecision>;
+    if (!payload || typeof payload !== 'object' || typeof payload.accepted !== 'boolean' || !payload.leaderInfo) {
+      return null;
+    }
+
+    return {
+      accepted: payload.accepted,
+      reason: payload.reason ?? 'handoff-in-progress',
+      leaderInfo: payload.leaderInfo as ConsoleLeaderInfo,
+    };
+  } catch (err) {
+    logger.debug('[UnifiedConsole] Leader handoff request failed', {
+      port,
+      candidateSessionId: candidateLeader.sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function waitForLeaderRelease(
+  port: number,
+  previousOwnerPid: number,
+  deps: LeaderHandoffDependencies = {},
+): Promise<boolean> {
+  const findPidOnPortImpl = deps.findPidOnPortImpl ?? findPidOnPort;
+  const setTimeoutImpl = deps.setTimeoutImpl ?? setTimeout;
+  const deadline = Date.now() + LEADER_HANDOFF_RELEASE_WAIT_MS;
+
+  while (Date.now() < deadline) {
+    const ownerPid = await findPidOnPortImpl(port);
+    if (ownerPid === null || ownerPid !== previousOwnerPid) {
+      return true;
+    }
+
+    await new Promise<void>((resolve) => {
+      const timer = setTimeoutImpl(resolve, LEADER_HANDOFF_RELEASE_POLL_MS);
+      timer.unref?.();
+    });
+  }
+
+  return false;
 }
 
 export async function fetchLeaderSessionsSnapshot(
@@ -525,7 +605,7 @@ function buildBindFailureLogContext(
   bindResult: WebServerResult['bindResult'],
   fallback: PortLeaderDiscovery,
   replacement?: PortOwnerReplacementDecision,
-  forcedKill?: KillStaleProcessOutcome | null,
+  handoff?: ConsoleLeadershipHandoffDecision | null,
 ) {
   return {
     port: consolePort,
@@ -543,9 +623,10 @@ function buildBindFailureLogContext(
     fallbackLeaderProtocolVersion: fallback.leaderInfo?.consoleProtocolVersion ?? CONSOLE_PROTOCOL_VERSION,
     replacementShouldEvict: replacement?.shouldEvict ?? false,
     replacementReason: replacement?.preference?.reason,
-    forcedKillReason: forcedKill?.reason,
-    forcedKillPid: forcedKill?.pid,
-    forcedKillDetail: forcedKill?.detail,
+    handoffAccepted: handoff?.accepted ?? false,
+    handoffReason: handoff?.reason ?? null,
+    handoffLeaderPid: handoff?.leaderInfo.pid ?? null,
+    handoffLeaderSessionId: handoff?.leaderInfo.sessionId ?? null,
   };
 }
 
@@ -853,7 +934,6 @@ export async function reconcileLeaderLease(
   const findPidOnPortImpl = deps.findPidOnPortImpl ?? findPidOnPort;
   const claimLeadershipImpl = deps.claimLeadershipImpl ?? claimLeadership;
   const deleteLeaderLockImpl = deps.deleteLeaderLockImpl ?? deleteLeaderLock;
-  const killStaleProcessDetailedImpl = deps.killStaleProcessDetailedImpl ?? killStaleProcessDetailed;
 
   const portOwnerPid = await findPidOnPortImpl(consolePort);
   if (portOwnerPid !== process.pid) {
@@ -882,9 +962,6 @@ export async function reconcileLeaderLease(
     replacementReason: replacement.preference?.reason ?? null,
   });
 
-  const killOutcome = await killStaleProcessDetailedImpl(currentLock.pid, consolePort, {
-    allowActiveHostParent: true,
-  });
   const lockAfterKill = await readLeaderLockImpl();
   let lockDeleted = false;
   let lockClaimAttempted = false;
@@ -908,9 +985,9 @@ export async function reconcileLeaderLease(
     displacedPid: currentLock.pid,
     displacedSessionId: currentLock.sessionId,
     displacedVersion: currentLock.serverVersion ?? LEGACY_SERVER_VERSION,
-    killAttempted: true,
-    killResult: killOutcome.reason,
-    killed: killOutcome.killed,
+    killAttempted: false,
+    killResult: null,
+    killed: false,
     lockDeleted,
     lockClaimAttempted,
     lockClaimed,
@@ -929,7 +1006,7 @@ export async function reconcileLeaderLease(
       finalLockOwnerPid: finalLock?.pid ?? null,
       finalLockOwnerSessionId: finalLock?.sessionId ?? null,
       finalLockOwnerVersion: finalLock?.serverVersion ?? null,
-      killResult: killOutcome.reason,
+      killResult: null,
       lockDeleted,
       lockClaimAttempted,
       lockClaimed,
@@ -1009,7 +1086,7 @@ async function attemptForceTakeover(
       fallback: initialFallback,
       replacement: initialReplacement,
       recoveredSessions: [],
-      forcedKill: null,
+      handoff: null,
       takeoverAttempted: false,
       reboundLockClaimed: false,
     };
@@ -1019,7 +1096,7 @@ async function attemptForceTakeover(
   const recoveredSessions = await fetchLeaderSessionsSnapshot(consolePort, primaryToken);
   const latestReplacement = evaluatePortOwnerReplacement(currentElection.leaderInfo, latestFallback);
   if (!shouldEvictDiscoveredOwner(latestFallback, latestReplacement)) {
-    logger.warn('[UnifiedConsole] Forced takeover target changed before eviction; skipping forced kill', {
+    logger.warn('[UnifiedConsole] Leadership handoff target changed before takeover; following the current leader instead', {
       ...buildBindFailureLogContext(
         consolePort,
         currentElection.leaderInfo,
@@ -1035,13 +1112,13 @@ async function attemptForceTakeover(
       fallback: latestFallback,
       replacement: latestReplacement,
       recoveredSessions,
-      forcedKill: null,
+      handoff: null,
       takeoverAttempted: false,
       reboundLockClaimed: false,
     };
   }
 
-  logger.warn('[UnifiedConsole] Attempting forced takeover from older or incompatible active leader', {
+  logger.warn('[UnifiedConsole] Requesting non-destructive leadership handoff from older or incompatible active leader', {
     ...buildBindFailureLogContext(
       consolePort,
       currentElection.leaderInfo,
@@ -1059,24 +1136,22 @@ async function attemptForceTakeover(
       fallback: latestFallback,
       replacement: latestReplacement,
       recoveredSessions,
-      forcedKill: null,
+      handoff: null,
       takeoverAttempted: false,
       reboundLockClaimed: false,
     };
   }
 
-  const forcedKill = await killStaleProcessDetailed(ownerPid, consolePort, {
-    allowActiveHostParent: true,
-  });
-  if (!forcedKill.killed) {
-    logger.warn('[UnifiedConsole] Forced takeover skipped or failed after identifying replaceable leader', {
+  const handoff = await requestLeaderHandoff(consolePort, primaryToken, currentElection.leaderInfo);
+  if (!handoff?.accepted) {
+    logger.warn('[UnifiedConsole] Leadership handoff was rejected or unavailable; following the existing leader', {
       ...buildBindFailureLogContext(
         consolePort,
         currentElection.leaderInfo,
         { success: false, error: 'EADDRINUSE', detail: `Port ${consolePort} already in use` },
         latestFallback,
         latestReplacement,
-        forcedKill,
+        handoff,
       ),
     });
     return {
@@ -1085,7 +1160,31 @@ async function attemptForceTakeover(
       fallback: latestFallback,
       replacement: latestReplacement,
       recoveredSessions,
-      forcedKill,
+      handoff,
+      takeoverAttempted: true,
+      reboundLockClaimed: false,
+    };
+  }
+
+  const released = await waitForLeaderRelease(consolePort, ownerPid);
+  if (!released) {
+    logger.warn('[UnifiedConsole] Leadership handoff was accepted but the older leader did not release the console port in time', {
+      ...buildBindFailureLogContext(
+        consolePort,
+        currentElection.leaderInfo,
+        { success: false, error: 'EADDRINUSE', detail: `Port ${consolePort} already in use` },
+        latestFallback,
+        latestReplacement,
+        handoff,
+      ),
+    });
+    return {
+      webResult: { bindResult: { success: false, error: 'EADDRINUSE', detail: `Port ${consolePort} already in use` } },
+      election: currentElection,
+      fallback: latestFallback,
+      replacement: latestReplacement,
+      recoveredSessions,
+      handoff,
       takeoverAttempted: true,
       reboundLockClaimed: false,
     };
@@ -1106,20 +1205,20 @@ async function attemptForceTakeover(
           reboundWebResult.bindResult,
           latestFallback,
           latestReplacement,
-          forcedKill,
+          handoff,
         ),
       });
     }
     reboundElection = { role: 'leader', leaderInfo: reboundLeaderInfo };
   } else {
-    logger.warn('[UnifiedConsole] Forced takeover killed old leader but bind retry still failed', {
+    logger.warn('[UnifiedConsole] Leadership handoff succeeded but the bind retry still failed', {
       ...buildBindFailureLogContext(
         consolePort,
         currentElection.leaderInfo,
         reboundWebResult.bindResult,
         latestFallback,
         latestReplacement,
-        forcedKill,
+        handoff,
       ),
     });
   }
@@ -1130,7 +1229,7 @@ async function attemptForceTakeover(
     fallback: latestFallback,
     replacement: latestReplacement,
     recoveredSessions,
-    forcedKill,
+    handoff,
     takeoverAttempted: true,
     reboundLockClaimed,
   };
@@ -1184,7 +1283,7 @@ async function startAsLeader(
   election: ElectionResult,
   consolePort: number = DEFAULT_CONSOLE_PORT,
 ): Promise<UnifiedConsoleResult> {
-  const { startWebServer } = await import('../server.js');
+  const { startWebServer, shutdownWebServer } = await import('../server.js');
   const { derivePreferredLeaderSessionName, pickRandomTokenName } = await import('./SessionNames.js');
 
   // Initialize the console token store (#1780). Creates the token file on
@@ -1204,16 +1303,98 @@ async function startAsLeader(
   // Pre-create a placeholder broadcast that we'll wire up after the server starts
   let liveBroadcast: ((entry: UnifiedLogEntry) => void) | undefined;
   let liveMetricsOnSnapshot: ((snapshot: MetricSnapshot) => void) | undefined;
+  let stopHeartbeat = () => {};
+  let stopLeaseMonitor = () => {};
+  let demotionInProgress = false;
+  let activeCleanup = async (): Promise<void> => {
+    stopHeartbeat();
+    stopLeaseMonitor();
+  };
+
+  const requestLeaderHandoff = async (candidateLeader: ConsoleLeaderInfo): Promise<ConsoleLeadershipHandoffDecision> => {
+    const currentLeaderInfo = createLeaderInfo(options.sessionId, consolePort);
+    const preference = evaluateLeaderPreference(candidateLeader, currentLeaderInfo);
+    if (!preference.shouldReplace) {
+      logger.info('[UnifiedConsole] Leadership handoff rejected because the requesting session is not preferred', {
+        currentLeaderSessionId: currentLeaderInfo.sessionId,
+        currentLeaderVersion: preference.existingVersion,
+        candidateSessionId: candidateLeader.sessionId,
+        candidateVersion: preference.candidateVersion,
+        reason: preference.reason,
+      });
+      return {
+        accepted: false,
+        reason: preference.reason,
+        leaderInfo: currentLeaderInfo,
+      };
+    }
+
+    if (demotionInProgress) {
+      return {
+        accepted: false,
+        reason: 'handoff-in-progress',
+        leaderInfo: currentLeaderInfo,
+      };
+    }
+
+    demotionInProgress = true;
+    logger.warn('[UnifiedConsole] Leadership handoff accepted; stepping down to follower for a newer compatible session', {
+      currentLeaderSessionId: currentLeaderInfo.sessionId,
+      currentLeaderVersion: currentLeaderInfo.serverVersion ?? LEGACY_SERVER_VERSION,
+      candidateSessionId: candidateLeader.sessionId,
+      candidateVersion: candidateLeader.serverVersion ?? LEGACY_SERVER_VERSION,
+      port: consolePort,
+    });
+
+    setImmediate(() => {
+      void (async () => {
+        try {
+          await activeCleanup();
+          shutdownWebServer();
+          await deleteLeaderLock();
+          const followerResult = await startAsFollower(
+            options,
+            { role: 'follower', leaderInfo: candidateLeader },
+            consolePort,
+            primaryToken.token,
+          );
+          activeCleanup = followerResult.cleanup;
+          logger.info('[UnifiedConsole] Former leader resumed as follower after leadership handoff', {
+            sessionId: options.sessionId,
+            stableSessionId: options.stableSessionId,
+            newLeaderSessionId: candidateLeader.sessionId,
+            port: consolePort,
+          });
+        } catch (err) {
+          demotionInProgress = false;
+          logger.error('[UnifiedConsole] Leadership handoff failed during leader demotion', {
+            sessionId: options.sessionId,
+            candidateLeaderSessionId: candidateLeader.sessionId,
+            port: consolePort,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      })();
+    });
+
+    return {
+      accepted: true,
+      reason: preference.reason,
+      leaderInfo: currentLeaderInfo,
+    };
+  };
 
   // Create ingestion routes with a deferred broadcast (wired after server starts)
   const ingestResult = createIngestRoutes({
     logBroadcast: (entry) => liveBroadcast?.(entry),
     metricsOnSnapshot: (snapshot) => liveMetricsOnSnapshot?.(snapshot),
     storeMetricsSnapshot: (snapshot) => options.metricsSink?.onSnapshot(snapshot),
+    requestLeaderHandoff,
   });
 
   // Start the web server with ingest routes mounted before the SPA fallback.
-  // If the port is occupied by a stale process, retry with exponential backoff.
+  // If the port is occupied, later recovery prefers non-destructive leader handoff
+  // over process termination for verified Dollhouse sessions.
   const serverOpts = {
     portfolioDir: options.portfolioDir,
     memorySink: options.memorySink,
@@ -1225,8 +1406,9 @@ async function startAsLeader(
     tokenStore,
     ...(options.mcpAqlHandler ? { mcpAqlHandler: options.mcpAqlHandler } : {}),
   };
-  // bindAndListen now handles EADDRINUSE by finding and killing the stale
-  // process on the port, then retrying. No external retry loop needed.
+  // bindAndListen handles the first bind attempt; explicit leader handoff logic
+  // below decides whether a newer compatible session should replace the current
+  // console leader without killing the live MCP process.
   let webResult = await startWebServer(serverOpts);
   let recoveredFollowerSessions: SessionInfo[] = [];
 
@@ -1252,7 +1434,7 @@ async function startAsLeader(
           webResult.bindResult,
           forceTakeover.fallback,
           forceTakeover.replacement,
-          forceTakeover.forcedKill,
+          forceTakeover.handoff,
         ),
         takeoverAttempted: forceTakeover.takeoverAttempted,
         reboundLockClaimed: forceTakeover.reboundLockClaimed,
@@ -1269,7 +1451,7 @@ async function startAsLeader(
           webResult.bindResult,
           forceTakeover.fallback,
           forceTakeover.replacement,
-          forceTakeover.forcedKill,
+          forceTakeover.handoff,
         ),
         takeoverAttempted: forceTakeover.takeoverAttempted,
         reboundLockClaimed: forceTakeover.reboundLockClaimed,
@@ -1317,8 +1499,12 @@ async function startAsLeader(
   logger.info('[UnifiedConsole] Ingestion routes mounted');
 
   // Start heartbeat and register cleanup
-  const stopHeartbeat = startHeartbeat(election.leaderInfo);
-  const stopLeaseMonitor = startLeaderLeaseMonitor(options.sessionId, consolePort);
+  stopHeartbeat = startHeartbeat(election.leaderInfo);
+  stopLeaseMonitor = startLeaderLeaseMonitor(options.sessionId, consolePort);
+  activeCleanup = async () => {
+    stopHeartbeat();
+    stopLeaseMonitor();
+  };
   registerLeaderCleanup();
 
   logger.info('[UnifiedConsole] Leader started', {
@@ -1330,10 +1516,7 @@ async function startAsLeader(
     role: 'leader',
     election,
     port: consolePort,
-    cleanup: async () => {
-      stopHeartbeat();
-      stopLeaseMonitor();
-    },
+    cleanup: async () => activeCleanup(),
   };
 }
 

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -311,10 +311,12 @@ export async function requestLeaderHandoff(
       return null;
     }
 
+    const { leaderInfo } = payload;
+
     return {
       accepted: payload.accepted,
       reason: payload.reason ?? 'handoff-in-progress',
-      leaderInfo: payload.leaderInfo as ConsoleLeaderInfo,
+      leaderInfo,
     };
   } catch (err) {
     logger.debug('[UnifiedConsole] Leader handoff request failed', {

--- a/tests/unit/web/console/UnifiedConsole.test.ts
+++ b/tests/unit/web/console/UnifiedConsole.test.ts
@@ -29,7 +29,9 @@ import {
   shouldEvictDiscoveredOwner,
   resolveFollowerAuthority,
   resolveLeaderPreflightAuthority,
+  requestLeaderHandoff,
   startFollowerAuthorityMonitor,
+  waitForLeaderRelease,
   reconcileLeaderLease,
   startLeaderLeaseMonitor,
 } from '../../../../src/web/console/UnifiedConsole.js';
@@ -1067,18 +1069,88 @@ describe('startFollowerAuthorityMonitor', () => {
   });
 });
 
+describe('requestLeaderHandoff', () => {
+  it('posts the candidate leader info and returns the leader decision', async () => {
+    const fetchStub = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      status: 202,
+      json: async () => ({
+        accepted: true,
+        reason: 'newer-compatible-version',
+        leaderInfo: {
+          version: 1,
+          pid: 57117,
+          port: 41715,
+          sessionId: 'current-leader',
+          startedAt: '2026-04-20T18:00:00.000Z',
+          heartbeat: '2026-04-20T18:00:00.000Z',
+          serverVersion: '2.0.27-rc.10',
+          consoleProtocolVersion: 1,
+        },
+      }),
+    } as Response);
+
+    const candidateLeader: ConsoleLeaderInfo = {
+      version: 1,
+      pid: process.pid,
+      port: 41715,
+      sessionId: 'candidate-newest',
+      startedAt: '2026-04-20T18:01:00.000Z',
+      heartbeat: '2026-04-20T18:01:00.000Z',
+      serverVersion: PACKAGE_VERSION,
+      consoleProtocolVersion: 1,
+    };
+
+    const result = await requestLeaderHandoff(41715, 'token-123', candidateLeader, {
+      fetchImpl: fetchStub,
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      accepted: true,
+      reason: 'newer-compatible-version',
+      leaderInfo: expect.objectContaining({
+        sessionId: 'current-leader',
+        serverVersion: '2.0.27-rc.10',
+      }),
+    }));
+    expect(fetchStub).toHaveBeenCalledWith('http://127.0.0.1:41715/api/console/handoff', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token-123',
+      }),
+      body: JSON.stringify({ candidateLeader }),
+      signal: expect.any(AbortSignal),
+    }));
+  });
+});
+
+describe('waitForLeaderRelease', () => {
+  it('returns true once the previous port owner relinquishes the console port', async () => {
+    const findPidOnPortImpl = jest
+      .fn<typeof import('../../../../src/web/console/StaleProcessRecovery.js').findPidOnPort>()
+      .mockResolvedValueOnce(57117)
+      .mockResolvedValueOnce(null);
+
+    const timerHandle = { unref: jest.fn() } as unknown as ReturnType<typeof setTimeout>;
+    const setTimeoutImpl = jest.fn<typeof setTimeout>((callback) => {
+      callback();
+      return timerHandle;
+    });
+
+    await expect(waitForLeaderRelease(41715, 57117, {
+      findPidOnPortImpl,
+      setTimeoutImpl,
+    })).resolves.toBe(true);
+  });
+});
+
 describe('reconcileLeaderLease', () => {
-  it('reclaims the lock and evicts the displaced lock writer when this process owns the console port', async () => {
+  it('reclaims the lock without killing the displaced lock writer when this process owns the console port', async () => {
     const claimLeadershipImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').claimLeadership>()
       .mockResolvedValue(true);
     const deleteLeaderLockImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').deleteLeaderLock>()
       .mockResolvedValue();
-    const killStaleProcessDetailedImpl = jest.fn<typeof import('../../../../src/web/console/StaleProcessRecovery.js').killStaleProcessDetailed>()
-      .mockResolvedValue({
-        killed: true,
-        reason: 'terminated',
-        pid: 3877,
-      });
     const displacedLock = {
       version: 1,
       pid: 3877,
@@ -1110,13 +1182,9 @@ describe('reconcileLeaderLease', () => {
       readLeaderLockImpl,
       claimLeadershipImpl,
       deleteLeaderLockImpl,
-      killStaleProcessDetailedImpl,
     });
 
     expect(result).toBe('reconciled');
-    expect(killStaleProcessDetailedImpl).toHaveBeenCalledWith(3877, 41715, {
-      allowActiveHostParent: true,
-    });
     expect(deleteLeaderLockImpl).toHaveBeenCalledTimes(1);
     expect(claimLeadershipImpl).toHaveBeenCalledWith(expect.objectContaining({
       sessionId: 'session-newest',
@@ -1126,7 +1194,6 @@ describe('reconcileLeaderLease', () => {
 
   it('does nothing when this process does not own the console port', async () => {
     const claimLeadershipImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').claimLeadership>();
-    const killStaleProcessDetailedImpl = jest.fn<typeof import('../../../../src/web/console/StaleProcessRecovery.js').killStaleProcessDetailed>();
 
     const result = await reconcileLeaderLease('session-newest', 41715, {
       findPidOnPortImpl: async () => 3877,
@@ -1141,25 +1208,17 @@ describe('reconcileLeaderLease', () => {
         consoleProtocolVersion: 1,
       }),
       claimLeadershipImpl,
-      killStaleProcessDetailedImpl,
     });
 
     expect(result).toBe('not-port-owner');
-    expect(killStaleProcessDetailedImpl).not.toHaveBeenCalled();
     expect(claimLeadershipImpl).not.toHaveBeenCalled();
   });
 
-  it('returns reclaim-failed when the displaced lock cannot be reclaimed after eviction', async () => {
+  it('returns reclaim-failed when the displaced lock cannot be reclaimed after non-destructive lock replacement', async () => {
     const claimLeadershipImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').claimLeadership>()
       .mockResolvedValue(false);
     const deleteLeaderLockImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').deleteLeaderLock>()
       .mockResolvedValue();
-    const killStaleProcessDetailedImpl = jest.fn<typeof import('../../../../src/web/console/StaleProcessRecovery.js').killStaleProcessDetailed>()
-      .mockResolvedValue({
-        killed: true,
-        reason: 'terminated',
-        pid: 3877,
-      });
     const displacedLock = {
       version: 1,
       pid: 3877,
@@ -1191,7 +1250,6 @@ describe('reconcileLeaderLease', () => {
       readLeaderLockImpl,
       claimLeadershipImpl,
       deleteLeaderLockImpl,
-      killStaleProcessDetailedImpl,
     });
 
     expect(result).toBe('reclaim-failed');
@@ -1208,7 +1266,6 @@ describe('startLeaderLeaseMonitor', () => {
     const claimLeadershipImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').claimLeadership>();
     const deleteLeaderLockImpl = jest.fn<typeof import('../../../../src/web/console/LeaderElection.js').deleteLeaderLock>()
       .mockResolvedValue();
-    const killStaleProcessDetailedImpl = jest.fn<typeof import('../../../../src/web/console/StaleProcessRecovery.js').killStaleProcessDetailed>();
     const clearTimeoutImpl = jest.fn<typeof clearTimeout>();
     const reclaimedLock = {
       version: 1,
@@ -1233,7 +1290,6 @@ describe('startLeaderLeaseMonitor', () => {
       readLeaderLockImpl,
       claimLeadershipImpl,
       deleteLeaderLockImpl,
-      killStaleProcessDetailedImpl,
     });
 
     expect(timeoutCallback).not.toBeNull();
@@ -1243,7 +1299,6 @@ describe('startLeaderLeaseMonitor', () => {
     timeoutCallback?.();
     await flushAuthorityMonitorTick();
     await flushAuthorityMonitorTick();
-    expect(killStaleProcessDetailedImpl).not.toHaveBeenCalled();
     expect(claimLeadershipImpl).not.toHaveBeenCalled();
     expect(deleteLeaderLockImpl).not.toHaveBeenCalled();
     expect(scheduledDelays).toEqual([2_000, 4_000]);
@@ -1252,7 +1307,6 @@ describe('startLeaderLeaseMonitor', () => {
     await flushAuthorityMonitorTick();
     await flushAuthorityMonitorTick();
 
-    expect(killStaleProcessDetailedImpl).not.toHaveBeenCalled();
     expect(claimLeadershipImpl).not.toHaveBeenCalled();
     expect(scheduledDelays).toEqual([2_000, 4_000, 8_000]);
 

--- a/tests/unit/web/console/sessionRegistry.test.ts
+++ b/tests/unit/web/console/sessionRegistry.test.ts
@@ -353,6 +353,79 @@ describe('Session registry (#1805)', () => {
     });
   });
 
+  describe('POST /api/console/handoff', () => {
+    it('accepts a newer compatible leader handoff request', async () => {
+      const requestLeaderHandoff = jest.fn().mockResolvedValue({
+        accepted: true,
+        reason: 'newer-compatible-version',
+        leaderInfo: {
+          version: 1,
+          pid: process.pid,
+          port: 41715,
+          sessionId: 'current-leader',
+          startedAt: '2026-04-20T18:00:00.000Z',
+          heartbeat: '2026-04-20T18:00:00.000Z',
+          serverVersion: PACKAGE_VERSION,
+          consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+        },
+      });
+      ingestResult = createIngestRoutes({
+        logBroadcast: () => {},
+        requestLeaderHandoff,
+      });
+      const app = buildApp(ingestResult);
+
+      const res = await request(app)
+        .post('/api/console/handoff')
+        .send({
+          candidateLeader: {
+            version: 1,
+            pid: 12345,
+            port: 41715,
+            sessionId: 'candidate-newest',
+            startedAt: '2026-04-20T18:01:00.000Z',
+            heartbeat: '2026-04-20T18:01:00.000Z',
+            serverVersion: '9.9.9',
+            consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+          },
+        });
+
+      expect(res.status).toBe(202);
+      expect(requestLeaderHandoff).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: 'candidate-newest',
+        pid: 12345,
+        port: 41715,
+        serverVersion: '9.9.9',
+        consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+      }));
+      expect(res.body).toEqual(expect.objectContaining({
+        accepted: true,
+        reason: 'newer-compatible-version',
+      }));
+    });
+
+    it('rejects an invalid handoff payload before invoking the callback', async () => {
+      const requestLeaderHandoff = jest.fn();
+      ingestResult = createIngestRoutes({
+        logBroadcast: () => {},
+        requestLeaderHandoff,
+      });
+      const app = buildApp(ingestResult);
+
+      const res = await request(app)
+        .post('/api/console/handoff')
+        .send({
+          candidateLeader: {
+            pid: 12345,
+            port: 41715,
+          },
+        });
+
+      expect(res.status).toBe(400);
+      expect(requestLeaderHandoff).not.toHaveBeenCalled();
+    });
+  });
+
   describe('stale session reaper', () => {
     it('does not reap console sessions (they have no heartbeat)', async () => {
       ingestResult.registerConsoleSession();


### PR DESCRIPTION
## Summary
- add a protected leader handoff request so newer compatible sessions can ask the current leader to step down
- demote the old leader into follower mode instead of killing its process, and make lock reconciliation non-destructive
- cover the handoff endpoint and helper flow with targeted unit tests

## Testing
- npm test -- --runInBand tests/unit/web/console/sessionRegistry.test.ts tests/unit/web/console/UnifiedConsole.test.ts tests/unit/web/console/LeaderElection.test.ts tests/unit/web/console/console-failure-modes.test.ts tests/unit/web/console/ghostSession.test.ts
- npx eslint src/web/console/IngestRoutes.ts src/web/console/UnifiedConsole.ts tests/unit/web/console/sessionRegistry.test.ts tests/unit/web/console/UnifiedConsole.test.ts
- npm run build
- ./docker/mixed-version/smoke-test.sh