### PR TITLE
feat: expose authoritative console session identity in build info

### DIFF
--- a/src/services/BuildInfoService.ts
+++ b/src/services/BuildInfoService.ts
@@ -14,12 +14,15 @@ import { logger } from '../utils/logger.js';
 import { IFileOperationsService } from './FileOperationsService.js';
 import { PACKAGE_NAME, PACKAGE_VERSION, BUILD_TIMESTAMP, BUILD_TYPE } from '../generated/version.js';
 import type { StartupTimer, StartupReport } from '../telemetry/StartupTimer.js';
+import type { CurrentConsoleSessionIdentity } from './currentConsoleSessionIdentity.js';
+import { getCurrentConsoleSessionIdentity } from './currentConsoleSessionIdentity.js';
 import { resolveSessionIdentity } from './sessionIdentity.js';
 
 export interface BuildInfo {
   sessionId: string;
   runtimeSessionId: string;
   sessionSource: 'env' | 'derived';
+  consoleSession?: CurrentConsoleSessionIdentity;
   package: {
     name: string;
     version: string;
@@ -144,6 +147,7 @@ export class BuildInfoService {
       sessionId: sessionIdentity.sessionId,
       runtimeSessionId: sessionIdentity.runtimeSessionId,
       sessionSource: sessionIdentity.source,
+      consoleSession: getCurrentConsoleSessionIdentity() ?? undefined,
       package: packageInfo,
       build: {
         timestamp: buildTimestamp,
@@ -202,6 +206,18 @@ export class BuildInfoService {
     ];
     if (info.runtimeSessionId !== info.sessionId) {
       sessionLines.splice(2, 0, `- **Runtime Session ID**: ${info.runtimeSessionId}`);
+    }
+    if (info.consoleSession) {
+      const authorityLabel = info.consoleSession.authoritative
+        ? 'Authoritative web console lease'
+        : 'Awaiting authoritative web console lease';
+      sessionLines.push(`- **Web Console Display Name**: ${info.consoleSession.displayName ?? 'pending authoritative assignment'}`);
+      sessionLines.push(`- **Web Console Role**: ${info.consoleSession.role}`);
+      sessionLines.push(`- **Web Console Kind**: ${info.consoleSession.kind}`);
+      sessionLines.push(`- **Web Console Identity**: ${authorityLabel}`);
+      if (info.consoleSession.authoritative && info.consoleSession.color) {
+        sessionLines.push(`- **Web Console Color**: ${info.consoleSession.color}`);
+      }
     }
     lines.push(...sessionLines, '');
     

--- a/src/services/BuildInfoService.ts
+++ b/src/services/BuildInfoService.ts
@@ -211,10 +211,12 @@ export class BuildInfoService {
       const authorityLabel = info.consoleSession.authoritative
         ? 'Authoritative web console lease'
         : 'Awaiting authoritative web console lease';
-      sessionLines.push(`- **Web Console Display Name**: ${info.consoleSession.displayName ?? 'pending authoritative assignment'}`);
-      sessionLines.push(`- **Web Console Role**: ${info.consoleSession.role}`);
-      sessionLines.push(`- **Web Console Kind**: ${info.consoleSession.kind}`);
-      sessionLines.push(`- **Web Console Identity**: ${authorityLabel}`);
+      sessionLines.push(
+        `- **Web Console Display Name**: ${info.consoleSession.displayName ?? 'pending authoritative assignment'}`,
+        `- **Web Console Role**: ${info.consoleSession.role}`,
+        `- **Web Console Kind**: ${info.consoleSession.kind}`,
+        `- **Web Console Identity**: ${authorityLabel}`,
+      );
       if (info.consoleSession.authoritative && info.consoleSession.color) {
         sessionLines.push(`- **Web Console Color**: ${info.consoleSession.color}`);
       }

--- a/src/services/currentConsoleSessionIdentity.ts
+++ b/src/services/currentConsoleSessionIdentity.ts
@@ -1,0 +1,23 @@
+export interface CurrentConsoleSessionIdentity {
+  displayName: string | null;
+  authoritative: boolean;
+  role: 'leader' | 'follower';
+  kind: 'mcp' | 'console';
+  color: string | null;
+  serverVersion: string;
+  consoleProtocolVersion: number;
+}
+
+let currentConsoleSessionIdentity: CurrentConsoleSessionIdentity | null = null;
+
+export function setCurrentConsoleSessionIdentity(identity: CurrentConsoleSessionIdentity): void {
+  currentConsoleSessionIdentity = { ...identity };
+}
+
+export function getCurrentConsoleSessionIdentity(): CurrentConsoleSessionIdentity | null {
+  return currentConsoleSessionIdentity ? { ...currentConsoleSessionIdentity } : null;
+}
+
+export function clearCurrentConsoleSessionIdentity(): void {
+  currentConsoleSessionIdentity = null;
+}

--- a/src/web/console/IngestRoutes.ts
+++ b/src/web/console/IngestRoutes.ts
@@ -179,7 +179,7 @@ export interface IngestRoutesResult {
     pid: number,
     displayName?: string,
     stableSessionId?: string,
-  ) => void;
+  ) => SessionInfo | null;
   /** Register the web console as a session so the indicator is never empty (#1805) */
   registerConsoleSession: () => void;
 }
@@ -994,7 +994,7 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     pid: number,
     displayName?: string,
     stableSessionId?: string,
-  ): void {
+  ): SessionInfo | null {
     const leaseResolution = registerOrResumeSessionLease({
       sessionId,
       stableSessionId,
@@ -1017,7 +1017,9 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
         pid,
         resolution: leaseResolution.resolution,
       });
+      return leaseResolution.session;
     }
+    return null;
   }
 
   /**

--- a/src/web/console/LeaderForwardingSink.ts
+++ b/src/web/console/LeaderForwardingSink.ts
@@ -83,6 +83,7 @@ export class SessionLeaseState {
   constructor(
     private readonly preferredDisplayName: string,
     private readonly stableSessionId: string | null = null,
+    private readonly onAssignedDisplayName?: (displayName: string) => void,
   ) {}
 
   getDisplayName(): string {
@@ -111,7 +112,11 @@ export class SessionLeaseState {
       return;
     }
 
+    const previousDisplayName = this.assignedDisplayName;
     this.assignedDisplayName = normalizedDisplayName;
+    if (previousDisplayName !== normalizedDisplayName) {
+      this.onAssignedDisplayName?.(normalizedDisplayName);
+    }
   }
 }
 

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -19,6 +19,7 @@ import type { MemoryLogSink } from '../../logging/sinks/MemoryLogSink.js';
 import type { MemoryMetricsSink } from '../../metrics/sinks/MemoryMetricsSink.js';
 import type { WebServerOptions, WebServerResult } from '../server.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
+import { PACKAGE_VERSION } from '../../generated/version.js';
 import { logger } from '../../utils/logger.js';
 import type { MCPAQLHandler } from '../../handlers/mcp-aql/MCPAQLHandler.js';
 import {
@@ -52,6 +53,7 @@ import {
   findPidOnPort,
 } from './StaleProcessRecovery.js';
 import { env } from '../../config/env.js';
+import { setCurrentConsoleSessionIdentity } from '../../services/currentConsoleSessionIdentity.js';
 import type {
   ConsoleLeadershipHandoffDecision,
   SessionInfo,
@@ -1463,12 +1465,23 @@ async function startAsLeader(
   }
 
   // Register the leader only after the HTTP listener is actually serving the port.
-  ingestResult.registerLeaderSession(
+  const leaderSession = ingestResult.registerLeaderSession(
     options.sessionId,
     process.pid,
     derivePreferredLeaderSessionName(options.sessionId),
     options.stableSessionId,
   );
+  if (leaderSession) {
+    setCurrentConsoleSessionIdentity({
+      displayName: leaderSession.displayName,
+      authoritative: true,
+      role: 'leader',
+      kind: leaderSession.kind,
+      color: leaderSession.color,
+      serverVersion: leaderSession.serverVersion,
+      consoleProtocolVersion: leaderSession.consoleProtocolVersion,
+    });
+  }
 
   // Register the web console itself so the session indicator is never empty (#1805)
   ingestResult.registerConsoleSession();
@@ -1548,11 +1561,32 @@ async function startAsFollower(
     logger.debug('[UnifiedConsole] No console auth token file found; follower will POST without Bearer header');
   }
 
-  const { derivePreferredFollowerSessionName } = await import('./SessionNames.js');
+  const { derivePreferredFollowerSessionName, getPuppetColor } = await import('./SessionNames.js');
+  const preferredDisplayName = derivePreferredFollowerSessionName(options.sessionId);
   const leaseState = new SessionLeaseState(
-    derivePreferredFollowerSessionName(options.sessionId),
+    preferredDisplayName,
     options.stableSessionId,
+    (assignedDisplayName) => {
+      setCurrentConsoleSessionIdentity({
+        displayName: assignedDisplayName,
+        authoritative: true,
+        role: 'follower',
+        kind: 'mcp',
+        color: getPuppetColor(assignedDisplayName) ?? null,
+        serverVersion: PACKAGE_VERSION,
+        consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+      });
+    },
   );
+  setCurrentConsoleSessionIdentity({
+    displayName: null,
+    authoritative: false,
+    role: 'follower',
+    kind: 'mcp',
+    color: null,
+    serverVersion: PACKAGE_VERSION,
+    consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+  });
 
   // Per-instance promotion manager — tracks its own attempt counter so
   // multiple followers don't interfere with each other's promotion budgets.

--- a/tests/unit/services/BuildInfoService.test.ts
+++ b/tests/unit/services/BuildInfoService.test.ts
@@ -13,6 +13,10 @@
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import { BuildInfoService, BuildInfo } from '../../../src/services/BuildInfoService.js';
 import { DollhouseContainer } from '../../../src/di/Container.js';
+import {
+  clearCurrentConsoleSessionIdentity,
+  setCurrentConsoleSessionIdentity,
+} from '../../../src/services/currentConsoleSessionIdentity.js';
 
 describe('BuildInfoService', () => {
   let service: BuildInfoService;
@@ -25,6 +29,7 @@ describe('BuildInfoService', () => {
 
   afterEach(async () => {
     await container.dispose();
+    clearCurrentConsoleSessionIdentity();
     jest.restoreAllMocks();
     jest.clearAllMocks();
   });
@@ -50,6 +55,30 @@ describe('BuildInfoService', () => {
       expect(info.sessionId).toMatch(/^local-[a-f0-9]{10}$/);
       expect(info.runtimeSessionId).toMatch(new RegExp(`^${info.sessionId}-[a-z0-9]+$`));
       expect(info.sessionSource).toBe('derived');
+    });
+
+    it('should include live console session identity when available', async () => {
+      setCurrentConsoleSessionIdentity({
+        displayName: 'Bunraku',
+        authoritative: true,
+        role: 'follower',
+        kind: 'mcp',
+        color: '#123456',
+        serverVersion: '2.0.27-rc.14',
+        consoleProtocolVersion: 2,
+      });
+
+      const info = await service.getBuildInfo();
+
+      expect(info.consoleSession).toEqual({
+        displayName: 'Bunraku',
+        authoritative: true,
+        role: 'follower',
+        kind: 'mcp',
+        color: '#123456',
+        serverVersion: '2.0.27-rc.14',
+        consoleProtocolVersion: 2,
+      });
     });
 
     it('should populate package information', async () => {
@@ -159,6 +188,15 @@ describe('BuildInfoService', () => {
         sessionId: 'workspace-a1b2c3d4e5',
         runtimeSessionId: 'workspace-a1b2c3d4e5-k9',
         sessionSource: 'derived',
+        consoleSession: {
+          displayName: 'Bunraku',
+          authoritative: true,
+          role: 'follower',
+          kind: 'mcp',
+          color: '#5C6370',
+          serverVersion: '1.3.2',
+          consoleProtocolVersion: 2,
+        },
         package: {
           name: '@dollhousemcp/mcp-server',
           version: '1.3.2'
@@ -209,6 +247,11 @@ describe('BuildInfoService', () => {
       expect(formatted).toContain('**Session ID**: workspace-a1b2c3d4e5');
       expect(formatted).toContain('**Runtime Session ID**: workspace-a1b2c3d4e5-k9');
       expect(formatted).toContain('**Identity Source**: Derived from workspace context');
+      expect(formatted).toContain('**Web Console Display Name**: Bunraku');
+      expect(formatted).toContain('**Web Console Role**: follower');
+      expect(formatted).toContain('**Web Console Kind**: mcp');
+      expect(formatted).toContain('**Web Console Identity**: Authoritative web console lease');
+      expect(formatted).toContain('**Web Console Color**: #5C6370');
       expect(formatted).toContain('## 🏗️ Build');
       expect(formatted).toContain('**Type**: git');
       expect(formatted).toContain('**Timestamp**: 2024-01-01T12:00:00.000Z');
@@ -278,6 +321,7 @@ describe('BuildInfoService', () => {
       expect(formatted).toContain('**MCP Connection**: ❌ Disconnected');
       expect(formatted).toContain('**Session ID**: session-from-env');
       expect(formatted).toContain('**Identity Source**: Explicit environment');
+      expect(formatted).not.toContain('**Web Console Display Name**:');
       expect(formatted).not.toContain('**Runtime Session ID**:');
       expect(formatted).not.toContain('**Timestamp**:');
       expect(formatted).not.toContain('**Git Commit**:');
@@ -460,6 +504,9 @@ describe('BuildInfoService', () => {
 
     it('should produce deterministic output for same input', () => {
       const testInfo: BuildInfo = {
+        sessionId: 'workspace-a1b2c3d4e5',
+        runtimeSessionId: 'workspace-a1b2c3d4e5-k9',
+        sessionSource: 'derived',
         package: { name: 'test', version: '1.0.0' },
         build: { type: 'git', gitCommit: 'abc123', gitBranch: 'main' },
         runtime: {
@@ -487,6 +534,50 @@ describe('BuildInfoService', () => {
       const formatted2 = service.formatBuildInfo(testInfo);
 
       expect(formatted1).toBe(formatted2);
+    });
+
+    it('should avoid provisional puppet names in build info output', () => {
+      const provisionalInfo: BuildInfo = {
+        sessionId: 'workspace-a1b2c3d4e5',
+        runtimeSessionId: 'workspace-a1b2c3d4e5-k9',
+        sessionSource: 'derived',
+        consoleSession: {
+          displayName: null,
+          authoritative: false,
+          role: 'follower',
+          kind: 'mcp',
+          color: null,
+          serverVersion: '2.0.27-rc.14',
+          consoleProtocolVersion: 2,
+        },
+        package: { name: 'test', version: '1.0.0' },
+        build: { type: 'git' },
+        runtime: {
+          nodeVersion: 'v18.17.0',
+          platform: 'linux',
+          arch: 'x64',
+          uptime: 3600,
+          memoryUsage: { rss: 100, heapTotal: 200, heapUsed: 150, external: 50, arrayBuffers: 25 },
+        },
+        environment: {
+          nodeEnv: 'test',
+          isProduction: false,
+          isDevelopment: true,
+          isDebug: false,
+          isDocker: false,
+        },
+        server: {
+          startTime: new Date('2024-01-01T00:00:00.000Z'),
+          uptime: 3600000,
+          mcpConnection: true,
+        },
+      };
+
+      const formatted = service.formatBuildInfo(provisionalInfo);
+
+      expect(formatted).toContain('**Web Console Display Name**: pending authoritative assignment');
+      expect(formatted).toContain('**Web Console Identity**: Awaiting authoritative web console lease');
+      expect(formatted).not.toContain('**Web Console Color**:');
     });
   });
 
@@ -535,6 +626,9 @@ describe('BuildInfoService', () => {
 
     it('should format startup timing section in formatBuildInfo', () => {
       const testInfo: BuildInfo = {
+        sessionId: 'workspace-a1b2c3d4e5',
+        runtimeSessionId: 'workspace-a1b2c3d4e5-k9',
+        sessionSource: 'derived',
         package: { name: 'test', version: '1.0.0' },
         build: { type: 'git' },
         runtime: {


### PR DESCRIPTION
## Summary
- add live console session identity to get_build_info output
- report only the authoritative web-console puppet/display name once assigned by the leader
- avoid showing provisional local puppet names as source of truth

## Testing
- npm test -- --runInBand tests/unit/services/BuildInfoService.test.ts
- npx eslint src/services/BuildInfoService.ts src/services/currentConsoleSessionIdentity.ts src/web/console/IngestRoutes.ts src/web/console/LeaderForwardingSink.ts src/web/console/UnifiedConsole.ts tests/unit/services/BuildInfoService.test.ts
- npm run build