### PR TITLE
Show session client name beneath the client badge

### DIFF
--- a/src/web/public/sessions.css
+++ b/src/web/public/sessions.css
@@ -185,7 +185,7 @@
 
 .session-dropdown-item {
   display: grid;
-  grid-template-columns: 1rem 8px 1fr 62px 72px 3.5rem 1.2rem;
+  grid-template-columns: 1rem 8px 1fr 62px 76px 3.5rem 1.2rem;
   align-items: center;
   gap: 0.4rem;
   padding: 0.45rem 0.75rem;
@@ -249,6 +249,24 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.session-dropdown-client-group {
+  min-width: 0;
+  display: grid;
+  justify-items: center;
+  gap: 0.1rem;
+}
+
+.session-dropdown-client-label {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.62rem;
+  font-family: var(--font-mono, monospace);
+  color: var(--ink-500, #677893);
+  text-align: center;
 }
 
 .session-dropdown-uptime {

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -592,20 +592,12 @@
       if (s.color) nameEl.style.color = s.color;
       nameGroup.appendChild(nameEl);
 
-      var metaParts = [];
-      var platform = displayPlatform(s);
-      if (platform) {
-        metaParts.push(platform);
-      }
       var version = displayVersion(s);
       if (version) {
-        metaParts.push(version);
-      }
-      if (metaParts.length) {
         var versionEl = document.createElement('span');
         versionEl.className = 'session-dropdown-version';
-        versionEl.textContent = metaParts.join(' \u2022 ');
-        versionEl.title = metaParts.join(' • ');
+        versionEl.textContent = version;
+        versionEl.title = version;
         nameGroup.appendChild(versionEl);
       }
 
@@ -630,6 +622,9 @@
       }
       item.appendChild(authBadge);
 
+      var clientGroup = document.createElement('span');
+      clientGroup.className = 'session-dropdown-client-group';
+
       var clientBadge = document.createElement('span');
       clientBadge.className = 'session-status-badge';
       if (isPolicyOnlySession(s)) {
@@ -645,7 +640,17 @@
         clientBadge.dataset.status = 'negative';
         clientBadge.title = 'No MCP client attached';
       }
-      item.appendChild(clientBadge);
+      clientGroup.appendChild(clientBadge);
+
+      var platform = displayPlatform(s);
+      if (platform) {
+        var clientLabel = document.createElement('span');
+        clientLabel.className = 'session-dropdown-client-label';
+        clientLabel.textContent = platform;
+        clientLabel.title = platform;
+        clientGroup.appendChild(clientLabel);
+      }
+      item.appendChild(clientGroup);
 
       var uptimeEl = document.createElement('span');
       uptimeEl.className = 'session-dropdown-uptime';

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -435,7 +435,9 @@ describe('Web console cleanup regressions', () => {
     await wait(DEFAULT_WAIT_MS);
 
     const initialVersion = win.document.querySelector('.session-dropdown-item[data-session-id="session-1"] .session-dropdown-version');
-    expect(initialVersion?.textContent).toBe('Claude Code • v2.0.27-rc.9');
+    const initialClientLabel = win.document.querySelector('.session-dropdown-item[data-session-id="session-1"] .session-dropdown-client-label');
+    expect(initialVersion?.textContent).toBe('v2.0.27-rc.9');
+    expect(initialClientLabel?.textContent).toBe('Claude Code');
 
     currentVersion = '2.0.27-rc.10';
     await wait(30);
@@ -445,7 +447,9 @@ describe('Web console cleanup regressions', () => {
     await wait(DEFAULT_WAIT_MS);
 
     const refreshedVersion = win.document.querySelector('.session-dropdown-item[data-session-id="session-1"] .session-dropdown-version');
-    expect(refreshedVersion?.textContent).toBe('Claude Code • v2.0.27-rc.10');
+    const refreshedClientLabel = win.document.querySelector('.session-dropdown-item[data-session-id="session-1"] .session-dropdown-client-label');
+    expect(refreshedVersion?.textContent).toBe('v2.0.27-rc.10');
+    expect(refreshedClientLabel?.textContent).toBe('Claude Code');
 
     cleanup();
   });


### PR DESCRIPTION
## Summary
- move the detected client/platform label into the client-status column in the session dropdown
- keep the session version on its own secondary line under the session name
- update the web-console regression test to cover the new layout and refresh path

## Verification
- npm test -- --runInBand tests/unit/web/console-ui-regressions.test.ts
- npx eslint src/web/public/sessions.js tests/unit/web/console-ui-regressions.test.ts