### PR TITLE
Preserve session identity through leader handoff

### DIFF
--- a/src/web/console/LeaderForwardingSink.ts
+++ b/src/web/console/LeaderForwardingSink.ts
@@ -78,13 +78,16 @@ type SessionLeaseInput = SessionLeaseState | string | null;
  * the leader-assigned authoritative display name once the leader responds.
  */
 export class SessionLeaseState {
-  private assignedDisplayName: string | null = null;
+  private assignedDisplayName: string | null;
 
   constructor(
     private readonly preferredDisplayName: string,
     private readonly stableSessionId: string | null = null,
     private readonly onAssignedDisplayName?: (displayName: string) => void,
-  ) {}
+    initialAssignedDisplayName: string | null = null,
+  ) {
+    this.assignedDisplayName = initialAssignedDisplayName;
+  }
 
   getDisplayName(): string {
     return this.assignedDisplayName ?? this.preferredDisplayName;
@@ -354,6 +357,7 @@ export class SessionHeartbeat {
     /** Local mutable lease state for this runtime session. */
     leaseStateOrDisplayName: SessionLeaseInput = null,
     stableSessionId: string | null = null,
+    private readonly startedAt: string = new Date().toISOString(),
   ) {
     this.leaseState = resolveLeaseState(leaseStateOrDisplayName, stableSessionId);
   }
@@ -390,7 +394,7 @@ export class SessionHeartbeat {
           ...(this.leaseState ? buildLeasePayload(this.leaseState) : {}),
           event,
           pid: this.pid,
-          startedAt: new Date().toISOString(),
+          startedAt: this.startedAt,
           serverVersion: PACKAGE_VERSION,
           consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
         }),

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -238,6 +238,12 @@ interface LeaderPreflightResolution {
   demotedToFollower: boolean;
 }
 
+interface FollowerResumeLeaseContext {
+  displayName: string | null;
+  color: string | null;
+  startedAt: string | null;
+}
+
 interface FollowerAuthorityDependencies {
   isLeaderWebConsoleReachableImpl?: typeof isLeaderWebConsoleReachable;
   discoverLeaderServingPortImpl?: typeof discoverLeaderServingPort;
@@ -1353,6 +1359,16 @@ async function startAsLeader(
     setImmediate(() => {
       void (async () => {
         try {
+          const currentLeaderSession = ingestResult.getSessions().find((session) =>
+            session.sessionId === options.sessionId && session.kind === 'mcp'
+          );
+          const resumeLeaseContext: FollowerResumeLeaseContext | undefined = currentLeaderSession
+            ? {
+                displayName: currentLeaderSession.displayName,
+                color: currentLeaderSession.color,
+                startedAt: currentLeaderSession.startedAt,
+              }
+            : undefined;
           await activeCleanup();
           shutdownWebServer();
           await deleteLeaderLock();
@@ -1361,6 +1377,7 @@ async function startAsLeader(
             { role: 'follower', leaderInfo: candidateLeader },
             consolePort,
             primaryToken.token,
+            resumeLeaseContext,
           );
           activeCleanup = followerResult.cleanup;
           logger.info('[UnifiedConsole] Former leader resumed as follower after leadership handoff', {
@@ -1544,6 +1561,7 @@ async function startAsFollower(
   election: ElectionResult,
   consolePort: number = DEFAULT_CONSOLE_PORT,
   initialAuthToken: string | null = null,
+  resumeLeaseContext?: FollowerResumeLeaseContext,
 ): Promise<UnifiedConsoleResult> {
   const leaderUrl = `http://127.0.0.1:${election.leaderInfo.port}`;
 
@@ -1562,7 +1580,10 @@ async function startAsFollower(
   }
 
   const { derivePreferredFollowerSessionName, getPuppetColor } = await import('./SessionNames.js');
-  const preferredDisplayName = derivePreferredFollowerSessionName(options.sessionId);
+  const preferredDisplayName = resumeLeaseContext?.displayName ?? derivePreferredFollowerSessionName(options.sessionId);
+  const authoritativeDisplayName = resumeLeaseContext?.displayName ?? null;
+  const authoritativeColor = resumeLeaseContext?.color
+    ?? (authoritativeDisplayName ? getPuppetColor(authoritativeDisplayName) ?? null : null);
   const leaseState = new SessionLeaseState(
     preferredDisplayName,
     options.stableSessionId,
@@ -1577,13 +1598,14 @@ async function startAsFollower(
         consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
       });
     },
+    authoritativeDisplayName,
   );
   setCurrentConsoleSessionIdentity({
-    displayName: null,
-    authoritative: false,
+    displayName: authoritativeDisplayName,
+    authoritative: Boolean(authoritativeDisplayName),
     role: 'follower',
     kind: 'mcp',
-    color: null,
+    color: authoritativeColor,
     serverVersion: PACKAGE_VERSION,
     consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
   });
@@ -1616,6 +1638,8 @@ async function startAsFollower(
     process.pid,
     authToken,
     leaseState,
+    options.stableSessionId,
+    resumeLeaseContext?.startedAt ?? undefined,
   );
   await sessionHeartbeat.start();
 

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -244,6 +244,22 @@ interface FollowerResumeLeaseContext {
   startedAt: string | null;
 }
 
+interface LeaderHandoffResumeContext {
+  options: UnifiedConsoleOptions;
+  candidateLeader: ConsoleLeaderInfo;
+  consolePort: number;
+  primaryToken: { token: string };
+  activeCleanup: () => Promise<void>;
+  shutdownWebServer: () => void;
+  ingestResult: IngestRoutesResultLike;
+  setActiveCleanup: (cleanup: () => Promise<void>) => void;
+  onFailure: () => void;
+}
+
+interface IngestRoutesResultLike {
+  getSessions: () => SessionInfo[];
+}
+
 interface FollowerAuthorityDependencies {
   isLeaderWebConsoleReachableImpl?: typeof isLeaderWebConsoleReachable;
   discoverLeaderServingPortImpl?: typeof discoverLeaderServingPort;
@@ -360,6 +376,67 @@ export async function waitForLeaderRelease(
   }
 
   return false;
+}
+
+function buildFollowerResumeLeaseContext(
+  ingestResult: IngestRoutesResultLike,
+  sessionId: string,
+): FollowerResumeLeaseContext | undefined {
+  const currentLeaderSession = ingestResult.getSessions().find((session) =>
+    session.sessionId === sessionId && session.kind === 'mcp'
+  );
+  return currentLeaderSession
+    ? {
+        displayName: currentLeaderSession.displayName,
+        color: currentLeaderSession.color,
+        startedAt: currentLeaderSession.startedAt,
+      }
+    : undefined;
+}
+
+async function resumeFormerLeaderAsFollowerAfterHandoff(
+  context: LeaderHandoffResumeContext,
+): Promise<void> {
+  const {
+    options,
+    candidateLeader,
+    consolePort,
+    primaryToken,
+    activeCleanup,
+    shutdownWebServer,
+    ingestResult,
+    setActiveCleanup,
+    onFailure,
+  } = context;
+
+  try {
+    const resumeLeaseContext = buildFollowerResumeLeaseContext(ingestResult, options.sessionId);
+    await activeCleanup();
+    shutdownWebServer();
+    await deleteLeaderLock();
+    const followerResult = await startAsFollower(
+      options,
+      { role: 'follower', leaderInfo: candidateLeader },
+      consolePort,
+      primaryToken.token,
+      resumeLeaseContext,
+    );
+    setActiveCleanup(followerResult.cleanup);
+    logger.info('[UnifiedConsole] Former leader resumed as follower after leadership handoff', {
+      sessionId: options.sessionId,
+      stableSessionId: options.stableSessionId,
+      newLeaderSessionId: candidateLeader.sessionId,
+      port: consolePort,
+    });
+  } catch (err) {
+    onFailure();
+    logger.error('[UnifiedConsole] Leadership handoff failed during leader demotion', {
+      sessionId: options.sessionId,
+      candidateLeaderSessionId: candidateLeader.sessionId,
+      port: consolePort,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 export async function fetchLeaderSessionsSnapshot(
@@ -1357,45 +1434,21 @@ async function startAsLeader(
     });
 
     setImmediate(() => {
-      void (async () => {
-        try {
-          const currentLeaderSession = ingestResult.getSessions().find((session) =>
-            session.sessionId === options.sessionId && session.kind === 'mcp'
-          );
-          const resumeLeaseContext: FollowerResumeLeaseContext | undefined = currentLeaderSession
-            ? {
-                displayName: currentLeaderSession.displayName,
-                color: currentLeaderSession.color,
-                startedAt: currentLeaderSession.startedAt,
-              }
-            : undefined;
-          await activeCleanup();
-          shutdownWebServer();
-          await deleteLeaderLock();
-          const followerResult = await startAsFollower(
-            options,
-            { role: 'follower', leaderInfo: candidateLeader },
-            consolePort,
-            primaryToken.token,
-            resumeLeaseContext,
-          );
-          activeCleanup = followerResult.cleanup;
-          logger.info('[UnifiedConsole] Former leader resumed as follower after leadership handoff', {
-            sessionId: options.sessionId,
-            stableSessionId: options.stableSessionId,
-            newLeaderSessionId: candidateLeader.sessionId,
-            port: consolePort,
-          });
-        } catch (err) {
+      void resumeFormerLeaderAsFollowerAfterHandoff({
+        options,
+        candidateLeader,
+        consolePort,
+        primaryToken,
+        activeCleanup,
+        shutdownWebServer,
+        ingestResult,
+        setActiveCleanup: (cleanup) => {
+          activeCleanup = cleanup;
+        },
+        onFailure: () => {
           demotionInProgress = false;
-          logger.error('[UnifiedConsole] Leadership handoff failed during leader demotion', {
-            sessionId: options.sessionId,
-            candidateLeaderSessionId: candidateLeader.sessionId,
-            port: consolePort,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      })();
+        },
+      });
     });
 
     return {

--- a/tests/unit/web/console/console-failure-modes.test.ts
+++ b/tests/unit/web/console/console-failure-modes.test.ts
@@ -547,6 +547,53 @@ describe('Console Failure Modes', () => {
       }
     });
 
+    it('preserves an authoritative lease name and original startedAt across follower lifecycle events', async () => {
+      const originalStartedAt = '2026-04-20T18:45:00.000Z';
+      const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true }),
+      } as Response);
+
+      try {
+        const {
+          SessionHeartbeat,
+          SessionLeaseState,
+        } = await import('../../../../src/web/console/LeaderForwardingSink.js');
+
+        const leaseState = new SessionLeaseState(
+          'Mortimer',
+          'claude-code-main',
+          undefined,
+          'Mortimer',
+        );
+        const heartbeat = new SessionHeartbeat(
+          'http://127.0.0.1:41715',
+          'test-session',
+          process.pid,
+          null,
+          leaseState,
+          'claude-code-main',
+          originalStartedAt,
+        );
+
+        await heartbeat.start();
+        await heartbeat.stop();
+
+        const startBody = parseRequestBody((fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined)?.body);
+        const stopBody = parseRequestBody((fetchSpy.mock.calls[1]?.[1] as RequestInit | undefined)?.body);
+
+        expect(startBody.displayName).toBe('Mortimer');
+        expect(startBody.lastAssignedDisplayName).toBe('Mortimer');
+        expect(startBody.startedAt).toBe(originalStartedAt);
+
+        expect(stopBody.displayName).toBe('Mortimer');
+        expect(stopBody.lastAssignedDisplayName).toBe('Mortimer');
+        expect(stopBody.startedAt).toBe(originalStartedAt);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
     it('reuses the leader-assigned lease name across other forwarding channels', async () => {
       const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
         ok: true,


### PR DESCRIPTION
## Summary
- preserve a session's assigned puppet name when it steps down from leader to follower
- keep the original session start time across follower heartbeat lifecycle events
- cover the preserved lease/start-time behavior with a console regression test

## Verification
- npm test -- --runInBand tests/unit/web/console/console-failure-modes.test.ts tests/unit/web/console/sessionRegistry.test.ts tests/unit/web/console/UnifiedConsole.test.ts
- npx eslint src/web/console/LeaderForwardingSink.ts src/web/console/UnifiedConsole.ts tests/unit/web/console/console-failure-modes.test.ts tests/unit/web/console/sessionRegistry.test.ts tests/unit/web/console/UnifiedConsole.test.ts
- npm run build