### PR TITLE
2.0.27 safe point release from 2.0.26

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -87,6 +87,9 @@ jobs:
           
           echo "✅ All build artifacts verified successfully!"
 
+      - name: Verify npm package contents
+        run: npm run verify:package-assets
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "update:version": "node scripts/update-version.mjs",
     "version:bump": "node scripts/update-version.mjs",
     "version:check": "node scripts/update-version.mjs --dry-run",
+    "verify:package-assets": "node scripts/verify-npm-package-assets.mjs",
     "tools:count": "node scripts/count-tools.js",
     "tools:list": "node scripts/count-tools.js --json",
     "memory:cleanup:duplicates": "tsx src/utils/cleanup-duplicate-memories.ts",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "dist/web/public/**",
     "dist/seed-elements/**",
     "scripts/pretooluse-dollhouse.sh",
+    "scripts/permission-port-discovery.sh",
     "scripts/pretooluse-vscode.sh",
     "scripts/pretooluse-cursor.sh",
     "scripts/pretooluse-windsurf.sh",

--- a/scripts/verify-npm-package-assets.mjs
+++ b/scripts/verify-npm-package-assets.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = dirname(scriptDir);
+
+const REQUIRED_PACKAGE_ENTRIES = [
+  'dist/index.js',
+  'dist/web/public/setup.js',
+  'dist/web/public/setup.css',
+  'dist/seed-elements/memories',
+  'scripts/pretooluse-dollhouse.sh',
+  'scripts/permission-port-discovery.sh',
+  'server.json',
+];
+
+function run(command, args, cwd) {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+let packedFile = null;
+let extractDir = null;
+
+try {
+  const packJson = run('npm', ['pack', '--json'], projectRoot);
+  const [packResult] = JSON.parse(packJson);
+  packedFile = packResult?.filename;
+
+  if (!packedFile) {
+    throw new Error('npm pack did not return a package filename');
+  }
+
+  extractDir = mkdtempSync(join(tmpdir(), 'dollhouse-package-check-'));
+  run('tar', ['-xf', packedFile, '-C', extractDir], projectRoot);
+
+  const packageRoot = join(extractDir, 'package');
+  const missingEntries = REQUIRED_PACKAGE_ENTRIES.filter((entry) => !existsSync(join(packageRoot, entry)));
+
+  if (missingEntries.length > 0) {
+    console.error('❌ npm package is missing required runtime assets:');
+    for (const entry of missingEntries) {
+      console.error(`   - ${entry}`);
+    }
+    process.exitCode = 1;
+  } else {
+    console.log('✅ npm package contains all required runtime assets.');
+    for (const entry of REQUIRED_PACKAGE_ENTRIES) {
+      console.log(`   - ${entry}`);
+    }
+  }
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`❌ Failed to verify npm package contents: ${message}`);
+  process.exitCode = 1;
+} finally {
+  if (packedFile) {
+    rmSync(join(projectRoot, packedFile), { force: true });
+  }
+  if (extractDir) {
+    rmSync(extractDir, { recursive: true, force: true });
+  }
+}

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -105,6 +105,7 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
   let activeSort = 'date-desc';
   let activeSource = 'all'; // 'all' | 'collection' | 'portfolio'
   let searchQuery = '';
+  const DOLLHOUSE_SERVER_VERSION = document.querySelector('meta[name="dollhouse-server-version"]')?.content || '';
   const DOLLHOUSE_SESSION_ID = document.querySelector('meta[name="dollhouse-session-id"]')?.content || '';
   const DOLLHOUSE_RUNTIME_SESSION_ID = document.querySelector('meta[name="dollhouse-runtime-session-id"]')?.content || '';
 
@@ -128,6 +129,12 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
       </span>`
       : '';
     return `${primaryMarkup}${sessionMarkup}`;
+  }
+
+  function updateFooterVersion() {
+    const footerVersion = document.getElementById('footer-version');
+    if (!footerVersion) return;
+    footerVersion.textContent = `Version: ${DOLLHOUSE_SERVER_VERSION || 'unknown'}`;
   }
 
   // ── Bootstrap ──────────────────────────────────────────────────────────────
@@ -1877,6 +1884,7 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
   // ── Event wiring ───────────────────────────────────────────────────────────
 
   document.addEventListener('DOMContentLoaded', () => {
+    updateFooterVersion();
 
     // Theme toggle
     const themeToggleBtn  = document.getElementById('theme-toggle');

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -18,6 +18,8 @@
   <meta name="dollhouse-runtime-session-id" content="{{DOLLHOUSE_RUNTIME_SESSION_ID}}">
   <!-- Asset version — injected at request time for cache-busting local CSS/JS/img files. -->
   <meta name="dollhouse-console-asset-version" content="{{DOLLHOUSE_ASSET_VERSION}}">
+  <link rel="icon" type="image/png" href="dollhouse-logo.png?v={{DOLLHOUSE_ASSET_VERSION}}">
+  <link rel="apple-touch-icon" href="dollhouse-logo.png?v={{DOLLHOUSE_ASSET_VERSION}}">
   <link rel="stylesheet" href="fonts.css?v={{DOLLHOUSE_ASSET_VERSION}}">
   <link rel="stylesheet" href="styles.css?v={{DOLLHOUSE_ASSET_VERSION}}">
   <link rel="stylesheet" href="logs.css?v={{DOLLHOUSE_ASSET_VERSION}}">

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -572,6 +572,7 @@ npm install @dollhousemcp/mcp-server</code></pre>
       <a href="https://github.com/DollhouseMCP/mcp-server" class="footer-link">GitHub Repository</a>
       <a href="./collection-index.json" class="footer-link">JSON API</a>
       <a href="https://dollhousemcp.com" class="footer-link">DollhouseMCP</a>
+      <span class="footer-version" id="footer-version"></span>
       <span class="footer-updated" id="footer-updated"></span>
       <span class="footer-copyright">&copy; 2026 DollhouseMCP</span>
     </div>

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -1430,11 +1430,15 @@ body.modal-open { overflow: hidden; }
   margin-left: auto;
 }
 
+.footer-version,
 .footer-updated {
-  margin-left: auto;
   font-family: var(--font-mono);
   font-size: 0.72rem;
   color: var(--ink-500);
+}
+
+.footer-updated {
+  margin-left: auto;
 }
 
 /* ── Topic filters ───────────────────────────────────────────────────────── */

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -147,6 +147,7 @@ p, li { max-width: 69ch; }
   top: 0;
   z-index: 35;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
@@ -168,8 +169,8 @@ p, li { max-width: 69ch; }
   pointer-events: none;
 }
 
-.header-brand { display: flex; flex-direction: row; align-items: center; gap: 0.6rem; }
-.header-brand-text { display: flex; flex-direction: column; gap: 0.05rem; }
+.header-brand { display: flex; flex-direction: row; align-items: center; gap: 0.6rem; min-width: 0; }
+.header-brand-text { display: flex; flex-direction: column; gap: 0.05rem; min-width: 0; }
 .header-logo { width: 32px; height: 32px; flex-shrink: 0; }
 
 .site-title {
@@ -191,17 +192,23 @@ p, li { max-width: 69ch; }
 .header-right {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
   gap: 0.65rem;
-  flex-shrink: 0;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .site-stats {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 0.5rem;
   font-family: var(--font-mono);
   font-size: 0.72rem;
   color: var(--ink-500);
+  min-width: 0;
 }
 
 .stat {
@@ -1338,6 +1345,7 @@ body.modal-open { overflow: hidden; }
   background: var(--surface-1);
   border-radius: var(--radius-sm);
   padding: 2px;
+  min-width: 0;
 }
 
 .console-tab {
@@ -1363,6 +1371,33 @@ body.modal-open { overflow: hidden; }
   background: var(--paper-strong);
   color: var(--signal);
   box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+}
+
+@media (max-width: 1100px) {
+  .site-header {
+    align-items: flex-start;
+  }
+
+  .header-right {
+    width: 100%;
+    justify-content: flex-start;
+    row-gap: 0.55rem;
+  }
+
+  .console-tabs {
+    order: 3;
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .site-stats {
+    flex: 1 1 auto;
+    justify-content: flex-start;
+  }
+
+  .theme-toggle {
+    margin-left: auto;
+  }
 }
 
 @media (max-width: 640px) {

--- a/tests/integration/server/workflow-validation.test.ts
+++ b/tests/integration/server/workflow-validation.test.ts
@@ -178,7 +178,7 @@ describe('GitHub Actions Workflow Validation', () => {
       try {
         const workflow = await loadWorkflow('build-artifacts.yml');
         
-        const buildJob = workflow.jobs?.build;
+        const buildJob = workflow.jobs?.['build-artifacts'];
         if (buildJob) {
           const steps = buildJob.steps || [];
           
@@ -193,7 +193,16 @@ describe('GitHub Actions Workflow Validation', () => {
             
             // Should check for required files
             expect(verifyStep.run).toContain('index.js');
-            expect(verifyStep.run).toContain('package.json');
+            expect(verifyStep.run).toContain('data/personas');
+          }
+
+          const packageStep = steps.find((s: any) =>
+            s.name?.includes('Verify npm package contents')
+          );
+
+          expect(packageStep).toBeDefined();
+          if (packageStep) {
+            expect(packageStep.run).toContain('verify:package-assets');
           }
         }
       } catch {

--- a/tests/unit/web/cacheBustingSources.test.ts
+++ b/tests/unit/web/cacheBustingSources.test.ts
@@ -17,6 +17,7 @@ describe('cache busting source wiring', () => {
     const html = readFileSync(join(PUBLIC_DIR, 'index.html'), 'utf-8');
     expect(html).toContain('name="dollhouse-console-asset-version"');
     expect(html).toContain('{{DOLLHOUSE_ASSET_VERSION}}');
+    expect(html).toContain('href="dollhouse-logo.png?v={{DOLLHOUSE_ASSET_VERSION}}"');
     expect(html).toContain('styles.css?v={{DOLLHOUSE_ASSET_VERSION}}');
     expect(html).toContain('app.js?v={{DOLLHOUSE_ASSET_VERSION}}');
     expect(html).toContain('sessions.js?v={{DOLLHOUSE_ASSET_VERSION}}');

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, beforeAll, afterEach, jest } from '@jest/globals'
 import { JSDOM } from 'jsdom';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { PACKAGE_VERSION } from '../../../src/generated/version.js';
 
 let appSource = '';
 let sessionsSource = '';
@@ -118,6 +119,57 @@ function installBannerHelper(win: Record<string, any>) {
 }
 
 describe('Web console cleanup regressions', () => {
+  it('shows the running server version in the footer', async () => {
+    const { window: win, cleanup } = createDom(`
+      <meta name="dollhouse-server-version" content="${PACKAGE_VERSION}">
+      <button id="theme-toggle"></button>
+      <span id="theme-toggle-icon"></span>
+      <span id="theme-toggle-label"></span>
+      <link id="hljs-theme-light">
+      <link id="hljs-theme-dark">
+      <div id="view-toggle"><button class="view-btn" data-view="grid"></button></div>
+      <select id="sort-select"><option value="date-desc">date-desc</option></select>
+      <input id="search-input">
+      <div id="source-toggle"><button data-source="all"></button></div>
+      <button id="btn-portfolio"></button>
+      <div id="console-tabs"><button class="console-tab active" data-tab="portfolio"></button></div>
+      <div id="tab-portfolio" class="tab-panel active"></div>
+      <div id="stats"></div>
+      <div><div id="type-filters"></div></div>
+      <div id="topic-filters"></div>
+      <div id="results-count"></div>
+      <div id="results-announcer"></div>
+      <div id="elements-grid"></div>
+      <div id="pagination" hidden><button id="btn-prev-page"></button><button id="btn-next-page"></button><span id="page-info"></span></div>
+      <div id="footer-version"></div>
+      <div id="footer-updated"></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn((url: string) => {
+      if (url === '/api/elements') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ elements: { personas: [] }, totalCount: 0 }),
+        });
+      }
+      if (url === '/api/collection') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ index: { personas: [] } }),
+        });
+      }
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    win.eval(appSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    await wait(DEFAULT_WAIT_MS);
+
+    expect(win.document.getElementById('footer-version')?.textContent).toBe(`Version: ${PACKAGE_VERSION}`);
+
+    cleanup();
+  });
+
   it('shows a visible collection banner when the community collection fetch fails', async () => {
     const { window: win, cleanup } = createDom(`
       <button id="theme-toggle"></button>

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -2082,9 +2082,10 @@ describe('Setup Tab — Package Inclusion', () => {
     expect(files).toContain('dist/seed-elements/**');
   });
 
-  it('files field includes manual permission hook wrapper scripts', () => {
+  it('files field includes manual permission hook scripts and helpers', () => {
     const files = packageJson.files as string[];
     expect(files).toContain('scripts/pretooluse-dollhouse.sh');
+    expect(files).toContain('scripts/permission-port-discovery.sh');
     expect(files).toContain('scripts/pretooluse-vscode.sh');
     expect(files).toContain('scripts/pretooluse-cursor.sh');
     expect(files).toContain('scripts/pretooluse-windsurf.sh');

--- a/tests/unit/web/tokenInjection.test.ts
+++ b/tests/unit/web/tokenInjection.test.ts
@@ -20,6 +20,7 @@ const INDEX_TEMPLATE = `<!DOCTYPE html>
 <head>
   <meta name="dollhouse-console-token" content="{{CONSOLE_TOKEN}}">
   <meta name="dollhouse-console-asset-version" content="{{DOLLHOUSE_ASSET_VERSION}}">
+  <link rel="icon" type="image/png" href="dollhouse-logo.png?v={{DOLLHOUSE_ASSET_VERSION}}">
   <link rel="stylesheet" href="styles.css?v={{DOLLHOUSE_ASSET_VERSION}}">
 </head>
 <body><h1>DollhouseMCP Console</h1><script src="app.js?v={{DOLLHOUSE_ASSET_VERSION}}"></script></body>
@@ -103,6 +104,7 @@ describe('token injection into index.html (#1804)', () => {
     expect(res.text).toContain(`content="${TEST_TOKEN}"`);
     expect(res.text).not.toContain('{{CONSOLE_TOKEN}}');
     expect(res.text).toContain('content="2.0.18"');
+    expect(res.text).toContain('href="dollhouse-logo.png?v=2.0.18"');
     expect(res.text).toContain('styles.css?v=2.0.18');
     expect(res.text).toContain('app.js?v=2.0.18');
     expect(res.text).not.toContain('{{DOLLHOUSE_ASSET_VERSION}}');


### PR DESCRIPTION
## Summary\n- carry forward the safe web-console polish from the 2.0.27 RC line\n- fix the missing permission port discovery helper in the published package\n- add tarball-level package verification so required runtime assets are checked after npm pack\n\n## Included\n- favicon for the web console\n- running version in the footer\n- responsive header cleanup at mid widths\n- permission helper packaging fix\n- package-asset verification in CI\n\n## Validation\n- npm test -- --runInBand tests/unit/web/tokenInjection.test.ts tests/unit/web/cacheBustingSources.test.ts tests/unit/web/setupRoutes.test.ts\n- npm run build && npm run verify:package-assets\n- npm test -- --runInBand tests/unit/web/setupRoutes.test.ts -t "Package Inclusion|files field includes manual permission hook scripts and helpers"\n- npm run test:integration -- tests/integration/server/workflow-validation.test.ts --runInBand --testNamePattern="should properly verify build artifacts"