### PR TITLE
Add explicit session platform metadata

### DIFF
--- a/src/web/console/IngestRoutes.ts
+++ b/src/web/console/IngestRoutes.ts
@@ -29,6 +29,11 @@ import {
   CONSOLE_PROTOCOL_VERSION,
   LEGACY_CONSOLE_PROTOCOL_VERSION,
 } from './LeaderElection.js';
+import {
+  getSessionClientPlatformLabel,
+  normalizeSessionClientPlatformId,
+  type SessionClientPlatformId,
+} from './sessionClientPlatform.js';
 
 /** Maximum payload size for ingestion requests */
 const MAX_PAYLOAD_SIZE = '1mb';
@@ -77,6 +82,10 @@ export interface SessionInfo {
   serverVersion: string;
   /** Console/session contract version used for compatibility-aware takeover. */
   consoleProtocolVersion: number;
+  /** Explicit MCP host platform, when the session reported one. */
+  clientPlatform: SessionClientPlatformId | null;
+  /** Human-readable MCP host label for UI rendering. */
+  clientPlatformLabel: string;
 }
 
 /**
@@ -105,6 +114,7 @@ export interface SessionEventPayload {
   startedAt: string;
   serverVersion?: string;
   consoleProtocolVersion?: number;
+  clientPlatform?: string;
 }
 
 /**
@@ -126,7 +136,7 @@ export interface IngestRoutesResult {
   /** Get all tracked sessions */
   getSessions: () => SessionInfo[];
   /** Register the leader as a session */
-  registerLeaderSession: (sessionId: string, pid: number) => void;
+  registerLeaderSession: (sessionId: string, pid: number, clientPlatform?: string | null) => void;
   /** Register the web console as a session so the indicator is never empty (#1805) */
   registerConsoleSession: () => void;
 }
@@ -148,6 +158,10 @@ function normalizeConsoleProtocolVersion(version?: number): number {
     return version;
   }
   return LEGACY_CONSOLE_PROTOCOL_VERSION;
+}
+
+function normalizeClientPlatform(platform?: string | null): SessionClientPlatformId | null {
+  return normalizeSessionClientPlatformId(platform);
 }
 
 /**
@@ -197,11 +211,13 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     authenticated = false,
     serverVersion?: string,
     consoleProtocolVersion?: number,
+    clientPlatform?: string,
   ): SessionInfo | null {
     try {
       const displayName = namePool.assign(sessionId);
       const color = namePool.getColor(sessionId) ?? '#3b82f6';
       const now = new Date().toISOString();
+      const normalizedClientPlatform = normalizeClientPlatform(clientPlatform);
       const info: SessionInfo = {
         sessionId, displayName, color,
         pid: pid || 0,
@@ -209,6 +225,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
         status: 'active', isLeader: false, authenticated, kind: 'mcp',
         serverVersion: normalizeServerVersion(serverVersion),
         consoleProtocolVersion: normalizeConsoleProtocolVersion(consoleProtocolVersion),
+        clientPlatform: normalizedClientPlatform,
+        clientPlatformLabel: getSessionClientPlatformLabel(normalizedClientPlatform),
       };
       sessions.set(sessionId, info);
       logger.info('[IngestRoutes] Auto-registered orphaned session', {
@@ -234,6 +252,7 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     authenticated = false,
     serverVersion?: string,
     consoleProtocolVersion?: number,
+    clientPlatform?: string,
   ): SessionInfo | null {
     if (killedSessions.has(sessionId)) return null;
     if (pendingKills.has(sessionId)) {
@@ -243,7 +262,14 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
 
     const existing = sessions.get(sessionId);
     if (!existing) {
-      return autoRegister(sessionId, pid, authenticated, serverVersion, consoleProtocolVersion);
+      return autoRegister(
+        sessionId,
+        pid,
+        authenticated,
+        serverVersion,
+        consoleProtocolVersion,
+        clientPlatform,
+      );
     }
 
     if (existing.status === 'ended') {
@@ -264,6 +290,10 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     }
     if (consoleProtocolVersion !== undefined) {
       existing.consoleProtocolVersion = normalizeConsoleProtocolVersion(consoleProtocolVersion);
+    }
+    if (clientPlatform !== undefined) {
+      existing.clientPlatform = normalizeClientPlatform(clientPlatform);
+      existing.clientPlatformLabel = getSessionClientPlatformLabel(existing.clientPlatform);
     }
     return existing;
   }
@@ -366,12 +396,15 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
         const displayName = namePool.assign(payload.sessionId);
         const color = namePool.getColor(payload.sessionId) ?? '#3b82f6';
         const isAuthenticated = Boolean((res as any).locals?.tokenEntry);
+        const normalizedClientPlatform = normalizeClientPlatform(payload.clientPlatform);
         sessions.set(payload.sessionId, {
           sessionId: payload.sessionId, displayName, color,
           pid: payload.pid, startedAt: payload.startedAt || now, lastHeartbeat: now,
           status: 'active', isLeader: false, authenticated: isAuthenticated, kind: 'mcp',
           serverVersion: normalizeServerVersion(payload.serverVersion),
           consoleProtocolVersion: normalizeConsoleProtocolVersion(payload.consoleProtocolVersion),
+          clientPlatform: normalizedClientPlatform,
+          clientPlatformLabel: getSessionClientPlatformLabel(normalizedClientPlatform),
         });
         logger.info('[IngestRoutes] Session registered', {
           displayName, sessionId: payload.sessionId, pid: payload.pid, color,
@@ -402,6 +435,7 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
           false,
           payload.serverVersion,
           payload.consoleProtocolVersion,
+          payload.clientPlatform,
         );
         break;
       }
@@ -438,12 +472,14 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
               localSessions.push({
                 ...ls,
                 authenticated: false,
-                kind: ls.kind || 'mcp',
-                serverVersion: normalizeServerVersion(ls.serverVersion),
-                consoleProtocolVersion: normalizeConsoleProtocolVersion(ls.consoleProtocolVersion),
-              });
-            }
+              kind: ls.kind || 'mcp',
+              serverVersion: normalizeServerVersion(ls.serverVersion),
+              consoleProtocolVersion: normalizeConsoleProtocolVersion(ls.consoleProtocolVersion),
+              clientPlatform: normalizeClientPlatform(ls.clientPlatform),
+              clientPlatformLabel: getSessionClientPlatformLabel(normalizeClientPlatform(ls.clientPlatform)),
+            });
           }
+        }
         }
       } catch {
         // Legacy instance not running or unreachable — that's fine
@@ -564,9 +600,10 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     return Array.from(sessions.values()).filter(s => s.status === 'active');
   }
 
-  function registerLeaderSession(sessionId: string, pid: number): void {
+  function registerLeaderSession(sessionId: string, pid: number, clientPlatform?: string | null): void {
     const displayName = namePool.assign(sessionId, true);
     const color = namePool.getColor(sessionId) ?? '#3b82f6';
+    const normalizedClientPlatform = normalizeClientPlatform(clientPlatform ?? undefined);
     sessions.set(sessionId, {
       sessionId,
       displayName,
@@ -580,6 +617,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       kind: 'mcp',
       serverVersion: PACKAGE_VERSION,
       consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+      clientPlatform: normalizedClientPlatform,
+      clientPlatformLabel: getSessionClientPlatformLabel(normalizedClientPlatform),
     });
     logger.info('[IngestRoutes] Leader session registered', { displayName, sessionId, pid, color });
   }
@@ -593,6 +632,7 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     const consoleId = `console-${process.pid}`;
     if (sessions.has(consoleId)) return;
     const displayName = 'Web Console';
+    const normalizedClientPlatform: SessionClientPlatformId = 'web-console';
     sessions.set(consoleId, {
       sessionId: consoleId,
       displayName,
@@ -606,6 +646,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       kind: 'console',
       serverVersion: PACKAGE_VERSION,
       consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+      clientPlatform: normalizedClientPlatform,
+      clientPlatformLabel: getSessionClientPlatformLabel(normalizedClientPlatform),
     });
     logger.info('[IngestRoutes] Console session registered', { sessionId: consoleId, pid: process.pid });
   }

--- a/src/web/console/LeaderForwardingSink.ts
+++ b/src/web/console/LeaderForwardingSink.ts
@@ -22,6 +22,10 @@ import { PACKAGE_VERSION } from '../../generated/version.js';
 import { logger } from '../../utils/logger.js';
 import { env } from '../../config/env.js';
 import { CONSOLE_PROTOCOL_VERSION } from './LeaderElection.js';
+import {
+  detectSessionClientPlatformId,
+  type SessionClientPlatformId,
+} from './sessionClientPlatform.js';
 
 /** Maximum entries to buffer when leader is unreachable */
 const MAX_BUFFER_SIZE = 10_000;
@@ -221,6 +225,8 @@ export class SessionHeartbeat {
     private readonly pid: number,
     /** Optional console auth token (#1780). Included as Bearer header on ingest POSTs. */
     private readonly authToken: string | null = null,
+    /** Explicit MCP host platform metadata for this runtime. */
+    private readonly clientPlatform: SessionClientPlatformId | null = detectSessionClientPlatformId(),
   ) {}
 
   /** Notify the leader that this session has started */
@@ -257,6 +263,7 @@ export class SessionHeartbeat {
           startedAt: new Date().toISOString(),
           serverVersion: PACKAGE_VERSION,
           consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+          clientPlatform: this.clientPlatform ?? undefined,
         }),
         signal: controller.signal,
       });

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -46,6 +46,7 @@ import {
 } from './LeaderForwardingSink.js';
 import { PromotionManager } from './PromotionManager.js';
 import { ConsoleTokenStore } from './consoleToken.js';
+import { detectSessionClientPlatformId } from './sessionClientPlatform.js';
 import {
   findPidOnPort,
   killStaleProcessDetailed,
@@ -707,6 +708,7 @@ async function startAsLeader(
   election: ElectionResult,
   consolePort: number = DEFAULT_CONSOLE_PORT,
 ): Promise<UnifiedConsoleResult> {
+  const clientPlatform = detectSessionClientPlatformId();
   const { startWebServer } = await import('../server.js');
   const { pickRandomTokenName } = await import('./SessionNames.js');
 
@@ -800,7 +802,7 @@ async function startAsLeader(
   }
 
   // Register the leader only after the HTTP listener is actually serving the port.
-  ingestResult.registerLeaderSession(options.sessionId, process.pid);
+  ingestResult.registerLeaderSession(options.sessionId, process.pid, clientPlatform);
 
   // Register the web console itself so the session indicator is never empty (#1805)
   ingestResult.registerConsoleSession();
@@ -853,6 +855,7 @@ async function startAsFollower(
   consolePort: number = DEFAULT_CONSOLE_PORT,
   initialAuthToken: string | null = null,
 ): Promise<UnifiedConsoleResult> {
+  const clientPlatform = detectSessionClientPlatformId();
   const leaderUrl = `http://127.0.0.1:${election.leaderInfo.port}`;
 
   // Read the console auth token (#1780) written by the leader. May be null
@@ -885,7 +888,13 @@ async function startAsFollower(
   options.registerLogSink(forwardingSink);
 
   // Start session heartbeat to the leader
-  sessionHeartbeat = new SessionHeartbeat(leaderUrl, options.sessionId, process.pid, authToken);
+  sessionHeartbeat = new SessionHeartbeat(
+    leaderUrl,
+    options.sessionId,
+    process.pid,
+    authToken,
+    clientPlatform,
+  );
   await sessionHeartbeat.start();
 
   logger.info('[UnifiedConsole] Follower started', {

--- a/src/web/console/sessionClientPlatform.ts
+++ b/src/web/console/sessionClientPlatform.ts
@@ -34,9 +34,27 @@ function normalizeText(value: string | undefined): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
 
-function includesAny(value: string, needles: string[]): boolean {
+function includesAny(value: string, needles: readonly string[]): boolean {
   return needles.some((needle) => value.includes(needle));
 }
+
+function matchesAnySource(values: readonly string[], needles: readonly string[]): boolean {
+  return values.some((value) => includesAny(value, needles));
+}
+
+const TEXT_PLATFORM_MATCHERS: ReadonlyArray<{
+  platform: SessionClientPlatformId;
+  needles: readonly string[];
+}> = [
+  { platform: 'cursor', needles: ['cursor'] },
+  { platform: 'windsurf', needles: ['windsurf'] },
+  { platform: 'gemini-cli', needles: ['gemini'] },
+  { platform: 'cline', needles: ['cline'] },
+  { platform: 'lmstudio', needles: ['lmstudio', 'lm studio'] },
+  { platform: 'claude-desktop', needles: ['claude desktop'] },
+  { platform: 'claude-code', needles: ['claude code'] },
+  { platform: 'codex', needles: ['codex'] },
+];
 
 export function normalizeSessionClientPlatformId(
   value: string | null | undefined,
@@ -73,6 +91,7 @@ export function detectSessionClientPlatformId(
   const argvText = normalizeText(argv.join(' '));
   const execPathText = normalizeText(execPath);
   const titleText = normalizeText(title);
+  const textSources = [argvText, execPathText, titleText];
 
   if (env.CLAUDE_DESKTOP === 'true' || env.CLAUDE_DESKTOP_VERSION) {
     return 'claude-desktop';
@@ -96,40 +115,10 @@ export function detectSessionClientPlatformId(
     return 'codex';
   }
 
-  if (includesAny(argvText, ['cursor']) || includesAny(execPathText, ['cursor']) || includesAny(titleText, ['cursor'])) {
-    return 'cursor';
-  }
-
-  if (includesAny(argvText, ['windsurf']) || includesAny(execPathText, ['windsurf']) || includesAny(titleText, ['windsurf'])) {
-    return 'windsurf';
-  }
-
-  if (includesAny(argvText, ['gemini']) || includesAny(execPathText, ['gemini']) || includesAny(titleText, ['gemini'])) {
-    return 'gemini-cli';
-  }
-
-  if (includesAny(argvText, ['cline']) || includesAny(execPathText, ['cline']) || includesAny(titleText, ['cline'])) {
-    return 'cline';
-  }
-
-  if (
-    includesAny(argvText, ['lmstudio', 'lm studio']) ||
-    includesAny(execPathText, ['lmstudio', 'lm studio']) ||
-    includesAny(titleText, ['lmstudio', 'lm studio'])
-  ) {
-    return 'lmstudio';
-  }
-
-  if (includesAny(argvText, ['claude desktop']) || includesAny(execPathText, ['claude desktop']) || includesAny(titleText, ['claude desktop'])) {
-    return 'claude-desktop';
-  }
-
-  if (includesAny(argvText, ['claude code']) || includesAny(execPathText, ['claude code']) || includesAny(titleText, ['claude code'])) {
-    return 'claude-code';
-  }
-
-  if (includesAny(argvText, ['codex']) || includesAny(execPathText, ['codex']) || includesAny(titleText, ['codex'])) {
-    return 'codex';
+  for (const matcher of TEXT_PLATFORM_MATCHERS) {
+    if (matchesAnySource(textSources, matcher.needles)) {
+      return matcher.platform;
+    }
   }
 
   return null;

--- a/src/web/console/sessionClientPlatform.ts
+++ b/src/web/console/sessionClientPlatform.ts
@@ -1,0 +1,136 @@
+/**
+ * Best-effort MCP client platform detection for session metadata.
+ *
+ * This is intentionally conservative: when we cannot identify the host
+ * confidently, we return null rather than guessing from a session ID.
+ */
+
+export type SessionClientPlatformId =
+  | 'claude-code'
+  | 'claude-desktop'
+  | 'codex'
+  | 'cursor'
+  | 'vscode'
+  | 'windsurf'
+  | 'gemini-cli'
+  | 'cline'
+  | 'lmstudio'
+  | 'web-console';
+
+const CLIENT_PLATFORM_LABELS: Record<SessionClientPlatformId, string> = {
+  'claude-code': 'Claude Code',
+  'claude-desktop': 'Claude Desktop',
+  codex: 'Codex',
+  cursor: 'Cursor',
+  vscode: 'VS Code',
+  windsurf: 'Windsurf',
+  'gemini-cli': 'Gemini CLI',
+  cline: 'Cline',
+  lmstudio: 'LM Studio',
+  'web-console': 'Web Console',
+};
+
+function normalizeText(value: string | undefined): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function includesAny(value: string, needles: string[]): boolean {
+  return needles.some((needle) => value.includes(needle));
+}
+
+export function normalizeSessionClientPlatformId(
+  value: string | null | undefined,
+): SessionClientPlatformId | null {
+  const normalized = normalizeText(value ?? undefined);
+  if (!normalized) {
+    return null;
+  }
+
+  if (normalized === 'gemini') {
+    return 'gemini-cli';
+  }
+
+  if (normalized in CLIENT_PLATFORM_LABELS) {
+    return normalized as SessionClientPlatformId;
+  }
+
+  return null;
+}
+
+export function getSessionClientPlatformLabel(
+  platform: SessionClientPlatformId | null | undefined,
+): string {
+  return platform ? CLIENT_PLATFORM_LABELS[platform] ?? '' : '';
+}
+
+export function detectSessionClientPlatformId(
+  env: NodeJS.ProcessEnv = process.env,
+  argv: readonly string[] = process.argv,
+  execPath: string = process.execPath,
+  title: string = process.title,
+): SessionClientPlatformId | null {
+  const termProgram = normalizeText(env.TERM_PROGRAM);
+  const argvText = normalizeText(argv.join(' '));
+  const execPathText = normalizeText(execPath);
+  const titleText = normalizeText(title);
+
+  if (env.CLAUDE_DESKTOP === 'true' || env.CLAUDE_DESKTOP_VERSION) {
+    return 'claude-desktop';
+  }
+
+  if (env.CLAUDE_CODE === 'true' || termProgram === 'claude-code') {
+    return 'claude-code';
+  }
+
+  if (
+    env.VSCODE_CWD ||
+    env.VSCODE_PID ||
+    env.VSCODE_IPC_HOOK ||
+    env.VSCODE_NLS_CONFIG ||
+    termProgram === 'vscode'
+  ) {
+    return 'vscode';
+  }
+
+  if (env.CODEX_HOME || termProgram === 'codex') {
+    return 'codex';
+  }
+
+  if (includesAny(argvText, ['cursor']) || includesAny(execPathText, ['cursor']) || includesAny(titleText, ['cursor'])) {
+    return 'cursor';
+  }
+
+  if (includesAny(argvText, ['windsurf']) || includesAny(execPathText, ['windsurf']) || includesAny(titleText, ['windsurf'])) {
+    return 'windsurf';
+  }
+
+  if (includesAny(argvText, ['gemini']) || includesAny(execPathText, ['gemini']) || includesAny(titleText, ['gemini'])) {
+    return 'gemini-cli';
+  }
+
+  if (includesAny(argvText, ['cline']) || includesAny(execPathText, ['cline']) || includesAny(titleText, ['cline'])) {
+    return 'cline';
+  }
+
+  if (
+    includesAny(argvText, ['lmstudio', 'lm studio']) ||
+    includesAny(execPathText, ['lmstudio', 'lm studio']) ||
+    includesAny(titleText, ['lmstudio', 'lm studio'])
+  ) {
+    return 'lmstudio';
+  }
+
+  if (includesAny(argvText, ['claude desktop']) || includesAny(execPathText, ['claude desktop']) || includesAny(titleText, ['claude desktop'])) {
+    return 'claude-desktop';
+  }
+
+  if (includesAny(argvText, ['claude code']) || includesAny(execPathText, ['claude code']) || includesAny(titleText, ['claude code'])) {
+    return 'claude-code';
+  }
+
+  if (includesAny(argvText, ['codex']) || includesAny(execPathText, ['codex']) || includesAny(titleText, ['codex'])) {
+    return 'codex';
+  }
+
+  return null;
+}

--- a/src/web/public/sessions.css
+++ b/src/web/public/sessions.css
@@ -184,8 +184,8 @@
 
 .session-dropdown-item {
   display: grid;
-  grid-template-columns: 1rem 8px 1fr 62px 72px 3.5rem 1.2rem;
-  align-items: center;
+  grid-template-columns: 1rem 8px minmax(0, 1fr) 62px 84px 3.5rem 1.2rem;
+  align-items: start;
   gap: 0.4rem;
   padding: 0.45rem 0.75rem;
   font-size: var(--step--1, 0.82rem);
@@ -235,12 +235,49 @@
   white-space: nowrap;
 }
 
+.session-dropdown-primary {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.12rem;
+}
+
+.session-dropdown-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.session-dropdown-version {
+  font-size: 0.7rem;
+  font-family: var(--font-mono, monospace);
+  color: var(--ink-500, #677893);
+  white-space: nowrap;
+}
+
+.session-dropdown-update {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 5px;
+  border-radius: 999px;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  background: #ecfdf5;
+  color: #166534;
+  border: 1px solid #86efac;
+  white-space: nowrap;
+}
+
 .session-dropdown-uptime {
   font-size: 0.7rem;
   font-family: var(--font-mono, monospace);
   color: var(--ink-500, #677893);
   white-space: nowrap;
   text-align: right;
+  padding-top: 0.1rem;
 }
 
 .session-dropdown-role {
@@ -285,6 +322,16 @@
 
 [data-theme="dark"] .session-dropdown-name {
   color: var(--ink-900, #e0e8f0);
+}
+
+[data-theme="dark"] .session-dropdown-version {
+  color: var(--ink-500, #8899bb);
+}
+
+[data-theme="dark"] .session-dropdown-update {
+  background: #052e16;
+  color: #bbf7d0;
+  border-color: #166534;
 }
 
 [data-theme="dark"] .session-dropdown-toggle-label {
@@ -374,6 +421,22 @@
   min-width: 52px;
 }
 
+.session-dropdown-badge-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.18rem;
+  min-width: 0;
+}
+
+.session-dropdown-client-label {
+  font-size: 0.62rem;
+  line-height: 1.15;
+  color: var(--ink-500, #677893);
+  text-align: center;
+  min-width: 0;
+}
+
 .session-status-badge[data-status="positive"] {
   background: #eff6ff;
   color: #1e40af;
@@ -396,6 +459,10 @@
   background: #431407;
   color: #fdba74;
   border-color: #9a3412;
+}
+
+[data-theme="dark"] .session-dropdown-client-label {
+  color: var(--ink-500, #8899bb);
 }
 
 /* Session filter in the log viewer */

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -33,6 +33,18 @@
   var lastReloadTargetVersion = '';
   var pendingLeaderReloadTimer = null;
   var showPolicySessions = loadPolicyDebugVisibility();
+  var CLIENT_PLATFORM_LABELS = {
+    'claude-code': 'Claude Code',
+    'claude-desktop': 'Claude Desktop',
+    'codex': 'Codex',
+    'cursor': 'Cursor',
+    'vscode': 'VS Code',
+    'windsurf': 'Windsurf',
+    'gemini-cli': 'Gemini CLI',
+    'cline': 'Cline',
+    'lmstudio': 'LM Studio',
+    'web-console': 'Web Console'
+  };
 
   function loadPolicyDebugVisibility() {
     try {
@@ -176,6 +188,55 @@
   /** NFC-normalize a string safely */
   function nfc(s) { try { return s.normalize('NFC'); } catch(e) { return s; } }
 
+  function normalizeClientPlatform(platform) {
+    if (typeof platform !== 'string') return '';
+    var normalized = nfc(platform).trim().toLowerCase();
+    if (!normalized) return '';
+    if (normalized === 'gemini') return 'gemini-cli';
+    return Object.prototype.hasOwnProperty.call(CLIENT_PLATFORM_LABELS, normalized) ? normalized : '';
+  }
+
+  function displayPlatform(session) {
+    if (!session || typeof session !== 'object') return '';
+    if (typeof session.clientPlatformLabel === 'string' && session.clientPlatformLabel.trim()) {
+      return nfc(session.clientPlatformLabel.trim());
+    }
+    var platform = normalizeClientPlatform(session.clientPlatform);
+    return platform ? CLIENT_PLATFORM_LABELS[platform] || '' : '';
+  }
+
+  function displayVersion(session) {
+    if (!session || typeof session !== 'object') return '';
+    var normalized = normalizeSemver(session.serverVersion);
+    if (!normalized && typeof session.serverVersion === 'string') {
+      normalized = nfc(session.serverVersion).trim();
+    }
+    if (!normalized) return '';
+    return normalized.charAt(0) === 'v' ? normalized : ('v' + normalized);
+  }
+
+  function getNewestKnownSessionVersion(list) {
+    if (!Array.isArray(list)) return '';
+    var newest = '';
+    for (var i = 0; i < list.length; i++) {
+      var session = list[i];
+      if (!session || isPolicyOnlySession(session) || session.status !== 'active') continue;
+      var version = normalizeSemver(session.serverVersion);
+      if (!version) continue;
+      if (!newest || compareSemver(version, newest) > 0) {
+        newest = version;
+      }
+    }
+    return newest;
+  }
+
+  function sessionHasUpdateAvailable(session, newestVersion) {
+    if (!session || !newestVersion || isPolicyOnlySession(session)) return false;
+    var version = normalizeSemver(session.serverVersion);
+    if (!version) return false;
+    return compareSemver(version, newestVersion) < 0;
+  }
+
   function isPolicyOnlySession(session) {
     return !!(session && session.isPolicyOnly);
   }
@@ -231,6 +292,9 @@
         isLeader: false,
         authenticated: false,
         kind: 'policy',
+        serverVersion: '',
+        clientPlatform: '',
+        clientPlatformLabel: '',
         isPolicyOnly: true,
       });
     }
@@ -254,10 +318,61 @@
   // Build a key from current sessions to detect changes
   function sessionListKey(list) {
     return list.map(function(s) {
-      return s.sessionId + ':' + s.status + ':' + (isPolicyOnlySession(s) ? 'policy' : 'live');
+      return [
+        s.sessionId,
+        s.status,
+        s.displayName || '',
+        s.serverVersion || '',
+        s.clientPlatform || '',
+        s.clientPlatformLabel || '',
+        s.isLeader ? 'leader' : 'member',
+        s.authenticated ? 'auth' : 'noauth',
+        isPolicyOnlySession(s) ? 'policy' : 'live'
+      ].join(':');
     }).join(',')
       + '|policyDebug:' + (showPolicySessions ? 'on' : 'off')
       + '|knownPolicy:' + policySessions.map(function(session) { return session.sessionId; }).join(',');
+  }
+
+  function normalizeLiveSessions(list) {
+    if (!Array.isArray(list)) return [];
+    var normalized = [];
+    var seen = new Set();
+
+    for (var i = 0; i < list.length; i++) {
+      var item = list[i];
+      if (!item || typeof item.sessionId !== 'string') continue;
+      var sessionId = nfc(item.sessionId).trim();
+      if (!sessionId || seen.has(sessionId)) continue;
+      seen.add(sessionId);
+
+      var clientPlatform = normalizeClientPlatform(item.clientPlatform);
+      var clientPlatformLabel = '';
+      if (typeof item.clientPlatformLabel === 'string' && item.clientPlatformLabel.trim()) {
+        clientPlatformLabel = nfc(item.clientPlatformLabel).trim();
+      } else if (clientPlatform) {
+        clientPlatformLabel = CLIENT_PLATFORM_LABELS[clientPlatform] || '';
+      }
+
+      normalized.push({
+        sessionId: sessionId,
+        displayName: nfc(typeof item.displayName === 'string' && item.displayName ? item.displayName : sessionId),
+        color: typeof item.color === 'string' ? item.color : '',
+        pid: typeof item.pid === 'number' ? item.pid : 0,
+        startedAt: typeof item.startedAt === 'string' ? item.startedAt : '',
+        lastHeartbeat: typeof item.lastHeartbeat === 'string' ? item.lastHeartbeat : '',
+        status: item.status === 'ended' ? 'ended' : 'active',
+        isLeader: !!item.isLeader,
+        authenticated: !!item.authenticated,
+        kind: typeof item.kind === 'string' ? item.kind : 'mcp',
+        serverVersion: normalizeSemver(item.serverVersion) || (typeof item.serverVersion === 'string' ? nfc(item.serverVersion).trim() : ''),
+        consoleProtocolVersion: typeof item.consoleProtocolVersion === 'number' ? item.consoleProtocolVersion : 0,
+        clientPlatform: clientPlatform,
+        clientPlatformLabel: clientPlatformLabel,
+      });
+    }
+
+    return normalized;
   }
 
   function setPolicyDebugVisibility(nextVisible, keepDropdownOpen) {
@@ -513,6 +628,7 @@
       if (!a.isLeader && b.isLeader) return 1;
       return 0;
     });
+    var newestKnownVersion = getNewestKnownSessionVersion(sorted);
 
     function appendSessionItem(s) {
       var item = document.createElement('div');
@@ -529,11 +645,36 @@
       if (s.color) dot.style.background = s.color;
       item.appendChild(dot);
 
+      var nameWrap = document.createElement('div');
+      nameWrap.className = 'session-dropdown-primary';
+
       var nameEl = document.createElement('span');
       nameEl.className = 'session-dropdown-name';
       nameEl.textContent = displayName(s);
       if (s.color) nameEl.style.color = s.color;
-      item.appendChild(nameEl);
+      nameWrap.appendChild(nameEl);
+
+      var versionText = displayVersion(s);
+      if (versionText) {
+        var metaRow = document.createElement('div');
+        metaRow.className = 'session-dropdown-meta';
+
+        var versionEl = document.createElement('span');
+        versionEl.className = 'session-dropdown-version';
+        versionEl.textContent = versionText;
+        metaRow.appendChild(versionEl);
+
+        if (sessionHasUpdateAvailable(s, newestKnownVersion)) {
+          var updateBadge = document.createElement('span');
+          updateBadge.className = 'session-dropdown-update';
+          updateBadge.textContent = 'Update available';
+          metaRow.appendChild(updateBadge);
+        }
+
+        nameWrap.appendChild(metaRow);
+      }
+
+      item.appendChild(nameWrap);
 
       // Session status badges (#1805) — for persisted policy sessions we
       // switch from "live/authenticated" semantics to "saved/no client".
@@ -554,6 +695,9 @@
       }
       item.appendChild(authBadge);
 
+      var clientWrap = document.createElement('div');
+      clientWrap.className = 'session-dropdown-badge-stack';
+
       var clientBadge = document.createElement('span');
       clientBadge.className = 'session-status-badge';
       if (isPolicyOnlySession(s)) {
@@ -569,7 +713,17 @@
         clientBadge.dataset.status = 'negative';
         clientBadge.title = 'No MCP client attached';
       }
-      item.appendChild(clientBadge);
+      clientWrap.appendChild(clientBadge);
+
+      var platformLabel = displayPlatform(s);
+      if (platformLabel) {
+        var clientLabel = document.createElement('span');
+        clientLabel.className = 'session-dropdown-client-label';
+        clientLabel.textContent = platformLabel;
+        clientWrap.appendChild(clientLabel);
+      }
+
+      item.appendChild(clientWrap);
 
       var uptimeEl = document.createElement('span');
       uptimeEl.className = 'session-dropdown-uptime';
@@ -727,7 +881,7 @@
       return res.json();
     }).then(function(data) {
       if (data && data.sessions) {
-        sessions = data.sessions;
+        sessions = normalizeLiveSessions(data.sessions);
         maybeForceReloadForNewLeader(sessions);
         updateSessionIndicator();
         updateSessionFilterOptions();
@@ -743,6 +897,7 @@
   window.DollhouseSessions = {
     getFilterSessionId: function() { return filterSessionId; },
     displayName: displayName,
+    displayPlatform: displayPlatform,
     getSessions: function() { return sessions; },
     getLiveSessions: getLiveSessions,
     getSelectableSessions: getSelectableSessions,

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -668,6 +668,7 @@
           var updateBadge = document.createElement('span');
           updateBadge.className = 'session-dropdown-update';
           updateBadge.textContent = 'Update available';
+          updateBadge.title = 'A newer local DollhouseMCP session version is active.';
           metaRow.appendChild(updateBadge);
         }
 

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -310,8 +310,68 @@ describe('Web console cleanup regressions', () => {
     expect(oldItem?.querySelector('.session-dropdown-version')?.textContent).toBe('v2.0.26');
     expect(oldItem?.querySelector('.session-dropdown-client-label')?.textContent).toBe('Codex');
     expect(oldItem?.querySelector('.session-dropdown-update')?.textContent).toBe('Update available');
+    expect(oldItem?.querySelector('.session-dropdown-update')?.getAttribute('title')).toBe(
+      'A newer local DollhouseMCP session version is active.',
+    );
 
     expect(consoleItem?.querySelector('.session-dropdown-client-label')?.textContent).toBe('Web Console');
+
+    cleanup();
+  });
+
+  it('handles prerelease update comparisons and missing platform metadata safely', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="session-indicator"></div>
+      <div id="tab-logs"><div class="log-controls"></div></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        sessions: [
+          {
+            sessionId: 'session-new',
+            status: 'active',
+            displayName: 'Bert',
+            startedAt: '2026-04-20T18:00:00.000Z',
+            isLeader: true,
+            authenticated: true,
+            kind: 'mcp',
+            color: '#1d4ed8',
+            serverVersion: '2.0.27-rc.17',
+            clientPlatform: 'claude-code',
+            clientPlatformLabel: 'Claude Code',
+          },
+          {
+            sessionId: 'session-old',
+            status: 'active',
+            displayName: 'Teddy',
+            startedAt: '2026-04-20T17:30:00.000Z',
+            isLeader: false,
+            authenticated: false,
+            kind: 'mcp',
+            color: '#92400e',
+            serverVersion: '2.0.27-rc.16',
+            clientPlatform: null,
+            clientPlatformLabel: null,
+          },
+        ],
+      }),
+    });
+    win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+
+    win.eval(sessionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    await wait(DEFAULT_WAIT_MS);
+
+    (win.document.querySelector('.session-box') as HTMLButtonElement | null)?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    const oldItem = win.document.querySelector('.session-dropdown-item[data-session-id="session-old"]') as HTMLElement | null;
+
+    expect(oldItem?.querySelector('.session-dropdown-version')?.textContent).toBe('v2.0.27-rc.16');
+    expect(oldItem?.querySelector('.session-dropdown-update')?.textContent).toBe('Update available');
+    expect(oldItem?.querySelector('.session-dropdown-client-label')).toBeNull();
 
     cleanup();
   });

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -239,6 +239,83 @@ describe('Web console cleanup regressions', () => {
     cleanup();
   });
 
+  it('renders explicit client platform labels and update-available metadata in the session dropdown', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="session-indicator"></div>
+      <div id="tab-logs"><div class="log-controls"></div></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        sessions: [
+          {
+            sessionId: 'session-new',
+            status: 'active',
+            displayName: 'Bert',
+            startedAt: '2026-04-20T18:00:00.000Z',
+            isLeader: true,
+            authenticated: true,
+            kind: 'mcp',
+            color: '#1d4ed8',
+            serverVersion: '2.0.27',
+            clientPlatform: 'claude-code',
+            clientPlatformLabel: 'Claude Code',
+          },
+          {
+            sessionId: 'session-old',
+            status: 'active',
+            displayName: 'Teddy',
+            startedAt: '2026-04-20T17:30:00.000Z',
+            isLeader: false,
+            authenticated: false,
+            kind: 'mcp',
+            color: '#92400e',
+            serverVersion: '2.0.26',
+            clientPlatform: 'codex',
+            clientPlatformLabel: 'Codex',
+          },
+          {
+            sessionId: 'console-1',
+            status: 'active',
+            displayName: 'Web Console',
+            startedAt: '2026-04-20T18:00:00.000Z',
+            isLeader: false,
+            authenticated: true,
+            kind: 'console',
+            color: '#6366f1',
+            serverVersion: '2.0.27',
+            clientPlatform: 'web-console',
+            clientPlatformLabel: 'Web Console',
+          },
+        ],
+      }),
+    });
+    win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+
+    win.eval(sessionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    await wait(DEFAULT_WAIT_MS);
+
+    (win.document.querySelector('.session-box') as HTMLButtonElement | null)?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    const leaderItem = win.document.querySelector('.session-dropdown-item[data-session-id="session-new"]') as HTMLElement | null;
+    const oldItem = win.document.querySelector('.session-dropdown-item[data-session-id="session-old"]') as HTMLElement | null;
+    const consoleItem = win.document.querySelector('.session-dropdown-item[data-session-id="console-1"]') as HTMLElement | null;
+
+    expect(leaderItem?.querySelector('.session-dropdown-version')?.textContent).toBe('v2.0.27');
+    expect(leaderItem?.querySelector('.session-dropdown-client-label')?.textContent).toBe('Claude Code');
+
+    expect(oldItem?.querySelector('.session-dropdown-version')?.textContent).toBe('v2.0.26');
+    expect(oldItem?.querySelector('.session-dropdown-client-label')?.textContent).toBe('Codex');
+    expect(oldItem?.querySelector('.session-dropdown-update')?.textContent).toBe('Update available');
+
+    expect(consoleItem?.querySelector('.session-dropdown-client-label')?.textContent).toBe('Web Console');
+
+    cleanup();
+  });
+
   it('injects the log session filter into .log-controls and populates active sessions', async () => {
     const { window: win, cleanup } = createDom(`
       <div id="session-indicator"></div>

--- a/tests/unit/web/console/console-failure-modes.test.ts
+++ b/tests/unit/web/console/console-failure-modes.test.ts
@@ -476,6 +476,7 @@ describe('Console Failure Modes', () => {
           'test-session',
           process.pid,
           null,
+          'claude-code',
         );
 
         await heartbeat.start();
@@ -485,6 +486,7 @@ describe('Console Failure Modes', () => {
         const body = parseRequestBody((firstCall?.[1] as RequestInit | undefined)?.body);
         expect(body.serverVersion).toBe(PACKAGE_VERSION);
         expect(body.consoleProtocolVersion).toBe(CONSOLE_PROTOCOL_VERSION);
+        expect(body.clientPlatform).toBe('claude-code');
       } finally {
         fetchSpy.mockRestore();
       }

--- a/tests/unit/web/console/sessionClientPlatform.test.ts
+++ b/tests/unit/web/console/sessionClientPlatform.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  detectSessionClientPlatformId,
+  getSessionClientPlatformLabel,
+  normalizeSessionClientPlatformId,
+} from '../../../../src/web/console/sessionClientPlatform.js';
+
+describe('sessionClientPlatform', () => {
+  it('normalizes supported platform IDs', () => {
+    expect(normalizeSessionClientPlatformId('claude-code')).toBe('claude-code');
+    expect(normalizeSessionClientPlatformId('gemini')).toBe('gemini-cli');
+    expect(normalizeSessionClientPlatformId('unknown-client')).toBeNull();
+  });
+
+  it('returns human labels for known platforms', () => {
+    expect(getSessionClientPlatformLabel('claude-code')).toBe('Claude Code');
+    expect(getSessionClientPlatformLabel('web-console')).toBe('Web Console');
+    expect(getSessionClientPlatformLabel(null)).toBe('');
+  });
+
+  it('detects Claude Code from TERM_PROGRAM', () => {
+    const detected = detectSessionClientPlatformId(
+      { TERM_PROGRAM: 'claude-code' },
+      ['node', 'dist/index.js'],
+      '/usr/local/bin/node',
+      'node',
+    );
+    expect(detected).toBe('claude-code');
+  });
+
+  it('detects Codex from CODEX_HOME', () => {
+    const detected = detectSessionClientPlatformId(
+      { CODEX_HOME: '/tmp/codex-home' },
+      ['node', 'dist/index.js'],
+      '/usr/local/bin/node',
+      'node',
+    );
+    expect(detected).toBe('codex');
+  });
+
+  it('returns null when the host cannot be identified confidently', () => {
+    const detected = detectSessionClientPlatformId(
+      {},
+      ['node', 'dist/index.js'],
+      '/usr/local/bin/node',
+      'node',
+    );
+    expect(detected).toBeNull();
+  });
+});

--- a/tests/unit/web/console/sessionClientPlatform.test.ts
+++ b/tests/unit/web/console/sessionClientPlatform.test.ts
@@ -30,12 +30,22 @@ describe('sessionClientPlatform', () => {
 
   it('detects Codex from CODEX_HOME', () => {
     const detected = detectSessionClientPlatformId(
-      { CODEX_HOME: '/tmp/codex-home' },
+      { CODEX_HOME: '/Users/test/.codex' },
       ['node', 'dist/index.js'],
       '/usr/local/bin/node',
       'node',
     );
     expect(detected).toBe('codex');
+  });
+
+  it('detects Gemini CLI from argv text when no explicit env markers exist', () => {
+    const detected = detectSessionClientPlatformId(
+      {},
+      ['node', '/Applications/Gemini CLI.app/Contents/MacOS/gemini'],
+      '/usr/local/bin/node',
+      'node',
+    );
+    expect(detected).toBe('gemini-cli');
   });
 
   it('returns null when the host cannot be identified confidently', () => {

--- a/tests/unit/web/console/sessionRegistry.test.ts
+++ b/tests/unit/web/console/sessionRegistry.test.ts
@@ -34,7 +34,7 @@ describe('Session registry (#1805)', () => {
 
   describe('registerLeaderSession', () => {
     it('registers a leader session with authenticated=true and kind=mcp', () => {
-      ingestResult.registerLeaderSession('test-leader-001', process.pid);
+      ingestResult.registerLeaderSession('test-leader-001', process.pid, 'claude-code');
       const sessions = ingestResult.getSessions();
       expect(sessions).toHaveLength(1);
       expect(sessions[0].authenticated).toBe(true);
@@ -43,6 +43,8 @@ describe('Session registry (#1805)', () => {
       expect(sessions[0].status).toBe('active');
       expect(sessions[0].serverVersion).toBe(PACKAGE_VERSION);
       expect(sessions[0].consoleProtocolVersion).toBe(CONSOLE_PROTOCOL_VERSION);
+      expect(sessions[0].clientPlatform).toBe('claude-code');
+      expect(sessions[0].clientPlatformLabel).toBe('Claude Code');
     });
 
     it('assigns a puppet display name', () => {
@@ -88,6 +90,8 @@ describe('Session registry (#1805)', () => {
       expect(consoleSessions[0].kind).toBe('console');
       expect(consoleSessions[0].displayName).toBe('Web Console');
       expect(consoleSessions[0].status).toBe('active');
+      expect(consoleSessions[0].clientPlatform).toBe('web-console');
+      expect(consoleSessions[0].clientPlatformLabel).toBe('Web Console');
     });
 
     it('is idempotent — calling twice does not create duplicates', () => {
@@ -169,6 +173,7 @@ describe('Session registry (#1805)', () => {
           startedAt: new Date().toISOString(),
           serverVersion: '2.0.99',
           consoleProtocolVersion: 1,
+          clientPlatform: 'codex',
         });
 
       const res = await request(app).get('/api/sessions');
@@ -177,6 +182,8 @@ describe('Session registry (#1805)', () => {
       expect(follower).toBeDefined();
       expect(follower.serverVersion).toBe('2.0.99');
       expect(follower.consoleProtocolVersion).toBe(1);
+      expect(follower.clientPlatform).toBe('codex');
+      expect(follower.clientPlatformLabel).toBe('Codex');
     });
   });
 
@@ -245,6 +252,8 @@ describe('Session registry (#1805)', () => {
         kind: 'console',
         serverVersion: PACKAGE_VERSION,
         consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+        clientPlatform: 'web-console',
+        clientPlatformLabel: 'Web Console',
       }));
       expect(session.sessionId).toMatch(/^console-\d+$/);
       expect(session.color).toBe('#6366f1');


### PR DESCRIPTION
## Summary
- add explicit session client platform metadata to the unified console session registry
- render platform labels directly in the session dropdown and show update-available state for older live sessions
- add focused regression coverage for session metadata plumbing and the updated dropdown UI

## Testing
- npm test -- --runInBand --forceExit tests/unit/web/console-ui-regressions.test.ts tests/unit/web/console/sessionClientPlatform.test.ts tests/unit/web/console/sessionRegistry.test.ts tests/unit/web/console/console-failure-modes.test.ts
- npx eslint src/web/console/sessionClientPlatform.ts src/web/console/IngestRoutes.ts src/web/console/LeaderForwardingSink.ts src/web/console/UnifiedConsole.ts src/web/public/sessions.js tests/unit/web/console/sessionRegistry.test.ts tests/unit/web/console/console-failure-modes.test.ts tests/unit/web/console/sessionClientPlatform.test.ts tests/unit/web/console-ui-regressions.test.ts
- npm run build

Closes #2136
