### PR TITLE
Align session dropdown status columns

### DIFF
--- a/src/web/public/sessions.css
+++ b/src/web/public/sessions.css
@@ -66,7 +66,8 @@
   position: absolute;
   top: calc(100% + 0.4rem);
   right: 0;
-  min-width: 480px;
+  width: min(34rem, calc(100vw - 1rem));
+  box-sizing: border-box;
   background: var(--paper-strong, #fff);
   border: 1px solid var(--line, #c8d5e9);
   border-radius: var(--radius-md, 0.85rem);
@@ -184,10 +185,11 @@
 
 .session-dropdown-item {
   display: grid;
-  grid-template-columns: 1rem 8px minmax(0, 1fr) 62px 84px 3.5rem 1.2rem;
-  align-items: start;
-  gap: 0.4rem;
-  padding: 0.45rem 0.75rem;
+  grid-template-columns: 1rem 8px minmax(0, 1fr) 5.5rem 6.75rem 4.5rem 1.2rem;
+  align-items: center;
+  column-gap: 0.7rem;
+  row-gap: 0.3rem;
+  padding: 0.55rem 0.9rem;
   font-size: var(--step--1, 0.82rem);
   cursor: pointer;
   transition: background 0.1s;
@@ -239,7 +241,8 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.12rem;
+  gap: 0.18rem;
+  align-self: center;
 }
 
 .session-dropdown-meta {
@@ -277,7 +280,8 @@
   color: var(--ink-500, #677893);
   white-space: nowrap;
   text-align: right;
-  padding-top: 0.1rem;
+  min-width: 4.5rem;
+  justify-self: end;
 }
 
 .session-dropdown-role {
@@ -410,23 +414,32 @@
  * - Color (blue=positive, orange=negative — colorblind-safe pair)
  */
 .session-status-badge {
-  display: inline-block;
-  padding: 1px 5px;
-  border-radius: 3px;
-  font-size: 9px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 7px;
+  border-radius: 5px;
+  font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.04em;
   white-space: nowrap;
   text-align: center;
-  min-width: 52px;
+  min-width: 4.75rem;
+  box-sizing: border-box;
+}
+
+.session-dropdown-item > .session-status-badge {
+  justify-self: center;
 }
 
 .session-dropdown-badge-stack {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.18rem;
-  min-width: 0;
+  justify-self: center;
+  gap: 0.24rem;
+  width: 100%;
+  max-width: 6.75rem;
 }
 
 .session-dropdown-client-label {
@@ -434,7 +447,7 @@
   line-height: 1.15;
   color: var(--ink-500, #677893);
   text-align: center;
-  min-width: 0;
+  width: 100%;
 }
 
 .session-status-badge[data-status="positive"] {


### PR DESCRIPTION
## Summary
- widen and rebalance the session dropdown grid so auth, client, uptime, and close controls keep consistent column alignment
- give the status badges and client stack more breathing room so longer uptime values no longer visually crowd the middle columns
- preserve the current session metadata behavior while making the dropdown easier to scan in both light and dark themes

## Testing
- npm test -- --runInBand --forceExit tests/unit/web/console-ui-regressions.test.ts
- npm run build
