### PR TITLE
Fix Codex pre-tool-use allow hook output

### DIFF
--- a/scripts/pretooluse-dollhouse.sh
+++ b/scripts/pretooluse-dollhouse.sh
@@ -114,6 +114,37 @@ normalize_response() {
         end
       ' 2>/dev/null
       ;;
+    codex)
+      echo "$response" | jq -c '
+        if type == "object" and (keys | length) == 0 then
+          {
+            hookSpecificOutput: {
+              hookEventName: "PreToolUse",
+              permissionDecision: "allow",
+              permissionDecisionReason: ""
+            }
+          }
+        elif (.hookSpecificOutput.permissionDecision? | type) == "string" then
+          {
+            hookSpecificOutput: {
+              hookEventName: "PreToolUse",
+              permissionDecision: (if .hookSpecificOutput.permissionDecision == "allow" then "allow" else "deny" end),
+              permissionDecisionReason: (.hookSpecificOutput.permissionDecisionReason // .hookSpecificOutput.reason // .reason // .message // "")
+            }
+          }
+        elif (.decision? | type) == "string" and (.decision | IN("allow", "deny", "ask")) then
+          {
+            hookSpecificOutput: {
+              hookEventName: "PreToolUse",
+              permissionDecision: (if .decision == "allow" then "allow" else "deny" end),
+              permissionDecisionReason: (.reason // .message // "")
+            }
+          }
+        else
+          empty
+        end
+      ' 2>/dev/null
+      ;;
     *)
       echo "$response"
       ;;

--- a/src/handlers/mcp-aql/OperationSchema.ts
+++ b/src/handlers/mcp-aql/OperationSchema.ts
@@ -1477,7 +1477,7 @@ export const GATEKEEPER_SCHEMAS: OperationSchemaMap = {
       platform: { type: 'string', description: 'Target platform for response formatting (default: "claude_code"). Options: claude_code, gemini, cursor, windsurf, codex' },
       session_id: { type: 'string', description: 'Optional persisted activation session ID to evaluate against when hooks run in a separate leader process' },
     },
-    returns: { name: 'PlatformPermissionDecision', kind: 'object', description: 'Platform-formatted permission decision. Claude Code: { hookSpecificOutput: { hookEventName: "PreToolUse", permissionDecision: "allow"|"deny"|"ask", permissionDecisionReason? } }. Gemini: { decision: "allow"|"deny", reason? }. Cursor: { permission: "allow"|"deny"|"ask", reason? }. Windsurf: { allowed: boolean, reason? }. Codex: { hookSpecificOutput: { permissionDecision, reason? } }.' },
+    returns: { name: 'PlatformPermissionDecision', kind: 'object', description: 'Platform-formatted permission decision. Claude Code: { hookSpecificOutput: { hookEventName: "PreToolUse", permissionDecision: "allow"|"deny"|"ask", permissionDecisionReason? } }. Gemini: { decision: "allow"|"deny", reason? }. Cursor: { permission: "allow"|"deny"|"ask", reason? }. Windsurf: { allowed: boolean, reason? }. Codex: { hookSpecificOutput: { hookEventName: "PreToolUse", permissionDecision: "allow"|"deny", permissionDecisionReason? } }.' },
     examples: [
       '{ operation: "evaluate_permission", params: { tool_name: "Bash", input: { command: "git status" } } }',
       '{ operation: "evaluate_permission", params: { tool_name: "Bash", input: { command: "git push --force" }, platform: "claude_code", session_id: "claude-code-session" } }',

--- a/src/handlers/mcp-aql/evaluatePermission.ts
+++ b/src/handlers/mcp-aql/evaluatePermission.ts
@@ -64,9 +64,15 @@ function formatWindsurf(decision: string, reason?: string): Record<string, unkno
   return withReason({ allowed: decision === 'allow' }, reason);
 }
 
-/** Codex: wraps in hookSpecificOutput, maps 'ask' to 'deny' */
+/** Codex: explicit PreToolUse payload, maps 'ask' to 'deny' */
 function formatCodex(decision: string, reason?: string): Record<string, unknown> {
-  return { hookSpecificOutput: withReason({ permissionDecision: decision === 'ask' ? 'deny' : decision }, reason) };
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: decision === 'ask' ? 'deny' : decision,
+      permissionDecisionReason: reason ?? '',
+    },
+  };
 }
 
 /** Claude Code (default): uses hookSpecificOutput.permissionDecision for PreToolUse */

--- a/tests/integration/hooks/permission-hook-docker.test.ts
+++ b/tests/integration/hooks/permission-hook-docker.test.ts
@@ -106,7 +106,9 @@ suite('Dockerized permission hook adapters', () => {
     expect(result.exitCode).toBe(0);
     expect(parseHookStdout(result, '/workspace/scripts/pretooluse-codex.sh')).toEqual({
       hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
         permissionDecision: 'allow',
+        permissionDecisionReason: '',
       },
     });
     expect(result.requestBody).toEqual({

--- a/tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts
+++ b/tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts
@@ -166,17 +166,16 @@ function toCursorHook(result: CliToolPolicyResult): CursorHookResponse {
 /**
  * Translate a CliToolPolicyResult to Codex CLI PreToolUse hook format.
  * Codex uses hookSpecificOutput with permissionDecision.
- * No 'ask' — confirm maps to deny (Codex fails open, so deny is safer).
+ * No 'ask' — confirm maps to deny.
  */
 function toCodexHook(result: CliToolPolicyResult): CodexHookResponse {
-  if (result.behavior === 'allow' || result.behavior === 'evaluate') {
-    return {}; // Empty response = allow (Codex fails open)
-  }
   return {
     hookSpecificOutput: {
       hookEventName: 'PreToolUse',
-      permissionDecision: 'deny',
-      permissionDecisionReason: result.message,
+      permissionDecision: result.behavior === 'allow' || result.behavior === 'evaluate'
+        ? 'allow'
+        : 'deny',
+      permissionDecisionReason: result.message ?? '',
     },
   };
 }
@@ -415,10 +414,9 @@ describe('Permission Flow Platform Adapters (Issue #1669)', () => {
         const response = toCodexHook(raw);
 
         if (scenario.expectedBehavior === 'allow') {
-          // Codex: empty response = allow (fails open)
-          expect(response.hookSpecificOutput).toBeUndefined();
+          expect(response.hookSpecificOutput?.permissionDecision).toBe('allow');
         } else {
-          // Both deny and confirm → deny in Codex (no ask, and fails open is dangerous for confirm)
+          // Both deny and confirm → deny in Codex (no ask)
           expect(response.hookSpecificOutput).toBeDefined();
           expect(response.hookSpecificOutput?.permissionDecision).toBe('deny');
         }
@@ -534,7 +532,7 @@ describe('Permission Flow Platform Adapters (Issue #1669)', () => {
         expect(toClaudeCode(raw, scenario.toolName).behavior).toBe('allow');
         expect(toGeminiHook(raw).decision).toBe('allow');
         expect(toCursorHook(raw).permission).toBe('allow');
-        expect(toCodexHook(raw).hookSpecificOutput).toBeUndefined();
+        expect(toCodexHook(raw).hookSpecificOutput?.permissionDecision).toBe('allow');
         expect(toWindsurfHook(raw).exitCode).toBe(0);
         expect(toVSCodeHook(raw).permission).toBe('allow');
       }
@@ -569,7 +567,7 @@ describe('Permission Flow Platform Adapters (Issue #1669)', () => {
         // Cursor: ask (has ask option)
         expect(toCursorHook(raw).permission).toBe('ask');
 
-        // Codex: deny (no ask, fails open is risky)
+        // Codex: deny (no ask)
         expect(toCodexHook(raw).hookSpecificOutput?.permissionDecision).toBe('deny');
 
         // Windsurf: exit 2 (binary, no ask)

--- a/tests/unit/di/permissionServerIntegration.test.ts
+++ b/tests/unit/di/permissionServerIntegration.test.ts
@@ -389,6 +389,98 @@ describe('Permission Server Integration', () => {
       expect(stdout.trim()).toBe('');
     });
 
+    itBash('hook script should emit Codex-compatible JSON for allow decisions', async () => {
+      let testPort = 0;
+      let capturedBody: Record<string, unknown> | null = null;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          let body = '';
+          req.on('data', chunk => { body += chunk; });
+          req.on('end', () => {
+            capturedBody = JSON.parse(body);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              hookSpecificOutput: {
+                permissionDecision: 'allow',
+              },
+            }));
+          });
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      testPort = await listenOnLoopback(mockServer);
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout } = await runHookScript(
+        {
+          toolName: 'Bash',
+          toolInput: { command: 'node -p "require(\'./package.json\').version"' },
+        },
+        { DOLLHOUSE_HOOK_PLATFORM: 'codex' },
+      );
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(0);
+      expect(capturedBody).toEqual({
+        tool_name: 'Bash',
+        input: { command: 'node -p "require(\'./package.json\').version"' },
+        platform: 'codex',
+        session_id: 'session-hook-test',
+      });
+      expect(JSON.parse(stdout.trim())).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          permissionDecisionReason: '',
+        },
+      });
+    });
+
+    itBash('hook script should normalize legacy empty Codex allow responses', async () => {
+      let testPort = 0;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({}));
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      testPort = await listenOnLoopback(mockServer);
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout } = await runHookScript(
+        {
+          toolName: 'Bash',
+          toolInput: { command: 'pwd' },
+        },
+        { DOLLHOUSE_HOOK_PLATFORM: 'codex' },
+      );
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(0);
+      expect(JSON.parse(stdout.trim())).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          permissionDecisionReason: '',
+        },
+      });
+    });
+
     itBash('hook script should fall back to the newest live PID-keyed port file and restore the shared file', async () => {
       let testPort = 0;
       let capturedBody: Record<string, unknown> | null = null;
@@ -550,13 +642,17 @@ async function reserveUnusedLoopbackPort(): Promise<number> {
   return port;
 }
 
-function runHookScript(payload: Record<string, unknown>): Promise<{ code: number; stdout: string }> {
+function runHookScript(
+  payload: Record<string, unknown>,
+  envOverrides: Record<string, string> = {},
+): Promise<{ code: number; stdout: string }> {
   return new Promise((resolve) => {
     const hookProc = spawn(BASH_BINARY, [HOOK_SCRIPT], {
       env: {
         HOME: os.homedir(),
         PATH: SAFE_TEST_PATH,
         DOLLHOUSE_SESSION_ID: 'session-hook-test',
+        ...envOverrides,
       },
       stdio: ['pipe', 'pipe', 'pipe'],
     });

--- a/tests/unit/handlers/mcp-aql/evaluatePermission.test.ts
+++ b/tests/unit/handlers/mcp-aql/evaluatePermission.test.ts
@@ -88,12 +88,24 @@ describe('evaluatePermission', () => {
         .toEqual({ allowed: false, reason: 'Nope' });
     });
 
+    it('should format codex allow response', () => {
+      expect(formatPermissionResponse('allow', 'codex', input))
+        .toEqual({
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
+            permissionDecision: 'allow',
+            permissionDecisionReason: '',
+          },
+        });
+    });
+
     it('should format codex response (maps ask to deny)', () => {
       expect(formatPermissionResponse('ask', 'codex', input, 'Review needed'))
         .toEqual({
           hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
             permissionDecision: 'deny',
-            reason: 'Review needed',
+            permissionDecisionReason: 'Review needed',
           },
         });
     });


### PR DESCRIPTION
## Summary
- normalize Codex allow responses to an explicit `PreToolUse` payload instead of emitting invalid/empty stdout
- align the shared hook adapter, Codex formatter, and schema docs around one explicit contract
- add regression coverage for direct hook execution, adapter formatting, and Dockerized hook execution

## Testing
- npm test -- --runInBand tests/unit/handlers/mcp-aql/evaluatePermission.test.ts tests/unit/di/permissionServerIntegration.test.ts
- npm run test:integration -- --runInBand tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts
- npm run test:integration -- --runInBand tests/integration/hooks/permission-hook-docker.test.ts
- bash -n scripts/pretooluse-dollhouse.sh