### PR TITLE
Audit permission hook contracts across platforms

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -19,6 +19,7 @@ For a high-level overview, see the [Architecture Overview](overview.md).
 
 ### Specialized Topics
 - [Version Storage](version-storage-approach.md) - How we handle element versions
+- [Permission Hook Platform Contracts](permission-hook-platform-contracts.md) - Authoritative stdout and exit-code contracts for Claude Code, Codex, Cursor, VS Code, Gemini CLI, and Windsurf hook integrations
 - [ADR-002: Version-Aware Web Console Leadership](ADR-002-CONSOLE-VERSION-AWARE-LEADERSHIP.md) - Why the newest compatible console leader wins and how stale tabs recover
 
 ## For Contributors

--- a/docs/architecture/permission-hook-platform-contracts.md
+++ b/docs/architecture/permission-hook-platform-contracts.md
@@ -3,11 +3,11 @@
 This document is the authoritative contract for DollhouseMCP permission hook output across the supported local clients.
 
 Keep this file in sync with:
-- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/src/handlers/mcp-aql/evaluatePermission.ts`
-- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/scripts/pretooluse-dollhouse.sh`
-- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/tests/unit/di/permissionServerIntegration.test.ts`
-- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/tests/integration/hooks/permission-hook-docker.test.ts`
-- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts`
+- `src/handlers/mcp-aql/evaluatePermission.ts`
+- `scripts/pretooluse-dollhouse.sh`
+- `tests/unit/di/permissionServerIntegration.test.ts`
+- `tests/integration/hooks/permission-hook-docker.test.ts`
+- `tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts`
 
 ## Principles
 

--- a/docs/architecture/permission-hook-platform-contracts.md
+++ b/docs/architecture/permission-hook-platform-contracts.md
@@ -1,0 +1,77 @@
+# Permission Hook Platform Contracts
+
+This document is the authoritative contract for DollhouseMCP permission hook output across the supported local clients.
+
+Keep this file in sync with:
+- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/src/handlers/mcp-aql/evaluatePermission.ts`
+- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/scripts/pretooluse-dollhouse.sh`
+- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/tests/unit/di/permissionServerIntegration.test.ts`
+- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/tests/integration/hooks/permission-hook-docker.test.ts`
+- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts`
+
+## Principles
+
+- Every supported hook client has one explicit, documented stdout contract.
+- Shared shell wrappers may normalize server output, but they must not invent undocumented fail-open shapes.
+- If a client expects structured JSON, DollhouseMCP should emit that structure explicitly for both allow and deny paths.
+- Windsurf is the exception: its hook contract is exit-code based instead of stdout-JSON based.
+- Hook installation assets must point each client to the wrapper script that matches its contract.
+
+## Contract Matrix
+
+| Client | Installed hook script | Permission platform id | Expected hook result |
+| --- | --- | --- | --- |
+| Claude Code | `pretooluse-dollhouse.sh` | `claude_code` | JSON on stdout: `hookSpecificOutput.hookEventName = "PreToolUse"`, `permissionDecision = "allow" | "deny" | "ask"` |
+| Codex | `pretooluse-codex.sh` | `codex` | JSON on stdout: `hookSpecificOutput.hookEventName = "PreToolUse"`, `permissionDecision = "allow" | "deny"`, `permissionDecisionReason` optional but emitted as `""` on allow |
+| Cursor | `pretooluse-cursor.sh` | `cursor` | JSON on stdout: `{ permission: "allow" | "deny" | "ask", reason? }` |
+| VS Code / Copilot | `pretooluse-vscode.sh` | `vscode` | JSON on stdout: Claude-compatible `hookSpecificOutput` payload |
+| Gemini CLI | `pretooluse-gemini.sh` | `gemini` | JSON on stdout: `{ decision: "allow" | "deny", reason? }` |
+| Windsurf | `pretooluse-windsurf.sh` | `windsurf` | Exit `0` to allow, exit `2` to block; denial reason goes to stderr |
+
+## Input Normalization
+
+The wrappers normalize each client's native payload into the shared `/api/evaluate_permission` request shape:
+
+```json
+{
+  "tool_name": "Bash",
+  "input": { "command": "git status" },
+  "platform": "cursor",
+  "session_id": "optional"
+}
+```
+
+Client-specific normalization includes:
+- VS Code: converts `runTerminalCommand` and related names into `Bash`
+- Windsurf: converts `pre_run_command` and `pre_mcp_tool_use` events into standard `tool_name` + `input`
+- Codex/Cursor/Gemini wrappers: primarily set the platform id and delegate to the shared shell bridge
+
+## Fail-Open Rules
+
+- Missing permission server port file: allow / no-op
+- Connection failure or timeout: allow / no-op
+- Malformed server response:
+  - JSON-based clients: allow / no-op with empty stdout
+  - Windsurf: allow with exit `0`
+- Legacy Codex bare `{}` allow responses are normalized into an explicit `hookSpecificOutput.permissionDecision = "allow"` payload for compatibility
+
+## Verification Matrix
+
+- Direct shell execution coverage:
+  - `tests/unit/di/permissionServerIntegration.test.ts`
+- Adapter-level formatter coverage:
+  - `tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts`
+- Dockerized wrapper coverage:
+  - `tests/integration/hooks/permission-hook-docker.test.ts`
+- Install/entrypoint wiring coverage:
+  - `tests/unit/utils/permissionHooks.test.ts`
+
+## Release Checklist
+
+Before changing a hook contract:
+- update this document first
+- update `evaluatePermission.ts` and any wrapper scripts
+- update the direct shell tests
+- update the adapter tests
+- update the Docker hook tests if the platform is covered there
+- confirm the install-hook tests still point the client at the correct wrapper script

--- a/scripts/pretooluse-dollhouse.sh
+++ b/scripts/pretooluse-dollhouse.sh
@@ -20,10 +20,13 @@ RUN_DIR="$HOME/.dollhouse/run"
 PORT_FILE="$RUN_DIR/permission-server.port"
 AUTHORITY_FILE="$RUN_DIR/permission-authority.json"
 AUTHORITY_CACHE_TTL_SECONDS=2
-MAX_RETRIES=2
-INITIAL_TIMEOUT=5
+MAX_RETRIES="${DOLLHOUSE_HOOK_MAX_RETRIES:-2}"
+INITIAL_TIMEOUT="${DOLLHOUSE_HOOK_INITIAL_TIMEOUT:-5}"
 HOOK_PLATFORM="${DOLLHOUSE_HOOK_PLATFORM:-claude_code}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+[[ "$MAX_RETRIES" =~ ^[0-9]+$ ]] || MAX_RETRIES=2
+[[ "$INITIAL_TIMEOUT" =~ ^[0-9]+$ ]] || INITIAL_TIMEOUT=5
 
 # Debug logging helper — writes to stderr so it doesn't pollute stdout
 debug() {

--- a/scripts/pretooluse-vscode.sh
+++ b/scripts/pretooluse-vscode.sh
@@ -7,10 +7,13 @@
 
 RUN_DIR="$HOME/.dollhouse/run"
 PORT_FILE="$RUN_DIR/permission-server.port"
-MAX_RETRIES=2
-INITIAL_TIMEOUT=5
+MAX_RETRIES="${DOLLHOUSE_HOOK_MAX_RETRIES:-2}"
+INITIAL_TIMEOUT="${DOLLHOUSE_HOOK_INITIAL_TIMEOUT:-5}"
 HOOK_PLATFORM="vscode"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+[[ "$MAX_RETRIES" =~ ^[0-9]+$ ]] || MAX_RETRIES=2
+[[ "$INITIAL_TIMEOUT" =~ ^[0-9]+$ ]] || INITIAL_TIMEOUT=5
 
 debug() {
   if [[ "${DOLLHOUSE_HOOK_DEBUG:-0}" == "1" ]]; then

--- a/scripts/pretooluse-windsurf.sh
+++ b/scripts/pretooluse-windsurf.sh
@@ -7,10 +7,13 @@
 
 RUN_DIR="$HOME/.dollhouse/run"
 PORT_FILE="$RUN_DIR/permission-server.port"
-MAX_RETRIES=2
-INITIAL_TIMEOUT=5
+MAX_RETRIES="${DOLLHOUSE_HOOK_MAX_RETRIES:-2}"
+INITIAL_TIMEOUT="${DOLLHOUSE_HOOK_INITIAL_TIMEOUT:-5}"
 HOOK_PLATFORM="windsurf"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+[[ "$MAX_RETRIES" =~ ^[0-9]+$ ]] || MAX_RETRIES=2
+[[ "$INITIAL_TIMEOUT" =~ ^[0-9]+$ ]] || INITIAL_TIMEOUT=5
 
 debug() {
   if [[ "${DOLLHOUSE_HOOK_DEBUG:-0}" == "1" ]]; then

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -13,6 +13,8 @@
   const PKG = '@dollhousemcp/mcp-server';
   const HOOKS_DIR = '~/.dollhouse/hooks';
   const HOOK_BASE_SCRIPT_PATH = `${HOOKS_DIR}/pretooluse-dollhouse.sh`;
+  // Keep hook entrypoints and output expectations in sync with
+  // docs/architecture/permission-hook-platform-contracts.md.
 
   /** Platform registry — drives config generation AND panel rendering */
   const PLATFORMS = [

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -13,6 +13,7 @@
   const PKG = '@dollhousemcp/mcp-server';
   const HOOKS_DIR = '~/.dollhouse/hooks';
   const HOOK_BASE_SCRIPT_PATH = `${HOOKS_DIR}/pretooluse-dollhouse.sh`;
+  const HOOK_CONTRACT_DOC_URL = 'https://github.com/DollhouseMCP/mcp-server/blob/main/docs/architecture/permission-hook-platform-contracts.md';
   // Keep hook entrypoints and output expectations in sync with
   // docs/architecture/permission-hook-platform-contracts.md.
 
@@ -1593,6 +1594,7 @@ codex_hooks = true`;
     intro.innerHTML = `<div class="setup-permissions-note">
         <strong>Permissions &amp; Security</strong>
         <p>Use this mode to turn on permission enforcement for supported clients. Claude Code is fully guided in this release. Gemini CLI, Cursor, VS Code, Windsurf, and Codex have native partial support, while Cline and LM Studio stay in the MCP and fallback lane for now. Other clients will be marked as coming soon.</p>
+        <p class="setup-hint">Need the advanced client-by-client hook contract details? <a href="${HOOK_CONTRACT_DOC_URL}" target="_blank" rel="noopener noreferrer">Read the platform contract reference</a>.</p>
       </div>`;
   };
 

--- a/tests/integration/hooks/permission-hook-docker.test.ts
+++ b/tests/integration/hooks/permission-hook-docker.test.ts
@@ -3,6 +3,9 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 
+// Keep Dockerized wrapper assertions in sync with
+// docs/architecture/permission-hook-platform-contracts.md.
+
 jest.setTimeout(180_000);
 
 const SAFE_HOST_PATH = '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin';

--- a/tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts
+++ b/tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts
@@ -18,6 +18,9 @@
  * These tests verify the TRANSLATION layer, not the policy evaluation
  * itself (that's covered by permission-flow-matrix.test.ts).
  *
+ * Keep adapter expectations in sync with
+ * docs/architecture/permission-hook-platform-contracts.md.
+ *
  * @module
  */
 

--- a/tests/unit/di/permissionServerIntegration.test.ts
+++ b/tests/unit/di/permissionServerIntegration.test.ts
@@ -396,6 +396,35 @@ describe('Permission Server Integration', () => {
       expect(stdout.trim()).toBe('');
     });
 
+    itBash('hook script should fail open when permission requests time out', async () => {
+      let testPort = 0;
+      const mockServer = http.createServer((_req, _res) => {
+        // Intentionally never respond so curl hits its max-time window.
+      });
+
+      testPort = await listenOnLoopback(mockServer);
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout } = await runHookScript(
+        {
+          tool_name: 'Read',
+          tool_input: { file_path: './test-fixture.txt' },
+        },
+        {
+          DOLLHOUSE_HOOK_INITIAL_TIMEOUT: '1',
+          DOLLHOUSE_HOOK_MAX_RETRIES: '0',
+        },
+      );
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(0);
+      expect(stdout.trim()).toBe('');
+    });
+
     itBash('hook script should emit Codex-compatible JSON for allow decisions', async () => {
       let testPort = 0;
       let capturedBody: Record<string, unknown> | null = null;
@@ -646,6 +675,51 @@ describe('Permission Server Integration', () => {
           permissionDecision: 'ask',
           permissionDecisionReason: 'Needs approval',
         },
+      });
+    });
+
+    itBash('vscode hook wrapper should fail open silently on malformed responses', async () => {
+      let testPort = 0;
+      let capturedBody: Record<string, unknown> | null = null;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          let body = '';
+          req.on('data', chunk => { body += chunk; });
+          req.on('end', () => {
+            capturedBody = JSON.parse(body);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ unexpected: true }));
+          });
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      testPort = await listenOnLoopback(mockServer);
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout } = await runHookScript(
+        {
+          toolName: 'runTerminalCommand',
+          toolInput: { command: 'npm test' },
+        },
+        {},
+        VSCODE_HOOK_SCRIPT,
+      );
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(0);
+      expect(stdout.trim()).toBe('');
+      expect(capturedBody).toEqual({
+        tool_name: 'Bash',
+        input: { command: 'npm test' },
+        platform: 'vscode',
+        session_id: 'session-hook-test',
       });
     });
 

--- a/tests/unit/di/permissionServerIntegration.test.ts
+++ b/tests/unit/di/permissionServerIntegration.test.ts
@@ -4,6 +4,9 @@
  * In mcp-server, permission routes are mounted on the unified web
  * console (port 41715). These tests verify port file lifecycle, HTTP
  * endpoint behavior, hook script compatibility, and error recovery.
+ *
+ * Keep platform-specific stdout/exit assertions in sync with
+ * docs/architecture/permission-hook-platform-contracts.md.
  */
 
 import { describe, expect, it, afterEach } from '@jest/globals';
@@ -18,6 +21,10 @@ const PORT_FILE = path.join(RUN_DIR, 'permission-server.port');
 const PID_PORT_FILE = path.join(RUN_DIR, `permission-server-${process.pid}.port`);
 // Hook script lives in the repo at scripts/ — works on both dev machines and CI
 const HOOK_SCRIPT = path.join(process.cwd(), 'scripts', 'pretooluse-dollhouse.sh');
+const CURSOR_HOOK_SCRIPT = path.join(process.cwd(), 'scripts', 'pretooluse-cursor.sh');
+const GEMINI_HOOK_SCRIPT = path.join(process.cwd(), 'scripts', 'pretooluse-gemini.sh');
+const VSCODE_HOOK_SCRIPT = path.join(process.cwd(), 'scripts', 'pretooluse-vscode.sh');
+const WINDSURF_HOOK_SCRIPT = path.join(process.cwd(), 'scripts', 'pretooluse-windsurf.sh');
 const SAFE_TEST_PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
 const BASH_BINARY = '/bin/bash';
 
@@ -481,6 +488,217 @@ describe('Permission Server Integration', () => {
       });
     });
 
+    itBash('cursor hook wrapper should preserve Cursor permission responses', async () => {
+      let testPort = 0;
+      let capturedBody: Record<string, unknown> | null = null;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          let body = '';
+          req.on('data', chunk => { body += chunk; });
+          req.on('end', () => {
+            capturedBody = JSON.parse(body);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              permission: 'deny',
+              reason: 'Blocked by policy',
+            }));
+          });
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      testPort = await listenOnLoopback(mockServer);
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout } = await runHookScript(
+        {
+          toolName: 'Bash',
+          toolInput: { command: 'git status' },
+        },
+        {},
+        CURSOR_HOOK_SCRIPT,
+      );
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(0);
+      expect(capturedBody).toEqual({
+        tool_name: 'Bash',
+        input: { command: 'git status' },
+        platform: 'cursor',
+        session_id: 'session-hook-test',
+      });
+      expect(JSON.parse(stdout.trim())).toEqual({
+        permission: 'deny',
+        reason: 'Blocked by policy',
+      });
+    });
+
+    itBash('gemini hook wrapper should preserve Gemini decision payloads', async () => {
+      let testPort = 0;
+      let capturedBody: Record<string, unknown> | null = null;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          let body = '';
+          req.on('data', chunk => { body += chunk; });
+          req.on('end', () => {
+            capturedBody = JSON.parse(body);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              decision: 'allow',
+            }));
+          });
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      testPort = await listenOnLoopback(mockServer);
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout } = await runHookScript(
+        {
+          toolName: 'Write',
+          toolInput: { file_path: 'notes.txt' },
+        },
+        {},
+        GEMINI_HOOK_SCRIPT,
+      );
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(0);
+      expect(capturedBody).toEqual({
+        tool_name: 'Write',
+        input: { file_path: 'notes.txt' },
+        platform: 'gemini',
+        session_id: 'session-hook-test',
+      });
+      expect(JSON.parse(stdout.trim())).toEqual({
+        decision: 'allow',
+      });
+    });
+
+    itBash('vscode hook wrapper should normalize terminal commands and preserve ask responses', async () => {
+      let testPort = 0;
+      let capturedBody: Record<string, unknown> | null = null;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          let body = '';
+          req.on('data', chunk => { body += chunk; });
+          req.on('end', () => {
+            capturedBody = JSON.parse(body);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              hookSpecificOutput: {
+                hookEventName: 'PreToolUse',
+                permissionDecision: 'ask',
+                permissionDecisionReason: 'Needs approval',
+              },
+            }));
+          });
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      testPort = await listenOnLoopback(mockServer);
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout } = await runHookScript(
+        {
+          toolName: 'runTerminalCommand',
+          toolInput: { command: 'npm install' },
+          cwd: '/workspace',
+        },
+        {},
+        VSCODE_HOOK_SCRIPT,
+      );
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(0);
+      expect(capturedBody).toEqual({
+        tool_name: 'Bash',
+        input: {
+          command: 'npm install',
+          cwd: '/workspace',
+        },
+        platform: 'vscode',
+        session_id: 'session-hook-test',
+      });
+      expect(JSON.parse(stdout.trim())).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'ask',
+          permissionDecisionReason: 'Needs approval',
+        },
+      });
+    });
+
+    itBash('windsurf hook wrapper should map deny decisions to exit code 2', async () => {
+      let testPort = 0;
+      let capturedBody: Record<string, unknown> | null = null;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          let body = '';
+          req.on('data', chunk => { body += chunk; });
+          req.on('end', () => {
+            capturedBody = JSON.parse(body);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              allowed: false,
+              reason: 'Blocked by policy',
+            }));
+          });
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      testPort = await listenOnLoopback(mockServer);
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout, stderr } = await runHookScript(
+        {
+          hook_event_name: 'pre_mcp_tool_use',
+          tool_name: 'Read',
+          tool_arguments: { file_path: 'src/index.ts' },
+        },
+        {},
+        WINDSURF_HOOK_SCRIPT,
+      );
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(2);
+      expect(stdout.trim()).toBe('');
+      expect(stderr).toContain('Blocked by policy');
+      expect(capturedBody).toEqual({
+        tool_name: 'Read',
+        input: { file_path: 'src/index.ts' },
+        platform: 'windsurf',
+        session_id: 'session-hook-test',
+      });
+    });
+
     itBash('hook script should fall back to the newest live PID-keyed port file and restore the shared file', async () => {
       let testPort = 0;
       let capturedBody: Record<string, unknown> | null = null;
@@ -645,9 +863,10 @@ async function reserveUnusedLoopbackPort(): Promise<number> {
 function runHookScript(
   payload: Record<string, unknown>,
   envOverrides: Record<string, string> = {},
-): Promise<{ code: number; stdout: string }> {
+  scriptPath = HOOK_SCRIPT,
+): Promise<{ code: number; stdout: string; stderr: string }> {
   return new Promise((resolve) => {
-    const hookProc = spawn(BASH_BINARY, [HOOK_SCRIPT], {
+    const hookProc = spawn(BASH_BINARY, [scriptPath], {
       env: {
         HOME: os.homedir(),
         PATH: SAFE_TEST_PATH,
@@ -657,8 +876,10 @@ function runHookScript(
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let out = '';
+    let err = '';
     hookProc.stdout.on('data', (data: Buffer) => { out += data.toString(); });
-    hookProc.on('close', (c: number) => resolve({ code: c, stdout: out }));
+    hookProc.stderr.on('data', (data: Buffer) => { err += data.toString(); });
+    hookProc.on('close', (c: number) => resolve({ code: c, stdout: out, stderr: err }));
     hookProc.stdin.write(JSON.stringify(payload));
     hookProc.stdin.end();
   });

--- a/tests/unit/utils/permissionHooks.test.ts
+++ b/tests/unit/utils/permissionHooks.test.ts
@@ -3,6 +3,9 @@ import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+// Keep installed wrapper-script expectations in sync with
+// docs/architecture/permission-hook-platform-contracts.md.
+
 import {
   ensureClaudePreToolUseHook,
   ensureCodexPreToolUseHook,

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -2057,6 +2057,15 @@ describe('Setup Tab — Channel Selector Interactions', () => {
       expect(status?.textContent).toContain('Permissions & security tools are unavailable for Claude Desktop right now.');
       expect(status?.textContent).not.toContain('already configured for this client');
     });
+
+    it('links to the platform contract reference for advanced hook details', () => {
+      const intro = document.getElementById('setup-permissions-intro');
+      const link = intro?.querySelector('a[href="https://github.com/DollhouseMCP/mcp-server/blob/main/docs/architecture/permission-hook-platform-contracts.md"]') as HTMLAnchorElement | null;
+
+      expect(link).not.toBeNull();
+      expect(link?.textContent).toContain('platform contract reference');
+      expect(link?.target).toBe('_blank');
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add direct shell execution regression coverage for the remaining supported hook wrappers
- document the authoritative hook contract for every supported platform in one place
- reference that contract from setup/config and the main test suites that enforce it

## Testing
- npm test -- --runInBand tests/unit/di/permissionServerIntegration.test.ts tests/unit/utils/permissionHooks.test.ts
- npm run test:integration -- --runInBand tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts tests/integration/hooks/permission-hook-docker.test.ts
- npx eslint src/web/public/setup.js tests/unit/di/permissionServerIntegration.test.ts tests/unit/utils/permissionHooks.test.ts tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts tests/integration/hooks/permission-hook-docker.test.ts
- bash -n scripts/pretooluse-dollhouse.sh scripts/pretooluse-codex.sh scripts/pretooluse-cursor.sh scripts/pretooluse-gemini.sh scripts/pretooluse-vscode.sh scripts/pretooluse-windsurf.sh

Closes #2140