### PR TITLE
Release 2.0.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.28] - 2026-04-21
+
+- Add explicit session client metadata and update-available status in the web console dropdown, with improved layout alignment.
+- Fix Codex pre-tool-use allow-hook output so Bash permission checks no longer fail with invalid JSON.
+- Audit and document permission-hook contracts across supported clients, including stronger fail-open regression coverage and setup guidance.
+
 ## [2.0.27] - 2026-04-20
 
 - Version bump

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -19,6 +19,7 @@ For a high-level overview, see the [Architecture Overview](overview.md).
 
 ### Specialized Topics
 - [Version Storage](version-storage-approach.md) - How we handle element versions
+- [Permission Hook Platform Contracts](permission-hook-platform-contracts.md) - Authoritative stdout and exit-code contracts for Claude Code, Codex, Cursor, VS Code, Gemini CLI, and Windsurf hook integrations
 - [ADR-002: Version-Aware Web Console Leadership](ADR-002-CONSOLE-VERSION-AWARE-LEADERSHIP.md) - Why the newest compatible console leader wins and how stale tabs recover
 
 ## For Contributors

--- a/docs/architecture/permission-hook-platform-contracts.md
+++ b/docs/architecture/permission-hook-platform-contracts.md
@@ -3,11 +3,11 @@
 This document is the authoritative contract for DollhouseMCP permission hook output across the supported local clients.
 
 Keep this file in sync with:
-- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/src/handlers/mcp-aql/evaluatePermission.ts`
-- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/scripts/pretooluse-dollhouse.sh`
-- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/tests/unit/di/permissionServerIntegration.test.ts`
-- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/tests/integration/hooks/permission-hook-docker.test.ts`
-- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts`
+- `src/handlers/mcp-aql/evaluatePermission.ts`
+- `scripts/pretooluse-dollhouse.sh`
+- `tests/unit/di/permissionServerIntegration.test.ts`
+- `tests/integration/hooks/permission-hook-docker.test.ts`
+- `tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts`
 
 ## Principles
 

--- a/docs/architecture/permission-hook-platform-contracts.md
+++ b/docs/architecture/permission-hook-platform-contracts.md
@@ -1,0 +1,77 @@
+# Permission Hook Platform Contracts
+
+This document is the authoritative contract for DollhouseMCP permission hook output across the supported local clients.
+
+Keep this file in sync with:
+- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/src/handlers/mcp-aql/evaluatePermission.ts`
+- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/scripts/pretooluse-dollhouse.sh`
+- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/tests/unit/di/permissionServerIntegration.test.ts`
+- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/tests/integration/hooks/permission-hook-docker.test.ts`
+- `/Users/mick/Developer/Organizations/DollhouseMCP/active/mcp-server/tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts`
+
+## Principles
+
+- Every supported hook client has one explicit, documented stdout contract.
+- Shared shell wrappers may normalize server output, but they must not invent undocumented fail-open shapes.
+- If a client expects structured JSON, DollhouseMCP should emit that structure explicitly for both allow and deny paths.
+- Windsurf is the exception: its hook contract is exit-code based instead of stdout-JSON based.
+- Hook installation assets must point each client to the wrapper script that matches its contract.
+
+## Contract Matrix
+
+| Client | Installed hook script | Permission platform id | Expected hook result |
+| --- | --- | --- | --- |
+| Claude Code | `pretooluse-dollhouse.sh` | `claude_code` | JSON on stdout: `hookSpecificOutput.hookEventName = "PreToolUse"`, `permissionDecision = "allow" | "deny" | "ask"` |
+| Codex | `pretooluse-codex.sh` | `codex` | JSON on stdout: `hookSpecificOutput.hookEventName = "PreToolUse"`, `permissionDecision = "allow" | "deny"`, `permissionDecisionReason` optional but emitted as `""` on allow |
+| Cursor | `pretooluse-cursor.sh` | `cursor` | JSON on stdout: `{ permission: "allow" | "deny" | "ask", reason? }` |
+| VS Code / Copilot | `pretooluse-vscode.sh` | `vscode` | JSON on stdout: Claude-compatible `hookSpecificOutput` payload |
+| Gemini CLI | `pretooluse-gemini.sh` | `gemini` | JSON on stdout: `{ decision: "allow" | "deny", reason? }` |
+| Windsurf | `pretooluse-windsurf.sh` | `windsurf` | Exit `0` to allow, exit `2` to block; denial reason goes to stderr |
+
+## Input Normalization
+
+The wrappers normalize each client's native payload into the shared `/api/evaluate_permission` request shape:
+
+```json
+{
+  "tool_name": "Bash",
+  "input": { "command": "git status" },
+  "platform": "cursor",
+  "session_id": "optional"
+}
+```
+
+Client-specific normalization includes:
+- VS Code: converts `runTerminalCommand` and related names into `Bash`
+- Windsurf: converts `pre_run_command` and `pre_mcp_tool_use` events into standard `tool_name` + `input`
+- Codex/Cursor/Gemini wrappers: primarily set the platform id and delegate to the shared shell bridge
+
+## Fail-Open Rules
+
+- Missing permission server port file: allow / no-op
+- Connection failure or timeout: allow / no-op
+- Malformed server response:
+  - JSON-based clients: allow / no-op with empty stdout
+  - Windsurf: allow with exit `0`
+- Legacy Codex bare `{}` allow responses are normalized into an explicit `hookSpecificOutput.permissionDecision = "allow"` payload for compatibility
+
+## Verification Matrix
+
+- Direct shell execution coverage:
+  - `tests/unit/di/permissionServerIntegration.test.ts`
+- Adapter-level formatter coverage:
+  - `tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts`
+- Dockerized wrapper coverage:
+  - `tests/integration/hooks/permission-hook-docker.test.ts`
+- Install/entrypoint wiring coverage:
+  - `tests/unit/utils/permissionHooks.test.ts`
+
+## Release Checklist
+
+Before changing a hook contract:
+- update this document first
+- update `evaluatePermission.ts` and any wrapper scripts
+- update the direct shell tests
+- update the adapter tests
+- update the Docker hook tests if the platform is covered there
+- confirm the install-hook tests still point the client at the correct wrapper script

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dollhousemcp",
   "display_name": "DollhouseMCP",
-  "version": "2.0.27",
+  "version": "2.0.28",
   "description": "Open-source AI customization through modular Dollhouse elements — personas, skills, templates, agents, memories, and ensembles.",
   "long_description": "DollhouseMCP is an MCP server that lets you customize your AI with modular Dollhouse elements. Create personas that shape behavior and permissions, skills that add capabilities, templates for consistent outputs, agents for autonomous multi-step goals, memories for persistent context, and ensembles that bundle elements together. Includes MCP-AQL query language with 5 semantic CRUDE endpoints, Gatekeeper permission system, community collection, and a built-in portfolio browser.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.27",
+  "version": "2.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.27",
+      "version": "2.0.28",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.27",
+  "version": "2.0.28",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/pretooluse-dollhouse.sh
+++ b/scripts/pretooluse-dollhouse.sh
@@ -20,10 +20,13 @@ RUN_DIR="$HOME/.dollhouse/run"
 PORT_FILE="$RUN_DIR/permission-server.port"
 AUTHORITY_FILE="$RUN_DIR/permission-authority.json"
 AUTHORITY_CACHE_TTL_SECONDS=2
-MAX_RETRIES=2
-INITIAL_TIMEOUT=5
+MAX_RETRIES="${DOLLHOUSE_HOOK_MAX_RETRIES:-2}"
+INITIAL_TIMEOUT="${DOLLHOUSE_HOOK_INITIAL_TIMEOUT:-5}"
 HOOK_PLATFORM="${DOLLHOUSE_HOOK_PLATFORM:-claude_code}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+[[ "$MAX_RETRIES" =~ ^[0-9]+$ ]] || MAX_RETRIES=2
+[[ "$INITIAL_TIMEOUT" =~ ^[0-9]+$ ]] || INITIAL_TIMEOUT=5
 
 # Debug logging helper — writes to stderr so it doesn't pollute stdout
 debug() {

--- a/scripts/pretooluse-dollhouse.sh
+++ b/scripts/pretooluse-dollhouse.sh
@@ -114,6 +114,37 @@ normalize_response() {
         end
       ' 2>/dev/null
       ;;
+    codex)
+      echo "$response" | jq -c '
+        if type == "object" and (keys | length) == 0 then
+          {
+            hookSpecificOutput: {
+              hookEventName: "PreToolUse",
+              permissionDecision: "allow",
+              permissionDecisionReason: ""
+            }
+          }
+        elif (.hookSpecificOutput.permissionDecision? | type) == "string" then
+          {
+            hookSpecificOutput: {
+              hookEventName: "PreToolUse",
+              permissionDecision: (if .hookSpecificOutput.permissionDecision == "allow" then "allow" else "deny" end),
+              permissionDecisionReason: (.hookSpecificOutput.permissionDecisionReason // .hookSpecificOutput.reason // .reason // .message // "")
+            }
+          }
+        elif (.decision? | type) == "string" and (.decision | IN("allow", "deny", "ask")) then
+          {
+            hookSpecificOutput: {
+              hookEventName: "PreToolUse",
+              permissionDecision: (if .decision == "allow" then "allow" else "deny" end),
+              permissionDecisionReason: (.reason // .message // "")
+            }
+          }
+        else
+          empty
+        end
+      ' 2>/dev/null
+      ;;
     *)
       echo "$response"
       ;;

--- a/scripts/pretooluse-vscode.sh
+++ b/scripts/pretooluse-vscode.sh
@@ -7,10 +7,13 @@
 
 RUN_DIR="$HOME/.dollhouse/run"
 PORT_FILE="$RUN_DIR/permission-server.port"
-MAX_RETRIES=2
-INITIAL_TIMEOUT=5
+MAX_RETRIES="${DOLLHOUSE_HOOK_MAX_RETRIES:-2}"
+INITIAL_TIMEOUT="${DOLLHOUSE_HOOK_INITIAL_TIMEOUT:-5}"
 HOOK_PLATFORM="vscode"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+[[ "$MAX_RETRIES" =~ ^[0-9]+$ ]] || MAX_RETRIES=2
+[[ "$INITIAL_TIMEOUT" =~ ^[0-9]+$ ]] || INITIAL_TIMEOUT=5
 
 debug() {
   if [[ "${DOLLHOUSE_HOOK_DEBUG:-0}" == "1" ]]; then

--- a/scripts/pretooluse-windsurf.sh
+++ b/scripts/pretooluse-windsurf.sh
@@ -7,10 +7,13 @@
 
 RUN_DIR="$HOME/.dollhouse/run"
 PORT_FILE="$RUN_DIR/permission-server.port"
-MAX_RETRIES=2
-INITIAL_TIMEOUT=5
+MAX_RETRIES="${DOLLHOUSE_HOOK_MAX_RETRIES:-2}"
+INITIAL_TIMEOUT="${DOLLHOUSE_HOOK_INITIAL_TIMEOUT:-5}"
 HOOK_PLATFORM="windsurf"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+[[ "$MAX_RETRIES" =~ ^[0-9]+$ ]] || MAX_RETRIES=2
+[[ "$INITIAL_TIMEOUT" =~ ^[0-9]+$ ]] || INITIAL_TIMEOUT=5
 
 debug() {
   if [[ "${DOLLHOUSE_HOOK_DEBUG:-0}" == "1" ]]; then

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.27",
+  "version": "2.0.28",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.27",
+      "version": "2.0.28",
       "transport": {
         "type": "stdio"
       }

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.27';
-export const BUILD_TIMESTAMP = '2026-04-20T21:58:23.766Z';
+export const PACKAGE_VERSION = '2.0.28';
+export const BUILD_TIMESTAMP = '2026-04-21T16:06:57.761Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';

--- a/src/handlers/mcp-aql/OperationSchema.ts
+++ b/src/handlers/mcp-aql/OperationSchema.ts
@@ -1477,7 +1477,7 @@ export const GATEKEEPER_SCHEMAS: OperationSchemaMap = {
       platform: { type: 'string', description: 'Target platform for response formatting (default: "claude_code"). Options: claude_code, gemini, cursor, windsurf, codex' },
       session_id: { type: 'string', description: 'Optional persisted activation session ID to evaluate against when hooks run in a separate leader process' },
     },
-    returns: { name: 'PlatformPermissionDecision', kind: 'object', description: 'Platform-formatted permission decision. Claude Code: { hookSpecificOutput: { hookEventName: "PreToolUse", permissionDecision: "allow"|"deny"|"ask", permissionDecisionReason? } }. Gemini: { decision: "allow"|"deny", reason? }. Cursor: { permission: "allow"|"deny"|"ask", reason? }. Windsurf: { allowed: boolean, reason? }. Codex: { hookSpecificOutput: { permissionDecision, reason? } }.' },
+    returns: { name: 'PlatformPermissionDecision', kind: 'object', description: 'Platform-formatted permission decision. Claude Code: { hookSpecificOutput: { hookEventName: "PreToolUse", permissionDecision: "allow"|"deny"|"ask", permissionDecisionReason? } }. Gemini: { decision: "allow"|"deny", reason? }. Cursor: { permission: "allow"|"deny"|"ask", reason? }. Windsurf: { allowed: boolean, reason? }. Codex: { hookSpecificOutput: { hookEventName: "PreToolUse", permissionDecision: "allow"|"deny", permissionDecisionReason? } }.' },
     examples: [
       '{ operation: "evaluate_permission", params: { tool_name: "Bash", input: { command: "git status" } } }',
       '{ operation: "evaluate_permission", params: { tool_name: "Bash", input: { command: "git push --force" }, platform: "claude_code", session_id: "claude-code-session" } }',

--- a/src/handlers/mcp-aql/evaluatePermission.ts
+++ b/src/handlers/mcp-aql/evaluatePermission.ts
@@ -64,9 +64,15 @@ function formatWindsurf(decision: string, reason?: string): Record<string, unkno
   return withReason({ allowed: decision === 'allow' }, reason);
 }
 
-/** Codex: wraps in hookSpecificOutput, maps 'ask' to 'deny' */
+/** Codex: explicit PreToolUse payload, maps 'ask' to 'deny' */
 function formatCodex(decision: string, reason?: string): Record<string, unknown> {
-  return { hookSpecificOutput: withReason({ permissionDecision: decision === 'ask' ? 'deny' : decision }, reason) };
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: decision === 'ask' ? 'deny' : decision,
+      permissionDecisionReason: reason ?? '',
+    },
+  };
 }
 
 /** Claude Code (default): uses hookSpecificOutput.permissionDecision for PreToolUse */

--- a/src/web/console/IngestRoutes.ts
+++ b/src/web/console/IngestRoutes.ts
@@ -29,6 +29,11 @@ import {
   CONSOLE_PROTOCOL_VERSION,
   LEGACY_CONSOLE_PROTOCOL_VERSION,
 } from './LeaderElection.js';
+import {
+  getSessionClientPlatformLabel,
+  normalizeSessionClientPlatformId,
+  type SessionClientPlatformId,
+} from './sessionClientPlatform.js';
 
 /** Maximum payload size for ingestion requests */
 const MAX_PAYLOAD_SIZE = '1mb';
@@ -77,6 +82,10 @@ export interface SessionInfo {
   serverVersion: string;
   /** Console/session contract version used for compatibility-aware takeover. */
   consoleProtocolVersion: number;
+  /** Explicit MCP host platform, when the session reported one. */
+  clientPlatform: SessionClientPlatformId | null;
+  /** Human-readable MCP host label for UI rendering. */
+  clientPlatformLabel: string;
 }
 
 /**
@@ -105,6 +114,7 @@ export interface SessionEventPayload {
   startedAt: string;
   serverVersion?: string;
   consoleProtocolVersion?: number;
+  clientPlatform?: string;
 }
 
 /**
@@ -126,7 +136,7 @@ export interface IngestRoutesResult {
   /** Get all tracked sessions */
   getSessions: () => SessionInfo[];
   /** Register the leader as a session */
-  registerLeaderSession: (sessionId: string, pid: number) => void;
+  registerLeaderSession: (sessionId: string, pid: number, clientPlatform?: string | null) => void;
   /** Register the web console as a session so the indicator is never empty (#1805) */
   registerConsoleSession: () => void;
 }
@@ -148,6 +158,10 @@ function normalizeConsoleProtocolVersion(version?: number): number {
     return version;
   }
   return LEGACY_CONSOLE_PROTOCOL_VERSION;
+}
+
+function normalizeClientPlatform(platform?: string | null): SessionClientPlatformId | null {
+  return normalizeSessionClientPlatformId(platform);
 }
 
 /**
@@ -197,11 +211,13 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     authenticated = false,
     serverVersion?: string,
     consoleProtocolVersion?: number,
+    clientPlatform?: string,
   ): SessionInfo | null {
     try {
       const displayName = namePool.assign(sessionId);
       const color = namePool.getColor(sessionId) ?? '#3b82f6';
       const now = new Date().toISOString();
+      const normalizedClientPlatform = normalizeClientPlatform(clientPlatform);
       const info: SessionInfo = {
         sessionId, displayName, color,
         pid: pid || 0,
@@ -209,6 +225,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
         status: 'active', isLeader: false, authenticated, kind: 'mcp',
         serverVersion: normalizeServerVersion(serverVersion),
         consoleProtocolVersion: normalizeConsoleProtocolVersion(consoleProtocolVersion),
+        clientPlatform: normalizedClientPlatform,
+        clientPlatformLabel: getSessionClientPlatformLabel(normalizedClientPlatform),
       };
       sessions.set(sessionId, info);
       logger.info('[IngestRoutes] Auto-registered orphaned session', {
@@ -234,6 +252,7 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     authenticated = false,
     serverVersion?: string,
     consoleProtocolVersion?: number,
+    clientPlatform?: string,
   ): SessionInfo | null {
     if (killedSessions.has(sessionId)) return null;
     if (pendingKills.has(sessionId)) {
@@ -243,7 +262,14 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
 
     const existing = sessions.get(sessionId);
     if (!existing) {
-      return autoRegister(sessionId, pid, authenticated, serverVersion, consoleProtocolVersion);
+      return autoRegister(
+        sessionId,
+        pid,
+        authenticated,
+        serverVersion,
+        consoleProtocolVersion,
+        clientPlatform,
+      );
     }
 
     if (existing.status === 'ended') {
@@ -264,6 +290,10 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     }
     if (consoleProtocolVersion !== undefined) {
       existing.consoleProtocolVersion = normalizeConsoleProtocolVersion(consoleProtocolVersion);
+    }
+    if (clientPlatform !== undefined) {
+      existing.clientPlatform = normalizeClientPlatform(clientPlatform);
+      existing.clientPlatformLabel = getSessionClientPlatformLabel(existing.clientPlatform);
     }
     return existing;
   }
@@ -366,12 +396,15 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
         const displayName = namePool.assign(payload.sessionId);
         const color = namePool.getColor(payload.sessionId) ?? '#3b82f6';
         const isAuthenticated = Boolean((res as any).locals?.tokenEntry);
+        const normalizedClientPlatform = normalizeClientPlatform(payload.clientPlatform);
         sessions.set(payload.sessionId, {
           sessionId: payload.sessionId, displayName, color,
           pid: payload.pid, startedAt: payload.startedAt || now, lastHeartbeat: now,
           status: 'active', isLeader: false, authenticated: isAuthenticated, kind: 'mcp',
           serverVersion: normalizeServerVersion(payload.serverVersion),
           consoleProtocolVersion: normalizeConsoleProtocolVersion(payload.consoleProtocolVersion),
+          clientPlatform: normalizedClientPlatform,
+          clientPlatformLabel: getSessionClientPlatformLabel(normalizedClientPlatform),
         });
         logger.info('[IngestRoutes] Session registered', {
           displayName, sessionId: payload.sessionId, pid: payload.pid, color,
@@ -402,6 +435,7 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
           false,
           payload.serverVersion,
           payload.consoleProtocolVersion,
+          payload.clientPlatform,
         );
         break;
       }
@@ -438,12 +472,14 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
               localSessions.push({
                 ...ls,
                 authenticated: false,
-                kind: ls.kind || 'mcp',
-                serverVersion: normalizeServerVersion(ls.serverVersion),
-                consoleProtocolVersion: normalizeConsoleProtocolVersion(ls.consoleProtocolVersion),
-              });
-            }
+              kind: ls.kind || 'mcp',
+              serverVersion: normalizeServerVersion(ls.serverVersion),
+              consoleProtocolVersion: normalizeConsoleProtocolVersion(ls.consoleProtocolVersion),
+              clientPlatform: normalizeClientPlatform(ls.clientPlatform),
+              clientPlatformLabel: getSessionClientPlatformLabel(normalizeClientPlatform(ls.clientPlatform)),
+            });
           }
+        }
         }
       } catch {
         // Legacy instance not running or unreachable — that's fine
@@ -564,9 +600,10 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     return Array.from(sessions.values()).filter(s => s.status === 'active');
   }
 
-  function registerLeaderSession(sessionId: string, pid: number): void {
+  function registerLeaderSession(sessionId: string, pid: number, clientPlatform?: string | null): void {
     const displayName = namePool.assign(sessionId, true);
     const color = namePool.getColor(sessionId) ?? '#3b82f6';
+    const normalizedClientPlatform = normalizeClientPlatform(clientPlatform ?? undefined);
     sessions.set(sessionId, {
       sessionId,
       displayName,
@@ -580,6 +617,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       kind: 'mcp',
       serverVersion: PACKAGE_VERSION,
       consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+      clientPlatform: normalizedClientPlatform,
+      clientPlatformLabel: getSessionClientPlatformLabel(normalizedClientPlatform),
     });
     logger.info('[IngestRoutes] Leader session registered', { displayName, sessionId, pid, color });
   }
@@ -593,6 +632,7 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
     const consoleId = `console-${process.pid}`;
     if (sessions.has(consoleId)) return;
     const displayName = 'Web Console';
+    const normalizedClientPlatform: SessionClientPlatformId = 'web-console';
     sessions.set(consoleId, {
       sessionId: consoleId,
       displayName,
@@ -606,6 +646,8 @@ export function createIngestRoutes(broadcasts: IngestBroadcasts): IngestRoutesRe
       kind: 'console',
       serverVersion: PACKAGE_VERSION,
       consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+      clientPlatform: normalizedClientPlatform,
+      clientPlatformLabel: getSessionClientPlatformLabel(normalizedClientPlatform),
     });
     logger.info('[IngestRoutes] Console session registered', { sessionId: consoleId, pid: process.pid });
   }

--- a/src/web/console/LeaderForwardingSink.ts
+++ b/src/web/console/LeaderForwardingSink.ts
@@ -22,6 +22,10 @@ import { PACKAGE_VERSION } from '../../generated/version.js';
 import { logger } from '../../utils/logger.js';
 import { env } from '../../config/env.js';
 import { CONSOLE_PROTOCOL_VERSION } from './LeaderElection.js';
+import {
+  detectSessionClientPlatformId,
+  type SessionClientPlatformId,
+} from './sessionClientPlatform.js';
 
 /** Maximum entries to buffer when leader is unreachable */
 const MAX_BUFFER_SIZE = 10_000;
@@ -221,6 +225,8 @@ export class SessionHeartbeat {
     private readonly pid: number,
     /** Optional console auth token (#1780). Included as Bearer header on ingest POSTs. */
     private readonly authToken: string | null = null,
+    /** Explicit MCP host platform metadata for this runtime. */
+    private readonly clientPlatform: SessionClientPlatformId | null = detectSessionClientPlatformId(),
   ) {}
 
   /** Notify the leader that this session has started */
@@ -257,6 +263,7 @@ export class SessionHeartbeat {
           startedAt: new Date().toISOString(),
           serverVersion: PACKAGE_VERSION,
           consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+          clientPlatform: this.clientPlatform ?? undefined,
         }),
         signal: controller.signal,
       });

--- a/src/web/console/UnifiedConsole.ts
+++ b/src/web/console/UnifiedConsole.ts
@@ -46,6 +46,7 @@ import {
 } from './LeaderForwardingSink.js';
 import { PromotionManager } from './PromotionManager.js';
 import { ConsoleTokenStore } from './consoleToken.js';
+import { detectSessionClientPlatformId } from './sessionClientPlatform.js';
 import {
   findPidOnPort,
   killStaleProcessDetailed,
@@ -707,6 +708,7 @@ async function startAsLeader(
   election: ElectionResult,
   consolePort: number = DEFAULT_CONSOLE_PORT,
 ): Promise<UnifiedConsoleResult> {
+  const clientPlatform = detectSessionClientPlatformId();
   const { startWebServer } = await import('../server.js');
   const { pickRandomTokenName } = await import('./SessionNames.js');
 
@@ -800,7 +802,7 @@ async function startAsLeader(
   }
 
   // Register the leader only after the HTTP listener is actually serving the port.
-  ingestResult.registerLeaderSession(options.sessionId, process.pid);
+  ingestResult.registerLeaderSession(options.sessionId, process.pid, clientPlatform);
 
   // Register the web console itself so the session indicator is never empty (#1805)
   ingestResult.registerConsoleSession();
@@ -853,6 +855,7 @@ async function startAsFollower(
   consolePort: number = DEFAULT_CONSOLE_PORT,
   initialAuthToken: string | null = null,
 ): Promise<UnifiedConsoleResult> {
+  const clientPlatform = detectSessionClientPlatformId();
   const leaderUrl = `http://127.0.0.1:${election.leaderInfo.port}`;
 
   // Read the console auth token (#1780) written by the leader. May be null
@@ -885,7 +888,13 @@ async function startAsFollower(
   options.registerLogSink(forwardingSink);
 
   // Start session heartbeat to the leader
-  sessionHeartbeat = new SessionHeartbeat(leaderUrl, options.sessionId, process.pid, authToken);
+  sessionHeartbeat = new SessionHeartbeat(
+    leaderUrl,
+    options.sessionId,
+    process.pid,
+    authToken,
+    clientPlatform,
+  );
   await sessionHeartbeat.start();
 
   logger.info('[UnifiedConsole] Follower started', {

--- a/src/web/console/sessionClientPlatform.ts
+++ b/src/web/console/sessionClientPlatform.ts
@@ -34,9 +34,27 @@ function normalizeText(value: string | undefined): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
 
-function includesAny(value: string, needles: string[]): boolean {
+function includesAny(value: string, needles: readonly string[]): boolean {
   return needles.some((needle) => value.includes(needle));
 }
+
+function matchesAnySource(values: readonly string[], needles: readonly string[]): boolean {
+  return values.some((value) => includesAny(value, needles));
+}
+
+const TEXT_PLATFORM_MATCHERS: ReadonlyArray<{
+  platform: SessionClientPlatformId;
+  needles: readonly string[];
+}> = [
+  { platform: 'cursor', needles: ['cursor'] },
+  { platform: 'windsurf', needles: ['windsurf'] },
+  { platform: 'gemini-cli', needles: ['gemini'] },
+  { platform: 'cline', needles: ['cline'] },
+  { platform: 'lmstudio', needles: ['lmstudio', 'lm studio'] },
+  { platform: 'claude-desktop', needles: ['claude desktop'] },
+  { platform: 'claude-code', needles: ['claude code'] },
+  { platform: 'codex', needles: ['codex'] },
+];
 
 export function normalizeSessionClientPlatformId(
   value: string | null | undefined,
@@ -73,6 +91,7 @@ export function detectSessionClientPlatformId(
   const argvText = normalizeText(argv.join(' '));
   const execPathText = normalizeText(execPath);
   const titleText = normalizeText(title);
+  const textSources = [argvText, execPathText, titleText];
 
   if (env.CLAUDE_DESKTOP === 'true' || env.CLAUDE_DESKTOP_VERSION) {
     return 'claude-desktop';
@@ -96,40 +115,10 @@ export function detectSessionClientPlatformId(
     return 'codex';
   }
 
-  if (includesAny(argvText, ['cursor']) || includesAny(execPathText, ['cursor']) || includesAny(titleText, ['cursor'])) {
-    return 'cursor';
-  }
-
-  if (includesAny(argvText, ['windsurf']) || includesAny(execPathText, ['windsurf']) || includesAny(titleText, ['windsurf'])) {
-    return 'windsurf';
-  }
-
-  if (includesAny(argvText, ['gemini']) || includesAny(execPathText, ['gemini']) || includesAny(titleText, ['gemini'])) {
-    return 'gemini-cli';
-  }
-
-  if (includesAny(argvText, ['cline']) || includesAny(execPathText, ['cline']) || includesAny(titleText, ['cline'])) {
-    return 'cline';
-  }
-
-  if (
-    includesAny(argvText, ['lmstudio', 'lm studio']) ||
-    includesAny(execPathText, ['lmstudio', 'lm studio']) ||
-    includesAny(titleText, ['lmstudio', 'lm studio'])
-  ) {
-    return 'lmstudio';
-  }
-
-  if (includesAny(argvText, ['claude desktop']) || includesAny(execPathText, ['claude desktop']) || includesAny(titleText, ['claude desktop'])) {
-    return 'claude-desktop';
-  }
-
-  if (includesAny(argvText, ['claude code']) || includesAny(execPathText, ['claude code']) || includesAny(titleText, ['claude code'])) {
-    return 'claude-code';
-  }
-
-  if (includesAny(argvText, ['codex']) || includesAny(execPathText, ['codex']) || includesAny(titleText, ['codex'])) {
-    return 'codex';
+  for (const matcher of TEXT_PLATFORM_MATCHERS) {
+    if (matchesAnySource(textSources, matcher.needles)) {
+      return matcher.platform;
+    }
   }
 
   return null;

--- a/src/web/console/sessionClientPlatform.ts
+++ b/src/web/console/sessionClientPlatform.ts
@@ -1,0 +1,136 @@
+/**
+ * Best-effort MCP client platform detection for session metadata.
+ *
+ * This is intentionally conservative: when we cannot identify the host
+ * confidently, we return null rather than guessing from a session ID.
+ */
+
+export type SessionClientPlatformId =
+  | 'claude-code'
+  | 'claude-desktop'
+  | 'codex'
+  | 'cursor'
+  | 'vscode'
+  | 'windsurf'
+  | 'gemini-cli'
+  | 'cline'
+  | 'lmstudio'
+  | 'web-console';
+
+const CLIENT_PLATFORM_LABELS: Record<SessionClientPlatformId, string> = {
+  'claude-code': 'Claude Code',
+  'claude-desktop': 'Claude Desktop',
+  codex: 'Codex',
+  cursor: 'Cursor',
+  vscode: 'VS Code',
+  windsurf: 'Windsurf',
+  'gemini-cli': 'Gemini CLI',
+  cline: 'Cline',
+  lmstudio: 'LM Studio',
+  'web-console': 'Web Console',
+};
+
+function normalizeText(value: string | undefined): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function includesAny(value: string, needles: string[]): boolean {
+  return needles.some((needle) => value.includes(needle));
+}
+
+export function normalizeSessionClientPlatformId(
+  value: string | null | undefined,
+): SessionClientPlatformId | null {
+  const normalized = normalizeText(value ?? undefined);
+  if (!normalized) {
+    return null;
+  }
+
+  if (normalized === 'gemini') {
+    return 'gemini-cli';
+  }
+
+  if (normalized in CLIENT_PLATFORM_LABELS) {
+    return normalized as SessionClientPlatformId;
+  }
+
+  return null;
+}
+
+export function getSessionClientPlatformLabel(
+  platform: SessionClientPlatformId | null | undefined,
+): string {
+  return platform ? CLIENT_PLATFORM_LABELS[platform] ?? '' : '';
+}
+
+export function detectSessionClientPlatformId(
+  env: NodeJS.ProcessEnv = process.env,
+  argv: readonly string[] = process.argv,
+  execPath: string = process.execPath,
+  title: string = process.title,
+): SessionClientPlatformId | null {
+  const termProgram = normalizeText(env.TERM_PROGRAM);
+  const argvText = normalizeText(argv.join(' '));
+  const execPathText = normalizeText(execPath);
+  const titleText = normalizeText(title);
+
+  if (env.CLAUDE_DESKTOP === 'true' || env.CLAUDE_DESKTOP_VERSION) {
+    return 'claude-desktop';
+  }
+
+  if (env.CLAUDE_CODE === 'true' || termProgram === 'claude-code') {
+    return 'claude-code';
+  }
+
+  if (
+    env.VSCODE_CWD ||
+    env.VSCODE_PID ||
+    env.VSCODE_IPC_HOOK ||
+    env.VSCODE_NLS_CONFIG ||
+    termProgram === 'vscode'
+  ) {
+    return 'vscode';
+  }
+
+  if (env.CODEX_HOME || termProgram === 'codex') {
+    return 'codex';
+  }
+
+  if (includesAny(argvText, ['cursor']) || includesAny(execPathText, ['cursor']) || includesAny(titleText, ['cursor'])) {
+    return 'cursor';
+  }
+
+  if (includesAny(argvText, ['windsurf']) || includesAny(execPathText, ['windsurf']) || includesAny(titleText, ['windsurf'])) {
+    return 'windsurf';
+  }
+
+  if (includesAny(argvText, ['gemini']) || includesAny(execPathText, ['gemini']) || includesAny(titleText, ['gemini'])) {
+    return 'gemini-cli';
+  }
+
+  if (includesAny(argvText, ['cline']) || includesAny(execPathText, ['cline']) || includesAny(titleText, ['cline'])) {
+    return 'cline';
+  }
+
+  if (
+    includesAny(argvText, ['lmstudio', 'lm studio']) ||
+    includesAny(execPathText, ['lmstudio', 'lm studio']) ||
+    includesAny(titleText, ['lmstudio', 'lm studio'])
+  ) {
+    return 'lmstudio';
+  }
+
+  if (includesAny(argvText, ['claude desktop']) || includesAny(execPathText, ['claude desktop']) || includesAny(titleText, ['claude desktop'])) {
+    return 'claude-desktop';
+  }
+
+  if (includesAny(argvText, ['claude code']) || includesAny(execPathText, ['claude code']) || includesAny(titleText, ['claude code'])) {
+    return 'claude-code';
+  }
+
+  if (includesAny(argvText, ['codex']) || includesAny(execPathText, ['codex']) || includesAny(titleText, ['codex'])) {
+    return 'codex';
+  }
+
+  return null;
+}

--- a/src/web/public/sessions.css
+++ b/src/web/public/sessions.css
@@ -184,8 +184,8 @@
 
 .session-dropdown-item {
   display: grid;
-  grid-template-columns: 1rem 8px 1fr 62px 72px 3.5rem 1.2rem;
-  align-items: center;
+  grid-template-columns: 1rem 8px minmax(0, 1fr) 62px 84px 3.5rem 1.2rem;
+  align-items: start;
   gap: 0.4rem;
   padding: 0.45rem 0.75rem;
   font-size: var(--step--1, 0.82rem);
@@ -235,12 +235,49 @@
   white-space: nowrap;
 }
 
+.session-dropdown-primary {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.12rem;
+}
+
+.session-dropdown-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.session-dropdown-version {
+  font-size: 0.7rem;
+  font-family: var(--font-mono, monospace);
+  color: var(--ink-500, #677893);
+  white-space: nowrap;
+}
+
+.session-dropdown-update {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 5px;
+  border-radius: 999px;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  background: #ecfdf5;
+  color: #166534;
+  border: 1px solid #86efac;
+  white-space: nowrap;
+}
+
 .session-dropdown-uptime {
   font-size: 0.7rem;
   font-family: var(--font-mono, monospace);
   color: var(--ink-500, #677893);
   white-space: nowrap;
   text-align: right;
+  padding-top: 0.1rem;
 }
 
 .session-dropdown-role {
@@ -285,6 +322,16 @@
 
 [data-theme="dark"] .session-dropdown-name {
   color: var(--ink-900, #e0e8f0);
+}
+
+[data-theme="dark"] .session-dropdown-version {
+  color: var(--ink-500, #8899bb);
+}
+
+[data-theme="dark"] .session-dropdown-update {
+  background: #052e16;
+  color: #bbf7d0;
+  border-color: #166534;
 }
 
 [data-theme="dark"] .session-dropdown-toggle-label {
@@ -374,6 +421,22 @@
   min-width: 52px;
 }
 
+.session-dropdown-badge-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.18rem;
+  min-width: 0;
+}
+
+.session-dropdown-client-label {
+  font-size: 0.62rem;
+  line-height: 1.15;
+  color: var(--ink-500, #677893);
+  text-align: center;
+  min-width: 0;
+}
+
 .session-status-badge[data-status="positive"] {
   background: #eff6ff;
   color: #1e40af;
@@ -396,6 +459,10 @@
   background: #431407;
   color: #fdba74;
   border-color: #9a3412;
+}
+
+[data-theme="dark"] .session-dropdown-client-label {
+  color: var(--ink-500, #8899bb);
 }
 
 /* Session filter in the log viewer */

--- a/src/web/public/sessions.css
+++ b/src/web/public/sessions.css
@@ -66,7 +66,8 @@
   position: absolute;
   top: calc(100% + 0.4rem);
   right: 0;
-  min-width: 480px;
+  width: min(34rem, calc(100vw - 1rem));
+  box-sizing: border-box;
   background: var(--paper-strong, #fff);
   border: 1px solid var(--line, #c8d5e9);
   border-radius: var(--radius-md, 0.85rem);
@@ -184,10 +185,11 @@
 
 .session-dropdown-item {
   display: grid;
-  grid-template-columns: 1rem 8px minmax(0, 1fr) 62px 84px 3.5rem 1.2rem;
-  align-items: start;
-  gap: 0.4rem;
-  padding: 0.45rem 0.75rem;
+  grid-template-columns: 1rem 8px minmax(0, 1fr) 5.5rem 6.75rem 4.5rem 1.2rem;
+  align-items: center;
+  column-gap: 0.7rem;
+  row-gap: 0.3rem;
+  padding: 0.55rem 0.9rem;
   font-size: var(--step--1, 0.82rem);
   cursor: pointer;
   transition: background 0.1s;
@@ -239,7 +241,8 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.12rem;
+  gap: 0.18rem;
+  align-self: center;
 }
 
 .session-dropdown-meta {
@@ -277,7 +280,8 @@
   color: var(--ink-500, #677893);
   white-space: nowrap;
   text-align: right;
-  padding-top: 0.1rem;
+  min-width: 4.5rem;
+  justify-self: end;
 }
 
 .session-dropdown-role {
@@ -410,23 +414,32 @@
  * - Color (blue=positive, orange=negative — colorblind-safe pair)
  */
 .session-status-badge {
-  display: inline-block;
-  padding: 1px 5px;
-  border-radius: 3px;
-  font-size: 9px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 7px;
+  border-radius: 5px;
+  font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.04em;
   white-space: nowrap;
   text-align: center;
-  min-width: 52px;
+  min-width: 4.75rem;
+  box-sizing: border-box;
+}
+
+.session-dropdown-item > .session-status-badge {
+  justify-self: center;
 }
 
 .session-dropdown-badge-stack {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.18rem;
-  min-width: 0;
+  justify-self: center;
+  gap: 0.24rem;
+  width: 100%;
+  max-width: 6.75rem;
 }
 
 .session-dropdown-client-label {
@@ -434,7 +447,7 @@
   line-height: 1.15;
   color: var(--ink-500, #677893);
   text-align: center;
-  min-width: 0;
+  width: 100%;
 }
 
 .session-status-badge[data-status="positive"] {

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -33,6 +33,18 @@
   var lastReloadTargetVersion = '';
   var pendingLeaderReloadTimer = null;
   var showPolicySessions = loadPolicyDebugVisibility();
+  var CLIENT_PLATFORM_LABELS = {
+    'claude-code': 'Claude Code',
+    'claude-desktop': 'Claude Desktop',
+    'codex': 'Codex',
+    'cursor': 'Cursor',
+    'vscode': 'VS Code',
+    'windsurf': 'Windsurf',
+    'gemini-cli': 'Gemini CLI',
+    'cline': 'Cline',
+    'lmstudio': 'LM Studio',
+    'web-console': 'Web Console'
+  };
 
   function loadPolicyDebugVisibility() {
     try {
@@ -176,6 +188,55 @@
   /** NFC-normalize a string safely */
   function nfc(s) { try { return s.normalize('NFC'); } catch(e) { return s; } }
 
+  function normalizeClientPlatform(platform) {
+    if (typeof platform !== 'string') return '';
+    var normalized = nfc(platform).trim().toLowerCase();
+    if (!normalized) return '';
+    if (normalized === 'gemini') return 'gemini-cli';
+    return Object.prototype.hasOwnProperty.call(CLIENT_PLATFORM_LABELS, normalized) ? normalized : '';
+  }
+
+  function displayPlatform(session) {
+    if (!session || typeof session !== 'object') return '';
+    if (typeof session.clientPlatformLabel === 'string' && session.clientPlatformLabel.trim()) {
+      return nfc(session.clientPlatformLabel.trim());
+    }
+    var platform = normalizeClientPlatform(session.clientPlatform);
+    return platform ? CLIENT_PLATFORM_LABELS[platform] || '' : '';
+  }
+
+  function displayVersion(session) {
+    if (!session || typeof session !== 'object') return '';
+    var normalized = normalizeSemver(session.serverVersion);
+    if (!normalized && typeof session.serverVersion === 'string') {
+      normalized = nfc(session.serverVersion).trim();
+    }
+    if (!normalized) return '';
+    return normalized.charAt(0) === 'v' ? normalized : ('v' + normalized);
+  }
+
+  function getNewestKnownSessionVersion(list) {
+    if (!Array.isArray(list)) return '';
+    var newest = '';
+    for (var i = 0; i < list.length; i++) {
+      var session = list[i];
+      if (!session || isPolicyOnlySession(session) || session.status !== 'active') continue;
+      var version = normalizeSemver(session.serverVersion);
+      if (!version) continue;
+      if (!newest || compareSemver(version, newest) > 0) {
+        newest = version;
+      }
+    }
+    return newest;
+  }
+
+  function sessionHasUpdateAvailable(session, newestVersion) {
+    if (!session || !newestVersion || isPolicyOnlySession(session)) return false;
+    var version = normalizeSemver(session.serverVersion);
+    if (!version) return false;
+    return compareSemver(version, newestVersion) < 0;
+  }
+
   function isPolicyOnlySession(session) {
     return !!(session && session.isPolicyOnly);
   }
@@ -231,6 +292,9 @@
         isLeader: false,
         authenticated: false,
         kind: 'policy',
+        serverVersion: '',
+        clientPlatform: '',
+        clientPlatformLabel: '',
         isPolicyOnly: true,
       });
     }
@@ -254,10 +318,61 @@
   // Build a key from current sessions to detect changes
   function sessionListKey(list) {
     return list.map(function(s) {
-      return s.sessionId + ':' + s.status + ':' + (isPolicyOnlySession(s) ? 'policy' : 'live');
+      return [
+        s.sessionId,
+        s.status,
+        s.displayName || '',
+        s.serverVersion || '',
+        s.clientPlatform || '',
+        s.clientPlatformLabel || '',
+        s.isLeader ? 'leader' : 'member',
+        s.authenticated ? 'auth' : 'noauth',
+        isPolicyOnlySession(s) ? 'policy' : 'live'
+      ].join(':');
     }).join(',')
       + '|policyDebug:' + (showPolicySessions ? 'on' : 'off')
       + '|knownPolicy:' + policySessions.map(function(session) { return session.sessionId; }).join(',');
+  }
+
+  function normalizeLiveSessions(list) {
+    if (!Array.isArray(list)) return [];
+    var normalized = [];
+    var seen = new Set();
+
+    for (var i = 0; i < list.length; i++) {
+      var item = list[i];
+      if (!item || typeof item.sessionId !== 'string') continue;
+      var sessionId = nfc(item.sessionId).trim();
+      if (!sessionId || seen.has(sessionId)) continue;
+      seen.add(sessionId);
+
+      var clientPlatform = normalizeClientPlatform(item.clientPlatform);
+      var clientPlatformLabel = '';
+      if (typeof item.clientPlatformLabel === 'string' && item.clientPlatformLabel.trim()) {
+        clientPlatformLabel = nfc(item.clientPlatformLabel).trim();
+      } else if (clientPlatform) {
+        clientPlatformLabel = CLIENT_PLATFORM_LABELS[clientPlatform] || '';
+      }
+
+      normalized.push({
+        sessionId: sessionId,
+        displayName: nfc(typeof item.displayName === 'string' && item.displayName ? item.displayName : sessionId),
+        color: typeof item.color === 'string' ? item.color : '',
+        pid: typeof item.pid === 'number' ? item.pid : 0,
+        startedAt: typeof item.startedAt === 'string' ? item.startedAt : '',
+        lastHeartbeat: typeof item.lastHeartbeat === 'string' ? item.lastHeartbeat : '',
+        status: item.status === 'ended' ? 'ended' : 'active',
+        isLeader: !!item.isLeader,
+        authenticated: !!item.authenticated,
+        kind: typeof item.kind === 'string' ? item.kind : 'mcp',
+        serverVersion: normalizeSemver(item.serverVersion) || (typeof item.serverVersion === 'string' ? nfc(item.serverVersion).trim() : ''),
+        consoleProtocolVersion: typeof item.consoleProtocolVersion === 'number' ? item.consoleProtocolVersion : 0,
+        clientPlatform: clientPlatform,
+        clientPlatformLabel: clientPlatformLabel,
+      });
+    }
+
+    return normalized;
   }
 
   function setPolicyDebugVisibility(nextVisible, keepDropdownOpen) {
@@ -513,6 +628,7 @@
       if (!a.isLeader && b.isLeader) return 1;
       return 0;
     });
+    var newestKnownVersion = getNewestKnownSessionVersion(sorted);
 
     function appendSessionItem(s) {
       var item = document.createElement('div');
@@ -529,11 +645,36 @@
       if (s.color) dot.style.background = s.color;
       item.appendChild(dot);
 
+      var nameWrap = document.createElement('div');
+      nameWrap.className = 'session-dropdown-primary';
+
       var nameEl = document.createElement('span');
       nameEl.className = 'session-dropdown-name';
       nameEl.textContent = displayName(s);
       if (s.color) nameEl.style.color = s.color;
-      item.appendChild(nameEl);
+      nameWrap.appendChild(nameEl);
+
+      var versionText = displayVersion(s);
+      if (versionText) {
+        var metaRow = document.createElement('div');
+        metaRow.className = 'session-dropdown-meta';
+
+        var versionEl = document.createElement('span');
+        versionEl.className = 'session-dropdown-version';
+        versionEl.textContent = versionText;
+        metaRow.appendChild(versionEl);
+
+        if (sessionHasUpdateAvailable(s, newestKnownVersion)) {
+          var updateBadge = document.createElement('span');
+          updateBadge.className = 'session-dropdown-update';
+          updateBadge.textContent = 'Update available';
+          metaRow.appendChild(updateBadge);
+        }
+
+        nameWrap.appendChild(metaRow);
+      }
+
+      item.appendChild(nameWrap);
 
       // Session status badges (#1805) — for persisted policy sessions we
       // switch from "live/authenticated" semantics to "saved/no client".
@@ -554,6 +695,9 @@
       }
       item.appendChild(authBadge);
 
+      var clientWrap = document.createElement('div');
+      clientWrap.className = 'session-dropdown-badge-stack';
+
       var clientBadge = document.createElement('span');
       clientBadge.className = 'session-status-badge';
       if (isPolicyOnlySession(s)) {
@@ -569,7 +713,17 @@
         clientBadge.dataset.status = 'negative';
         clientBadge.title = 'No MCP client attached';
       }
-      item.appendChild(clientBadge);
+      clientWrap.appendChild(clientBadge);
+
+      var platformLabel = displayPlatform(s);
+      if (platformLabel) {
+        var clientLabel = document.createElement('span');
+        clientLabel.className = 'session-dropdown-client-label';
+        clientLabel.textContent = platformLabel;
+        clientWrap.appendChild(clientLabel);
+      }
+
+      item.appendChild(clientWrap);
 
       var uptimeEl = document.createElement('span');
       uptimeEl.className = 'session-dropdown-uptime';
@@ -727,7 +881,7 @@
       return res.json();
     }).then(function(data) {
       if (data && data.sessions) {
-        sessions = data.sessions;
+        sessions = normalizeLiveSessions(data.sessions);
         maybeForceReloadForNewLeader(sessions);
         updateSessionIndicator();
         updateSessionFilterOptions();
@@ -743,6 +897,7 @@
   window.DollhouseSessions = {
     getFilterSessionId: function() { return filterSessionId; },
     displayName: displayName,
+    displayPlatform: displayPlatform,
     getSessions: function() { return sessions; },
     getLiveSessions: getLiveSessions,
     getSelectableSessions: getSelectableSessions,

--- a/src/web/public/sessions.js
+++ b/src/web/public/sessions.js
@@ -668,6 +668,7 @@
           var updateBadge = document.createElement('span');
           updateBadge.className = 'session-dropdown-update';
           updateBadge.textContent = 'Update available';
+          updateBadge.title = 'A newer local DollhouseMCP session version is active.';
           metaRow.appendChild(updateBadge);
         }
 

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -13,6 +13,8 @@
   const PKG = '@dollhousemcp/mcp-server';
   const HOOKS_DIR = '~/.dollhouse/hooks';
   const HOOK_BASE_SCRIPT_PATH = `${HOOKS_DIR}/pretooluse-dollhouse.sh`;
+  // Keep hook entrypoints and output expectations in sync with
+  // docs/architecture/permission-hook-platform-contracts.md.
 
   /** Platform registry — drives config generation AND panel rendering */
   const PLATFORMS = [

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -13,6 +13,7 @@
   const PKG = '@dollhousemcp/mcp-server';
   const HOOKS_DIR = '~/.dollhouse/hooks';
   const HOOK_BASE_SCRIPT_PATH = `${HOOKS_DIR}/pretooluse-dollhouse.sh`;
+  const HOOK_CONTRACT_DOC_URL = 'https://github.com/DollhouseMCP/mcp-server/blob/main/docs/architecture/permission-hook-platform-contracts.md';
   // Keep hook entrypoints and output expectations in sync with
   // docs/architecture/permission-hook-platform-contracts.md.
 
@@ -1593,6 +1594,7 @@ codex_hooks = true`;
     intro.innerHTML = `<div class="setup-permissions-note">
         <strong>Permissions &amp; Security</strong>
         <p>Use this mode to turn on permission enforcement for supported clients. Claude Code is fully guided in this release. Gemini CLI, Cursor, VS Code, Windsurf, and Codex have native partial support, while Cline and LM Studio stay in the MCP and fallback lane for now. Other clients will be marked as coming soon.</p>
+        <p class="setup-hint">Need the advanced client-by-client hook contract details? <a href="${HOOK_CONTRACT_DOC_URL}" target="_blank" rel="noopener noreferrer">Read the platform contract reference</a>.</p>
       </div>`;
   };
 

--- a/tests/integration/hooks/permission-hook-docker.test.ts
+++ b/tests/integration/hooks/permission-hook-docker.test.ts
@@ -106,7 +106,9 @@ suite('Dockerized permission hook adapters', () => {
     expect(result.exitCode).toBe(0);
     expect(parseHookStdout(result, '/workspace/scripts/pretooluse-codex.sh')).toEqual({
       hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
         permissionDecision: 'allow',
+        permissionDecisionReason: '',
       },
     });
     expect(result.requestBody).toEqual({

--- a/tests/integration/hooks/permission-hook-docker.test.ts
+++ b/tests/integration/hooks/permission-hook-docker.test.ts
@@ -3,6 +3,9 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { resolve } from 'node:path';
 
+// Keep Dockerized wrapper assertions in sync with
+// docs/architecture/permission-hook-platform-contracts.md.
+
 jest.setTimeout(180_000);
 
 const SAFE_HOST_PATH = '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin';

--- a/tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts
+++ b/tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts
@@ -18,6 +18,9 @@
  * These tests verify the TRANSLATION layer, not the policy evaluation
  * itself (that's covered by permission-flow-matrix.test.ts).
  *
+ * Keep adapter expectations in sync with
+ * docs/architecture/permission-hook-platform-contracts.md.
+ *
  * @module
  */
 

--- a/tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts
+++ b/tests/integration/mcp-aql/permission-flow-platform-adapters.test.ts
@@ -166,17 +166,16 @@ function toCursorHook(result: CliToolPolicyResult): CursorHookResponse {
 /**
  * Translate a CliToolPolicyResult to Codex CLI PreToolUse hook format.
  * Codex uses hookSpecificOutput with permissionDecision.
- * No 'ask' — confirm maps to deny (Codex fails open, so deny is safer).
+ * No 'ask' — confirm maps to deny.
  */
 function toCodexHook(result: CliToolPolicyResult): CodexHookResponse {
-  if (result.behavior === 'allow' || result.behavior === 'evaluate') {
-    return {}; // Empty response = allow (Codex fails open)
-  }
   return {
     hookSpecificOutput: {
       hookEventName: 'PreToolUse',
-      permissionDecision: 'deny',
-      permissionDecisionReason: result.message,
+      permissionDecision: result.behavior === 'allow' || result.behavior === 'evaluate'
+        ? 'allow'
+        : 'deny',
+      permissionDecisionReason: result.message ?? '',
     },
   };
 }
@@ -415,10 +414,9 @@ describe('Permission Flow Platform Adapters (Issue #1669)', () => {
         const response = toCodexHook(raw);
 
         if (scenario.expectedBehavior === 'allow') {
-          // Codex: empty response = allow (fails open)
-          expect(response.hookSpecificOutput).toBeUndefined();
+          expect(response.hookSpecificOutput?.permissionDecision).toBe('allow');
         } else {
-          // Both deny and confirm → deny in Codex (no ask, and fails open is dangerous for confirm)
+          // Both deny and confirm → deny in Codex (no ask)
           expect(response.hookSpecificOutput).toBeDefined();
           expect(response.hookSpecificOutput?.permissionDecision).toBe('deny');
         }
@@ -534,7 +532,7 @@ describe('Permission Flow Platform Adapters (Issue #1669)', () => {
         expect(toClaudeCode(raw, scenario.toolName).behavior).toBe('allow');
         expect(toGeminiHook(raw).decision).toBe('allow');
         expect(toCursorHook(raw).permission).toBe('allow');
-        expect(toCodexHook(raw).hookSpecificOutput).toBeUndefined();
+        expect(toCodexHook(raw).hookSpecificOutput?.permissionDecision).toBe('allow');
         expect(toWindsurfHook(raw).exitCode).toBe(0);
         expect(toVSCodeHook(raw).permission).toBe('allow');
       }
@@ -569,7 +567,7 @@ describe('Permission Flow Platform Adapters (Issue #1669)', () => {
         // Cursor: ask (has ask option)
         expect(toCursorHook(raw).permission).toBe('ask');
 
-        // Codex: deny (no ask, fails open is risky)
+        // Codex: deny (no ask)
         expect(toCodexHook(raw).hookSpecificOutput?.permissionDecision).toBe('deny');
 
         // Windsurf: exit 2 (binary, no ask)

--- a/tests/unit/di/permissionServerIntegration.test.ts
+++ b/tests/unit/di/permissionServerIntegration.test.ts
@@ -396,6 +396,35 @@ describe('Permission Server Integration', () => {
       expect(stdout.trim()).toBe('');
     });
 
+    itBash('hook script should fail open when permission requests time out', async () => {
+      let testPort = 0;
+      const mockServer = http.createServer((_req, _res) => {
+        // Intentionally never respond so curl hits its max-time window.
+      });
+
+      testPort = await listenOnLoopback(mockServer);
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout } = await runHookScript(
+        {
+          tool_name: 'Read',
+          tool_input: { file_path: './test-fixture.txt' },
+        },
+        {
+          DOLLHOUSE_HOOK_INITIAL_TIMEOUT: '1',
+          DOLLHOUSE_HOOK_MAX_RETRIES: '0',
+        },
+      );
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(0);
+      expect(stdout.trim()).toBe('');
+    });
+
     itBash('hook script should emit Codex-compatible JSON for allow decisions', async () => {
       let testPort = 0;
       let capturedBody: Record<string, unknown> | null = null;
@@ -646,6 +675,51 @@ describe('Permission Server Integration', () => {
           permissionDecision: 'ask',
           permissionDecisionReason: 'Needs approval',
         },
+      });
+    });
+
+    itBash('vscode hook wrapper should fail open silently on malformed responses', async () => {
+      let testPort = 0;
+      let capturedBody: Record<string, unknown> | null = null;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          let body = '';
+          req.on('data', chunk => { body += chunk; });
+          req.on('end', () => {
+            capturedBody = JSON.parse(body);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ unexpected: true }));
+          });
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      testPort = await listenOnLoopback(mockServer);
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout } = await runHookScript(
+        {
+          toolName: 'runTerminalCommand',
+          toolInput: { command: 'npm test' },
+        },
+        {},
+        VSCODE_HOOK_SCRIPT,
+      );
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(0);
+      expect(stdout.trim()).toBe('');
+      expect(capturedBody).toEqual({
+        tool_name: 'Bash',
+        input: { command: 'npm test' },
+        platform: 'vscode',
+        session_id: 'session-hook-test',
       });
     });
 

--- a/tests/unit/di/permissionServerIntegration.test.ts
+++ b/tests/unit/di/permissionServerIntegration.test.ts
@@ -389,6 +389,98 @@ describe('Permission Server Integration', () => {
       expect(stdout.trim()).toBe('');
     });
 
+    itBash('hook script should emit Codex-compatible JSON for allow decisions', async () => {
+      let testPort = 0;
+      let capturedBody: Record<string, unknown> | null = null;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          let body = '';
+          req.on('data', chunk => { body += chunk; });
+          req.on('end', () => {
+            capturedBody = JSON.parse(body);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              hookSpecificOutput: {
+                permissionDecision: 'allow',
+              },
+            }));
+          });
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      testPort = await listenOnLoopback(mockServer);
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout } = await runHookScript(
+        {
+          toolName: 'Bash',
+          toolInput: { command: 'node -p "require(\'./package.json\').version"' },
+        },
+        { DOLLHOUSE_HOOK_PLATFORM: 'codex' },
+      );
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(0);
+      expect(capturedBody).toEqual({
+        tool_name: 'Bash',
+        input: { command: 'node -p "require(\'./package.json\').version"' },
+        platform: 'codex',
+        session_id: 'session-hook-test',
+      });
+      expect(JSON.parse(stdout.trim())).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          permissionDecisionReason: '',
+        },
+      });
+    });
+
+    itBash('hook script should normalize legacy empty Codex allow responses', async () => {
+      let testPort = 0;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({}));
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      testPort = await listenOnLoopback(mockServer);
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout } = await runHookScript(
+        {
+          toolName: 'Bash',
+          toolInput: { command: 'pwd' },
+        },
+        { DOLLHOUSE_HOOK_PLATFORM: 'codex' },
+      );
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(0);
+      expect(JSON.parse(stdout.trim())).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          permissionDecisionReason: '',
+        },
+      });
+    });
+
     itBash('hook script should fall back to the newest live PID-keyed port file and restore the shared file', async () => {
       let testPort = 0;
       let capturedBody: Record<string, unknown> | null = null;
@@ -550,13 +642,17 @@ async function reserveUnusedLoopbackPort(): Promise<number> {
   return port;
 }
 
-function runHookScript(payload: Record<string, unknown>): Promise<{ code: number; stdout: string }> {
+function runHookScript(
+  payload: Record<string, unknown>,
+  envOverrides: Record<string, string> = {},
+): Promise<{ code: number; stdout: string }> {
   return new Promise((resolve) => {
     const hookProc = spawn(BASH_BINARY, [HOOK_SCRIPT], {
       env: {
         HOME: os.homedir(),
         PATH: SAFE_TEST_PATH,
         DOLLHOUSE_SESSION_ID: 'session-hook-test',
+        ...envOverrides,
       },
       stdio: ['pipe', 'pipe', 'pipe'],
     });

--- a/tests/unit/di/permissionServerIntegration.test.ts
+++ b/tests/unit/di/permissionServerIntegration.test.ts
@@ -4,6 +4,9 @@
  * In mcp-server, permission routes are mounted on the unified web
  * console (port 41715). These tests verify port file lifecycle, HTTP
  * endpoint behavior, hook script compatibility, and error recovery.
+ *
+ * Keep platform-specific stdout/exit assertions in sync with
+ * docs/architecture/permission-hook-platform-contracts.md.
  */
 
 import { describe, expect, it, afterEach } from '@jest/globals';
@@ -18,6 +21,10 @@ const PORT_FILE = path.join(RUN_DIR, 'permission-server.port');
 const PID_PORT_FILE = path.join(RUN_DIR, `permission-server-${process.pid}.port`);
 // Hook script lives in the repo at scripts/ — works on both dev machines and CI
 const HOOK_SCRIPT = path.join(process.cwd(), 'scripts', 'pretooluse-dollhouse.sh');
+const CURSOR_HOOK_SCRIPT = path.join(process.cwd(), 'scripts', 'pretooluse-cursor.sh');
+const GEMINI_HOOK_SCRIPT = path.join(process.cwd(), 'scripts', 'pretooluse-gemini.sh');
+const VSCODE_HOOK_SCRIPT = path.join(process.cwd(), 'scripts', 'pretooluse-vscode.sh');
+const WINDSURF_HOOK_SCRIPT = path.join(process.cwd(), 'scripts', 'pretooluse-windsurf.sh');
 const SAFE_TEST_PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
 const BASH_BINARY = '/bin/bash';
 
@@ -481,6 +488,217 @@ describe('Permission Server Integration', () => {
       });
     });
 
+    itBash('cursor hook wrapper should preserve Cursor permission responses', async () => {
+      let testPort = 0;
+      let capturedBody: Record<string, unknown> | null = null;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          let body = '';
+          req.on('data', chunk => { body += chunk; });
+          req.on('end', () => {
+            capturedBody = JSON.parse(body);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              permission: 'deny',
+              reason: 'Blocked by policy',
+            }));
+          });
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      testPort = await listenOnLoopback(mockServer);
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout } = await runHookScript(
+        {
+          toolName: 'Bash',
+          toolInput: { command: 'git status' },
+        },
+        {},
+        CURSOR_HOOK_SCRIPT,
+      );
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(0);
+      expect(capturedBody).toEqual({
+        tool_name: 'Bash',
+        input: { command: 'git status' },
+        platform: 'cursor',
+        session_id: 'session-hook-test',
+      });
+      expect(JSON.parse(stdout.trim())).toEqual({
+        permission: 'deny',
+        reason: 'Blocked by policy',
+      });
+    });
+
+    itBash('gemini hook wrapper should preserve Gemini decision payloads', async () => {
+      let testPort = 0;
+      let capturedBody: Record<string, unknown> | null = null;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          let body = '';
+          req.on('data', chunk => { body += chunk; });
+          req.on('end', () => {
+            capturedBody = JSON.parse(body);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              decision: 'allow',
+            }));
+          });
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      testPort = await listenOnLoopback(mockServer);
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout } = await runHookScript(
+        {
+          toolName: 'Write',
+          toolInput: { file_path: 'notes.txt' },
+        },
+        {},
+        GEMINI_HOOK_SCRIPT,
+      );
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(0);
+      expect(capturedBody).toEqual({
+        tool_name: 'Write',
+        input: { file_path: 'notes.txt' },
+        platform: 'gemini',
+        session_id: 'session-hook-test',
+      });
+      expect(JSON.parse(stdout.trim())).toEqual({
+        decision: 'allow',
+      });
+    });
+
+    itBash('vscode hook wrapper should normalize terminal commands and preserve ask responses', async () => {
+      let testPort = 0;
+      let capturedBody: Record<string, unknown> | null = null;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          let body = '';
+          req.on('data', chunk => { body += chunk; });
+          req.on('end', () => {
+            capturedBody = JSON.parse(body);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              hookSpecificOutput: {
+                hookEventName: 'PreToolUse',
+                permissionDecision: 'ask',
+                permissionDecisionReason: 'Needs approval',
+              },
+            }));
+          });
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      testPort = await listenOnLoopback(mockServer);
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout } = await runHookScript(
+        {
+          toolName: 'runTerminalCommand',
+          toolInput: { command: 'npm install' },
+          cwd: '/workspace',
+        },
+        {},
+        VSCODE_HOOK_SCRIPT,
+      );
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(0);
+      expect(capturedBody).toEqual({
+        tool_name: 'Bash',
+        input: {
+          command: 'npm install',
+          cwd: '/workspace',
+        },
+        platform: 'vscode',
+        session_id: 'session-hook-test',
+      });
+      expect(JSON.parse(stdout.trim())).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'ask',
+          permissionDecisionReason: 'Needs approval',
+        },
+      });
+    });
+
+    itBash('windsurf hook wrapper should map deny decisions to exit code 2', async () => {
+      let testPort = 0;
+      let capturedBody: Record<string, unknown> | null = null;
+      const mockServer = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
+          let body = '';
+          req.on('data', chunk => { body += chunk; });
+          req.on('end', () => {
+            capturedBody = JSON.parse(body);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              allowed: false,
+              reason: 'Blocked by policy',
+            }));
+          });
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+
+      testPort = await listenOnLoopback(mockServer);
+      await fs.mkdir(RUN_DIR, { recursive: true });
+      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+
+      const { code, stdout, stderr } = await runHookScript(
+        {
+          hook_event_name: 'pre_mcp_tool_use',
+          tool_name: 'Read',
+          tool_arguments: { file_path: 'src/index.ts' },
+        },
+        {},
+        WINDSURF_HOOK_SCRIPT,
+      );
+
+      await new Promise<void>(resolve => mockServer.close(() => resolve()));
+      await fs.unlink(PORT_FILE).catch(() => {});
+      await fs.unlink(PID_PORT_FILE).catch(() => {});
+
+      expect(code).toBe(2);
+      expect(stdout.trim()).toBe('');
+      expect(stderr).toContain('Blocked by policy');
+      expect(capturedBody).toEqual({
+        tool_name: 'Read',
+        input: { file_path: 'src/index.ts' },
+        platform: 'windsurf',
+        session_id: 'session-hook-test',
+      });
+    });
+
     itBash('hook script should fall back to the newest live PID-keyed port file and restore the shared file', async () => {
       let testPort = 0;
       let capturedBody: Record<string, unknown> | null = null;
@@ -645,9 +863,10 @@ async function reserveUnusedLoopbackPort(): Promise<number> {
 function runHookScript(
   payload: Record<string, unknown>,
   envOverrides: Record<string, string> = {},
-): Promise<{ code: number; stdout: string }> {
+  scriptPath = HOOK_SCRIPT,
+): Promise<{ code: number; stdout: string; stderr: string }> {
   return new Promise((resolve) => {
-    const hookProc = spawn(BASH_BINARY, [HOOK_SCRIPT], {
+    const hookProc = spawn(BASH_BINARY, [scriptPath], {
       env: {
         HOME: os.homedir(),
         PATH: SAFE_TEST_PATH,
@@ -657,8 +876,10 @@ function runHookScript(
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let out = '';
+    let err = '';
     hookProc.stdout.on('data', (data: Buffer) => { out += data.toString(); });
-    hookProc.on('close', (c: number) => resolve({ code: c, stdout: out }));
+    hookProc.stderr.on('data', (data: Buffer) => { err += data.toString(); });
+    hookProc.on('close', (c: number) => resolve({ code: c, stdout: out, stderr: err }));
     hookProc.stdin.write(JSON.stringify(payload));
     hookProc.stdin.end();
   });

--- a/tests/unit/handlers/mcp-aql/evaluatePermission.test.ts
+++ b/tests/unit/handlers/mcp-aql/evaluatePermission.test.ts
@@ -88,12 +88,24 @@ describe('evaluatePermission', () => {
         .toEqual({ allowed: false, reason: 'Nope' });
     });
 
+    it('should format codex allow response', () => {
+      expect(formatPermissionResponse('allow', 'codex', input))
+        .toEqual({
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
+            permissionDecision: 'allow',
+            permissionDecisionReason: '',
+          },
+        });
+    });
+
     it('should format codex response (maps ask to deny)', () => {
       expect(formatPermissionResponse('ask', 'codex', input, 'Review needed'))
         .toEqual({
           hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
             permissionDecision: 'deny',
-            reason: 'Review needed',
+            permissionDecisionReason: 'Review needed',
           },
         });
     });

--- a/tests/unit/utils/permissionHooks.test.ts
+++ b/tests/unit/utils/permissionHooks.test.ts
@@ -3,6 +3,9 @@ import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+// Keep installed wrapper-script expectations in sync with
+// docs/architecture/permission-hook-platform-contracts.md.
+
 import {
   ensureClaudePreToolUseHook,
   ensureCodexPreToolUseHook,

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -310,8 +310,68 @@ describe('Web console cleanup regressions', () => {
     expect(oldItem?.querySelector('.session-dropdown-version')?.textContent).toBe('v2.0.26');
     expect(oldItem?.querySelector('.session-dropdown-client-label')?.textContent).toBe('Codex');
     expect(oldItem?.querySelector('.session-dropdown-update')?.textContent).toBe('Update available');
+    expect(oldItem?.querySelector('.session-dropdown-update')?.getAttribute('title')).toBe(
+      'A newer local DollhouseMCP session version is active.',
+    );
 
     expect(consoleItem?.querySelector('.session-dropdown-client-label')?.textContent).toBe('Web Console');
+
+    cleanup();
+  });
+
+  it('handles prerelease update comparisons and missing platform metadata safely', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="session-indicator"></div>
+      <div id="tab-logs"><div class="log-controls"></div></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        sessions: [
+          {
+            sessionId: 'session-new',
+            status: 'active',
+            displayName: 'Bert',
+            startedAt: '2026-04-20T18:00:00.000Z',
+            isLeader: true,
+            authenticated: true,
+            kind: 'mcp',
+            color: '#1d4ed8',
+            serverVersion: '2.0.27-rc.17',
+            clientPlatform: 'claude-code',
+            clientPlatformLabel: 'Claude Code',
+          },
+          {
+            sessionId: 'session-old',
+            status: 'active',
+            displayName: 'Teddy',
+            startedAt: '2026-04-20T17:30:00.000Z',
+            isLeader: false,
+            authenticated: false,
+            kind: 'mcp',
+            color: '#92400e',
+            serverVersion: '2.0.27-rc.16',
+            clientPlatform: null,
+            clientPlatformLabel: null,
+          },
+        ],
+      }),
+    });
+    win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+
+    win.eval(sessionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    await wait(DEFAULT_WAIT_MS);
+
+    (win.document.querySelector('.session-box') as HTMLButtonElement | null)?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    const oldItem = win.document.querySelector('.session-dropdown-item[data-session-id="session-old"]') as HTMLElement | null;
+
+    expect(oldItem?.querySelector('.session-dropdown-version')?.textContent).toBe('v2.0.27-rc.16');
+    expect(oldItem?.querySelector('.session-dropdown-update')?.textContent).toBe('Update available');
+    expect(oldItem?.querySelector('.session-dropdown-client-label')).toBeNull();
 
     cleanup();
   });

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -239,6 +239,83 @@ describe('Web console cleanup regressions', () => {
     cleanup();
   });
 
+  it('renders explicit client platform labels and update-available metadata in the session dropdown', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="session-indicator"></div>
+      <div id="tab-logs"><div class="log-controls"></div></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        sessions: [
+          {
+            sessionId: 'session-new',
+            status: 'active',
+            displayName: 'Bert',
+            startedAt: '2026-04-20T18:00:00.000Z',
+            isLeader: true,
+            authenticated: true,
+            kind: 'mcp',
+            color: '#1d4ed8',
+            serverVersion: '2.0.27',
+            clientPlatform: 'claude-code',
+            clientPlatformLabel: 'Claude Code',
+          },
+          {
+            sessionId: 'session-old',
+            status: 'active',
+            displayName: 'Teddy',
+            startedAt: '2026-04-20T17:30:00.000Z',
+            isLeader: false,
+            authenticated: false,
+            kind: 'mcp',
+            color: '#92400e',
+            serverVersion: '2.0.26',
+            clientPlatform: 'codex',
+            clientPlatformLabel: 'Codex',
+          },
+          {
+            sessionId: 'console-1',
+            status: 'active',
+            displayName: 'Web Console',
+            startedAt: '2026-04-20T18:00:00.000Z',
+            isLeader: false,
+            authenticated: true,
+            kind: 'console',
+            color: '#6366f1',
+            serverVersion: '2.0.27',
+            clientPlatform: 'web-console',
+            clientPlatformLabel: 'Web Console',
+          },
+        ],
+      }),
+    });
+    win.DollhouseConsole = { logs: { refilter: jest.fn() } };
+
+    win.eval(sessionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    await wait(DEFAULT_WAIT_MS);
+
+    (win.document.querySelector('.session-box') as HTMLButtonElement | null)?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    const leaderItem = win.document.querySelector('.session-dropdown-item[data-session-id="session-new"]') as HTMLElement | null;
+    const oldItem = win.document.querySelector('.session-dropdown-item[data-session-id="session-old"]') as HTMLElement | null;
+    const consoleItem = win.document.querySelector('.session-dropdown-item[data-session-id="console-1"]') as HTMLElement | null;
+
+    expect(leaderItem?.querySelector('.session-dropdown-version')?.textContent).toBe('v2.0.27');
+    expect(leaderItem?.querySelector('.session-dropdown-client-label')?.textContent).toBe('Claude Code');
+
+    expect(oldItem?.querySelector('.session-dropdown-version')?.textContent).toBe('v2.0.26');
+    expect(oldItem?.querySelector('.session-dropdown-client-label')?.textContent).toBe('Codex');
+    expect(oldItem?.querySelector('.session-dropdown-update')?.textContent).toBe('Update available');
+
+    expect(consoleItem?.querySelector('.session-dropdown-client-label')?.textContent).toBe('Web Console');
+
+    cleanup();
+  });
+
   it('injects the log session filter into .log-controls and populates active sessions', async () => {
     const { window: win, cleanup } = createDom(`
       <div id="session-indicator"></div>

--- a/tests/unit/web/console/console-failure-modes.test.ts
+++ b/tests/unit/web/console/console-failure-modes.test.ts
@@ -476,6 +476,7 @@ describe('Console Failure Modes', () => {
           'test-session',
           process.pid,
           null,
+          'claude-code',
         );
 
         await heartbeat.start();
@@ -485,6 +486,7 @@ describe('Console Failure Modes', () => {
         const body = parseRequestBody((firstCall?.[1] as RequestInit | undefined)?.body);
         expect(body.serverVersion).toBe(PACKAGE_VERSION);
         expect(body.consoleProtocolVersion).toBe(CONSOLE_PROTOCOL_VERSION);
+        expect(body.clientPlatform).toBe('claude-code');
       } finally {
         fetchSpy.mockRestore();
       }

--- a/tests/unit/web/console/sessionClientPlatform.test.ts
+++ b/tests/unit/web/console/sessionClientPlatform.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  detectSessionClientPlatformId,
+  getSessionClientPlatformLabel,
+  normalizeSessionClientPlatformId,
+} from '../../../../src/web/console/sessionClientPlatform.js';
+
+describe('sessionClientPlatform', () => {
+  it('normalizes supported platform IDs', () => {
+    expect(normalizeSessionClientPlatformId('claude-code')).toBe('claude-code');
+    expect(normalizeSessionClientPlatformId('gemini')).toBe('gemini-cli');
+    expect(normalizeSessionClientPlatformId('unknown-client')).toBeNull();
+  });
+
+  it('returns human labels for known platforms', () => {
+    expect(getSessionClientPlatformLabel('claude-code')).toBe('Claude Code');
+    expect(getSessionClientPlatformLabel('web-console')).toBe('Web Console');
+    expect(getSessionClientPlatformLabel(null)).toBe('');
+  });
+
+  it('detects Claude Code from TERM_PROGRAM', () => {
+    const detected = detectSessionClientPlatformId(
+      { TERM_PROGRAM: 'claude-code' },
+      ['node', 'dist/index.js'],
+      '/usr/local/bin/node',
+      'node',
+    );
+    expect(detected).toBe('claude-code');
+  });
+
+  it('detects Codex from CODEX_HOME', () => {
+    const detected = detectSessionClientPlatformId(
+      { CODEX_HOME: '/tmp/codex-home' },
+      ['node', 'dist/index.js'],
+      '/usr/local/bin/node',
+      'node',
+    );
+    expect(detected).toBe('codex');
+  });
+
+  it('returns null when the host cannot be identified confidently', () => {
+    const detected = detectSessionClientPlatformId(
+      {},
+      ['node', 'dist/index.js'],
+      '/usr/local/bin/node',
+      'node',
+    );
+    expect(detected).toBeNull();
+  });
+});

--- a/tests/unit/web/console/sessionClientPlatform.test.ts
+++ b/tests/unit/web/console/sessionClientPlatform.test.ts
@@ -30,12 +30,22 @@ describe('sessionClientPlatform', () => {
 
   it('detects Codex from CODEX_HOME', () => {
     const detected = detectSessionClientPlatformId(
-      { CODEX_HOME: '/tmp/codex-home' },
+      { CODEX_HOME: '/Users/test/.codex' },
       ['node', 'dist/index.js'],
       '/usr/local/bin/node',
       'node',
     );
     expect(detected).toBe('codex');
+  });
+
+  it('detects Gemini CLI from argv text when no explicit env markers exist', () => {
+    const detected = detectSessionClientPlatformId(
+      {},
+      ['node', '/Applications/Gemini CLI.app/Contents/MacOS/gemini'],
+      '/usr/local/bin/node',
+      'node',
+    );
+    expect(detected).toBe('gemini-cli');
   });
 
   it('returns null when the host cannot be identified confidently', () => {

--- a/tests/unit/web/console/sessionRegistry.test.ts
+++ b/tests/unit/web/console/sessionRegistry.test.ts
@@ -34,7 +34,7 @@ describe('Session registry (#1805)', () => {
 
   describe('registerLeaderSession', () => {
     it('registers a leader session with authenticated=true and kind=mcp', () => {
-      ingestResult.registerLeaderSession('test-leader-001', process.pid);
+      ingestResult.registerLeaderSession('test-leader-001', process.pid, 'claude-code');
       const sessions = ingestResult.getSessions();
       expect(sessions).toHaveLength(1);
       expect(sessions[0].authenticated).toBe(true);
@@ -43,6 +43,8 @@ describe('Session registry (#1805)', () => {
       expect(sessions[0].status).toBe('active');
       expect(sessions[0].serverVersion).toBe(PACKAGE_VERSION);
       expect(sessions[0].consoleProtocolVersion).toBe(CONSOLE_PROTOCOL_VERSION);
+      expect(sessions[0].clientPlatform).toBe('claude-code');
+      expect(sessions[0].clientPlatformLabel).toBe('Claude Code');
     });
 
     it('assigns a puppet display name', () => {
@@ -88,6 +90,8 @@ describe('Session registry (#1805)', () => {
       expect(consoleSessions[0].kind).toBe('console');
       expect(consoleSessions[0].displayName).toBe('Web Console');
       expect(consoleSessions[0].status).toBe('active');
+      expect(consoleSessions[0].clientPlatform).toBe('web-console');
+      expect(consoleSessions[0].clientPlatformLabel).toBe('Web Console');
     });
 
     it('is idempotent — calling twice does not create duplicates', () => {
@@ -169,6 +173,7 @@ describe('Session registry (#1805)', () => {
           startedAt: new Date().toISOString(),
           serverVersion: '2.0.99',
           consoleProtocolVersion: 1,
+          clientPlatform: 'codex',
         });
 
       const res = await request(app).get('/api/sessions');
@@ -177,6 +182,8 @@ describe('Session registry (#1805)', () => {
       expect(follower).toBeDefined();
       expect(follower.serverVersion).toBe('2.0.99');
       expect(follower.consoleProtocolVersion).toBe(1);
+      expect(follower.clientPlatform).toBe('codex');
+      expect(follower.clientPlatformLabel).toBe('Codex');
     });
   });
 
@@ -245,6 +252,8 @@ describe('Session registry (#1805)', () => {
         kind: 'console',
         serverVersion: PACKAGE_VERSION,
         consoleProtocolVersion: CONSOLE_PROTOCOL_VERSION,
+        clientPlatform: 'web-console',
+        clientPlatformLabel: 'Web Console',
       }));
       expect(session.sessionId).toMatch(/^console-\d+$/);
       expect(session.color).toBe('#6366f1');

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -2057,6 +2057,15 @@ describe('Setup Tab — Channel Selector Interactions', () => {
       expect(status?.textContent).toContain('Permissions & security tools are unavailable for Claude Desktop right now.');
       expect(status?.textContent).not.toContain('already configured for this client');
     });
+
+    it('links to the platform contract reference for advanced hook details', () => {
+      const intro = document.getElementById('setup-permissions-intro');
+      const link = intro?.querySelector('a[href="https://github.com/DollhouseMCP/mcp-server/blob/main/docs/architecture/permission-hook-platform-contracts.md"]') as HTMLAnchorElement | null;
+
+      expect(link).not.toBeNull();
+      expect(link?.textContent).toContain('platform contract reference');
+      expect(link?.target).toBe('_blank');
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- release `2.0.28` from current `develop`
- include the safe session metadata and dropdown alignment improvements
- include the Codex pre-tool-use JSON output fix
- include the cross-platform permission hook contract audit and setup docs-link follow-up

## Included work
- #2137
- #2138
- #2139
- #2141

## Verification
- `npm test -- --runInBand tests/scripts/update-version.test.ts tests/unit/scripts/version-generation.test.ts`
