### PR TITLE
Automatically refresh stale permission hook assets

### DIFF
--- a/src/services/BuildInfoService.ts
+++ b/src/services/BuildInfoService.ts
@@ -15,6 +15,7 @@ import { IFileOperationsService } from './FileOperationsService.js';
 import { PACKAGE_NAME, PACKAGE_VERSION, BUILD_TIMESTAMP, BUILD_TYPE } from '../generated/version.js';
 import type { StartupTimer, StartupReport } from '../telemetry/StartupTimer.js';
 import { resolveSessionIdentity } from './sessionIdentity.js';
+import { getPermissionHookAuditSummary } from '../utils/permissionHooks.js';
 
 export interface BuildInfo {
   sessionId: string;
@@ -50,6 +51,12 @@ export interface BuildInfo {
     startTime: Date;
     uptime: number;
     mcpConnection: boolean;
+  };
+  permissionHooks?: {
+    installedHosts: string[];
+    currentHosts: string[];
+    repairedHosts: string[];
+    needsRepairHosts: string[];
   };
   /** Issue #706: Startup timing and readiness status. */
   startup?: {
@@ -100,7 +107,8 @@ export class BuildInfoService {
     // Use Promise.allSettled to collect all available info, even if some sources fail
     const results = await Promise.allSettled([
       this.getGitInfo(),
-      this.getDockerInfo()
+      this.getDockerInfo(),
+      getPermissionHookAuditSummary(),
     ]);
 
     // Package info comes from build-time generated constants
@@ -113,6 +121,9 @@ export class BuildInfoService {
     const dockerInfo = results[1].status === 'fulfilled'
       ? results[1].value
       : { isDocker: false, info: undefined };
+    const permissionHookInfo = results[2].status === 'fulfilled'
+      ? results[2].value
+      : { installedHosts: [], currentHosts: [], repairedHosts: [], needsRepairHosts: [] };
 
     // Log any failures for diagnostics
     const failures: string[] = [];
@@ -121,6 +132,9 @@ export class BuildInfoService {
     }
     if (results[1].status === 'rejected') {
       failures.push(`docker info: ${results[1].reason}`);
+    }
+    if (results[2].status === 'rejected') {
+      failures.push(`permission hook audit: ${results[2].reason}`);
     }
 
     if (failures.length > 0) {
@@ -172,6 +186,7 @@ export class BuildInfoService {
         uptime: Date.now() - this.startTime.getTime(),
         mcpConnection: true // We're connected if this method is being called via MCP
       },
+      permissionHooks: permissionHookInfo,
       startup: startupInfo,
     };
   }
@@ -244,6 +259,26 @@ export class BuildInfoService {
     lines.push(`- **Started**: ${info.server.startTime.toISOString()}`);
     lines.push(`- **Uptime**: ${this.formatUptime(info.server.uptime / 1000)}`);
     lines.push(`- **MCP Connection**: ${info.server.mcpConnection ? '✅ Connected' : '❌ Disconnected'}`);
+
+    if (info.permissionHooks) {
+      const installedHosts = info.permissionHooks.installedHosts.length > 0
+        ? info.permissionHooks.installedHosts.join(', ')
+        : 'None';
+      const currentHosts = info.permissionHooks.currentHosts.length > 0
+        ? info.permissionHooks.currentHosts.join(', ')
+        : 'None';
+      const needsRepairHosts = info.permissionHooks.needsRepairHosts.length > 0
+        ? info.permissionHooks.needsRepairHosts.join(', ')
+        : 'None';
+
+      lines.push(
+        '',
+        '## 🔐 Permission Hooks',
+        `- **Installed Hosts**: ${installedHosts}`,
+        `- **Current Assets**: ${currentHosts}`,
+        `- **Needs Repair**: ${needsRepairHosts}`,
+      );
+    }
 
     // Issue #706: Startup timing
     if (info.startup) {

--- a/src/utils/permissionHooks.ts
+++ b/src/utils/permissionHooks.ts
@@ -20,6 +20,10 @@ export interface PermissionHookStatus {
   installed: boolean;
   configured?: boolean;
   assetsPrepared?: boolean;
+  assetsCurrent?: boolean;
+  autoRepaired?: boolean;
+  needsRepair?: boolean;
+  repairError?: string;
   host?: string;
   scriptPath?: string;
   settingsPath?: string;
@@ -45,6 +49,43 @@ export interface InstallPermissionHookOptions {
   sourceScriptPath?: string;
   now?: Date;
 }
+
+export interface ReconcilePermissionHookOptions {
+  homeDir?: string;
+  sourceScriptPath?: string;
+  autoRepair?: boolean;
+}
+
+export interface PermissionHookAuditSummary {
+  installedHosts: string[];
+  currentHosts: string[];
+  repairedHosts: string[];
+  needsRepairHosts: string[];
+}
+
+interface HookAssetDescriptor {
+  kind: 'bridge' | 'port-helper' | 'wrapper';
+  sourcePath: string;
+  targetPath: string;
+}
+
+interface HookAssetAuditResult {
+  assetsPrepared: boolean;
+  assetsCurrent: boolean;
+  staleAssets: HookAssetDescriptor[];
+}
+
+const MANAGED_HOOK_WRAPPER_BASENAMES = {
+  'vscode': 'pretooluse-vscode.sh',
+  'cursor': 'pretooluse-cursor.sh',
+  'windsurf': 'pretooluse-windsurf.sh',
+  'gemini-cli': 'pretooluse-gemini.sh',
+  'codex': 'pretooluse-codex.sh',
+} as const;
+
+const WRAPPER_HOOK_HOSTS = Object.keys(MANAGED_HOOK_WRAPPER_BASENAMES) as Array<keyof typeof MANAGED_HOOK_WRAPPER_BASENAMES>;
+
+const AUTO_REPAIRABLE_HOOK_HOSTS = ['claude-code', ...WRAPPER_HOOK_HOSTS] as const;
 
 function repoRootFromModule(): string {
   const currentFile = fileURLToPath(import.meta.url);
@@ -141,20 +182,8 @@ function summarizeMarkerStatuses(markerPaths: Iterable<string>): PermissionHookS
 }
 
 function getHookWrapperBasename(host: string): string | null {
-  switch (normalizeHookHost(host)) {
-    case 'vscode':
-      return 'pretooluse-vscode.sh';
-    case 'cursor':
-      return 'pretooluse-cursor.sh';
-    case 'windsurf':
-      return 'pretooluse-windsurf.sh';
-    case 'gemini-cli':
-      return 'pretooluse-gemini.sh';
-    case 'codex':
-      return 'pretooluse-codex.sh';
-    default:
-      return null;
-  }
+  const normalizedHost = normalizeHookHost(host);
+  return MANAGED_HOOK_WRAPPER_BASENAMES[normalizedHost as keyof typeof MANAGED_HOOK_WRAPPER_BASENAMES] ?? null;
 }
 
 function getHookWrapperPath(host: string, homeDir = homedir()): string | null {
@@ -166,6 +195,87 @@ function getHookSourcePath(host: string): string {
   const root = repoRootFromModule();
   const basename = getHookWrapperBasename(host);
   return basename ? join(root, 'scripts', basename) : join(root, 'scripts', 'pretooluse-dollhouse.sh');
+}
+
+function supportsManagedHookAssets(host: string): boolean {
+  const normalized = normalizeHookHost(host);
+  return normalized === 'claude-code' || getHookWrapperBasename(normalized) !== null;
+}
+
+function getPrimaryHookScriptPath(host: string, homeDir = homedir()): string {
+  return getHookWrapperPath(host, homeDir) ?? getPermissionHookScriptPath(homeDir);
+}
+
+function getManagedHookAssets(
+  host: string,
+  homeDir = homedir(),
+  sourceScriptPath?: string,
+): HookAssetDescriptor[] {
+  const normalized = normalizeHookHost(host);
+  const hooksDir = dirname(getPermissionHookScriptPath(homeDir));
+  const assets: HookAssetDescriptor[] = [
+    {
+      kind: 'bridge',
+      sourcePath: sourceScriptPath ?? join(repoRootFromModule(), 'scripts', 'pretooluse-dollhouse.sh'),
+      targetPath: getPermissionHookScriptPath(homeDir),
+    },
+    {
+      kind: 'port-helper',
+      sourcePath: join(repoRootFromModule(), 'scripts', 'permission-port-discovery.sh'),
+      targetPath: join(hooksDir, 'permission-port-discovery.sh'),
+    },
+  ];
+
+  const wrapperTargetPath = getHookWrapperPath(normalized, homeDir);
+  if (wrapperTargetPath) {
+    assets.push({
+      kind: 'wrapper',
+      sourcePath: getHookSourcePath(normalized),
+      targetPath: wrapperTargetPath,
+    });
+  }
+
+  return assets;
+}
+
+async function readOptionalUtf8File(filePath: string): Promise<string | undefined> {
+  try {
+    return await readFile(filePath, 'utf-8');
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function auditHookAssets(
+  host: string,
+  homeDir = homedir(),
+  sourceScriptPath?: string,
+): Promise<HookAssetAuditResult> {
+  const assets = getManagedHookAssets(host, homeDir, sourceScriptPath);
+  const staleAssets: HookAssetDescriptor[] = [];
+  let assetsPrepared = true;
+
+  for (const asset of assets) {
+    const sourceRaw = await readFile(asset.sourcePath, 'utf-8');
+    const targetRaw = await readOptionalUtf8File(asset.targetPath);
+    if (targetRaw === undefined) {
+      assetsPrepared = false;
+      staleAssets.push(asset);
+      continue;
+    }
+    if (targetRaw !== sourceRaw) {
+      staleAssets.push(asset);
+    }
+  }
+
+  return {
+    assetsPrepared,
+    assetsCurrent: staleAssets.length === 0,
+    staleAssets,
+  };
 }
 
 export function getPermissionHookMarkerPath(homeDir = homedir(), host?: string): string {
@@ -266,6 +376,163 @@ export async function getPermissionHookStatusAsync(homeDir = homedir(), host?: s
   }
 
   return summarizeMarkerStatuses(await collectHookMarkerPathsAsync(homeDir));
+}
+
+function shouldAttemptHookAssetRepair(
+  status: PermissionHookStatus,
+  audit: HookAssetAuditResult,
+): boolean {
+  return Boolean(
+    status.installed
+    || status.assetsPrepared
+    || status.scriptPath
+    || audit.assetsPrepared
+    || audit.staleAssets.length > 0,
+  );
+}
+
+function buildFallbackPermissionHookStatus(
+  baseStatus: PermissionHookStatus,
+  normalizedHost: string,
+  homeDir: string,
+): PermissionHookStatus {
+  return {
+    ...baseStatus,
+    host: baseStatus.host ?? normalizedHost,
+    scriptPath: baseStatus.scriptPath ?? getPrimaryHookScriptPath(normalizedHost, homeDir),
+  };
+}
+
+async function auditAndMaybeRepairHookAssets(
+  normalizedHost: string,
+  homeDir: string,
+  sourceScriptPath: string | undefined,
+  autoRepair: boolean,
+  fallbackStatus: PermissionHookStatus,
+): Promise<{ audit: HookAssetAuditResult; autoRepaired: boolean }> {
+  let audit = await auditHookAssets(normalizedHost, homeDir, sourceScriptPath);
+  let autoRepaired = false;
+
+  if (!audit.assetsCurrent && autoRepair && shouldAttemptHookAssetRepair(fallbackStatus, audit)) {
+    await installHookAssetsForHost(normalizedHost, homeDir, sourceScriptPath);
+    audit = await auditHookAssets(normalizedHost, homeDir, sourceScriptPath);
+    autoRepaired = audit.assetsCurrent;
+  }
+
+  return { audit, autoRepaired };
+}
+
+function buildHookRepairFailureStatus(
+  fallbackStatus: PermissionHookStatus,
+  error: unknown,
+): PermissionHookStatus {
+  const message = error instanceof Error ? error.message : String(error);
+  logger.warn(`[PermissionHooks] Failed to reconcile hook assets for ${fallbackStatus.host}: ${message}`);
+
+  return {
+    ...fallbackStatus,
+    assetsCurrent: false,
+    autoRepaired: false,
+    needsRepair: true,
+    repairError: message,
+  };
+}
+
+export async function reconcilePermissionHookStatus(
+  host: string,
+  options: ReconcilePermissionHookOptions = {},
+): Promise<PermissionHookStatus> {
+  const normalizedHost = normalizeHookHost(host);
+  const homeDir = options.homeDir ?? homedir();
+  const sourceScriptPath = options.sourceScriptPath;
+  const autoRepair = options.autoRepair ?? false;
+  const baseStatus = readHostSpecificHookStatus(homeDir, normalizedHost);
+
+  if (!supportsManagedHookAssets(normalizedHost)) {
+    return baseStatus;
+  }
+
+  const fallbackStatus = buildFallbackPermissionHookStatus(baseStatus, normalizedHost, homeDir);
+
+  try {
+    const { audit, autoRepaired } = await auditAndMaybeRepairHookAssets(
+      normalizedHost,
+      homeDir,
+      sourceScriptPath,
+      autoRepair,
+      fallbackStatus,
+    );
+
+    return {
+      ...fallbackStatus,
+      assetsPrepared: audit.assetsPrepared,
+      assetsCurrent: audit.assetsCurrent,
+      autoRepaired,
+      needsRepair: !audit.assetsCurrent,
+    };
+  } catch (error) {
+    return buildHookRepairFailureStatus(fallbackStatus, error);
+  }
+}
+
+export async function getPermissionHookAuditSummary(homeDir = homedir()): Promise<PermissionHookAuditSummary> {
+  const statuses = await Promise.all(
+    AUTO_REPAIRABLE_HOOK_HOSTS.map(async (host) => ({
+      host,
+      status: await reconcilePermissionHookStatus(host, { homeDir }),
+    })),
+  );
+
+  const installedHosts = statuses
+    .filter(({ status }) => status.installed || status.assetsPrepared)
+    .map(({ host }) => host);
+  const currentHosts = statuses
+    .filter(({ status }) => status.assetsCurrent)
+    .map(({ host }) => host);
+  const repairedHosts = statuses
+    .filter(({ status }) => status.autoRepaired)
+    .map(({ host }) => host);
+  const needsRepairHosts = statuses
+    .filter(({ status }) => status.needsRepair)
+    .map(({ host }) => host);
+
+  return {
+    installedHosts,
+    currentHosts,
+    repairedHosts,
+    needsRepairHosts,
+  };
+}
+
+export async function repairPermissionHooksOnStartup(homeDir = homedir()): Promise<void> {
+  const startedAt = Date.now();
+  let repairedCount = 0;
+  let needsRepairCount = 0;
+
+  await Promise.allSettled(
+    AUTO_REPAIRABLE_HOOK_HOSTS.map(async (host) => {
+      const status = await reconcilePermissionHookStatus(host, {
+        homeDir,
+        autoRepair: true,
+      });
+
+      if (status.autoRepaired) {
+        repairedCount += 1;
+        logger.info(`[PermissionHooks] Refreshed installed hook assets for ${host}`);
+      } else if (status.needsRepair && status.installed) {
+        needsRepairCount += 1;
+        logger.warn(
+          `[PermissionHooks] Hook assets still need repair for ${host}` +
+          (status.repairError ? `: ${status.repairError}` : ''),
+        );
+      }
+    }),
+  );
+
+  logger.info(
+    `[PermissionHooks] Startup hook asset audit completed in ${Date.now() - startedAt}ms ` +
+    `(repaired=${repairedCount}, needsRepair=${needsRepairCount})`,
+  );
 }
 
 function normalizeHooksRoot(parsed: Record<string, unknown>): Record<string, unknown[]> {

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -225,6 +225,16 @@
       } else if (data.permissionPromptActive) {
         hookDot.dataset.status = 'active';
         hookLabel.textContent = 'Prompt tool active';
+      } else if (data.hookNeedsRepair) {
+        hookDot.dataset.status = 'warning';
+        hookLabel.textContent = data.hookHost
+          ? `Hook needs repair (${data.hookHost})`
+          : 'Hook needs repair';
+      } else if (data.hookAutoRepaired) {
+        hookDot.dataset.status = 'active';
+        hookLabel.textContent = data.hookHost
+          ? `Hook refreshed (${data.hookHost})`
+          : 'Hook refreshed';
       } else if (data.hookInstalled) {
         hookDot.dataset.status = 'active';
         hookLabel.textContent = data.hookHost ? `Hook installed (${data.hookHost})` : 'Hook installed';

--- a/src/web/public/setup.js
+++ b/src/web/public/setup.js
@@ -680,6 +680,13 @@ codex_hooks = true`;
   const updatePermissionInstallButton = (btn, detected) => {
     if (!btn || btn.classList.contains('is-success')) return;
 
+    if (detected?.hookNeedsRepair) {
+      btn.textContent = 'Repair hooks';
+      btn.disabled = false;
+      btn.classList.remove('is-match');
+      return;
+    }
+
     if (detected?.hookInstalled) {
       btn.textContent = 'Permissions enabled';
       btn.disabled = true;
@@ -1119,7 +1126,30 @@ codex_hooks = true`;
     return PERMISSION_SUPPORT_MATRIX[platformId];
   };
 
+  const getHookRepairStatusCopy = (support, detected) => {
+    if (detected?.hookNeedsRepair) {
+      return {
+        tone: 'warning',
+        titleText: `${support.label} hook files need repair.`,
+        messageText: 'DollhouseMCP detected stale local hook assets. Use Configure Now below to rewrite them, or reload the local server so the automatic repair pass can run again.',
+      };
+    }
+
+    if (detected?.hookAutoRepaired) {
+      return {
+        tone: 'info',
+        titleText: `${support.label} hook files were refreshed automatically.`,
+        messageText: 'The installed local hook assets were updated to match this release. Restart the client if it is already running.',
+      };
+    }
+
+    return null;
+  };
+
   const getFullNativePermissionStatusCopy = (support, detected) => {
+    const repairCopy = getHookRepairStatusCopy(support, detected);
+    if (repairCopy) return repairCopy;
+
     if (detected?.hookInstalled) {
       return {
         tone: 'info',
@@ -1145,6 +1175,9 @@ codex_hooks = true`;
 
   const getPartialPermissionStatusCopy = (support, detected) => {
     const activationLabel = support.label === 'Codex' ? 'Bash guardrails' : 'permission hooks';
+    const repairCopy = getHookRepairStatusCopy(support, detected);
+    if (repairCopy) return repairCopy;
+
     if (detected?.hookInstalled) {
       return {
         tone: 'info',
@@ -1185,6 +1218,9 @@ codex_hooks = true`;
   };
 
   const getManualPermissionStatusCopy = (support, detected) => {
+    const repairCopy = getHookRepairStatusCopy(support, detected);
+    if (repairCopy) return repairCopy;
+
     if (detected?.hookAssetsPrepared) {
       return {
         tone: 'info',

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -13,7 +13,7 @@ import { logger } from '../../utils/logger.js';
 import type { MCPAQLHandler } from '../../handlers/mcp-aql/MCPAQLHandler.js';
 import { formatPermissionResponse } from '../../handlers/mcp-aql/evaluatePermission.js';
 import { ensureLatestPortFile } from '../portDiscovery.js';
-import { getPermissionHookStatusAsync } from '../../utils/permissionHooks.js';
+import { getPermissionHookStatusAsync, reconcilePermissionHookStatus } from '../../utils/permissionHooks.js';
 
 import { SlidingWindowRateLimiter } from '../../utils/SlidingWindowRateLimiter.js';
 import {
@@ -48,6 +48,32 @@ interface PermissionDecisionDetail {
   monospace?: boolean;
 }
 
+type PermissionDecisionTargetKey =
+  | 'file_path'
+  | 'path'
+  | 'url'
+  | 'pattern'
+  | 'query'
+  | 'element_name'
+  | 'request_id';
+
+interface PermissionDecisionInput extends Record<string, unknown> {
+  command?: string;
+  file_path?: string;
+  path?: string;
+  url?: string;
+  pattern?: string;
+  query?: string;
+  element_name?: string;
+  request_id?: string;
+}
+
+interface PermissionDecisionTargetDescriptor {
+  key: PermissionDecisionTargetKey;
+  label: string;
+  monospace?: boolean;
+}
+
 interface KnownPolicySession {
   sessionId: string;
   displayName: string;
@@ -62,7 +88,7 @@ interface PermissionDecisionTracker {
   trackDecision(
     sessionId: string | undefined,
     toolName: string,
-    input: Record<string, unknown>,
+    input: PermissionDecisionInput,
     result: Record<string, unknown>,
     platform: string,
   ): void;
@@ -142,7 +168,7 @@ function normalizePermissionResponseForPlatform(
 
 function buildDecisionDetails(
   toolName: string,
-  input: Record<string, unknown>,
+  input: PermissionDecisionInput,
   result: Record<string, unknown>,
   platform: string,
 ): { target?: string; targetLabel?: string; details: PermissionDecisionDetail[] } {
@@ -156,7 +182,7 @@ function buildDecisionDetails(
     details.push({ label: 'Command', value: input.command, monospace: true });
   }
 
-  const targetDescriptors: Array<{ key: string; label: string; monospace?: boolean }> = [
+  const targetDescriptors: PermissionDecisionTargetDescriptor[] = [
     { key: 'file_path', label: 'File', monospace: true },
     { key: 'path', label: 'Path', monospace: true },
     { key: 'url', label: 'URL' },
@@ -202,7 +228,7 @@ function createPermissionDecisionTracker(bufferSize = DECISION_BUFFER_SIZE): Per
     trackDecision(
       sessionId: string | undefined,
       toolName: string,
-      input: Record<string, unknown>,
+      input: PermissionDecisionInput,
       result: Record<string, unknown>,
       platform: string,
     ): void {
@@ -309,11 +335,12 @@ async function selfHealLatestPermissionPortFile(port: number | undefined): Promi
 async function resolveInstalledPermissionAuthorityHosts(
   homeDir: string,
   authorityState: Awaited<ReturnType<typeof readPermissionAuthorityState>>,
+  autoRepairHookAssets: boolean,
 ): Promise<PermissionAuthorityHost[]> {
   const installedStatuses = await Promise.all(
     PERMISSION_AUTHORITY_HOSTS.map(async (host) => ({
       host,
-      status: await getPermissionHookStatusAsync(homeDir, host),
+      status: await reconcilePermissionHookStatus(host, { homeDir, autoRepair: autoRepairHookAssets }),
     })),
   );
 
@@ -334,6 +361,7 @@ async function resolveInstalledPermissionAuthorityHosts(
  */
 export interface RegisterPermissionRoutesOptions {
   homeDir?: string;
+  autoRepairHookAssets?: boolean;
 }
 
 export function registerPermissionRoutes(
@@ -342,6 +370,7 @@ export function registerPermissionRoutes(
   options: RegisterPermissionRoutesOptions = {},
 ): void {
   const authorityHomeDir = options.homeDir ?? homedir();
+  const autoRepairHookAssets = options.autoRepairHookAssets ?? process.env.NODE_ENV !== 'test';
   const decisionTracker = createPermissionDecisionTracker();
   /**
    * POST /api/evaluate_permission
@@ -358,7 +387,7 @@ export function registerPermissionRoutes(
 
     const body = req.body as {
       tool_name?: string;
-      input?: Record<string, unknown>;
+      input?: PermissionDecisionInput;
       platform?: string;
       session_id?: string;
     };
@@ -447,7 +476,15 @@ export function registerPermissionRoutes(
 
       const data = opResult.data as Record<string, unknown>;
       const authorityState = await readPermissionAuthorityState(authorityHomeDir);
-      const installedAuthorityHosts = await resolveInstalledPermissionAuthorityHosts(authorityHomeDir, authorityState);
+      const installedAuthorityHosts = await resolveInstalledPermissionAuthorityHosts(
+        authorityHomeDir,
+        authorityState,
+        autoRepairHookAssets,
+      );
+      const hookHost = typeof data.hookHost === 'string' ? data.hookHost : undefined;
+      const hookStatus = hookHost
+        ? await reconcilePermissionHookStatus(hookHost, { homeDir: authorityHomeDir, autoRepair: autoRepairHookAssets })
+        : await getPermissionHookStatusAsync(authorityHomeDir);
       const elements = normalizePolicyElements((data.elements || []) as Array<Record<string, unknown>>);
 
       const denyPatterns = (data.combinedDenyPatterns as string[] | undefined) ?? [];
@@ -473,8 +510,13 @@ export function registerPermissionRoutes(
         elements,
         knownSessions: extractKnownPolicySessions(elements),
         permissionPromptActive: data.permissionPromptActive,
-        hookInstalled: data.hookInstalled,
+        hookInstalled: hookStatus.installed,
         hookHost: data.hookHost,
+        hookAssetsPrepared: hookStatus.assetsPrepared,
+        hookAssetsCurrent: hookStatus.assetsCurrent,
+        hookAutoRepaired: hookStatus.autoRepaired,
+        hookNeedsRepair: hookStatus.needsRepair,
+        hookRepairError: hookStatus.repairError,
         authority: authorityState,
         authoritySupportedHosts: installedAuthorityHosts,
         authoritySupportedModes: [...PERMISSION_AUTHORITY_MODES],
@@ -493,7 +535,11 @@ export function registerPermissionRoutes(
   router.get('/permissions/authority', async (_req, res) => {
     try {
       const authorityState = await readPermissionAuthorityState(authorityHomeDir);
-      const installedAuthorityHosts = await resolveInstalledPermissionAuthorityHosts(authorityHomeDir, authorityState);
+      const installedAuthorityHosts = await resolveInstalledPermissionAuthorityHosts(
+        authorityHomeDir,
+        authorityState,
+        autoRepairHookAssets,
+      );
       res.json({
         ...authorityState,
         supportedHosts: installedAuthorityHosts,

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -21,7 +21,12 @@ const __dirname = dirname(__filename);
 import { logger } from '../../utils/logger.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { PACKAGE_VERSION } from '../../generated/version.js';
-import { getPermissionHookStatusAsync, installPermissionHook, type InstallPermissionHookResult } from '../../utils/permissionHooks.js';
+import {
+  installPermissionHook,
+  reconcilePermissionHookStatus,
+  type InstallPermissionHookResult,
+  type PermissionHookStatus,
+} from '../../utils/permissionHooks.js';
 
 const GITHUB_REPO = 'DollhouseMCP/mcp-server';
 const MCPB_ASSET_PATTERN = /^dollhousemcp-.*\.mcpb$/;
@@ -71,6 +76,7 @@ type ConfigPathClient =
   | 'claude'
   | 'claude-code'
   | 'cursor'
+  | 'vscode'
   | 'windsurf'
   | 'cline'
   | 'lmstudio'
@@ -116,6 +122,11 @@ function getConfigPath(client: string): string | null {
     },
     'claude-code': () => join(home, '.claude.json'),
     'cursor': () => join(home, '.cursor', 'mcp.json'),
+    'vscode': () => {
+      if (plat === 'darwin') return join(home, 'Library', 'Application Support', 'Code', 'User', 'settings.json');
+      if (plat === 'win32') return join(process.env.APPDATA || join(home, 'AppData', 'Roaming'), 'Code', 'User', 'settings.json');
+      return join(home, '.config', 'Code', 'User', 'settings.json');
+    },
     'windsurf': () => join(home, '.codeium', 'windsurf', 'mcp_config.json'),
     'cline': () => {
       if (plat === 'darwin') return join(home, 'Library', 'Application Support', 'Code', 'User', 'globalStorage', 'saoudrizwan.claude-dev', 'settings', 'cline_mcp_settings.json');
@@ -566,6 +577,10 @@ export function createSetupRoutes(opts?: {
   _runInstallMcp?: (client: string, version?: string) => Promise<string>;
   /** Override permission hook installer. For testing only. */
   _installPermissionHook?: (client: string) => Promise<InstallPermissionHookResult>;
+  /** Override permission hook status reconciler. For testing only. */
+  _reconcilePermissionHookStatus?: (client: string) => Promise<PermissionHookStatus>;
+  /** Enable automatic hook asset repair during detect. Defaults off in tests. */
+  _autoRepairPermissionHooksOnDetect?: boolean;
   /** Skip the sliding-window rate limiter. For testing only. */
   _skipRateLimit?: boolean;
 }): {
@@ -581,6 +596,9 @@ export function createSetupRoutes(opts?: {
 } {
   const installer = opts?._runInstallMcp ?? runInstallMcp;
   const permissionHookInstaller = opts?._installPermissionHook ?? installPermissionHook;
+  const autoRepairPermissionHooksOnDetect = opts?._autoRepairPermissionHooksOnDetect ?? process.env.NODE_ENV !== 'test';
+  const hookStatusReconciler = opts?._reconcilePermissionHookStatus ?? (async (client: string) =>
+    reconcilePermissionHookStatus(client, { autoRepair: autoRepairPermissionHooksOnDetect }));
   const skipRateLimit = opts?._skipRateLimit ?? false;
   // ── Detect existing installations ───────────────────────────────────
   const detectHandler = async (_req: Request, res: Response): Promise<void> => {
@@ -588,6 +606,7 @@ export function createSetupRoutes(opts?: {
       { id: 'claude', name: 'Claude Desktop' },
       { id: 'claude-code', name: 'Claude Code' },
       { id: 'cursor', name: 'Cursor' },
+      { id: 'vscode', name: 'VS Code' },
       { id: 'cline', name: 'Cline' },
       { id: 'windsurf', name: 'Windsurf' },
       { id: 'lmstudio', name: 'LM Studio' },
@@ -604,10 +623,14 @@ export function createSetupRoutes(opts?: {
           support: { level: SETUP_SUPPORT_LEVELS[id] },
           ...detection,
         };
-        if (id === 'claude-code' || id === 'cursor' || id === 'windsurf' || id === 'gemini-cli' || id === 'codex') {
-          const hookStatus = await getPermissionHookStatusAsync(undefined, id);
+        if (id === 'claude-code' || id === 'cursor' || id === 'vscode' || id === 'windsurf' || id === 'gemini-cli' || id === 'codex') {
+          const hookStatus = await hookStatusReconciler(id);
           result.hookInstalled = hookStatus.installed;
           result.hookAssetsPrepared = hookStatus.assetsPrepared;
+          result.hookAssetsCurrent = hookStatus.assetsCurrent;
+          result.hookAutoRepaired = hookStatus.autoRepaired;
+          result.hookNeedsRepair = hookStatus.needsRepair;
+          result.hookRepairError = hookStatus.repairError;
         }
         results[id] = result;
       }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -22,6 +22,7 @@ import { createLogRoutes, type LogRoutesResult } from './routes/logRoutes.js';
 import { createMetricsRoutes, type MetricsRoutesResult } from './routes/metricsRoutes.js';
 import { createHealthRoutes } from './routes/healthRoutes.js';
 import { createSetupRoutes, repairNvmLauncherOnStartup } from './routes/setupRoutes.js';
+import { repairPermissionHooksOnStartup } from '../utils/permissionHooks.js';
 import { createTotpRoutes } from './routes/totpRoutes.js';
 import { createTokenRoutes } from './routes/tokenRoutes.js';
 import { logger } from '../utils/logger.js';
@@ -324,6 +325,11 @@ export async function startWebServer(options: WebServerOptions): Promise<WebServ
   repairNvmLauncherOnStartup().catch(err =>
     logger.warn(`[Setup] NVM startup repair threw unexpectedly: ${err instanceof Error ? err.message : String(err)}`)
   );
+  if (process.env.NODE_ENV !== 'test') {
+    repairPermissionHooksOnStartup().catch(err =>
+      logger.warn(`[Setup] Permission hook startup repair threw unexpectedly: ${err instanceof Error ? err.message : String(err)}`)
+    );
+  }
 
   // API routes — use MCP-AQL gateway when handler is available (Issue #796)
   if (options.mcpAqlHandler) {

--- a/tests/unit/services/BuildInfoService.test.ts
+++ b/tests/unit/services/BuildInfoService.test.ts
@@ -121,6 +121,16 @@ describe('BuildInfoService', () => {
       expect(info.server.mcpConnection).toBe(true);
     });
 
+    it('includes permission hook audit summary in build info', async () => {
+      const info = await service.getBuildInfo();
+
+      expect(info.permissionHooks).toBeDefined();
+      expect(Array.isArray(info.permissionHooks?.installedHosts)).toBe(true);
+      expect(Array.isArray(info.permissionHooks?.currentHosts)).toBe(true);
+      expect(Array.isArray(info.permissionHooks?.repairedHosts)).toBe(true);
+      expect(Array.isArray(info.permissionHooks?.needsRepairHosts)).toBe(true);
+    });
+
     it('should have consistent results across calls', async () => {
       const info1 = await service.getBuildInfo();
       const info2 = await service.getBuildInfo();
@@ -194,7 +204,13 @@ describe('BuildInfoService', () => {
           startTime: new Date('2024-01-01T10:00:00.000Z'),
           uptime: 7200000, // 2 hours in ms
           mcpConnection: true
-        }
+        },
+        permissionHooks: {
+          installedHosts: [],
+          currentHosts: [],
+          repairedHosts: [],
+          needsRepairHosts: [],
+        },
       };
     });
 
@@ -230,6 +246,10 @@ describe('BuildInfoService', () => {
       expect(formatted).toContain('**Started**: 2024-01-01T10:00:00.000Z');
       expect(formatted).toContain('**Uptime**: 2h');
       expect(formatted).toContain('**MCP Connection**: ✅ Connected');
+      expect(formatted).toContain('## 🔐 Permission Hooks');
+      expect(formatted).toContain('**Installed Hosts**: None');
+      expect(formatted).toContain('**Current Assets**: None');
+      expect(formatted).toContain('**Needs Repair**: None');
     });
 
     it('should handle missing optional fields gracefully', () => {

--- a/tests/unit/utils/permissionHooks.repair.test.ts
+++ b/tests/unit/utils/permissionHooks.repair.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  getPermissionHookAuditSummary,
+  getPermissionHookScriptPath,
+  installPermissionHook,
+  reconcilePermissionHookStatus,
+  repairPermissionHooksOnStartup,
+} from '../../../src/utils/permissionHooks.js';
+
+describe('permissionHooks repair flows', () => {
+  let tempHome: string;
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(join(tmpdir(), 'permission-hooks-repair-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempHome, { recursive: true, force: true });
+  });
+
+  it('reconciles stale installed hook assets and rewrites them automatically', async () => {
+    await installPermissionHook('codex', { homeDir: tempHome });
+    const sharedScriptPath = getPermissionHookScriptPath(tempHome);
+    const wrapperScriptPath = join(tempHome, '.dollhouse', 'hooks', 'pretooluse-codex.sh');
+    const expectedShared = await readFile(join(process.cwd(), 'scripts', 'pretooluse-dollhouse.sh'), 'utf-8');
+    const expectedWrapper = await readFile(join(process.cwd(), 'scripts', 'pretooluse-codex.sh'), 'utf-8');
+
+    await writeFile(sharedScriptPath, '#!/bin/bash\necho stale-shared\n', 'utf-8');
+    await writeFile(wrapperScriptPath, '#!/bin/bash\necho stale-wrapper\n', 'utf-8');
+
+    const status = await reconcilePermissionHookStatus('codex', {
+      homeDir: tempHome,
+      autoRepair: true,
+    });
+
+    expect(status.installed).toBe(true);
+    expect(status.assetsPrepared).toBe(true);
+    expect(status.assetsCurrent).toBe(true);
+    expect(status.autoRepaired).toBe(true);
+    expect(status.needsRepair).toBe(false);
+    expect(await readFile(sharedScriptPath, 'utf-8')).toBe(expectedShared);
+    expect(await readFile(wrapperScriptPath, 'utf-8')).toBe(expectedWrapper);
+  });
+
+  it('reports when stale hook assets still need repair after a failed reconciliation', async () => {
+    await installPermissionHook('codex', { homeDir: tempHome });
+    const sharedScriptPath = getPermissionHookScriptPath(tempHome);
+    await writeFile(sharedScriptPath, '#!/bin/bash\necho stale-shared\n', 'utf-8');
+
+    const status = await reconcilePermissionHookStatus('codex', {
+      homeDir: tempHome,
+      autoRepair: true,
+      sourceScriptPath: join(tempHome, 'missing-shared-script.sh'),
+    });
+
+    expect(status.installed).toBe(true);
+    expect(status.assetsCurrent).toBe(false);
+    expect(status.autoRepaired).toBe(false);
+    expect(status.needsRepair).toBe(true);
+    expect(status.repairError).toContain('ENOENT');
+  });
+
+  it('repairs previously installed hook assets during startup reconciliation', async () => {
+    await installPermissionHook('claude-code', { homeDir: tempHome });
+    await writeFile(getPermissionHookScriptPath(tempHome), '#!/bin/bash\necho stale-shared\n', 'utf-8');
+
+    await expect(repairPermissionHooksOnStartup(tempHome)).resolves.not.toThrow();
+
+    const status = await reconcilePermissionHookStatus('claude-code', { homeDir: tempHome });
+    expect(status.assetsCurrent).toBe(true);
+    expect(status.needsRepair).toBe(false);
+  });
+
+  it('summarizes installed and repair-needed hook hosts for build info', async () => {
+    await installPermissionHook('claude-code', { homeDir: tempHome });
+    await installPermissionHook('codex', { homeDir: tempHome });
+    await writeFile(getPermissionHookScriptPath(tempHome), '#!/bin/bash\necho stale-shared\n', 'utf-8');
+
+    const summary = await getPermissionHookAuditSummary(tempHome);
+
+    expect(summary.installedHosts).toEqual(expect.arrayContaining(['claude-code', 'codex']));
+    expect(summary.currentHosts).not.toContain('claude-code');
+    expect(summary.needsRepairHosts).toEqual(expect.arrayContaining(['claude-code', 'codex']));
+  });
+});

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -12,7 +12,7 @@ import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { mkdir, mkdtemp, readFile, rm, unlink, writeFile } from 'node:fs/promises';
 import { registerPermissionRoutes } from '../../../src/web/routes/permissionRoutes.js';
-import { getPermissionHookMarkerPath } from '../../../src/utils/permissionHooks.js';
+import { getPermissionHookMarkerPath, installPermissionHook } from '../../../src/utils/permissionHooks.js';
 
 function createMockHandler(readResult?: unknown) {
   return {
@@ -220,6 +220,8 @@ describe('permissionRoutes', () => {
 
   describe('GET /api/permissions/status', () => {
     it('should return policy status', async () => {
+      await installPermissionHook('codex', { homeDir: tempHome });
+
       const handler = {
         handleRead: jest.fn().mockResolvedValue([{
           success: true,
@@ -239,13 +241,13 @@ describe('permissionRoutes', () => {
               },
             ],
             permissionPromptActive: false,
-            hookInstalled: false,
+            hookHost: 'codex',
             enforcementReady: false,
             advisory: 'Policies are loaded but NOT enforced.',
           },
         }]),
       } as any;
-      const app = createApp(handler);
+      const app = createApp(handler, { homeDir: tempHome });
 
       const res = await request(app).get('/api/permissions/status');
 
@@ -268,7 +270,11 @@ describe('permissionRoutes', () => {
           confirmRules: ['Bash:git merge*', 'edit_*'],
         }),
       ]);
-      expect(res.body.hookInstalled).toBe(false);
+      expect(res.body.hookInstalled).toBe(true);
+      expect(res.body.hookAssetsPrepared).toBe(true);
+      expect(res.body.hookAssetsCurrent).toBe(true);
+      expect(res.body.hookAutoRepaired).toBe(false);
+      expect(res.body.hookNeedsRepair).toBe(false);
       expect(res.body.enforcementReady).toBe(false);
       expect(res.body.advisory).toContain('NOT enforced');
       expect(Array.isArray(res.body.recentDecisions)).toBe(true);

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -292,6 +292,36 @@ describe('Setup Routes — API Endpoints', () => {
       expect(res.body['lmstudio'].support.level).toBe('mcp_only');
     });
 
+    it('includes repaired hook freshness metadata for native hook clients', async () => {
+      const { createSetupRoutes } = await import('../../../src/web/routes/setupRoutes.js');
+      const { detectHandler } = createSetupRoutes({
+        _reconcilePermissionHookStatus: async (client: string) => ({
+          installed: client === 'codex',
+          configured: client === 'codex',
+          assetsPrepared: true,
+          assetsCurrent: true,
+          autoRepaired: client === 'codex',
+          needsRepair: false,
+          host: client,
+          scriptPath: `/Users/test/.dollhouse/hooks/pretooluse-${client}.sh`,
+        }),
+      });
+
+      const testApp = express();
+      testApp.get('/api/setup/detect', detectHandler);
+
+      const res = await request(testApp)
+        .get('/api/setup/detect')
+        .expect(200);
+
+      expect(res.body.codex.hookInstalled).toBe(true);
+      expect(res.body.codex.hookAssetsPrepared).toBe(true);
+      expect(res.body.codex.hookAssetsCurrent).toBe(true);
+      expect(res.body.codex.hookAutoRepaired).toBe(true);
+      expect(res.body.codex.hookNeedsRepair).toBe(false);
+      expect(res.body.vscode.hookAssetsCurrent).toBe(true);
+    });
+
     it('includes currentConfig when installed', async () => {
       const res = await request(app)
         .get('/api/setup/detect')


### PR DESCRIPTION
## Summary
- automatically audit and refresh managed local permission hook assets during startup and setup/permissions status checks
- surface hook freshness, repair state, and repair guidance in setup, permissions status, and build info
- add regression coverage for stale hook repair, setup detection metadata, and permission status reporting

## Testing
- npm test -- --runInBand tests/unit/utils/permissionHooks.test.ts tests/unit/web/setupRoutes.test.ts tests/unit/web/permissionRoutes.test.ts tests/unit/services/BuildInfoService.test.ts
- npx eslint src/utils/permissionHooks.ts src/web/routes/setupRoutes.ts src/web/routes/permissionRoutes.ts src/web/server.ts src/web/public/setup.js src/web/public/permissions.js src/services/BuildInfoService.ts tests/unit/utils/permissionHooks.test.ts tests/unit/web/setupRoutes.test.ts tests/unit/web/permissionRoutes.test.ts tests/unit/services/BuildInfoService.test.ts
- npm run build

Closes #2143