### PR TITLE
Emit valid fail-open JSON for hook adapters

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -49,6 +49,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Lint shell scripts
+        run: npm run lint:shell
+
       - name: Build project
         run: npm run build
 

--- a/docs/architecture/permission-hook-platform-contracts.md
+++ b/docs/architecture/permission-hook-platform-contracts.md
@@ -51,7 +51,7 @@ Client-specific normalization includes:
 - Missing permission server port file: allow / no-op
 - Connection failure or timeout: allow / no-op
 - Malformed server response:
-  - JSON-based clients: allow / no-op with empty stdout
+  - JSON-based clients: allow with an explicit valid allow payload for that platform
   - Windsurf: allow with exit `0`
 - Legacy Codex bare `{}` allow responses are normalized into an explicit `hookSpecificOutput.permissionDecision = "allow"` payload for compatibility
 

--- a/docs/architecture/permission-hook-platform-contracts.md
+++ b/docs/architecture/permission-hook-platform-contracts.md
@@ -55,6 +55,89 @@ Client-specific normalization includes:
   - Windsurf: allow with exit `0`
 - Legacy Codex bare `{}` allow responses are normalized into an explicit `hookSpecificOutput.permissionDecision = "allow"` payload for compatibility
 
+## Example Payloads
+
+### Claude Code / VS Code allow
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow"
+  }
+}
+```
+
+### Claude Code / VS Code deny
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Command blocked by active Dollhouse policy."
+  }
+}
+```
+
+### Codex allow
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "permissionDecisionReason": ""
+  }
+}
+```
+
+### Codex deny
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Command blocked by active Dollhouse policy."
+  }
+}
+```
+
+### Cursor allow
+
+```json
+{
+  "permission": "allow"
+}
+```
+
+### Cursor deny
+
+```json
+{
+  "permission": "deny",
+  "reason": "Command blocked by active Dollhouse policy."
+}
+```
+
+### Gemini CLI allow
+
+```json
+{
+  "decision": "allow"
+}
+```
+
+### Gemini CLI deny
+
+```json
+{
+  "decision": "deny",
+  "reason": "Command blocked by active Dollhouse policy."
+}
+```
+
 ## Verification Matrix
 
 - Direct shell execution coverage:

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:all": "npm test && npm run test:performance && npm run test:integration",
     "test:all:coverage": "npm run test:coverage && npm run test:integration:coverage",
     "lint": "eslint --max-warnings=0 --ext .ts src tests scripts",
+    "lint:shell": "shellcheck -x scripts/pretooluse-dollhouse.sh scripts/pretooluse-codex.sh scripts/pretooluse-cursor.sh scripts/pretooluse-gemini.sh scripts/pretooluse-vscode.sh scripts/pretooluse-windsurf.sh scripts/permission-port-discovery.sh",
     "lint:fix": "eslint --ext .ts src tests scripts --fix",
     "security:critical": "cross-env \"NODE_OPTIONS=--experimental-vm-modules --no-warnings\" jest --config tests/jest.config.cjs tests/security/tests --testNamePattern=\"(Command Injection|Path Traversal|YAML)\" --maxWorkers=4",
     "security:rapid": "npm run security:critical -- --testTimeout=30000",

--- a/scripts/pretooluse-dollhouse.sh
+++ b/scripts/pretooluse-dollhouse.sh
@@ -17,6 +17,7 @@
 # Set DOLLHOUSE_HOOK_PLATFORM to override the platform sent to the server.
 
 RUN_DIR="$HOME/.dollhouse/run"
+# shellcheck disable=SC2034 # Consumed by permission-port-discovery.sh after sourcing.
 PORT_FILE="$RUN_DIR/permission-server.port"
 AUTHORITY_FILE="$RUN_DIR/permission-authority.json"
 AUTHORITY_CACHE_TTL_SECONDS=2
@@ -184,6 +185,7 @@ normalize_response() {
   return 0
 }
 
+# shellcheck disable=SC1091 # Resolved at runtime via SCRIPT_DIR.
 source "$SCRIPT_DIR/permission-port-discovery.sh"
 
 # Discover the port from the shared file or the newest live PID-keyed file

--- a/scripts/pretooluse-dollhouse.sh
+++ b/scripts/pretooluse-dollhouse.sh
@@ -36,6 +36,34 @@ debug() {
   return 0
 }
 
+emit_allow_response() {
+  case "$HOOK_PLATFORM" in
+    claude_code|vscode)
+      printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+      ;;
+    codex)
+      printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":""}}'
+      ;;
+    cursor)
+      printf '%s\n' '{"permission":"allow"}'
+      ;;
+    gemini)
+      printf '%s\n' '{"decision":"allow"}'
+      ;;
+    *)
+      printf '%s\n' '{}'
+      ;;
+  esac
+
+  return 0
+}
+
+fail_open() {
+  debug "$1"
+  emit_allow_response
+  exit 0
+}
+
 authority_host_for_platform() {
   case "$HOOK_PLATFORM" in
     claude_code) echo "claude-code" ;;
@@ -160,8 +188,7 @@ source "$SCRIPT_DIR/permission-port-discovery.sh"
 
 # Discover the port from the shared file or the newest live PID-keyed file
 if ! PORT=$(resolve_permission_port); then
-  debug "No usable permission server port file found — fail open"
-  exit 0
+  fail_open "No usable permission server port file found — fail open"
 fi
 
 ENDPOINT="http://127.0.0.1:${PORT}/api/evaluate_permission"
@@ -176,8 +203,7 @@ TOOL_INPUT=$(echo "$INPUT" | jq -c '.tool_input // .toolInput // .input // {}' 2
 
 # If we can't parse the input, fail open
 if [[ -z "$TOOL_NAME" ]]; then
-  debug "Could not parse tool_name from input — fail open"
-  exit 0
+  fail_open "Could not parse tool_name from input — fail open"
 fi
 
 debug "Evaluating: $TOOL_NAME"
@@ -188,8 +214,7 @@ AUTHORITY_MODE=$(resolve_authority_mode "$AUTHORITY_HOST")
 debug "Authority mode for ${AUTHORITY_HOST:-unknown}: $AUTHORITY_MODE"
 
 if [[ "$AUTHORITY_MODE" == "off" ]]; then
-  debug "Authority mode is off — hook no-op"
-  exit 0
+  fail_open "Authority mode is off — hook no-op"
 fi
 
 if [[ -n "${DOLLHOUSE_SESSION_ID:-}" ]]; then
@@ -222,14 +247,13 @@ while [[ $ATTEMPT -le $MAX_RETRIES ]]; do
   if [[ $CURL_EXIT -eq 0 ]] && [[ -n "$RESPONSE" ]]; then
     debug "Response (attempt $((ATTEMPT+1))): $RESPONSE"
     if ! echo "$RESPONSE" | jq -e . >/dev/null 2>&1; then
-      debug "Non-JSON response for platform $HOOK_PLATFORM — fail open"
-      exit 0
+      fail_open "Non-JSON response for platform $HOOK_PLATFORM — fail open"
     fi
     NORMALIZED_RESPONSE=$(normalize_response "$RESPONSE")
     if [[ -n "$NORMALIZED_RESPONSE" ]]; then
       echo "$NORMALIZED_RESPONSE"
     else
-      debug "Malformed response for platform $HOOK_PLATFORM — fail open"
+      fail_open "Malformed response for platform $HOOK_PLATFORM — fail open"
     fi
     exit 0
   fi
@@ -244,5 +268,4 @@ while [[ $ATTEMPT -le $MAX_RETRIES ]]; do
 done
 
 # All retries exhausted — fail open
-debug "All $((MAX_RETRIES + 1)) attempts failed — fail open"
-exit 0
+fail_open "All $((MAX_RETRIES + 1)) attempts failed — fail open"

--- a/scripts/pretooluse-dollhouse.sh
+++ b/scripts/pretooluse-dollhouse.sh
@@ -60,9 +60,10 @@ emit_allow_response() {
 }
 
 fail_open() {
-  debug "$1"
+  local message="$1"
+  debug "$message"
   emit_allow_response
-  exit 0
+  return 0
 }
 
 authority_host_for_platform() {
@@ -191,6 +192,7 @@ source "$SCRIPT_DIR/permission-port-discovery.sh"
 # Discover the port from the shared file or the newest live PID-keyed file
 if ! PORT=$(resolve_permission_port); then
   fail_open "No usable permission server port file found — fail open"
+  exit 0
 fi
 
 ENDPOINT="http://127.0.0.1:${PORT}/api/evaluate_permission"
@@ -206,6 +208,7 @@ TOOL_INPUT=$(echo "$INPUT" | jq -c '.tool_input // .toolInput // .input // {}' 2
 # If we can't parse the input, fail open
 if [[ -z "$TOOL_NAME" ]]; then
   fail_open "Could not parse tool_name from input — fail open"
+  exit 0
 fi
 
 debug "Evaluating: $TOOL_NAME"
@@ -217,6 +220,7 @@ debug "Authority mode for ${AUTHORITY_HOST:-unknown}: $AUTHORITY_MODE"
 
 if [[ "$AUTHORITY_MODE" == "off" ]]; then
   fail_open "Authority mode is off — hook no-op"
+  exit 0
 fi
 
 if [[ -n "${DOLLHOUSE_SESSION_ID:-}" ]]; then
@@ -250,12 +254,14 @@ while [[ $ATTEMPT -le $MAX_RETRIES ]]; do
     debug "Response (attempt $((ATTEMPT+1))): $RESPONSE"
     if ! echo "$RESPONSE" | jq -e . >/dev/null 2>&1; then
       fail_open "Non-JSON response for platform $HOOK_PLATFORM — fail open"
+      exit 0
     fi
     NORMALIZED_RESPONSE=$(normalize_response "$RESPONSE")
     if [[ -n "$NORMALIZED_RESPONSE" ]]; then
       echo "$NORMALIZED_RESPONSE"
     else
       fail_open "Malformed response for platform $HOOK_PLATFORM — fail open"
+      exit 0
     fi
     exit 0
   fi
@@ -271,3 +277,4 @@ done
 
 # All retries exhausted — fail open
 fail_open "All $((MAX_RETRIES + 1)) attempts failed — fail open"
+exit 0

--- a/scripts/pretooluse-vscode.sh
+++ b/scripts/pretooluse-vscode.sh
@@ -29,9 +29,10 @@ emit_allow_response() {
 }
 
 fail_open() {
-  debug "$1"
+  local message="$1"
+  debug "$message"
   emit_allow_response
-  exit 0
+  return 0
 }
 
 # shellcheck disable=SC1091 # Resolved at runtime via SCRIPT_DIR.
@@ -39,6 +40,7 @@ source "$SCRIPT_DIR/permission-port-discovery.sh"
 
 if ! PORT=$(resolve_permission_port); then
   fail_open "No usable permission server port file found — fail open"
+  exit 0
 fi
 
 ENDPOINT="http://127.0.0.1:${PORT}/api/evaluate_permission"
@@ -97,6 +99,7 @@ esac
 
 if [[ -z "$TOOL_NAME" ]]; then
   fail_open "Could not parse VS Code tool name — fail open"
+  exit 0
 fi
 
 if [[ -z "$TOOL_INPUT" ]]; then
@@ -159,6 +162,7 @@ while [[ $ATTEMPT -le $MAX_RETRIES ]]; do
       echo "$HOOK_RESPONSE"
     else
       fail_open "Permission evaluation returned an unrecognized response — fail open"
+      exit 0
     fi
     exit 0
   fi
@@ -171,3 +175,4 @@ while [[ $ATTEMPT -le $MAX_RETRIES ]]; do
 done
 
 fail_open "Permission evaluation failed — fail open"
+exit 0

--- a/scripts/pretooluse-vscode.sh
+++ b/scripts/pretooluse-vscode.sh
@@ -6,6 +6,7 @@
 # most relevant built-in tool names into Dollhouse's existing permission model.
 
 RUN_DIR="$HOME/.dollhouse/run"
+# shellcheck disable=SC2034 # Consumed by permission-port-discovery.sh after sourcing.
 PORT_FILE="$RUN_DIR/permission-server.port"
 MAX_RETRIES="${DOLLHOUSE_HOOK_MAX_RETRIES:-2}"
 INITIAL_TIMEOUT="${DOLLHOUSE_HOOK_INITIAL_TIMEOUT:-5}"
@@ -33,6 +34,7 @@ fail_open() {
   exit 0
 }
 
+# shellcheck disable=SC1091 # Resolved at runtime via SCRIPT_DIR.
 source "$SCRIPT_DIR/permission-port-discovery.sh"
 
 if ! PORT=$(resolve_permission_port); then

--- a/scripts/pretooluse-vscode.sh
+++ b/scripts/pretooluse-vscode.sh
@@ -22,11 +22,21 @@ debug() {
   return 0
 }
 
+emit_allow_response() {
+  printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+  return 0
+}
+
+fail_open() {
+  debug "$1"
+  emit_allow_response
+  exit 0
+}
+
 source "$SCRIPT_DIR/permission-port-discovery.sh"
 
 if ! PORT=$(resolve_permission_port); then
-  debug "No usable permission server port file found — fail open"
-  exit 0
+  fail_open "No usable permission server port file found — fail open"
 fi
 
 ENDPOINT="http://127.0.0.1:${PORT}/api/evaluate_permission"
@@ -84,8 +94,7 @@ case "$RAW_TOOL_NAME" in
 esac
 
 if [[ -z "$TOOL_NAME" ]]; then
-  debug "Could not parse VS Code tool name — fail open"
-  exit 0
+  fail_open "Could not parse VS Code tool name — fail open"
 fi
 
 if [[ -z "$TOOL_INPUT" ]]; then
@@ -147,7 +156,7 @@ while [[ $ATTEMPT -le $MAX_RETRIES ]]; do
     if [[ -n "$HOOK_RESPONSE" ]]; then
       echo "$HOOK_RESPONSE"
     else
-      debug "Permission evaluation returned an unrecognized response — fail open"
+      fail_open "Permission evaluation returned an unrecognized response — fail open"
     fi
     exit 0
   fi
@@ -159,5 +168,4 @@ while [[ $ATTEMPT -le $MAX_RETRIES ]]; do
   fi
 done
 
-debug "Permission evaluation failed — fail open"
-exit 0
+fail_open "Permission evaluation failed — fail open"

--- a/scripts/pretooluse-windsurf.sh
+++ b/scripts/pretooluse-windsurf.sh
@@ -6,6 +6,7 @@
 # evaluations and then maps the response back to Windsurf exit codes.
 
 RUN_DIR="$HOME/.dollhouse/run"
+# shellcheck disable=SC2034 # Consumed by permission-port-discovery.sh after sourcing.
 PORT_FILE="$RUN_DIR/permission-server.port"
 MAX_RETRIES="${DOLLHOUSE_HOOK_MAX_RETRIES:-2}"
 INITIAL_TIMEOUT="${DOLLHOUSE_HOOK_INITIAL_TIMEOUT:-5}"
@@ -22,6 +23,7 @@ debug() {
   return 0
 }
 
+# shellcheck disable=SC1091 # Resolved at runtime via SCRIPT_DIR.
 source "$SCRIPT_DIR/permission-port-discovery.sh"
 
 if ! PORT=$(resolve_permission_port); then

--- a/src/services/BuildInfoService.ts
+++ b/src/services/BuildInfoService.ts
@@ -15,7 +15,7 @@ import { IFileOperationsService } from './FileOperationsService.js';
 import { PACKAGE_NAME, PACKAGE_VERSION, BUILD_TIMESTAMP, BUILD_TYPE } from '../generated/version.js';
 import type { StartupTimer, StartupReport } from '../telemetry/StartupTimer.js';
 import { resolveSessionIdentity } from './sessionIdentity.js';
-import { getPermissionHookAuditSummary } from '../utils/permissionHooks.js';
+import { getPermissionHookAuditSummary, type PermissionHookStartupRepairSummary } from '../utils/permissionHooks.js';
 
 export interface BuildInfo {
   sessionId: string;
@@ -56,6 +56,7 @@ export interface BuildInfo {
     currentHosts: string[];
     repairedHosts: string[];
     needsRepairHosts: string[];
+    lastStartupRepair: PermissionHookStartupRepairSummary | null;
   };
   /** Issue #706: Startup timing and readiness status. */
   startup?: {
@@ -122,7 +123,7 @@ export class BuildInfoService {
       : { isDocker: false, info: undefined };
     const permissionHookInfo = results[2].status === 'fulfilled'
       ? results[2].value
-      : { installedHosts: [], currentHosts: [], repairedHosts: [], needsRepairHosts: [] };
+      : { installedHosts: [], currentHosts: [], repairedHosts: [], needsRepairHosts: [], lastStartupRepair: null };
 
     // Log any failures for diagnostics
     const failures: string[] = [];
@@ -268,6 +269,13 @@ export class BuildInfoService {
       const needsRepairHosts = info.permissionHooks.needsRepairHosts.length > 0
         ? info.permissionHooks.needsRepairHosts.join(', ')
         : 'None';
+      const lastStartupRepair = info.permissionHooks.lastStartupRepair;
+      const startupRepairIssues = lastStartupRepair
+        ? lastStartupRepair.hostResults
+          .filter((result) => result.outcome === 'needs_repair' || result.outcome === 'error')
+          .map((result) => result.repairError ? `${result.host} (${result.repairError})` : result.host)
+          .join('; ')
+        : '';
 
       lines.push(
         '',
@@ -276,6 +284,14 @@ export class BuildInfoService {
         `- **Current Assets**: ${currentHosts}`,
         `- **Needs Repair**: ${needsRepairHosts}`,
       );
+
+      if (lastStartupRepair) {
+        lines.push(
+          `- **Last Startup Audit**: ${lastStartupRepair.completedAt} (${lastStartupRepair.durationMs}ms)`,
+          `- **Startup Repairs Applied**: ${lastStartupRepair.repairedCount}`,
+          `- **Startup Repair Issues**: ${startupRepairIssues || 'None'}`,
+        );
+      }
     }
 
     // Issue #706: Startup timing

--- a/src/utils/permissionHooks.ts
+++ b/src/utils/permissionHooks.ts
@@ -61,6 +61,21 @@ export interface PermissionHookAuditSummary {
   currentHosts: string[];
   repairedHosts: string[];
   needsRepairHosts: string[];
+  lastStartupRepair: PermissionHookStartupRepairSummary | null;
+}
+
+export interface PermissionHookStartupRepairHostResult extends PermissionHookStatus {
+  host: string;
+  outcome: 'current' | 'repaired' | 'needs_repair' | 'not_installed' | 'error';
+}
+
+export interface PermissionHookStartupRepairSummary {
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  repairedCount: number;
+  needsRepairCount: number;
+  hostResults: PermissionHookStartupRepairHostResult[];
 }
 
 interface HookAssetDescriptor {
@@ -86,6 +101,8 @@ const MANAGED_HOOK_WRAPPER_BASENAMES = {
 const WRAPPER_HOOK_HOSTS = Object.keys(MANAGED_HOOK_WRAPPER_BASENAMES) as Array<keyof typeof MANAGED_HOOK_WRAPPER_BASENAMES>;
 
 const AUTO_REPAIRABLE_HOOK_HOSTS = ['claude-code', ...WRAPPER_HOOK_HOSTS] as const;
+
+let lastPermissionHookStartupRepairSummary: PermissionHookStartupRepairSummary | null = null;
 
 function repoRootFromModule(): string {
   const currentFile = fileURLToPath(import.meta.url);
@@ -438,6 +455,43 @@ function buildHookRepairFailureStatus(
   };
 }
 
+function toStartupRepairOutcome(status: PermissionHookStatus): PermissionHookStartupRepairHostResult['outcome'] {
+  if (status.repairError) return 'error';
+  if (status.autoRepaired) return 'repaired';
+  if (status.needsRepair && (status.installed || status.assetsPrepared)) return 'needs_repair';
+  if (status.assetsCurrent) return 'current';
+  return 'not_installed';
+}
+
+function toStartupRepairHostResult(
+  host: string,
+  status: PermissionHookStatus,
+): PermissionHookStartupRepairHostResult {
+  return {
+    ...status,
+    host,
+    outcome: toStartupRepairOutcome(status),
+  };
+}
+
+function cloneStartupRepairSummary(
+  summary: PermissionHookStartupRepairSummary | null,
+): PermissionHookStartupRepairSummary | null {
+  if (!summary) return null;
+  return {
+    ...summary,
+    hostResults: summary.hostResults.map((result) => ({ ...result })),
+  };
+}
+
+export function getLastPermissionHookStartupRepairSummary(): PermissionHookStartupRepairSummary | null {
+  return cloneStartupRepairSummary(lastPermissionHookStartupRepairSummary);
+}
+
+export function _resetPermissionHookStartupRepairSummaryForTests(): void {
+  lastPermissionHookStartupRepairSummary = null;
+}
+
 export async function reconcilePermissionHookStatus(
   host: string,
   options: ReconcilePermissionHookOptions = {},
@@ -501,38 +555,69 @@ export async function getPermissionHookAuditSummary(homeDir = homedir()): Promis
     currentHosts,
     repairedHosts,
     needsRepairHosts,
+    lastStartupRepair: getLastPermissionHookStartupRepairSummary(),
   };
 }
 
-export async function repairPermissionHooksOnStartup(homeDir = homedir()): Promise<void> {
+export async function repairPermissionHooksOnStartup(
+  homeDir = homedir(),
+  sourceScriptPath?: string,
+): Promise<PermissionHookStartupRepairSummary> {
   const startedAt = Date.now();
-  let repairedCount = 0;
-  let needsRepairCount = 0;
-
-  await Promise.allSettled(
+  const startedAtIso = new Date(startedAt).toISOString();
+  const hostResults = await Promise.all(
     AUTO_REPAIRABLE_HOOK_HOSTS.map(async (host) => {
-      const status = await reconcilePermissionHookStatus(host, {
-        homeDir,
-        autoRepair: true,
-      });
+      try {
+        const status = await reconcilePermissionHookStatus(host, {
+          homeDir,
+          autoRepair: true,
+          sourceScriptPath,
+        });
 
-      if (status.autoRepaired) {
-        repairedCount += 1;
-        logger.info(`[PermissionHooks] Refreshed installed hook assets for ${host}`);
-      } else if (status.needsRepair && status.installed) {
-        needsRepairCount += 1;
-        logger.warn(
-          `[PermissionHooks] Hook assets still need repair for ${host}` +
-          (status.repairError ? `: ${status.repairError}` : ''),
-        );
+        if (status.autoRepaired) {
+          logger.info(`[PermissionHooks] Refreshed installed hook assets for ${host}`);
+        } else if (status.needsRepair && status.installed) {
+          logger.warn(
+            `[PermissionHooks] Hook assets still need repair for ${host}` +
+            (status.repairError ? `: ${status.repairError}` : ''),
+          );
+        }
+
+        return toStartupRepairHostResult(host, status);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn(`[PermissionHooks] Startup hook repair failed for ${host}: ${message}`);
+        return {
+          host,
+          installed: false,
+          assetsPrepared: false,
+          assetsCurrent: false,
+          autoRepaired: false,
+          needsRepair: true,
+          repairError: message,
+          outcome: 'error',
+        } satisfies PermissionHookStartupRepairHostResult;
       }
     }),
   );
-
+  const repairedCount = hostResults.filter((result) => result.outcome === 'repaired').length;
+  const needsRepairCount = hostResults.filter((result) =>
+    result.outcome === 'needs_repair' || result.outcome === 'error').length;
+  const completedAt = Date.now();
+  const summary: PermissionHookStartupRepairSummary = {
+    startedAt: startedAtIso,
+    completedAt: new Date(completedAt).toISOString(),
+    durationMs: completedAt - startedAt,
+    repairedCount,
+    needsRepairCount,
+    hostResults,
+  };
+  lastPermissionHookStartupRepairSummary = cloneStartupRepairSummary(summary);
   logger.info(
-    `[PermissionHooks] Startup hook asset audit completed in ${Date.now() - startedAt}ms ` +
+    `[PermissionHooks] Startup hook asset audit completed in ${summary.durationMs}ms ` +
     `(repaired=${repairedCount}, needsRepair=${needsRepairCount})`,
   );
+  return summary;
 }
 
 function normalizeHooksRoot(parsed: Record<string, unknown>): Record<string, unknown[]> {

--- a/src/utils/permissionHooks.ts
+++ b/src/utils/permissionHooks.ts
@@ -565,41 +565,43 @@ export async function repairPermissionHooksOnStartup(
 ): Promise<PermissionHookStartupRepairSummary> {
   const startedAt = Date.now();
   const startedAtIso = new Date(startedAt).toISOString();
-  const hostResults = await Promise.all(
-    AUTO_REPAIRABLE_HOOK_HOSTS.map(async (host) => {
-      try {
-        const status = await reconcilePermissionHookStatus(host, {
-          homeDir,
-          autoRepair: true,
-          sourceScriptPath,
-        });
+  const hostResults: PermissionHookStartupRepairHostResult[] = [];
 
-        if (status.autoRepaired) {
-          logger.info(`[PermissionHooks] Refreshed installed hook assets for ${host}`);
-        } else if (status.needsRepair && status.installed) {
-          logger.warn(
-            `[PermissionHooks] Hook assets still need repair for ${host}` +
-            (status.repairError ? `: ${status.repairError}` : ''),
-          );
-        }
+  // Process sequentially because several hosts share the same bridge/helper
+  // targets under ~/.dollhouse/hooks, and concurrent writes are flaky on Windows.
+  for (const host of AUTO_REPAIRABLE_HOOK_HOSTS) {
+    try {
+      const status = await reconcilePermissionHookStatus(host, {
+        homeDir,
+        autoRepair: true,
+        sourceScriptPath,
+      });
 
-        return toStartupRepairHostResult(host, status);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        logger.warn(`[PermissionHooks] Startup hook repair failed for ${host}: ${message}`);
-        return {
-          host,
-          installed: false,
-          assetsPrepared: false,
-          assetsCurrent: false,
-          autoRepaired: false,
-          needsRepair: true,
-          repairError: message,
-          outcome: 'error',
-        } satisfies PermissionHookStartupRepairHostResult;
+      if (status.autoRepaired) {
+        logger.info(`[PermissionHooks] Refreshed installed hook assets for ${host}`);
+      } else if (status.needsRepair && status.installed) {
+        logger.warn(
+          `[PermissionHooks] Hook assets still need repair for ${host}` +
+          (status.repairError ? `: ${status.repairError}` : ''),
+        );
       }
-    }),
-  );
+
+      hostResults.push(toStartupRepairHostResult(host, status));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(`[PermissionHooks] Startup hook repair failed for ${host}: ${message}`);
+      hostResults.push({
+        host,
+        installed: false,
+        assetsPrepared: false,
+        assetsCurrent: false,
+        autoRepaired: false,
+        needsRepair: true,
+        repairError: message,
+        outcome: 'error',
+      } satisfies PermissionHookStartupRepairHostResult);
+    }
+  }
   const repairedCount = hostResults.filter((result) => result.outcome === 'repaired').length;
   const needsRepairCount = hostResults.filter((result) =>
     result.outcome === 'needs_repair' || result.outcome === 'error').length;

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -13,7 +13,11 @@ import { logger } from '../../utils/logger.js';
 import type { MCPAQLHandler } from '../../handlers/mcp-aql/MCPAQLHandler.js';
 import { formatPermissionResponse } from '../../handlers/mcp-aql/evaluatePermission.js';
 import { ensureLatestPortFile } from '../portDiscovery.js';
-import { getPermissionHookStatusAsync, reconcilePermissionHookStatus } from '../../utils/permissionHooks.js';
+import {
+  getLastPermissionHookStartupRepairSummary,
+  getPermissionHookStatusAsync,
+  reconcilePermissionHookStatus,
+} from '../../utils/permissionHooks.js';
 
 import { SlidingWindowRateLimiter } from '../../utils/SlidingWindowRateLimiter.js';
 import {
@@ -517,6 +521,7 @@ export function registerPermissionRoutes(
         hookAutoRepaired: hookStatus.autoRepaired,
         hookNeedsRepair: hookStatus.needsRepair,
         hookRepairError: hookStatus.repairError,
+        hookStartupRepair: getLastPermissionHookStartupRepairSummary(),
         authority: authorityState,
         authoritySupportedHosts: installedAuthorityHosts,
         authoritySupportedModes: [...PERMISSION_AUTHORITY_MODES],

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -326,9 +326,18 @@ export async function startWebServer(options: WebServerOptions): Promise<WebServ
     logger.warn(`[Setup] NVM startup repair threw unexpectedly: ${err instanceof Error ? err.message : String(err)}`)
   );
   if (process.env.NODE_ENV !== 'test') {
-    repairPermissionHooksOnStartup().catch(err =>
-      logger.warn(`[Setup] Permission hook startup repair threw unexpectedly: ${err instanceof Error ? err.message : String(err)}`)
-    );
+    repairPermissionHooksOnStartup()
+      .then((summary) => {
+        if (summary.needsRepairCount > 0) {
+          logger.warn(
+            `[Setup] Permission hook startup repair completed with ${summary.needsRepairCount} issue(s) ` +
+            `across ${summary.hostResults.length} host(s)`,
+          );
+        }
+      })
+      .catch(err =>
+        logger.warn(`[Setup] Permission hook startup repair threw unexpectedly: ${err instanceof Error ? err.message : String(err)}`)
+      );
   }
 
   // API routes — use MCP-AQL gateway when handler is available (Issue #796)

--- a/tests/unit/di/permissionServerIntegration.test.ts
+++ b/tests/unit/di/permissionServerIntegration.test.ts
@@ -184,7 +184,12 @@ describe('Permission Server Integration', () => {
       await fs.rm(tempHome, { recursive: true, force: true });
 
       expect(code).toBe(0);
-      expect(stdout.trim()).toBe('');
+      expect(JSON.parse(stdout.trim())).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+        },
+      });
     });
 
     itBash('hook script should no-op when authority mode is off for Claude Code', async () => {
@@ -225,7 +230,12 @@ describe('Permission Server Integration', () => {
       await fs.rm(tempHome, { recursive: true, force: true });
 
       expect(code).toBe(0);
-      expect(stdout.trim()).toBe('');
+      expect(JSON.parse(stdout.trim())).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+        },
+      });
     });
 
     itBash('hook script should discover server via port file and get a response', async () => {
@@ -393,7 +403,12 @@ describe('Permission Server Integration', () => {
       await fs.unlink(PID_PORT_FILE).catch(() => {});
 
       expect(code).toBe(0);
-      expect(stdout.trim()).toBe('');
+      expect(JSON.parse(stdout.trim())).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+        },
+      });
     });
 
     itBash('hook script should fail open when permission requests time out', async () => {
@@ -422,7 +437,12 @@ describe('Permission Server Integration', () => {
       await fs.unlink(PID_PORT_FILE).catch(() => {});
 
       expect(code).toBe(0);
-      expect(stdout.trim()).toBe('');
+      expect(JSON.parse(stdout.trim())).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+        },
+      });
     });
 
     itBash('hook script should emit Codex-compatible JSON for allow decisions', async () => {
@@ -470,6 +490,43 @@ describe('Permission Server Integration', () => {
         platform: 'codex',
         session_id: 'session-hook-test',
       });
+      expect(JSON.parse(stdout.trim())).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          permissionDecisionReason: '',
+        },
+      });
+    });
+
+    itBash('codex hook wrapper should emit allow JSON when fail-open triggers before the server is ready', async () => {
+      const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'dollhouse-hook-home-'));
+      const codexScript = path.join(tempHome, 'pretooluse-codex.sh');
+      const sharedScript = path.join(tempHome, 'pretooluse-dollhouse.sh');
+      const portHelper = path.join(tempHome, 'permission-port-discovery.sh');
+
+      await fs.copyFile(path.join(process.cwd(), 'scripts', 'pretooluse-codex.sh'), codexScript);
+      await fs.copyFile(path.join(process.cwd(), 'scripts', 'pretooluse-dollhouse.sh'), sharedScript);
+      await fs.copyFile(path.join(process.cwd(), 'scripts', 'permission-port-discovery.sh'), portHelper);
+
+      const { code, stdout } = await new Promise<{ code: number; stdout: string }>((resolve) => {
+        const hookProc = spawn(BASH_BINARY, [codexScript], {
+          env: { HOME: tempHome, PATH: SAFE_TEST_PATH },
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        let out = '';
+        hookProc.stdout.on('data', (data: Buffer) => { out += data.toString(); });
+        hookProc.on('close', (c: number) => resolve({ code: c, stdout: out }));
+        hookProc.stdin.write(JSON.stringify({
+          toolName: 'Bash',
+          toolInput: { command: 'pwd' },
+        }));
+        hookProc.stdin.end();
+      });
+
+      await fs.rm(tempHome, { recursive: true, force: true });
+
+      expect(code).toBe(0);
       expect(JSON.parse(stdout.trim())).toEqual({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
@@ -714,7 +771,12 @@ describe('Permission Server Integration', () => {
       await fs.unlink(PID_PORT_FILE).catch(() => {});
 
       expect(code).toBe(0);
-      expect(stdout.trim()).toBe('');
+      expect(JSON.parse(stdout.trim())).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+        },
+      });
       expect(capturedBody).toEqual({
         tool_name: 'Bash',
         input: { command: 'npm test' },

--- a/tests/unit/services/BuildInfoService.test.ts
+++ b/tests/unit/services/BuildInfoService.test.ts
@@ -13,17 +13,23 @@
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import { BuildInfoService, BuildInfo } from '../../../src/services/BuildInfoService.js';
 import { DollhouseContainer } from '../../../src/di/Container.js';
+import {
+  _resetPermissionHookStartupRepairSummaryForTests,
+  repairPermissionHooksOnStartup,
+} from '../../../src/utils/permissionHooks.js';
 
 describe('BuildInfoService', () => {
   let service: BuildInfoService;
   let container: DollhouseContainer;
 
   beforeEach(() => {
+    _resetPermissionHookStartupRepairSummaryForTests();
     container = new DollhouseContainer();
     service = container.resolve<BuildInfoService>('BuildInfoService');
   });
 
   afterEach(async () => {
+    _resetPermissionHookStartupRepairSummaryForTests();
     await container.dispose();
     jest.restoreAllMocks();
     jest.clearAllMocks();
@@ -123,6 +129,7 @@ describe('BuildInfoService', () => {
     });
 
     it('includes permission hook audit summary in build info', async () => {
+      await repairPermissionHooksOnStartup();
       const info = await service.getBuildInfo();
 
       expect(info.permissionHooks).toBeDefined();
@@ -130,6 +137,8 @@ describe('BuildInfoService', () => {
       expect(Array.isArray(info.permissionHooks?.currentHosts)).toBe(true);
       expect(Array.isArray(info.permissionHooks?.repairedHosts)).toBe(true);
       expect(Array.isArray(info.permissionHooks?.needsRepairHosts)).toBe(true);
+      expect(info.permissionHooks?.lastStartupRepair).toBeTruthy();
+      expect(Array.isArray(info.permissionHooks?.lastStartupRepair?.hostResults)).toBe(true);
     });
 
     it('should have consistent results across calls', async () => {
@@ -211,6 +220,34 @@ describe('BuildInfoService', () => {
           currentHosts: [],
           repairedHosts: [],
           needsRepairHosts: [],
+          lastStartupRepair: {
+            startedAt: '2024-01-01T09:59:58.000Z',
+            completedAt: '2024-01-01T10:00:00.000Z',
+            durationMs: 2000,
+            repairedCount: 1,
+            needsRepairCount: 1,
+            hostResults: [
+              {
+                host: 'codex',
+                installed: true,
+                assetsPrepared: true,
+                assetsCurrent: true,
+                autoRepaired: true,
+                needsRepair: false,
+                outcome: 'repaired',
+              },
+              {
+                host: 'vscode',
+                installed: true,
+                assetsPrepared: true,
+                assetsCurrent: false,
+                autoRepaired: false,
+                needsRepair: true,
+                repairError: 'ENOENT: missing shared script',
+                outcome: 'error',
+              },
+            ],
+          },
         },
       };
     });
@@ -252,6 +289,9 @@ describe('BuildInfoService', () => {
       expect(formatted).toContain('**Installed Hosts**: None');
       expect(formatted).toContain('**Current Assets**: None');
       expect(formatted).toContain('**Needs Repair**: None');
+      expect(formatted).toContain('**Last Startup Audit**: 2024-01-01T10:00:00.000Z (2000ms)');
+      expect(formatted).toContain('**Startup Repairs Applied**: 1');
+      expect(formatted).toContain('**Startup Repair Issues**: vscode (ENOENT: missing shared script)');
     });
 
     it('should handle missing optional fields gracefully', () => {

--- a/tests/unit/utils/permissionHooks.repair.test.ts
+++ b/tests/unit/utils/permissionHooks.repair.test.ts
@@ -4,7 +4,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import {
+  _resetPermissionHookStartupRepairSummaryForTests,
   getPermissionHookAuditSummary,
+  getLastPermissionHookStartupRepairSummary,
   getPermissionHookScriptPath,
   installPermissionHook,
   reconcilePermissionHookStatus,
@@ -16,9 +18,11 @@ describe('permissionHooks repair flows', () => {
 
   beforeEach(async () => {
     tempHome = await mkdtemp(join(tmpdir(), 'permission-hooks-repair-'));
+    _resetPermissionHookStartupRepairSummaryForTests();
   });
 
   afterEach(async () => {
+    _resetPermissionHookStartupRepairSummaryForTests();
     await rm(tempHome, { recursive: true, force: true });
   });
 
@@ -68,22 +72,44 @@ describe('permissionHooks repair flows', () => {
     await installPermissionHook('claude-code', { homeDir: tempHome });
     await writeFile(getPermissionHookScriptPath(tempHome), '#!/bin/bash\necho stale-shared\n', 'utf-8');
 
-    await expect(repairPermissionHooksOnStartup(tempHome)).resolves.not.toThrow();
+    const summary = await repairPermissionHooksOnStartup(tempHome);
 
     const status = await reconcilePermissionHookStatus('claude-code', { homeDir: tempHome });
+    const hostSummary = summary.hostResults.find((result) => result.host === 'claude-code');
+
     expect(status.assetsCurrent).toBe(true);
     expect(status.needsRepair).toBe(false);
+    expect(summary.repairedCount).toBeGreaterThanOrEqual(1);
+    expect(hostSummary?.outcome).toBe('repaired');
+    expect(getLastPermissionHookStartupRepairSummary()).toEqual(summary);
   });
 
   it('summarizes installed and repair-needed hook hosts for build info', async () => {
     await installPermissionHook('claude-code', { homeDir: tempHome });
     await installPermissionHook('codex', { homeDir: tempHome });
     await writeFile(getPermissionHookScriptPath(tempHome), '#!/bin/bash\necho stale-shared\n', 'utf-8');
+    await repairPermissionHooksOnStartup(tempHome);
 
     const summary = await getPermissionHookAuditSummary(tempHome);
 
     expect(summary.installedHosts).toEqual(expect.arrayContaining(['claude-code', 'codex']));
-    expect(summary.currentHosts).not.toContain('claude-code');
-    expect(summary.needsRepairHosts).toEqual(expect.arrayContaining(['claude-code', 'codex']));
+    expect(summary.currentHosts).toEqual(expect.arrayContaining(['claude-code', 'codex']));
+    expect(summary.needsRepairHosts).toEqual([]);
+    expect(summary.lastStartupRepair).toBeTruthy();
+  });
+
+  it('records startup repair errors with per-host reasons', async () => {
+    await installPermissionHook('codex', { homeDir: tempHome });
+    await writeFile(getPermissionHookScriptPath(tempHome), '#!/bin/bash\necho stale-shared\n', 'utf-8');
+
+    const failedSummary = await repairPermissionHooksOnStartup(
+      tempHome,
+      join(tempHome, 'missing-shared-script.sh'),
+    );
+    const errorHost = failedSummary.hostResults.find((result) => result.host === 'codex');
+
+    expect(failedSummary.needsRepairCount).toBeGreaterThanOrEqual(1);
+    expect(errorHost?.outcome).toBe('error');
+    expect(errorHost?.repairError).toContain('ENOENT');
   });
 });

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -12,7 +12,12 @@ import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { mkdir, mkdtemp, readFile, rm, unlink, writeFile } from 'node:fs/promises';
 import { registerPermissionRoutes } from '../../../src/web/routes/permissionRoutes.js';
-import { getPermissionHookMarkerPath, installPermissionHook } from '../../../src/utils/permissionHooks.js';
+import {
+  _resetPermissionHookStartupRepairSummaryForTests,
+  getPermissionHookMarkerPath,
+  installPermissionHook,
+  repairPermissionHooksOnStartup,
+} from '../../../src/utils/permissionHooks.js';
 
 function createMockHandler(readResult?: unknown) {
   return {
@@ -45,9 +50,11 @@ describe('permissionRoutes', () => {
 
   beforeEach(async () => {
     tempHome = await mkdtemp(join(tmpdir(), 'permission-routes-home-'));
+    _resetPermissionHookStartupRepairSummaryForTests();
   });
 
   afterEach(async () => {
+    _resetPermissionHookStartupRepairSummaryForTests();
     await unlink(latestPortFile).catch(() => {});
     await rm(tempHome, { recursive: true, force: true });
   });
@@ -221,6 +228,7 @@ describe('permissionRoutes', () => {
   describe('GET /api/permissions/status', () => {
     it('should return policy status', async () => {
       await installPermissionHook('codex', { homeDir: tempHome });
+      await repairPermissionHooksOnStartup(tempHome);
 
       const handler = {
         handleRead: jest.fn().mockResolvedValue([{
@@ -275,6 +283,15 @@ describe('permissionRoutes', () => {
       expect(res.body.hookAssetsCurrent).toBe(true);
       expect(res.body.hookAutoRepaired).toBe(false);
       expect(res.body.hookNeedsRepair).toBe(false);
+      expect(res.body.hookStartupRepair).toEqual(
+        expect.objectContaining({
+          repairedCount: expect.any(Number),
+          needsRepairCount: expect.any(Number),
+          hostResults: expect.arrayContaining([
+            expect.objectContaining({ host: 'codex' }),
+          ]),
+        }),
+      );
       expect(res.body.enforcementReady).toBe(false);
       expect(res.body.advisory).toContain('NOT enforced');
       expect(Array.isArray(res.body.recentDecisions)).toBe(true);


### PR DESCRIPTION
## Summary
- emit explicit allow JSON for shared hook fail-open paths instead of exiting with empty stdout
- do the same for the VS Code wrapper so startup races and transient outages stay JSON-valid
- update the hook contract doc and regression tests to match

## Why
Codex was still hitting  during restart/startup races because the shared hook bridge had early  branches that emitted no JSON at all when the permission server port file was missing, the authority mode was off, the response was malformed, or retries were exhausted.

## Testing
- npm test -- --runInBand tests/unit/di/permissionServerIntegration.test.ts
- npm run test:integration -- --runInBand tests/integration/hooks/permission-hook-docker.test.ts
- bash -n scripts/pretooluse-dollhouse.sh scripts/pretooluse-codex.sh scripts/pretooluse-cursor.sh scripts/pretooluse-gemini.sh scripts/pretooluse-vscode.sh