### PR TITLE
Deduplicate legacy ensemble warning spam

### DIFF
--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -46,6 +46,7 @@ import { FileWatchService } from '../../services/FileWatchService.js';
 import { ElementMessages } from '../../utils/elementMessages.js';
 import { VALIDATION_PATTERNS, SECURITY_LIMITS } from '../../security/constants.js';
 import { sanitizeGatekeeperPolicy } from '../../handlers/mcp-aql/policies/ElementPolicies.js';
+import { SecureYamlParser } from '../../security/secureYamlParser.js';
 
 // Issue #83: Centralized active element limits (configurable via env vars)
 import { getActiveElementLimitConfig, getMaxActiveLimit } from '../../config/active-element-limits.js';
@@ -71,6 +72,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
   private validationService: ValidationService;
   private serializationService: SerializationService;
   private activeEnsembleNames: Set<string> = new Set();
+  private readonly legacyElementFieldWarnings: Set<string> = new Set();
 
   constructor(
     portfolioManager: PortfolioManager,
@@ -91,6 +93,103 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
 
   protected override getElementLabel(): string {
     return 'ensemble';
+  }
+
+  /**
+   * Clear in-memory warn-once state for legacy ensemble element fields.
+   *
+   * Useful for long-lived processes or tests that intentionally want to
+   * observe the warning path again after a maintenance boundary.
+   */
+  public clearLegacyElementWarningHistory(): void {
+    this.legacyElementFieldWarnings.clear();
+  }
+
+  override dispose(): void {
+    super.dispose();
+    this.clearLegacyElementWarningHistory();
+  }
+
+  private warnOnceForLegacyElementField(
+    ensembleName: string,
+    index: number,
+    field: 'name' | 'type',
+    replacement: 'element_name' | 'element_type',
+  ): void {
+    const fingerprint = `${ensembleName}:${index}:${field}`;
+    if (this.legacyElementFieldWarnings.has(fingerprint)) {
+      return;
+    }
+
+    this.legacyElementFieldWarnings.add(fingerprint);
+    logger.warn(
+      `Ensemble '${ensembleName}' element at index ${index} uses deprecated '${field}' field. Use '${replacement}' instead.`,
+    );
+  }
+
+  private hasLegacyElementFields(elementsRaw: unknown): boolean {
+    if (!Array.isArray(elementsRaw)) {
+      return false;
+    }
+
+    return elementsRaw.some((elem) =>
+      elem
+      && typeof elem === 'object'
+      && (
+        ('name' in (elem as Record<string, unknown>) && !('element_name' in (elem as Record<string, unknown>)))
+        || ('type' in (elem as Record<string, unknown>) && !('element_type' in (elem as Record<string, unknown>)))
+      )
+    );
+  }
+
+  /**
+   * Rewrite legacy ensemble element field names (`name`/`type`) to the
+   * canonical `element_name`/`element_type` form by loading and resaving
+   * affected ensembles.
+   */
+  async repairLegacyElementFields(): Promise<{
+    scanned: number;
+    repaired: number;
+    errors: number;
+    repairedEnsembles: Array<{ name: string; path: string }>;
+  }> {
+    const result = {
+      scanned: 0,
+      repaired: 0,
+      errors: 0,
+      repairedEnsembles: [] as Array<{ name: string; path: string }>,
+    };
+
+    const elementType = this.getElementType();
+    const files = await this.portfolioManager.listElements(elementType);
+    for (const file of files) {
+      result.scanned++;
+      try {
+        const absolutePath = this.resolveAbsolutePath(file);
+        const raw = await this.fileOperations.readElementFile(absolutePath, elementType, {
+          source: `${this.constructor.name}.repairLegacyElementFields`,
+        });
+        const parsed = SecureYamlParser.safeMatter(raw, undefined);
+
+        if (!this.hasLegacyElementFields(parsed.data?.elements)) {
+          continue;
+        }
+
+        const ensemble = await this.load(file);
+        await this.save(ensemble, file);
+
+        result.repaired++;
+        result.repairedEnsembles.push({
+          name: ensemble.metadata.name,
+          path: file,
+        });
+      } catch (error) {
+        result.errors++;
+        logger.error(`[EnsembleManager] Failed to repair legacy element fields in '${file}':`, error);
+      }
+    }
+
+    return result;
   }
 
   /**
@@ -217,7 +316,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       }
       // Log deprecation warning if using legacy 'name' field
       if (elem.name && !elem.element_name) {
-        logger.warn(`Ensemble element at index ${index} uses deprecated 'name' field. Use 'element_name' instead.`);
+        this.warnOnceForLegacyElementField(name, index, 'name', 'element_name');
       }
       const elementNameResult = this.validationService.validateAndSanitizeInput(
         String(rawElementName),
@@ -233,7 +332,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       const rawElementType = elem.element_type || elem.type || 'skill';
       // Log deprecation warning if using legacy 'type' field
       if (elem.type && !elem.element_type) {
-        logger.warn(`Ensemble element at index ${index} uses deprecated 'type' field. Use 'element_type' instead.`);
+        this.warnOnceForLegacyElementField(name, index, 'type', 'element_type');
       }
       const elementTypeResult = this.validationService.validateAndSanitizeInput(
         String(rawElementType),
@@ -629,6 +728,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
     if (!metadata.name) {
       throw new Error('Ensemble must have a name');
     }
+    const ensembleName = metadata.name;
 
     let rawElements = metadata.elements || [];
 
@@ -642,7 +742,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       }
       // Log deprecation warning if using legacy 'name' field
       if (elem.name && !elem.element_name) {
-        logger.warn(`Ensemble element at index ${index} uses deprecated 'name' field. Use 'element_name' instead.`);
+        this.warnOnceForLegacyElementField(ensembleName, index, 'name', 'element_name');
       }
 
       // Support both element_type (new standard) and type (legacy)
@@ -657,7 +757,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       }
       // Log deprecation warning if using legacy 'type' field
       if (elem.type && !elem.element_type) {
-        logger.warn(`Ensemble element at index ${index} uses deprecated 'type' field. Use 'element_type' instead.`);
+        this.warnOnceForLegacyElementField(ensembleName, index, 'type', 'element_type');
       }
 
       return {

--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -58,6 +58,13 @@ export { resolveElementTypes, type ElementManagersForResolution } from '../../ut
 /** @deprecated Use resolveElementTypes from '../../utils/elementTypeResolver.js' */
 export const resolveEnsembleElementTypes = resolveElementTypes;
 
+const LEGACY_ELEMENT_FIELD_REPLACEMENTS = {
+  name: 'element_name',
+  type: 'element_type',
+} as const;
+
+type LegacyElementField = keyof typeof LEGACY_ELEMENT_FIELD_REPLACEMENTS;
+
 /**
  * EnsembleManager - Manages ensemble element lifecycle
  *
@@ -110,12 +117,23 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
     this.clearLegacyElementWarningHistory();
   }
 
+  /**
+   * Warn once per ensemble/index/field combination when a legacy nested field
+   * is encountered while loading or parsing an ensemble.
+   *
+   * Fingerprinting keeps the warning visible for each distinct legacy field
+   * without re-emitting the same deprecation notice on every re-parse.
+   *
+   * @param ensembleName - Name of the ensemble containing the legacy field
+   * @param index - Zero-based index of the element within the ensemble
+   * @param field - Legacy nested field name that should be migrated
+   */
   private warnOnceForLegacyElementField(
     ensembleName: string,
     index: number,
-    field: 'name' | 'type',
-    replacement: 'element_name' | 'element_type',
+    field: LegacyElementField,
   ): void {
+    const replacement = LEGACY_ELEMENT_FIELD_REPLACEMENTS[field];
     const fingerprint = `${ensembleName}:${index}:${field}`;
     if (this.legacyElementFieldWarnings.has(fingerprint)) {
       return;
@@ -316,7 +334,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       }
       // Log deprecation warning if using legacy 'name' field
       if (elem.name && !elem.element_name) {
-        this.warnOnceForLegacyElementField(name, index, 'name', 'element_name');
+        this.warnOnceForLegacyElementField(name, index, 'name');
       }
       const elementNameResult = this.validationService.validateAndSanitizeInput(
         String(rawElementName),
@@ -332,7 +350,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       const rawElementType = elem.element_type || elem.type || 'skill';
       // Log deprecation warning if using legacy 'type' field
       if (elem.type && !elem.element_type) {
-        this.warnOnceForLegacyElementField(name, index, 'type', 'element_type');
+        this.warnOnceForLegacyElementField(name, index, 'type');
       }
       const elementTypeResult = this.validationService.validateAndSanitizeInput(
         String(rawElementType),
@@ -742,7 +760,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       }
       // Log deprecation warning if using legacy 'name' field
       if (elem.name && !elem.element_name) {
-        this.warnOnceForLegacyElementField(ensembleName, index, 'name', 'element_name');
+        this.warnOnceForLegacyElementField(ensembleName, index, 'name');
       }
 
       // Support both element_type (new standard) and type (legacy)
@@ -757,7 +775,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       }
       // Log deprecation warning if using legacy 'type' field
       if (elem.type && !elem.element_type) {
-        this.warnOnceForLegacyElementField(ensembleName, index, 'type', 'element_type');
+        this.warnOnceForLegacyElementField(ensembleName, index, 'type');
       }
 
       return {

--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -187,7 +187,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
         const raw = await this.fileOperations.readElementFile(absolutePath, elementType, {
           source: `${this.constructor.name}.repairLegacyElementFields`,
         });
-        const parsed = SecureYamlParser.safeMatter(raw, undefined);
+        const parsed = SecureYamlParser.safeMatter(raw);
 
         if (!this.hasLegacyElementFields(parsed.data?.elements)) {
           continue;

--- a/tests/unit/di/permissionServerIntegration.test.ts
+++ b/tests/unit/di/permissionServerIntegration.test.ts
@@ -309,6 +309,9 @@ describe('Permission Server Integration', () => {
     });
 
     itBash('hook script should translate legacy flat Claude responses', async () => {
+      const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'dollhouse-hook-home-'));
+      const tempRunDir = path.join(tempHome, '.dollhouse', 'run');
+      const tempPortFile = path.join(tempRunDir, 'permission-server.port');
       let testPort = 0;
       const mockServer = http.createServer((req, res) => {
         if (req.method === 'POST' && req.url === '/api/evaluate_permission') {
@@ -324,17 +327,19 @@ describe('Permission Server Integration', () => {
       });
 
       testPort = await listenOnLoopback(mockServer);
-      await fs.mkdir(RUN_DIR, { recursive: true });
-      await fs.writeFile(PORT_FILE, String(testPort), 'utf-8');
+      await fs.mkdir(tempRunDir, { recursive: true });
+      await fs.writeFile(tempPortFile, String(testPort), 'utf-8');
 
-      const { stdout } = await runHookScript({
-        tool_name: 'Bash',
-        tool_input: { command: 'git push --force' },
-      });
+      const { stdout } = await runHookScript(
+        {
+          tool_name: 'Bash',
+          tool_input: { command: 'git push --force' },
+        },
+        { HOME: tempHome },
+      );
 
       await new Promise<void>(resolve => mockServer.close(() => resolve()));
-      await fs.unlink(PORT_FILE).catch(() => {});
-      await fs.unlink(PID_PORT_FILE).catch(() => {});
+      await fs.rm(tempHome, { recursive: true, force: true });
 
       expect(JSON.parse(stdout.trim())).toEqual({
         hookSpecificOutput: {

--- a/tests/unit/elements/ensembles/EnsembleManager.test.ts
+++ b/tests/unit/elements/ensembles/EnsembleManager.test.ts
@@ -26,6 +26,7 @@ import { createTestMetadataService } from '../../../helpers/di-mocks.js';
 import { ValidationRegistry } from '../../../../src/services/validation/ValidationRegistry.js';
 import { TriggerValidationService } from '../../../../src/services/validation/TriggerValidationService.js';
 import { ValidationService } from '../../../../src/services/validation/ValidationService.js';
+import { logger } from '../../../../src/utils/logger.js';
 
 describe('EnsembleManager', () => {
   let ensembleManager: EnsembleManager;
@@ -157,6 +158,82 @@ describe('EnsembleManager', () => {
       // Verify migration happened - element should have element_name/element_type
       expect(ensemble.metadata.elements[0].element_name).toBe('legacy-skill');
       expect(ensemble.metadata.elements[0].element_type).toBe('skill');
+    });
+
+    it('should warn once for repeated legacy field parsing on the same ensemble', async () => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+      const legacyMetadata = {
+        name: 'Legacy Parse Ensemble',
+        elements: [
+          {
+            name: 'legacy-skill',
+            type: 'skill',
+            role: 'primary',
+            priority: 80,
+            activation: 'always'
+          }
+        ]
+      };
+
+      await (ensembleManager as any).parseMetadata(legacyMetadata);
+      await (ensembleManager as any).parseMetadata(legacyMetadata);
+
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      expect(warnSpy).toHaveBeenNthCalledWith(
+        1,
+        "Ensemble 'Legacy Parse Ensemble' element at index 0 uses deprecated 'name' field. Use 'element_name' instead."
+      );
+      expect(warnSpy).toHaveBeenNthCalledWith(
+        2,
+        "Ensemble 'Legacy Parse Ensemble' element at index 0 uses deprecated 'type' field. Use 'element_type' instead."
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('should not re-warn for the same legacy fields across create and parse paths', async () => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+      const metadata: any = {
+        name: 'Legacy Shared Warning Ensemble',
+        description: 'Testing bounded legacy warnings',
+        elements: [
+          {
+            name: 'legacy-skill',
+            type: 'skill',
+            role: 'primary',
+            priority: 80,
+            activation: 'always'
+          }
+        ]
+      };
+
+      await ensembleManager.create(metadata);
+      await (ensembleManager as any).parseMetadata(metadata);
+
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      warnSpy.mockRestore();
+    });
+
+    it('should allow warning history to be cleared for long-running managers', async () => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+      const metadata: any = {
+        name: 'Legacy Resettable Warning Ensemble',
+        elements: [
+          {
+            name: 'legacy-skill',
+            type: 'skill',
+            role: 'primary',
+            priority: 80,
+            activation: 'always'
+          }
+        ]
+      };
+
+      await (ensembleManager as any).parseMetadata(metadata);
+      ensembleManager.clearLegacyElementWarningHistory();
+      await (ensembleManager as any).parseMetadata(metadata);
+
+      expect(warnSpy).toHaveBeenCalledTimes(4);
+      warnSpy.mockRestore();
     });
 
     it('should reject duplicate metadata name even with different filename (Issue #613)', async () => {
@@ -344,6 +421,85 @@ Test instructions.
       expect(ensemble.metadata.activationStrategy).toBe('priority');
       expect(ensemble.metadata.elements.length).toBe(1);
       expect(ensemble.metadata.elements[0].element_name).toBe('loaded-element');
+    });
+
+    it('should warn once when the same legacy ensemble file is loaded repeatedly', async () => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+      const fileContent = `---
+name: Repeated Legacy Load
+type: ensemble
+version: 1.0.0
+author: tester
+description: Test repeated legacy warning suppression
+elements:
+  - name: loaded-element
+    type: skill
+    role: primary
+    priority: 85
+    activation: always
+---
+`;
+
+      const filePath = 'repeated-legacy-load.md';
+      const fullPath = path.join(portfolioPath, 'ensembles', filePath);
+      await fs.writeFile(fullPath, fileContent, 'utf-8');
+      mockPortfolioManager.listElements.mockResolvedValue([filePath]);
+      (fileLockManager.atomicReadFile as jest.Mock).mockImplementation(async (targetPath: string) =>
+        fs.readFile(targetPath, 'utf-8')
+      );
+
+      await ensembleManager.load(filePath);
+      await ensembleManager.load(filePath);
+
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      warnSpy.mockRestore();
+    });
+
+    it('should repair legacy element fields by resaving canonical ensemble metadata', async () => {
+      const fileContent = `---
+name: Repair Legacy Ensemble
+type: ensemble
+version: 1.0.0
+author: tester
+description: Repair old nested field names
+elements:
+  - name: repair-skill
+    type: skill
+    role: primary
+    priority: 90
+    activation: always
+---
+`;
+
+      const filePath = 'repair-legacy-ensemble.md';
+      const fullPath = path.join(portfolioPath, 'ensembles', filePath);
+      await fs.writeFile(fullPath, fileContent, 'utf-8');
+      mockPortfolioManager.listElements.mockResolvedValue([filePath]);
+      (fileLockManager.atomicReadFile as jest.Mock).mockImplementation(async (targetPath: string) =>
+        fs.readFile(targetPath, 'utf-8')
+      );
+
+      const result = await ensembleManager.repairLegacyElementFields();
+
+      expect(result).toEqual({
+        scanned: 1,
+        repaired: 1,
+        errors: 0,
+        repairedEnsembles: [
+          {
+            name: 'Repair Legacy Ensemble',
+            path: filePath,
+          }
+        ]
+      });
+
+      const writes = (fileLockManager.atomicWriteFile as jest.Mock).mock.calls;
+      expect(writes.length).toBeGreaterThan(0);
+      const [, content] = writes[writes.length - 1] as [string, string];
+      expect(content).toContain('element_name: repair-skill');
+      expect(content).toContain('element_type: skill');
+      expect(content).not.toMatch(/^\s*-\s+name:\s+repair-skill$/m);
+      expect(content).not.toMatch(/^\s+type:\s+skill$/m);
     });
   });
 

--- a/tests/unit/elements/ensembles/EnsembleManager.test.ts
+++ b/tests/unit/elements/ensembles/EnsembleManager.test.ts
@@ -496,10 +496,11 @@ elements:
       const writes = (fileLockManager.atomicWriteFile as jest.Mock).mock.calls;
       expect(writes.length).toBeGreaterThan(0);
       const [, content] = writes[writes.length - 1] as [string, string];
+      const contentLines = content.split('\n').map((line) => line.trim());
       expect(content).toContain('element_name: repair-skill');
       expect(content).toContain('element_type: skill');
-      expect(content).not.toMatch(/^\s*-\s+name:\s+repair-skill$/m);
-      expect(content).not.toMatch(/^\s+type:\s+skill$/m);
+      expect(contentLines).not.toContain('- name: repair-skill');
+      expect(contentLines).not.toContain('type: skill');
     });
   });
 


### PR DESCRIPTION
## Summary
- warn once per ensemble/index/field for legacy nested `name` and `type` usage in `EnsembleManager`
- add an `EnsembleManager.repairLegacyElementFields()` helper that rewrites legacy nested fields by resaving canonical metadata
- add focused tests covering repeated reads, create/parse reuse, warning reset, and repair output

Closes #2160

## Validation
- npm test -- --runInBand tests/unit/elements/ensembles/EnsembleManager.test.ts
- npx eslint src/elements/ensembles/EnsembleManager.ts tests/unit/elements/ensembles/EnsembleManager.test.ts
- npm run build
- npm test -- --runInBand tests/unit/elements/ensembles/Ensemble.test.ts