### PR TITLE
Restore responsive management console header layout

### DIFF
--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -2132,12 +2132,6 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
       return Array.from(consoleTabMenu.querySelectorAll('.console-tab-menu-item'));
     }
 
-    function focusConsoleTabMenuItem(items, index) {
-      if (!items.length) return;
-      const boundedIndex = Math.max(0, Math.min(index, items.length - 1));
-      items[boundedIndex].focus();
-    }
-
     function openConsoleTabMenu(focusTarget) {
       if (!consoleTabMenu || !consoleTabMenuToggle) return;
       consoleTabMenu.hidden = false;
@@ -2147,19 +2141,23 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
 
       const items = getConsoleTabMenuItems();
       if (!items.length) return;
+      const focusItem = (index) => {
+        const boundedIndex = Math.max(0, Math.min(index, items.length - 1));
+        items[boundedIndex].focus();
+      };
 
       if (focusTarget === 'first') {
-        focusConsoleTabMenuItem(items, 0);
+        focusItem(0);
         return;
       }
 
       if (focusTarget === 'last') {
-        focusConsoleTabMenuItem(items, items.length - 1);
+        focusItem(items.length - 1);
         return;
       }
 
-      const activeIndex = items.findIndex((item) => item.classList.contains('active'));
-      focusConsoleTabMenuItem(items, activeIndex >= 0 ? activeIndex : 0);
+      const activeIndex = Math.max(items.findIndex((item) => item.classList.contains('active')), 0);
+      focusItem(activeIndex);
     }
 
     function moveConsoleTabMenuFocus(step, origin) {
@@ -2169,10 +2167,10 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
       const currentIndex = origin instanceof Element
         ? items.findIndex((item) => item === origin || item.contains(origin))
         : -1;
-      const activeIndex = items.findIndex((item) => item.classList.contains('active'));
-      const baseIndex = currentIndex >= 0 ? currentIndex : (activeIndex >= 0 ? activeIndex : 0);
+      const activeIndex = Math.max(items.findIndex((item) => item.classList.contains('active')), 0);
+      const baseIndex = currentIndex >= 0 ? currentIndex : activeIndex;
       const nextIndex = (baseIndex + step + items.length) % items.length;
-      focusConsoleTabMenuItem(items, nextIndex);
+      items[nextIndex].focus();
     }
 
     function handleConsoleTabMenuToggleKeydown(event) {
@@ -2197,12 +2195,12 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
         break;
       case 'Home':
         event.preventDefault();
-        focusConsoleTabMenuItem(getConsoleTabMenuItems(), 0);
+        getConsoleTabMenuItems()[0]?.focus();
         break;
       case 'End': {
         event.preventDefault();
         const items = getConsoleTabMenuItems();
-        focusConsoleTabMenuItem(items, items.length - 1);
+        items[items.length - 1]?.focus();
         break;
       }
       case 'Escape':

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -2006,6 +2006,9 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
 
     // ── Tab switching ─────────────────────────────────────────────────────────
     const consoleTabs = document.getElementById('console-tabs');
+    const headerNavRow = document.querySelector('.header-nav-row');
+    const consoleTabMenuToggle = document.getElementById('console-tab-menu-toggle');
+    const consoleTabMenu = document.getElementById('console-tab-menu');
     const tabInits = { logs: false, metrics: false, permissions: false, security: false };
 
     const TAB_KEY = 'dollhousemcp-active-tab';
@@ -2090,7 +2093,70 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
         p.hidden = p.id !== 'tab-' + tabName;
         p.classList.toggle('active', p.id === 'tab-' + tabName);
       });
+      syncConsoleTabMenuSelection();
+      closeConsoleTabMenu();
+      scheduleConsoleTabOverflowCheck();
     };
+
+    function renderConsoleTabMenu() {
+      if (!consoleTabs || !consoleTabMenu) return;
+      consoleTabMenu.innerHTML = '';
+      consoleTabs.querySelectorAll('.console-tab').forEach((btn) => {
+        const item = document.createElement('button');
+        item.type = 'button';
+        item.className = 'console-tab-menu-item';
+        item.dataset.tab = btn.dataset.tab || '';
+        item.setAttribute('role', 'menuitem');
+        item.textContent = btn.textContent || '';
+        if (btn.classList.contains('active')) item.classList.add('active');
+        consoleTabMenu.appendChild(item);
+      });
+    }
+
+    function syncConsoleTabMenuSelection() {
+      if (!consoleTabs || !consoleTabMenu) return;
+      const activeTab = consoleTabs.querySelector('.console-tab.active')?.dataset.tab || '';
+      consoleTabMenu.querySelectorAll('.console-tab-menu-item').forEach((item) => {
+        item.classList.toggle('active', item.dataset.tab === activeTab);
+      });
+    }
+
+    function closeConsoleTabMenu() {
+      if (!consoleTabMenu || !consoleTabMenuToggle) return;
+      consoleTabMenu.hidden = true;
+      consoleTabMenuToggle.setAttribute('aria-expanded', 'false');
+    }
+
+    function tabsNeedOverflowMenu() {
+      if (!consoleTabs) return false;
+      const buttons = Array.from(consoleTabs.querySelectorAll('.console-tab'));
+      if (buttons.length < 2) return false;
+      const firstTop = buttons[0].offsetTop;
+      return buttons.some((btn) => btn.offsetTop !== firstTop);
+    }
+
+    let consoleTabOverflowFrame = 0;
+    function updateConsoleTabOverflow() {
+      if (!consoleTabs || !headerNavRow || !consoleTabMenuToggle) return;
+      headerNavRow.classList.remove('header-nav-row--collapsed');
+      consoleTabMenuToggle.hidden = true;
+      const shouldCollapse = tabsNeedOverflowMenu();
+      if (shouldCollapse) {
+        headerNavRow.classList.add('header-nav-row--collapsed');
+        consoleTabMenuToggle.hidden = false;
+      }
+      if (!shouldCollapse) {
+        closeConsoleTabMenu();
+      }
+    }
+
+    function scheduleConsoleTabOverflowCheck() {
+      if (consoleTabOverflowFrame) cancelAnimationFrame(consoleTabOverflowFrame);
+      consoleTabOverflowFrame = requestAnimationFrame(() => {
+        consoleTabOverflowFrame = 0;
+        updateConsoleTabOverflow();
+      });
+    }
 
     /**
      * Parse the URL hash into tab name and query parameters.
@@ -2226,6 +2292,15 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
     // Handle hash changes for deep-linking (e.g., open_logs operation)
     globalThis.addEventListener('hashchange', () => applyHashTab());
 
+    renderConsoleTabMenu();
+    syncConsoleTabMenuSelection();
+    scheduleConsoleTabOverflowCheck();
+    globalThis.addEventListener('resize', scheduleConsoleTabOverflowCheck);
+    if (typeof ResizeObserver === 'function' && headerNavRow) {
+      const tabOverflowObserver = new ResizeObserver(() => scheduleConsoleTabOverflowCheck());
+      tabOverflowObserver.observe(headerNavRow);
+    }
+
     if (consoleTabs) {
       consoleTabs.addEventListener('click', (e) => {
         const btn = e.target.closest('.console-tab');
@@ -2239,6 +2314,31 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
         lazyInitTab(tab, tabInits);
       });
     }
+
+    consoleTabMenuToggle?.addEventListener('click', () => {
+      if (!consoleTabMenu) return;
+      const willOpen = consoleTabMenu.hidden;
+      consoleTabMenu.hidden = !willOpen;
+      consoleTabMenuToggle.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+    });
+
+    consoleTabMenu?.addEventListener('click', (e) => {
+      const btn = e.target.closest('.console-tab-menu-item');
+      if (!btn || !btn.dataset.tab) return;
+      const tab = btn.dataset.tab;
+      switchToTab(tab);
+      localStorage.setItem(TAB_KEY, tab);
+      lazyInitTab(tab, tabInits);
+    });
+
+    globalThis.addEventListener('click', (e) => {
+      if (!consoleTabMenu || !consoleTabMenuToggle) return;
+      if (consoleTabMenu.hidden) return;
+      const target = e.target;
+      if (!(target instanceof Element)) return;
+      if (consoleTabMenu.contains(target) || consoleTabMenuToggle.contains(target)) return;
+      closeConsoleTabMenu();
+    });
 
     function lazyInitTab(tab, tabInits, params) {
       const dc = globalThis.DollhouseConsole;

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -2127,6 +2127,94 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
       consoleTabMenuToggle.setAttribute('aria-expanded', 'false');
     }
 
+    function getConsoleTabMenuItems() {
+      if (!consoleTabMenu) return [];
+      return Array.from(consoleTabMenu.querySelectorAll('.console-tab-menu-item'));
+    }
+
+    function focusConsoleTabMenuItem(items, index) {
+      if (!items.length) return;
+      const boundedIndex = Math.max(0, Math.min(index, items.length - 1));
+      items[boundedIndex].focus();
+    }
+
+    function openConsoleTabMenu(focusTarget) {
+      if (!consoleTabMenu || !consoleTabMenuToggle) return;
+      consoleTabMenu.hidden = false;
+      consoleTabMenuToggle.setAttribute('aria-expanded', 'true');
+
+      if (!focusTarget) return;
+
+      const items = getConsoleTabMenuItems();
+      if (!items.length) return;
+
+      if (focusTarget === 'first') {
+        focusConsoleTabMenuItem(items, 0);
+        return;
+      }
+
+      if (focusTarget === 'last') {
+        focusConsoleTabMenuItem(items, items.length - 1);
+        return;
+      }
+
+      const activeIndex = items.findIndex((item) => item.classList.contains('active'));
+      focusConsoleTabMenuItem(items, activeIndex >= 0 ? activeIndex : 0);
+    }
+
+    function moveConsoleTabMenuFocus(step, origin) {
+      const items = getConsoleTabMenuItems();
+      if (!items.length) return;
+
+      const currentIndex = origin instanceof Element
+        ? items.findIndex((item) => item === origin || item.contains(origin))
+        : -1;
+      const activeIndex = items.findIndex((item) => item.classList.contains('active'));
+      const baseIndex = currentIndex >= 0 ? currentIndex : (activeIndex >= 0 ? activeIndex : 0);
+      const nextIndex = (baseIndex + step + items.length) % items.length;
+      focusConsoleTabMenuItem(items, nextIndex);
+    }
+
+    function handleConsoleTabMenuToggleKeydown(event) {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        openConsoleTabMenu('first');
+      } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        openConsoleTabMenu('last');
+      }
+    }
+
+    function handleConsoleTabMenuKeydown(event) {
+      switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        moveConsoleTabMenuFocus(1, event.target);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        moveConsoleTabMenuFocus(-1, event.target);
+        break;
+      case 'Home':
+        event.preventDefault();
+        focusConsoleTabMenuItem(getConsoleTabMenuItems(), 0);
+        break;
+      case 'End': {
+        event.preventDefault();
+        const items = getConsoleTabMenuItems();
+        focusConsoleTabMenuItem(items, items.length - 1);
+        break;
+      }
+      case 'Escape':
+        event.preventDefault();
+        closeConsoleTabMenu();
+        consoleTabMenuToggle?.focus();
+        break;
+      default:
+        break;
+      }
+    }
+
     function tabsNeedOverflowMenu() {
       if (!consoleTabs) return false;
       const buttons = Array.from(consoleTabs.querySelectorAll('.console-tab'));
@@ -2274,35 +2362,41 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
       return false;
     }
 
-    if (!applyHashTab()) {
+    function restoreInitialConsoleTab() {
       // Version check takes priority over saved tab — upgraders must see Setup
       // regardless of whether they have a saved tab from their previous session.
       if (localStorage.getItem(SETUP_SEEN_KEY) === currentServerVersion) {
         const savedTab = localStorage.getItem(TAB_KEY);
-        if (savedTab) {
-          switchToTab(savedTab);
-          lazyInitTab(savedTab, tabInits);
-        }
-      } else {
-        localStorage.setItem(SETUP_SEEN_KEY, currentServerVersion);
-        switchToTab('setup');
+        if (!savedTab) return;
+        switchToTab(savedTab);
+        lazyInitTab(savedTab, tabInits);
+        return;
       }
+
+      localStorage.setItem(SETUP_SEEN_KEY, currentServerVersion);
+      switchToTab('setup');
     }
 
-    // Handle hash changes for deep-linking (e.g., open_logs operation)
-    globalThis.addEventListener('hashchange', () => applyHashTab());
+    function initializeConsoleTabs() {
+      if (applyHashTab()) return;
+      restoreInitialConsoleTab();
+    }
 
-    renderConsoleTabMenu();
-    syncConsoleTabMenuSelection();
-    scheduleConsoleTabOverflowCheck();
-    globalThis.addEventListener('resize', scheduleConsoleTabOverflowCheck);
-    if (typeof ResizeObserver === 'function' && headerNavRow) {
+    function registerConsoleTabObservers() {
+      globalThis.addEventListener('hashchange', () => applyHashTab());
+      renderConsoleTabMenu();
+      syncConsoleTabMenuSelection();
+      scheduleConsoleTabOverflowCheck();
+      globalThis.addEventListener('resize', scheduleConsoleTabOverflowCheck);
+
+      if (typeof ResizeObserver !== 'function' || !headerNavRow) return;
+
       const tabOverflowObserver = new ResizeObserver(() => scheduleConsoleTabOverflowCheck());
       tabOverflowObserver.observe(headerNavRow);
     }
 
-    if (consoleTabs) {
-      consoleTabs.addEventListener('click', (e) => {
+    function registerConsoleTabInteractions() {
+      consoleTabs?.addEventListener('click', (e) => {
         const btn = e.target.closest('.console-tab');
         if (!btn) return;
         const tab = btn.dataset.tab;
@@ -2313,32 +2407,41 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
 
         lazyInitTab(tab, tabInits);
       });
+
+      consoleTabMenuToggle?.addEventListener('click', () => {
+        if (!consoleTabMenu) return;
+        if (consoleTabMenu.hidden) {
+          openConsoleTabMenu();
+          return;
+        }
+
+        closeConsoleTabMenu();
+      });
+
+      consoleTabMenuToggle?.addEventListener('keydown', handleConsoleTabMenuToggleKeydown);
+      consoleTabMenu?.addEventListener('keydown', handleConsoleTabMenuKeydown);
+      consoleTabMenu?.addEventListener('click', (e) => {
+        const btn = e.target.closest('.console-tab-menu-item');
+        const tab = btn?.dataset.tab;
+        if (!tab) return;
+        switchToTab(tab);
+        localStorage.setItem(TAB_KEY, tab);
+        lazyInitTab(tab, tabInits);
+      });
+
+      globalThis.addEventListener('click', (e) => {
+        if (!consoleTabMenu || !consoleTabMenuToggle) return;
+        if (consoleTabMenu.hidden) return;
+        const target = e.target;
+        if (!(target instanceof Element)) return;
+        if (consoleTabMenu.contains(target) || consoleTabMenuToggle.contains(target)) return;
+        closeConsoleTabMenu();
+      });
     }
 
-    consoleTabMenuToggle?.addEventListener('click', () => {
-      if (!consoleTabMenu) return;
-      const willOpen = consoleTabMenu.hidden;
-      consoleTabMenu.hidden = !willOpen;
-      consoleTabMenuToggle.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
-    });
-
-    consoleTabMenu?.addEventListener('click', (e) => {
-      const btn = e.target.closest('.console-tab-menu-item');
-      if (!btn || !btn.dataset.tab) return;
-      const tab = btn.dataset.tab;
-      switchToTab(tab);
-      localStorage.setItem(TAB_KEY, tab);
-      lazyInitTab(tab, tabInits);
-    });
-
-    globalThis.addEventListener('click', (e) => {
-      if (!consoleTabMenu || !consoleTabMenuToggle) return;
-      if (consoleTabMenu.hidden) return;
-      const target = e.target;
-      if (!(target instanceof Element)) return;
-      if (consoleTabMenu.contains(target) || consoleTabMenuToggle.contains(target)) return;
-      closeConsoleTabMenu();
-    });
+    initializeConsoleTabs();
+    registerConsoleTabObservers();
+    registerConsoleTabInteractions();
 
     function lazyInitTab(tab, tabInits, params) {
       const dc = globalThis.DollhouseConsole;

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -2200,7 +2200,7 @@ globalThis.DollhouseConsoleUI.clearBanner = function(bannerId) {
       case 'End': {
         event.preventDefault();
         const items = getConsoleTabMenuItems();
-        items[items.length - 1]?.focus();
+        items.at(-1)?.focus();
         break;
       }
       case 'Escape':

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -43,7 +43,14 @@
         <p class="site-tagline">Management Console</p>
       </div>
     </div>
-    <div class="header-right">
+    <div class="header-controls">
+      <div class="site-stats" id="stats" aria-live="polite"></div>
+      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode" title="Switch to dark mode">
+        <span class="theme-toggle-icon" id="theme-toggle-icon" aria-hidden="true">&#9790;</span>
+        <span class="sr-only" id="theme-toggle-label">Switch to dark mode</span>
+      </button>
+    </div>
+    <div class="header-nav-row">
       <nav class="console-tabs" id="console-tabs" aria-label="Console tabs">
         <button class="console-tab" data-tab="setup">Setup</button>
         <button class="console-tab" data-tab="security">Auth</button>
@@ -52,12 +59,14 @@
         <button class="console-tab" data-tab="permissions">Permissions</button>
         <button class="console-tab active" data-tab="portfolio">Portfolio</button>
       </nav>
+      <div class="console-tab-menu-shell" id="console-tab-menu-shell">
+        <button class="console-tab-menu-toggle" id="console-tab-menu-toggle" type="button" hidden aria-haspopup="menu" aria-expanded="false" aria-controls="console-tab-menu">
+          <span class="console-tab-menu-icon" aria-hidden="true">&#9776;</span>
+          <span class="console-tab-menu-label">Menu</span>
+        </button>
+        <div class="console-tab-menu" id="console-tab-menu" role="menu" hidden></div>
+      </div>
       <div class="session-indicator" id="session-indicator" title="Active sessions"></div>
-      <div class="site-stats" id="stats" aria-live="polite"></div>
-      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to dark mode" title="Switch to dark mode">
-        <span class="theme-toggle-icon" id="theme-toggle-icon" aria-hidden="true">&#9790;</span>
-        <span class="sr-only" id="theme-toggle-label">Switch to dark mode</span>
-      </button>
     </div>
   </header>
 
@@ -572,7 +581,7 @@ npm install @dollhousemcp/mcp-server</code></pre>
       <a href="https://github.com/DollhouseMCP/mcp-server" class="footer-link">GitHub Repository</a>
       <a href="./collection-index.json" class="footer-link">JSON API</a>
       <a href="https://dollhousemcp.com" class="footer-link">DollhouseMCP</a>
-      <span class="footer-version" id="footer-version"></span>
+      <span class="footer-version" id="footer-version" aria-live="polite" aria-atomic="true"></span>
       <span class="footer-updated" id="footer-updated"></span>
       <span class="footer-copyright">&copy; 2026 DollhouseMCP</span>
     </div>

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -64,7 +64,7 @@
           <span class="console-tab-menu-icon" aria-hidden="true">&#9776;</span>
           <span class="console-tab-menu-label">Menu</span>
         </button>
-        <div class="console-tab-menu" id="console-tab-menu" role="menu" hidden></div>
+        <div class="console-tab-menu" id="console-tab-menu" role="menu" aria-orientation="vertical" hidden></div>
       </div>
       <div class="session-indicator" id="session-indicator" title="Active sessions"></div>
     </div>

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -146,12 +146,15 @@ p, li { max-width: 69ch; }
   position: sticky;
   top: 0;
   z-index: 35;
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-areas:
+    "brand controls"
+    "nav nav";
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.55rem var(--gutter);
+  column-gap: 1rem;
+  row-gap: 0.12rem;
+  padding: 0.44rem var(--gutter) 0.4rem;
   border-bottom: 1px solid var(--line);
   background: color-mix(in srgb, var(--paper-strong) 90%, transparent);
   backdrop-filter: blur(8px);
@@ -169,8 +172,8 @@ p, li { max-width: 69ch; }
   pointer-events: none;
 }
 
-.header-brand { display: flex; flex-direction: row; align-items: center; gap: 0.6rem; min-width: 0; }
-.header-brand-text { display: flex; flex-direction: column; gap: 0.05rem; min-width: 0; }
+.header-brand { grid-area: brand; display: flex; flex-direction: row; align-items: center; gap: 0.6rem; min-width: 0; min-height: 2.35rem; }
+.header-brand-text { display: flex; flex-direction: column; justify-content: center; gap: 0.05rem; min-width: 0; min-height: 2.35rem; }
 .header-logo { width: 32px; height: 32px; flex-shrink: 0; }
 
 .site-title {
@@ -187,15 +190,37 @@ p, li { max-width: 69ch; }
   font-size: var(--step--1);
   color: var(--ink-700);
   max-width: none;
+  line-height: 1.15;
 }
 
-.header-right {
+.header-controls {
+  grid-area: controls;
   display: flex;
   align-items: center;
   justify-content: flex-end;
   flex-wrap: wrap;
   gap: 0.65rem;
-  flex: 1 1 auto;
+  width: auto;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.header-nav-row {
+  grid-area: nav;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: nowrap;
+  gap: 0.55rem;
+  width: 100%;
+  min-width: 0;
+}
+
+.console-tab-menu-shell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
   min-width: 0;
 }
 
@@ -1346,6 +1371,85 @@ body.modal-open { overflow: hidden; }
   border-radius: var(--radius-sm);
   padding: 2px;
   min-width: 0;
+  width: fit-content;
+  max-width: 100%;
+  flex-wrap: wrap;
+}
+
+.console-tab-menu-toggle {
+  display: none;
+  align-items: center;
+  gap: 0.42rem;
+  border: 1px solid color-mix(in srgb, var(--signal) 24%, var(--line));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-1) 70%, var(--paper-strong));
+  color: var(--ink-700);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.48rem 0.78rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.console-tab-menu-toggle:hover,
+.console-tab-menu-toggle:focus-visible {
+  background: color-mix(in srgb, var(--surface-1) 88%, var(--paper-strong));
+  outline: 2px solid var(--signal);
+  outline-offset: 2px;
+}
+
+.console-tab-menu-icon {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.console-tab-menu {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  right: 0;
+  min-width: 13rem;
+  max-width: min(18rem, calc(100vw - (2 * var(--gutter, 1rem))));
+  background: var(--paper-strong);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-soft);
+  padding: 0.3rem;
+  z-index: 200;
+}
+
+.console-tab-menu-item {
+  width: 100%;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--ink-700);
+  font-family: var(--font-body);
+  font-size: var(--step--1);
+  font-weight: 600;
+  text-align: left;
+  padding: 0.52rem 0.68rem;
+  cursor: pointer;
+}
+
+.console-tab-menu-item:hover,
+.console-tab-menu-item:focus-visible {
+  background: var(--surface-1);
+  outline: none;
+}
+
+.console-tab-menu-item.active {
+  background: color-mix(in srgb, var(--signal-2) 10%, var(--paper-strong));
+  color: var(--signal);
+}
+
+.header-nav-row--collapsed .console-tabs {
+  display: none;
+}
+
+.header-nav-row--collapsed .console-tab-menu-toggle:not([hidden]) {
+  display: inline-flex;
 }
 
 .console-tab {
@@ -1373,41 +1477,144 @@ body.modal-open { overflow: hidden; }
   box-shadow: 0 1px 3px rgba(0,0,0,0.08);
 }
 
-@media (max-width: 1100px) {
-  .site-header {
-    align-items: flex-start;
-  }
-
-  .header-right {
-    width: 100%;
-    justify-content: flex-start;
-    row-gap: 0.55rem;
-  }
-
-  .console-tabs {
-    order: 3;
-    width: 100%;
-    flex-wrap: wrap;
+@media (max-width: 960px) {
+  .header-controls {
+    align-items: center;
+    justify-content: flex-end;
+    width: auto;
+    max-width: 100%;
+    gap: 0.5rem;
   }
 
   .site-stats {
-    flex: 1 1 auto;
-    justify-content: flex-start;
-  }
-
-  .theme-toggle {
-    margin-left: auto;
+    flex: 0 1 auto;
+    width: auto;
+    justify-content: flex-end;
   }
 }
 
-@media (max-width: 640px) {
-  .console-tabs {
-    order: -1;
+@media (max-width: 860px) {
+  .site-header {
+    column-gap: 0.7rem;
+  }
+
+  .header-brand {
+    gap: 0.5rem;
+    min-height: 0;
+  }
+
+  .header-brand-text {
+    min-height: 0;
+    gap: 0;
+  }
+
+  .header-brand .site-tagline {
+    display: none;
+  }
+
+  .header-controls,
+  .site-stats {
+    gap: 0.35rem;
+  }
+
+  .header-controls {
+    align-items: center;
+  }
+
+  .stat {
+    padding: 0.12rem 0.34rem;
+  }
+
+  .stat strong {
+    font-size: 0.92rem;
+  }
+
+  .stat--session strong {
+    font-size: 0.74rem;
+  }
+
+  .theme-toggle {
+    width: 1.85rem;
+    height: 1.85rem;
+  }
+
+  .console-tab {
+    padding: 4px 11px;
+  }
+}
+
+@media (max-width: 46rem) {
+  .stat--session {
+    display: none;
+  }
+}
+
+@media (max-width: 31rem) {
+  .site-stats .stat:nth-child(2) {
+    display: none;
+  }
+}
+
+@media (max-width: 28rem) {
+  .site-header {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    grid-template-areas: "brand nav controls";
+    column-gap: 0.45rem;
+  }
+
+  .header-brand {
+    gap: 0;
+    min-width: 0;
+  }
+
+  .header-logo {
+    display: block;
+    width: 28px;
+    height: 28px;
+  }
+
+  .header-brand-text {
+    display: none;
+  }
+
+  .site-stats {
+    display: none;
+  }
+
+  .header-controls {
+    width: auto;
+    justify-content: flex-end;
+  }
+
+  .header-nav-row {
+    width: auto;
+    min-width: 0;
+    justify-content: flex-end;
+    gap: 0.4rem;
+  }
+}
+
+@media (max-width: 24rem) {
+  .site-header {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "brand"
+      "controls"
+      "nav";
+  }
+
+  .header-controls {
+    justify-content: flex-end;
     width: 100%;
   }
-  .console-tab {
-    flex: 1;
-    text-align: center;
+
+  .site-stats {
+    justify-content: flex-end;
+  }
+
+  .header-nav-row {
+    width: 100%;
+    justify-content: flex-end;
   }
 }
 

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -1549,12 +1549,6 @@ body.modal-open { overflow: hidden; }
   }
 }
 
-@media (max-width: 31rem) {
-  .site-stats .stat:nth-child(2) {
-    display: none;
-  }
-}
-
 @media (max-width: 28rem) {
   .site-header {
     grid-template-columns: minmax(0, 1fr) auto auto;
@@ -1932,8 +1926,6 @@ fieldset.topic-filters {
 
 @media (max-width: 52rem) {
   .header-brand .site-tagline { display: none; }
-  .stat { display: none; }
-  .stat:first-child { display: inline-flex; }
   .elements-grid { grid-template-columns: repeat(auto-fill, minmax(min(100%, 11.5rem), 1fr)); }
   .elements-grid[data-view="detail"] { grid-template-columns: 1fr; }
   .modal-dialog { height: calc(100vh - 0.5rem); border-radius: 0; }

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -189,8 +189,8 @@ describe('Web console cleanup regressions', () => {
           <button class="console-tab" data-tab="permissions">Permissions</button>
         </div>
         <div id="console-tab-menu-shell">
-          <button id="console-tab-menu-toggle" hidden aria-expanded="false"></button>
-          <div id="console-tab-menu" hidden></div>
+          <button id="console-tab-menu-toggle" hidden aria-expanded="false" aria-haspopup="menu"></button>
+          <div id="console-tab-menu" role="menu" hidden></div>
         </div>
       </div>
       <div id="tab-portfolio" class="tab-panel active"></div>
@@ -244,8 +244,91 @@ describe('Web console cleanup regressions', () => {
     menuButton?.click();
     await wait(DEFAULT_WAIT_MS);
 
-    expect(win.document.querySelector('#console-tabs .console-tab.active')?.getAttribute('data-tab')).toBe('permissions');
+    expect((win.document.querySelector('#console-tabs .console-tab.active') as HTMLElement | null)?.dataset.tab).toBe('permissions');
     expect(win.document.getElementById('tab-permissions')?.classList.contains('active')).toBe(true);
+
+    cleanup();
+  });
+
+  it('supports keyboard navigation in the collapsed console tab menu', async () => {
+    const { window: win, cleanup } = createDom(`
+      <button id="theme-toggle"></button>
+      <span id="theme-toggle-icon"></span>
+      <span id="theme-toggle-label"></span>
+      <link id="hljs-theme-light">
+      <link id="hljs-theme-dark">
+      <div id="view-toggle"><button class="view-btn" data-view="grid"></button></div>
+      <select id="sort-select"><option value="date-desc">date-desc</option></select>
+      <input id="search-input">
+      <div id="source-toggle"><button data-source="all"></button></div>
+      <button id="btn-portfolio"></button>
+      <div class="header-nav-row">
+        <div id="console-tabs">
+          <button class="console-tab active" data-tab="portfolio">Portfolio</button>
+          <button class="console-tab" data-tab="permissions">Permissions</button>
+        </div>
+        <div id="console-tab-menu-shell">
+          <button id="console-tab-menu-toggle" hidden aria-expanded="false" aria-haspopup="menu"></button>
+          <div id="console-tab-menu" role="menu" hidden></div>
+        </div>
+      </div>
+      <div id="tab-portfolio" class="tab-panel active"></div>
+      <div id="tab-permissions" class="tab-panel"></div>
+      <div id="session-indicator"></div>
+      <div id="stats"></div>
+      <div><div id="type-filters"></div></div>
+      <div id="topic-filters"></div>
+      <div id="results-count"></div>
+      <div id="results-announcer"></div>
+      <div id="elements-grid"></div>
+      <div id="pagination" hidden><button id="btn-prev-page"></button><button id="btn-next-page"></button><span id="page-info"></span></div>
+      <div id="footer-updated"></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn((url: string) => {
+      if (url === '/api/elements') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ elements: { personas: [] }, totalCount: 0 }),
+        });
+      }
+      if (url === '/api/collection') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ index: { personas: [] } }),
+        });
+      }
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    win.eval(appSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    await wait(DEFAULT_WAIT_MS);
+
+    const tabButtons = Array.from(win.document.querySelectorAll('#console-tabs .console-tab')) as HTMLElement[];
+    Object.defineProperty(tabButtons[0], 'offsetTop', { configurable: true, get: () => 0 });
+    Object.defineProperty(tabButtons[1], 'offsetTop', { configurable: true, get: () => 24 });
+    win.dispatchEvent(new win.Event('resize'));
+    await wait(DEFAULT_WAIT_MS);
+
+    const menuToggle = win.document.getElementById('console-tab-menu-toggle') as HTMLButtonElement | null;
+    const menu = win.document.getElementById('console-tab-menu');
+    menuToggle?.focus();
+    menuToggle?.dispatchEvent(new win.KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await wait(DEFAULT_WAIT_MS);
+
+    const menuItems = Array.from(win.document.querySelectorAll('.console-tab-menu-item')) as HTMLButtonElement[];
+    expect(menu?.hidden).toBe(false);
+    expect(win.document.activeElement).toBe(menuItems[0]);
+
+    menuItems[0]?.dispatchEvent(new win.KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await wait(DEFAULT_WAIT_MS);
+    expect(win.document.activeElement).toBe(menuItems[1]);
+
+    menuItems[1]?.dispatchEvent(new win.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    await wait(DEFAULT_WAIT_MS);
+    expect(menu?.hidden).toBe(true);
+    expect(win.document.activeElement).toBe(menuToggle);
 
     cleanup();
   });

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -141,7 +141,7 @@ describe('Web console cleanup regressions', () => {
       <div id="results-announcer"></div>
       <div id="elements-grid"></div>
       <div id="pagination" hidden><button id="btn-prev-page"></button><button id="btn-next-page"></button><span id="page-info"></span></div>
-      <div id="footer-version"></div>
+      <div id="footer-version" aria-live="polite" aria-atomic="true"></div>
       <div id="footer-updated"></div>
     `);
 
@@ -166,6 +166,86 @@ describe('Web console cleanup regressions', () => {
     await wait(DEFAULT_WAIT_MS);
 
     expect(win.document.getElementById('footer-version')?.textContent).toBe(`Version: ${PACKAGE_VERSION}`);
+    expect(win.document.getElementById('footer-version')?.getAttribute('aria-live')).toBe('polite');
+
+    cleanup();
+  });
+
+  it('collapses wrapped console tabs into a menu instead of a second row', async () => {
+    const { window: win, cleanup } = createDom(`
+      <button id="theme-toggle"></button>
+      <span id="theme-toggle-icon"></span>
+      <span id="theme-toggle-label"></span>
+      <link id="hljs-theme-light">
+      <link id="hljs-theme-dark">
+      <div id="view-toggle"><button class="view-btn" data-view="grid"></button></div>
+      <select id="sort-select"><option value="date-desc">date-desc</option></select>
+      <input id="search-input">
+      <div id="source-toggle"><button data-source="all"></button></div>
+      <button id="btn-portfolio"></button>
+      <div class="header-nav-row">
+        <div id="console-tabs">
+          <button class="console-tab active" data-tab="portfolio">Portfolio</button>
+          <button class="console-tab" data-tab="permissions">Permissions</button>
+        </div>
+        <div id="console-tab-menu-shell">
+          <button id="console-tab-menu-toggle" hidden aria-expanded="false"></button>
+          <div id="console-tab-menu" hidden></div>
+        </div>
+      </div>
+      <div id="tab-portfolio" class="tab-panel active"></div>
+      <div id="tab-permissions" class="tab-panel"></div>
+      <div id="session-indicator"></div>
+      <div id="stats"></div>
+      <div><div id="type-filters"></div></div>
+      <div id="topic-filters"></div>
+      <div id="results-count"></div>
+      <div id="results-announcer"></div>
+      <div id="elements-grid"></div>
+      <div id="pagination" hidden><button id="btn-prev-page"></button><button id="btn-next-page"></button><span id="page-info"></span></div>
+      <div id="footer-updated"></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn((url: string) => {
+      if (url === '/api/elements') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ elements: { personas: [] }, totalCount: 0 }),
+        });
+      }
+      if (url === '/api/collection') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ index: { personas: [] } }),
+        });
+      }
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    win.eval(appSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    await wait(DEFAULT_WAIT_MS);
+
+    const tabButtons = Array.from(win.document.querySelectorAll('#console-tabs .console-tab')) as HTMLElement[];
+    Object.defineProperty(tabButtons[0], 'offsetTop', { configurable: true, get: () => 0 });
+    Object.defineProperty(tabButtons[1], 'offsetTop', { configurable: true, get: () => 24 });
+    win.dispatchEvent(new win.Event('resize'));
+    await wait(DEFAULT_WAIT_MS);
+
+    const navRow = win.document.querySelector('.header-nav-row');
+    const menuToggle = win.document.getElementById('console-tab-menu-toggle') as HTMLButtonElement | null;
+    expect(navRow?.classList.contains('header-nav-row--collapsed')).toBe(true);
+    expect(menuToggle?.hidden).toBe(false);
+
+    menuToggle?.click();
+    await wait(DEFAULT_WAIT_MS);
+    const menuButton = win.document.querySelector('.console-tab-menu-item[data-tab="permissions"]') as HTMLButtonElement | null;
+    expect(menuButton).not.toBeNull();
+    menuButton?.click();
+    await wait(DEFAULT_WAIT_MS);
+
+    expect(win.document.querySelector('#console-tabs .console-tab.active')?.getAttribute('data-tab')).toBe('permissions');
+    expect(win.document.getElementById('tab-permissions')?.classList.contains('active')).toBe(true);
 
     cleanup();
   });


### PR DESCRIPTION
## Summary
- restore the stronger responsive management-console header layout from the archived RC line
- collapse wrapped console tabs into an overflow menu instead of letting the header degrade into a second row
- add regression coverage for the overflow behavior and footer live-region metadata

## Testing
- npm test -- --runInBand tests/unit/web/console-ui-regressions.test.ts
- npx eslint src/web/public/app.js tests/unit/web/console-ui-regressions.test.ts
- npm run build

## Related
- Closes #2162
