### PR TITLE
Fix MCP-AQL agent execution loop guidance

### DIFF
--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -909,7 +909,10 @@ export class AgentManager extends BaseElementManager<Agent> {
    */
   async executeAgent(
     name: string,
-    parameters: Record<string, unknown>
+    parameters: Record<string, unknown>,
+    context: {
+      operationName?: 'execute_agent' | 'continue_execution';
+    } = {}
   ): Promise<ExecuteAgentResult> {
     try {
       // 1. Load agent by name
@@ -964,7 +967,10 @@ export class AgentManager extends BaseElementManager<Agent> {
       this.validateParameterSecurity(clonedParameters);
 
       // 3. Validate parameters against goal.parameters schema
-      this.validateParameters(metadata.goal, clonedParameters);
+      this.validateParameters(metadata.goal, clonedParameters, {
+        agentName: name,
+        operationName: context.operationName ?? 'execute_agent',
+      });
 
       // 4. Render goal template by replacing {parameter} placeholders
       const renderedGoal = this.renderGoalTemplate(metadata.goal.template, clonedParameters);
@@ -1206,15 +1212,27 @@ export class AgentManager extends BaseElementManager<Agent> {
    */
   private validateParameters(
     goalConfig: AgentGoalConfig,
-    parameters: Record<string, unknown>
+    parameters: Record<string, unknown>,
+    context: {
+      agentName?: string;
+      operationName?: 'execute_agent' | 'continue_execution';
+    } = {}
   ): void {
     const paramDefs = goalConfig.parameters || [];
+    const requiredParamNames = paramDefs
+      .filter(paramDef => paramDef.required)
+      .map(paramDef => paramDef.name);
 
     // Check all required parameters are present
-    for (const paramDef of paramDefs) {
-      if (paramDef.required && !(paramDef.name in parameters)) {
-        throw new Error(`Missing required parameter: ${paramDef.name}`);
-      }
+    const missingRequired = requiredParamNames.filter(paramName => !(paramName in parameters));
+    if (missingRequired.length > 0) {
+      throw new Error(
+        this.formatMissingRequiredParametersError(
+          missingRequired,
+          requiredParamNames,
+          context
+        )
+      );
     }
 
     // Type check provided parameters
@@ -1259,6 +1277,39 @@ export class AgentManager extends BaseElementManager<Agent> {
         parameters[paramDef.name] = paramDef.default;
       }
     }
+  }
+
+  /**
+   * Build an actionable missing-parameter error for execute/continue calls.
+   * @private
+   */
+  private formatMissingRequiredParametersError(
+    missingRequired: string[],
+    requiredParamNames: string[],
+    context: {
+      agentName?: string;
+      operationName?: 'execute_agent' | 'continue_execution';
+    }
+  ): string {
+    const agentSuffix = context.agentName ? ` for agent '${context.agentName}'` : '';
+    let message =
+      `Missing required parameters${agentSuffix}: ${missingRequired.join(', ')}.`;
+
+    if (requiredParamNames.length > 0) {
+      message += ` Required goal parameters: ${requiredParamNames.join(', ')}.`;
+    }
+
+    message += ' Discover the full execution contract via mcp_aql_read introspect: ' +
+      '{ operation: "introspect", params: { query: "operations", name: "execute_agent" } }.';
+
+    if (context.operationName === 'continue_execution') {
+      message += ' If you are reporting progress after execute_agent, use ' +
+        'mcp_aql_create record_execution_step instead. continue_execution is only ' +
+        'for resuming a previously paused execution and still requires the same ' +
+        'goal parameters as execute_agent.';
+    }
+
+    return message;
   }
 
   /**
@@ -2979,6 +3030,24 @@ export class AgentManager extends BaseElementManager<Agent> {
 
     // 2. Get current state
     const state = agent.getState();
+    const activeGoal = state.goals.find(goal => goal.status === 'in_progress');
+
+    if (!activeGoal) {
+      throw new Error(
+        `continue_execution requires an in-progress goal for agent '${params.agentName}'. ` +
+        `Use execute_agent to start a new goal. If you are reporting progress for ` +
+        `the current goal, use mcp_aql_create record_execution_step.`
+      );
+    }
+
+    const activeGoalDecisions = state.decisions.filter(decision => decision.goalId === activeGoal.id);
+    if (activeGoalDecisions.length === 0) {
+      throw new Error(
+        `continue_execution is only for resuming a paused execution after at least ` +
+        `one recorded step for agent '${params.agentName}'. After execute_agent, the ` +
+        `next lifecycle call is mcp_aql_create record_execution_step.`
+      );
+    }
 
     // 3. Check if agent has been executed before
     const isResuming = state.sessionCount > 0 || state.decisions.length > 0;
@@ -2988,7 +3057,8 @@ export class AgentManager extends BaseElementManager<Agent> {
 
     const executionResult = await this.executeAgent(
       params.agentName,
-      executionParams
+      executionParams,
+      { operationName: 'continue_execution' }
     );
 
     // 5. Build previous state summary

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -910,6 +910,8 @@ export class AgentManager extends BaseElementManager<Agent> {
   async executeAgent(
     name: string,
     parameters: Record<string, unknown>,
+    // Thread the triggering MCP lifecycle op through validation so error messages
+    // can distinguish a fresh execute_agent call from a misused continue_execution.
     context: {
       operationName?: 'execute_agent' | 'continue_execution';
     } = {}

--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -126,6 +126,47 @@ function validateRequiredString(
   return value;
 }
 
+const EXECUTION_OPERATION_NAMES: Record<string, string> = {
+  execute: 'execute_agent',
+  getState: 'get_execution_state',
+  updateState: 'record_execution_step',
+  complete: 'complete_execution',
+  continue: 'continue_execution',
+  abort: 'abort_execution',
+  getGatheredData: 'get_gathered_data',
+  prepareHandoff: 'prepare_handoff',
+  resumeFromHandoff: 'resume_from_handoff',
+};
+
+function validateExecutionElementName(
+  method: string,
+  params: Record<string, unknown>
+): string {
+  const value = params.element_name;
+  if (value !== undefined && value !== null && typeof value === 'string' && value.trim() !== '') {
+    return value;
+  }
+
+  const operationName = EXECUTION_OPERATION_NAMES[method] || 'execution lifecycle operation';
+
+  if (method === 'getState') {
+    throw new Error(
+      `Missing required parameter 'element_name'. Expected: string ` +
+      `(the name of the agent/executable element whose execution state you want to inspect). ` +
+      `Use the same element_name you passed to execute_agent. ` +
+      `Retry with: { operation: "get_execution_state", params: { element_name: "code-reviewer", includeDecisionHistory: true } }. ` +
+      `If you're unsure which name to use, call introspect for "get_execution_state" or list active agents first.`
+    );
+  }
+
+  throw new Error(
+    `Missing required parameter 'element_name'. Expected: string ` +
+    `(the name of the agent/executable element for ${operationName}). ` +
+    `If this is part of an existing execution lifecycle, reuse the same element_name you passed to execute_agent. ` +
+    `If you're unsure which name to use, call introspect for "${operationName}" or list active agents first.`
+  );
+}
+
 /**
  * Normalize flat pagination params into a { page, pageSize } object.
  *
@@ -3575,11 +3616,7 @@ export class MCPAQLHandler {
 
     // Issue #323: Validate element_name parameter (was incorrectly using 'name')
     // All execute operations require element_name to identify the target
-    const elementName = validateRequiredString(
-      params,
-      'element_name',
-      'the name of the agent/element to execute'
-    );
+    const elementName = validateExecutionElementName(method, params);
 
     // Issue #110: Programmatic enforcement for DANGER_ZONE tier
     // Issue #402: Use DI-injected enforcer instead of singleton

--- a/src/handlers/mcp-aql/OperationSchema.ts
+++ b/src/handlers/mcp-aql/OperationSchema.ts
@@ -1235,9 +1235,9 @@ export const EXECUTION_SCHEMAS: OperationSchemaMap = {
     handler: 'mcpAqlHandler',
     method: 'dispatchExecute',
     category: 'Agent Execution',
-    description: 'Query current execution state including progress and findings',
+    description: 'Query current execution state including progress and findings. Use the same element_name you passed to execute_agent for this execution.',
     params: {
-      element_name: { type: 'string', required: true, description: 'Agent or executable element name' },
+      element_name: { type: 'string', required: true, description: 'Agent or executable element name. Reuse the same element_name from execute_agent.' },
       includeDecisionHistory: { type: 'boolean', description: 'Include decision history in response' },
       includeContext: { type: 'boolean', description: 'Include execution context in response' },
     },

--- a/src/handlers/mcp-aql/OperationSchema.ts
+++ b/src/handlers/mcp-aql/OperationSchema.ts
@@ -1215,6 +1215,7 @@ export const EXECUTION_SCHEMAS: OperationSchemaMap = {
     method: 'dispatchExecute',
     category: 'Agent Execution',
     description: 'Start execution of an agent. The agent must have a goal.template defined (set during create_element). Pass values for the template placeholders in parameters. ' +
+      'Canonical loop: call execute_agent once to start, then use mcp_aql_create record_execution_step after each work chunk, inspect autonomy.continue and autonomy.notifications, and call complete_execution when done. continue_execution is only for resuming an already-paused execution and is not the normal next call after execute_agent. ' +
       'Lifecycle: Elements listed in the agent\'s activates field (e.g., activates: { personas: ["Reviewer"], skills: ["code-analysis"] }) are automatically activated when execution begins — their gatekeeper policies, instructions, and capabilities become active for the duration. ' +
       'Resilience: If the agent has a resilience policy, it governs automatic recovery during execution. onStepLimitReached (pause|continue|restart) controls what happens when maxAutonomousSteps is hit. onExecutionFailure (pause|retry|restart-fresh) controls recovery from step failures. Additional fields: maxRetries (default 3), maxContinuations (default 10), retryBackoff (linear|exponential). Without a resilience policy, execution pauses at step limits and failures (safe default).',
     params: {
@@ -1250,7 +1251,7 @@ export const EXECUTION_SCHEMAS: OperationSchemaMap = {
     handler: 'mcpAqlHandler',
     method: 'dispatchExecute',
     category: 'Agent Execution',
-    description: 'Record execution progress, step completion, or findings. Returns autonomy directive with continue/pause decision and notifications.',
+    description: 'Record execution progress, step completion, or findings. This is the normal follow-up call after execute_agent. Returns autonomy directive with continue/pause decision and notifications.',
     params: {
       element_name: { type: 'string', required: true, description: 'Agent or executable element name' },
       stepDescription: { type: 'string', required: true, description: 'Description of step completed' },
@@ -1288,7 +1289,7 @@ export const EXECUTION_SCHEMAS: OperationSchemaMap = {
     handler: 'mcpAqlHandler',
     method: 'dispatchExecute',
     category: 'Agent Execution',
-    description: 'Resume execution from saved state',
+    description: 'Resume a previously paused execution from saved state. Use only after a pause or handoff boundary, not as the normal next call after execute_agent. Pass the same goal parameters used for execute_agent so the goal template can be revalidated before resuming.',
     params: {
       element_name: { type: 'string', required: true, description: 'Agent or executable element name' },
       previousStepResult: { type: 'string', description: 'Result from previous step' },
@@ -1296,7 +1297,7 @@ export const EXECUTION_SCHEMAS: OperationSchemaMap = {
     },
     returns: { name: 'ContinueResult', kind: 'object', description: 'Resumed execution state with updated context and stateVersion' },
     examples: [
-      '{ operation: "continue_execution", params: { element_name: "code-reviewer", previousStepResult: "Files analyzed" } }',
+      '{ operation: "continue_execution", params: { element_name: "rubric-qa-agent", previousStepResult: "Verified citations", parameters: { run_dir: "/app/run", deliverable_path: "/app/run/output.docx" } } }',
     ],
   },
   abort_execution: {

--- a/src/server/tools/MCPAQLTools.ts
+++ b/src/server/tools/MCPAQLTools.ts
@@ -356,6 +356,7 @@ Memory-specific search (filter by tags):
 Execution lifecycle — read-only queries:
 { operation: "get_execution_state", params: { element_name: "code-reviewer" } }
 { operation: "get_gathered_data", params: { element_name: "code-reviewer", goalId: "goal-id" } }
+For execution-state reads, reuse the same element_name you passed to execute_agent. If element_name is missing, retry with the same agent name rather than inventing a new one.
 
 Collection:
 { operation: "browse_collection", params: { section: "personas" } }

--- a/src/server/tools/MCPAQLTools.ts
+++ b/src/server/tools/MCPAQLTools.ts
@@ -197,6 +197,13 @@ Quick start examples:
 { operation: "create_element", element_type: "memory", params: { element_name: "session-notes", description: "Session context and notes" } }
 { operation: "addEntry", params: { element_name: "session-notes", content: "Remember this fact", tags: ["important"] } }
 { operation: "execute_agent", params: { element_name: "MyAgent", parameters: { objective: "Review code" } } }
+{ operation: "record_execution_step", params: { element_name: "MyAgent", stepDescription: "Reviewed auth module", outcome: "success", findings: "Found 2 issues" } }
+{ operation: "complete_execution", params: { element_name: "MyAgent", outcome: "success", summary: "Review complete" } }
+
+Execution loop: call execute_agent once to start, then record_execution_step after
+each work chunk, then complete_execution when done. Use continue_execution only to
+resume a paused execution, and pass the same goal parameters you used for
+execute_agent when resuming.
 
 Gatekeeper: Some operations may return a confirmation prompt instead of executing immediately. Use confirm_operation to approve, then retry.
 
@@ -266,6 +273,7 @@ Note: addEntry content supports markdown (headers, lists, bold, tables, code blo
 
 Execution lifecycle — record agent progress (appends step records, like addEntry):
 { operation: "record_execution_step", params: { element_name: "code-reviewer", stepDescription: "Analyzed files", outcome: "success", findings: "Found 3 issues" } }
+This is the normal next lifecycle call after mcp_aql_execute { operation: "execute_agent", ... }.
 Response flow: record_execution_step returns { autonomy: { continue, factors, notifications? } }. Check autonomy.continue to decide whether to proceed. Check autonomy.notifications for permission_pending (gatekeeper blocks), autonomy_pause, or danger_zone alerts to relay to human operators.
 
 Import & portfolio:
@@ -505,8 +513,8 @@ Supported operations: ${getOperationsString('EXECUTE')}
 
 These operations manage runtime execution state. Unlike CRUD operations (which manage definitions), Execute operations handle the execution lifecycle:
 - execute_agent: Start a new execution (returns goalId and stateVersion for tracking)
-- complete_execution: Signal successful completion
-- continue_execution: Resume from saved state
+- complete_execution: Signal successful completion once the goal is done
+- continue_execution: Resume a previously paused execution with the same goal parameters
 - abort_execution: Abort a running execution, rejecting further operations
 - confirm_operation: Confirm a pending operation that requires user approval (Gatekeeper flow)
 - approve_cli_permission: Approve a pending CLI tool permission request
@@ -517,13 +525,20 @@ IMPORTANT: Execute operations are potentially destructive (agents can perform an
 
 ⚠️ SECURITY: Do not auto-allow this endpoint in your host settings (e.g., Claude Code settings.json). Each execution should require explicit human approval. Auto-allowing bypasses the per-operation confirmation gate. While DangerZone verification and element deny policies still provide protection, the primary human review checkpoint is lost.
 
-Response flow: execute_agent returns { goalId, stateVersion, activeElements, safetyTier, ... }. Use goalId with record_execution_step and complete_execution. stateVersion enables optimistic locking. record_execution_step returns { autonomy: { continue, notifications? } } — check notifications for gatekeeper blocks and danger zone alerts.
+Canonical loop:
+1. Call execute_agent once to start the goal and receive { goalId, stateVersion, activeElements, safetyTier, ... }.
+2. After each chunk of work, use mcp_aql_create: { operation: "record_execution_step", ... }.
+3. Read record_execution_step.autonomy.continue and any autonomy.notifications to decide whether to continue, pause for a human, or handle a gatekeeper block.
+4. When the goal is finished, call complete_execution.
+Use continue_execution only when an already-started goal was paused and you are resuming it with the same goal parameters. It is not the normal next call after execute_agent.
 
 Quick start examples:
 { operation: "execute_agent", params: { element_name: "code-reviewer", parameters: { objective: "Review code" } } }
+Next lifecycle step — use mcp_aql_create:
+{ operation: "record_execution_step", params: { element_name: "code-reviewer", stepDescription: "Reviewed auth module", outcome: "success", findings: "Found 2 security issues" } }
 { operation: "complete_execution", params: { element_name: "code-reviewer", outcome: "success", summary: "Completed review" } }
 { operation: "abort_execution", params: { element_name: "data-collector", reason: "User requested cancellation" } }
-{ operation: "continue_execution", params: { element_name: "code-reviewer" } }
+{ operation: "continue_execution", params: { element_name: "rubric-qa-agent", previousStepResult: "Verified citation set", parameters: { run_dir: "/app/run", deliverable_path: "/app/run/output.docx" } } }
 { operation: "confirm_operation", params: { operation: "execute_agent" } }
 { operation: "approve_cli_permission", params: { request_id: "req-123", decision: "allow" } }
 { operation: "prepare_handoff", params: { element_name: "code-reviewer" } }

--- a/tests/integration/mcp-aql/agent-execution-edge-cases.test.ts
+++ b/tests/integration/mcp-aql/agent-execution-edge-cases.test.ts
@@ -174,6 +174,19 @@ describe('Agent execution lifecycle edge cases', () => {
         expect(data.agentName).toBe('edge-noexec-4');
       }
     });
+
+    it('should fail continue_execution before any recorded step with record_execution_step guidance', async () => {
+      await createAgent('edge-noexec-5');
+      await executeAgent('edge-noexec-5');
+
+      const result = await continueAgent('edge-noexec-5');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain('edge-noexec-5');
+        expect(result.error).toContain('record_execution_step');
+        expect(result.error).toContain('After execute_agent');
+      }
+    });
   });
 
   // ===========================================================================
@@ -221,24 +234,18 @@ describe('Agent execution lifecycle edge cases', () => {
       }
     });
 
-    it('should succeed continue_execution after complete (creates new execution)', async () => {
+    it('should fail continue_execution after complete with execute_agent guidance', async () => {
       await createAgent('edge-postcomplete-4');
       await executeAgent('edge-postcomplete-4');
       await completeAgent('edge-postcomplete-4');
 
-      // continue_execution calls executeAgent internally, creating a fresh goal
       const result = await continueAgent('edge-postcomplete-4');
-      expect(result.success).toBe(true);
-      if (result.success) {
-        const data = result.data as any;
-        expect(data._type).toBe('ContinueResult');
-        expect(data.goalId).toBeDefined();
-        expect(data.continuation).toBeDefined();
-        expect(data.continuation.isResuming).toBe(true);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain('edge-postcomplete-4');
+        expect(result.error).toContain('execute_agent');
+        expect(result.error).toContain('record_execution_step');
       }
-
-      // Clean up: complete the new execution
-      await completeAgent('edge-postcomplete-4');
     });
 
     it('should succeed execute_agent after complete (creates new execution)', async () => {
@@ -289,22 +296,16 @@ describe('Agent execution lifecycle edge cases', () => {
       }
     });
 
-    it('should handle continue_execution after abort', async () => {
+    it('should fail continue_execution after abort with execute_agent guidance', async () => {
       await createAgent('edge-postabort-3');
       await executeAgent('edge-postabort-3');
       await abortAgent('edge-postabort-3');
 
-      // continue_execution is NOT exempt from abort check, but after a successful
-      // abort the goal is marked 'failed' and getActiveGoalIds returns empty,
-      // so the abort check may not fire. The result depends on internal state:
-      // either succeeds (creates new execution) or fails (abort check).
       const result = await continueAgent('edge-postabort-3');
-      if (result.success) {
-        const data = result.data as any;
-        expect(data._type).toBe('ContinueResult');
-        await completeAgent('edge-postabort-3');
-      } else {
+      expect(result.success).toBe(false);
+      if (!result.success) {
         expect(result.error).toContain('edge-postabort-3');
+        expect(result.error).toContain('execute_agent');
       }
     });
 
@@ -398,6 +399,60 @@ describe('Agent execution lifecycle edge cases', () => {
         expect(data.entries.length).toBeGreaterThanOrEqual(2);
         expect(data.summary).toBeDefined();
         expect(data.summary.totalSteps).toBeGreaterThanOrEqual(1);
+      }
+    });
+  });
+
+  describe('Evaluation regression coverage (#2165)', () => {
+    it('should enumerate all missing continue_execution parameters for rubric-style agents', async () => {
+      await createAgent('rubric-regression-agent', {
+        goal: {
+          template: 'Verify {deliverable_path} against {run_dir}',
+          parameters: [
+            { name: 'run_dir', type: 'string', required: true },
+            { name: 'deliverable_path', type: 'string', required: true },
+          ],
+          successCriteria: ['Produce a verified attestation'],
+        },
+      });
+
+      const executeResult = await mcpAqlHandler.handleExecute({
+        operation: 'execute_agent',
+        params: {
+          element_name: 'rubric-regression-agent',
+          parameters: {
+            run_dir: '/app/run',
+            deliverable_path: '/app/run/output.docx',
+          },
+        },
+      });
+      expect(executeResult.success).toBe(true);
+
+      const recordResult = await mcpAqlHandler.handleCreate({
+        operation: 'record_execution_step',
+        params: {
+          element_name: 'rubric-regression-agent',
+          stepDescription: 'Loaded rubric checklist',
+          outcome: 'success',
+          findings: 'Checklist parsed',
+        },
+      });
+      expect(recordResult.success).toBe(true);
+
+      const continueResult = await mcpAqlHandler.handleExecute({
+        operation: 'continue_execution',
+        params: {
+          element_name: 'rubric-regression-agent',
+          previousStepResult: 'Checklist parsed',
+          parameters: {},
+        },
+      });
+      expect(continueResult.success).toBe(false);
+      if (!continueResult.success) {
+        expect(continueResult.error).toContain('run_dir');
+        expect(continueResult.error).toContain('deliverable_path');
+        expect(continueResult.error).toContain('introspect');
+        expect(continueResult.error).toContain('record_execution_step');
       }
     });
   });

--- a/tests/unit/elements/agents/AgentManager.executeAgent.test.ts
+++ b/tests/unit/elements/agents/AgentManager.executeAgent.test.ts
@@ -407,6 +407,39 @@ goal:
         agentManager.executeAgent('hello-world-agent', {})
       ).rejects.toThrow(/missing required parameter.*directory/i);
     });
+
+    it('should enumerate all missing goal parameters with introspect guidance', async () => {
+      fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
+        if (filePath.includes('rubric-qa-agent.md')) {
+          return `---
+name: "Rubric QA Agent"
+type: "agent"
+version: "2.0.0"
+
+goal:
+  template: "Verify {deliverable_path} against {run_dir}"
+  parameters:
+    - name: run_dir
+      type: string
+      required: true
+    - name: deliverable_path
+      type: string
+      required: true
+---
+
+# Rubric QA Agent`;
+        }
+        throw new Error(`Unexpected file read: ${filePath}`);
+      });
+
+      await expect(
+        agentManager.executeAgent('rubric-qa-agent', {})
+      ).rejects.toThrow(/missing required parameters.*run_dir.*deliverable_path/i);
+
+      await expect(
+        agentManager.executeAgent('rubric-qa-agent', {})
+      ).rejects.toThrow(/introspect/i);
+    });
   });
 
   /**

--- a/tests/unit/handlers/mcp-aql/IntrospectionResolver.test.ts
+++ b/tests/unit/handlers/mcp-aql/IntrospectionResolver.test.ts
@@ -818,6 +818,32 @@ describe('IntrospectionResolver', () => {
         expect(result.operation!.returns.description).toContain('goalId');
         expect(result.operation!.returns.description).toContain('stateVersion');
       });
+
+      it('should expose the canonical lifecycle loop in introspection', () => {
+        const result = IntrospectionResolver.resolve({
+          query: 'operations',
+          name: 'execute_agent',
+        });
+
+        expect(result.operation!.description).toContain('record_execution_step');
+        expect(result.operation!.description).toContain('mcp_aql_create');
+        expect(result.operation!.description).toContain('complete_execution');
+      });
+    });
+
+    describe('continue_execution introspection', () => {
+      it('should explain paused-only semantics and full-parameter resume', () => {
+        const result = IntrospectionResolver.resolve({
+          query: 'operations',
+          name: 'continue_execution',
+        });
+
+        expect(result.operation).toBeDefined();
+        expect(result.operation!.description).toContain('paused');
+        expect(result.operation!.description).toContain('same goal parameters');
+        expect(result.operation!.examples[0]).toContain('run_dir');
+        expect(result.operation!.examples[0]).toContain('deliverable_path');
+      });
     });
 
     describe('addEntry introspection', () => {

--- a/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
+++ b/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
@@ -1367,6 +1367,23 @@ describe('MCPAQLHandler', () => {
           includeContext: undefined,
         });
       });
+
+      it('should explain how to recover when element_name is missing', async () => {
+        const input: OperationInput = {
+          operation: 'get_execution_state',
+          params: {},
+        };
+
+        const result = await handler.handleRead(input);
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error).toContain("Missing required parameter 'element_name'");
+          expect(result.error).toContain('Use the same element_name you passed to execute_agent');
+          expect(result.error).toContain('{ operation: "get_execution_state", params: { element_name: "code-reviewer", includeDecisionHistory: true } }');
+          expect(result.error).toContain('list active agents first');
+        }
+      });
     });
 
     describe('Permission violations', () => {

--- a/tests/unit/handlers/mcp-aql/OperationSchema.test.ts
+++ b/tests/unit/handlers/mcp-aql/OperationSchema.test.ts
@@ -610,6 +610,12 @@ describe('OperationSchema', () => {
         expect(EXECUTION_SCHEMAS.record_execution_step.params?.riskScore?.required).toBeUndefined();
       });
 
+      it('should document get_execution_state name reuse guidance', () => {
+        const schema = EXECUTION_SCHEMAS.get_execution_state;
+        expect(schema.description).toContain('same element_name you passed to execute_agent');
+        expect(schema.params?.element_name?.description).toContain('Reuse the same element_name from execute_agent');
+      });
+
       it('should define required params for complete_execution', () => {
         expect(EXECUTION_SCHEMAS.complete_execution.params?.element_name?.required).toBe(true);
         expect(EXECUTION_SCHEMAS.complete_execution.params?.outcome?.required).toBe(true);

--- a/tests/unit/handlers/mcp-aql/OperationSchema.test.ts
+++ b/tests/unit/handlers/mcp-aql/OperationSchema.test.ts
@@ -587,6 +587,14 @@ describe('OperationSchema', () => {
         expect(desc).toContain('automatically activated');
       });
 
+      it('should document the canonical execution loop in execute_agent description', () => {
+        const desc = EXECUTION_SCHEMAS.execute_agent.description;
+        expect(desc).toContain('record_execution_step');
+        expect(desc).toContain('mcp_aql_create');
+        expect(desc).toContain('complete_execution');
+        expect(desc).toContain('not the normal next call after execute_agent');
+      });
+
       it('should document resilience interaction in maxAutonomousSteps param (issue #736)', () => {
         const paramDesc = EXECUTION_SCHEMAS.execute_agent.params?.maxAutonomousSteps?.description;
         expect(paramDesc).toContain('resilience');
@@ -607,6 +615,13 @@ describe('OperationSchema', () => {
         expect(EXECUTION_SCHEMAS.complete_execution.params?.outcome?.required).toBe(true);
         expect(EXECUTION_SCHEMAS.complete_execution.params?.summary?.required).toBe(true);
         expect(EXECUTION_SCHEMAS.complete_execution.params?.goalId?.required).toBeUndefined();
+      });
+
+      it('should document paused-only semantics and full-parameter resume for continue_execution', () => {
+        expect(EXECUTION_SCHEMAS.continue_execution.description).toContain('paused');
+        expect(EXECUTION_SCHEMAS.continue_execution.description).toContain('same goal parameters');
+        expect(EXECUTION_SCHEMAS.continue_execution.examples?.[0]).toContain('run_dir');
+        expect(EXECUTION_SCHEMAS.continue_execution.examples?.[0]).toContain('deliverable_path');
       });
 
       it('should define required params for handoff operations', () => {

--- a/tests/unit/server/tools/MCPAQLToolDescriptionIntegrity.test.ts
+++ b/tests/unit/server/tools/MCPAQLToolDescriptionIntegrity.test.ts
@@ -283,4 +283,12 @@ describe('Tool Description ↔ Operation Route Integrity (Issue #535)', () => {
       ]);
     });
   });
+
+  it('mcp_aql_read documents get_execution_state name reuse guidance', async () => {
+    const descriptions = await getToolDescriptions();
+    const description = descriptions.mcp_aql_read;
+
+    expect(description).toContain('{ operation: "get_execution_state", params: { element_name: "code-reviewer" } }');
+    expect(description).toContain('reuse the same element_name you passed to execute_agent');
+  });
 });

--- a/tests/unit/server/tools/MCPAQLToolDescriptionIntegrity.test.ts
+++ b/tests/unit/server/tools/MCPAQLToolDescriptionIntegrity.test.ts
@@ -188,6 +188,28 @@ describe('Tool Description ↔ Operation Route Integrity (Issue #535)', () => {
     }
   });
 
+  describe('Agent execution guidance remains actionable', () => {
+    it('mcp_aql_execute documents the canonical loop and paused-only continue semantics', async () => {
+      const descriptions = await getToolDescriptions();
+      const description = descriptions.mcp_aql_execute;
+
+      expect(description).toContain('mcp_aql_create');
+      expect(description).toContain('record_execution_step');
+      expect(description).toContain('complete_execution');
+      expect(description).toContain('paused');
+      expect(description).toContain('not the normal next call after execute_agent');
+      expect(description).toContain('deliverable_path');
+    });
+
+    it('mcp_aql_create documents record_execution_step as the normal post-execute call', async () => {
+      const descriptions = await getToolDescriptions();
+      const description = descriptions.mcp_aql_create;
+
+      expect(description).toContain('normal next lifecycle call after mcp_aql_execute');
+      expect(description).toContain('record_execution_step');
+    });
+  });
+
   describe('100% operation example coverage', () => {
     for (const [suffix, endpoint] of Object.entries(TOOL_ENDPOINT_MAP)) {
       const toolName = `mcp_aql_${suffix}`;


### PR DESCRIPTION
## Summary
- fix the MCP-AQL execute and introspection guidance so models see the canonical `execute_agent -> record_execution_step -> complete_execution` loop
- make `continue_execution` resume-only instead of silently restarting after complete/abort, with actionable hints for `record_execution_step` and `introspect`
- add regression coverage that mirrors the rubric QA evaluation failure mode from #2165

## Testing
- npm test -- --runInBand tests/unit/elements/agents/AgentManager.executeAgent.test.ts
- npm test -- --runInBand tests/unit/server/tools/MCPAQLToolDescriptionIntegrity.test.ts tests/unit/handlers/mcp-aql/OperationSchema.test.ts tests/unit/handlers/mcp-aql/IntrospectionResolver.test.ts
- npm run test:integration -- --runInBand tests/integration/mcp-aql/agent-execution-edge-cases.test.ts
- npx eslint src/elements/agents/AgentManager.ts src/server/tools/MCPAQLTools.ts src/handlers/mcp-aql/OperationSchema.ts tests/unit/elements/agents/AgentManager.executeAgent.test.ts tests/unit/server/tools/MCPAQLToolDescriptionIntegrity.test.ts tests/unit/handlers/mcp-aql/OperationSchema.test.ts tests/unit/handlers/mcp-aql/IntrospectionResolver.test.ts tests/integration/mcp-aql/agent-execution-edge-cases.test.ts
- npm run build

Closes #2165
