### PR TITLE
Improve get_execution_state recovery guidance

### DIFF
--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -126,6 +126,47 @@ function validateRequiredString(
   return value;
 }
 
+const EXECUTION_OPERATION_NAMES: Record<string, string> = {
+  execute: 'execute_agent',
+  getState: 'get_execution_state',
+  updateState: 'record_execution_step',
+  complete: 'complete_execution',
+  continue: 'continue_execution',
+  abort: 'abort_execution',
+  getGatheredData: 'get_gathered_data',
+  prepareHandoff: 'prepare_handoff',
+  resumeFromHandoff: 'resume_from_handoff',
+};
+
+function validateExecutionElementName(
+  method: string,
+  params: Record<string, unknown>
+): string {
+  const value = params.element_name;
+  if (value !== undefined && value !== null && typeof value === 'string' && value.trim() !== '') {
+    return value;
+  }
+
+  const operationName = EXECUTION_OPERATION_NAMES[method] || 'execution lifecycle operation';
+
+  if (method === 'getState') {
+    throw new Error(
+      `Missing required parameter 'element_name'. Expected: string ` +
+      `(the name of the agent/executable element whose execution state you want to inspect). ` +
+      `Use the same element_name you passed to execute_agent. ` +
+      `Retry with: { operation: "get_execution_state", params: { element_name: "code-reviewer", includeDecisionHistory: true } }. ` +
+      `If you're unsure which name to use, call introspect for "get_execution_state" or list active agents first.`
+    );
+  }
+
+  throw new Error(
+    `Missing required parameter 'element_name'. Expected: string ` +
+    `(the name of the agent/executable element for ${operationName}). ` +
+    `If this is part of an existing execution lifecycle, reuse the same element_name you passed to execute_agent. ` +
+    `If you're unsure which name to use, call introspect for "${operationName}" or list active agents first.`
+  );
+}
+
 /**
  * Normalize flat pagination params into a { page, pageSize } object.
  *
@@ -3575,11 +3616,7 @@ export class MCPAQLHandler {
 
     // Issue #323: Validate element_name parameter (was incorrectly using 'name')
     // All execute operations require element_name to identify the target
-    const elementName = validateRequiredString(
-      params,
-      'element_name',
-      'the name of the agent/element to execute'
-    );
+    const elementName = validateExecutionElementName(method, params);
 
     // Issue #110: Programmatic enforcement for DANGER_ZONE tier
     // Issue #402: Use DI-injected enforcer instead of singleton

--- a/src/handlers/mcp-aql/OperationSchema.ts
+++ b/src/handlers/mcp-aql/OperationSchema.ts
@@ -1234,9 +1234,9 @@ export const EXECUTION_SCHEMAS: OperationSchemaMap = {
     handler: 'mcpAqlHandler',
     method: 'dispatchExecute',
     category: 'Agent Execution',
-    description: 'Query current execution state including progress and findings',
+    description: 'Query current execution state including progress and findings. Use the same element_name you passed to execute_agent for this execution.',
     params: {
-      element_name: { type: 'string', required: true, description: 'Agent or executable element name' },
+      element_name: { type: 'string', required: true, description: 'Agent or executable element name. Reuse the same element_name from execute_agent.' },
       includeDecisionHistory: { type: 'boolean', description: 'Include decision history in response' },
       includeContext: { type: 'boolean', description: 'Include execution context in response' },
     },

--- a/src/server/tools/MCPAQLTools.ts
+++ b/src/server/tools/MCPAQLTools.ts
@@ -348,6 +348,7 @@ Memory-specific search (filter by tags):
 Execution lifecycle — read-only queries:
 { operation: "get_execution_state", params: { element_name: "code-reviewer" } }
 { operation: "get_gathered_data", params: { element_name: "code-reviewer", goalId: "goal-id" } }
+For execution-state reads, reuse the same element_name you passed to execute_agent. If element_name is missing, retry with the same agent name rather than inventing a new one.
 
 Collection:
 { operation: "browse_collection", params: { section: "personas" } }

--- a/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
+++ b/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
@@ -1367,6 +1367,23 @@ describe('MCPAQLHandler', () => {
           includeContext: undefined,
         });
       });
+
+      it('should explain how to recover when element_name is missing', async () => {
+        const input: OperationInput = {
+          operation: 'get_execution_state',
+          params: {},
+        };
+
+        const result = await handler.handleRead(input);
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error).toContain("Missing required parameter 'element_name'");
+          expect(result.error).toContain('Use the same element_name you passed to execute_agent');
+          expect(result.error).toContain('{ operation: "get_execution_state", params: { element_name: "code-reviewer", includeDecisionHistory: true } }');
+          expect(result.error).toContain('list active agents first');
+        }
+      });
     });
 
     describe('Permission violations', () => {

--- a/tests/unit/handlers/mcp-aql/OperationSchema.test.ts
+++ b/tests/unit/handlers/mcp-aql/OperationSchema.test.ts
@@ -602,6 +602,12 @@ describe('OperationSchema', () => {
         expect(EXECUTION_SCHEMAS.record_execution_step.params?.riskScore?.required).toBeUndefined();
       });
 
+      it('should document get_execution_state name reuse guidance', () => {
+        const schema = EXECUTION_SCHEMAS.get_execution_state;
+        expect(schema.description).toContain('same element_name you passed to execute_agent');
+        expect(schema.params?.element_name?.description).toContain('Reuse the same element_name from execute_agent');
+      });
+
       it('should define required params for complete_execution', () => {
         expect(EXECUTION_SCHEMAS.complete_execution.params?.element_name?.required).toBe(true);
         expect(EXECUTION_SCHEMAS.complete_execution.params?.outcome?.required).toBe(true);

--- a/tests/unit/server/tools/MCPAQLToolDescriptionIntegrity.test.ts
+++ b/tests/unit/server/tools/MCPAQLToolDescriptionIntegrity.test.ts
@@ -261,4 +261,12 @@ describe('Tool Description ↔ Operation Route Integrity (Issue #535)', () => {
       ]);
     });
   });
+
+  it('mcp_aql_read documents get_execution_state name reuse guidance', async () => {
+    const descriptions = await getToolDescriptions();
+    const description = descriptions.mcp_aql_read;
+
+    expect(description).toContain('{ operation: "get_execution_state", params: { element_name: "code-reviewer" } }');
+    expect(description).toContain('reuse the same element_name you passed to execute_agent');
+  });
 });


### PR DESCRIPTION
## Summary
- add corrective runtime guidance when get_execution_state is called without element_name
- reinforce the same execute_agent -> get_execution_state name reuse guidance in MCP-AQL tool/schema text
- add focused tests for the recovery message and description integrity

## Testing
- npm test -- --runInBand tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts tests/unit/handlers/mcp-aql/OperationSchema.test.ts tests/unit/server/tools/MCPAQLToolDescriptionIntegrity.test.ts
- npx eslint src/handlers/mcp-aql/MCPAQLHandler.ts src/handlers/mcp-aql/OperationSchema.ts src/server/tools/MCPAQLTools.ts tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts tests/unit/handlers/mcp-aql/OperationSchema.test.ts tests/unit/server/tools/MCPAQLToolDescriptionIntegrity.test.ts
- npm run build