### PR TITLE
[codex] Remove arbitrary description length cap

### DIFF
--- a/docs/architecture/element-manager-consolidation.md
+++ b/docs/architecture/element-manager-consolidation.md
@@ -720,7 +720,7 @@ export abstract class BaseElementManager<T extends IElement> {
     // Sanitize inputs
     const sanitizedName = sanitizeInput(metadata.name, 100);
     const sanitizedDesc = metadata.description ?
-      sanitizeInput(metadata.description, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : '';
+      sanitizeInput(metadata.description, SECURITY_LIMITS.MAX_YAML_LENGTH) : '';
     const sanitizedContent = content ?
       sanitizeInput(content, 50000) : '';
 
@@ -1094,7 +1094,7 @@ const skillConfig: ElementTypeConfig = {
   },
   validation: {
     namePattern: /^[a-zA-Z0-9-]+$/,
-    descriptionMaxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
+    descriptionMaxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
     contentMaxLength: 50000,
     customValidation: (element) => {
       const skill = element as Skill;
@@ -1126,7 +1126,7 @@ const agentConfig: ElementTypeConfig = {
   },
   validation: {
     namePattern: /^[a-zA-Z0-9_-]+$/,
-    descriptionMaxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
+    descriptionMaxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
     contentMaxLength: 50000
   },
   fileExtension: '.md',

--- a/docs/architecture/element-manager-consolidation.md
+++ b/docs/architecture/element-manager-consolidation.md
@@ -720,7 +720,7 @@ export abstract class BaseElementManager<T extends IElement> {
     // Sanitize inputs
     const sanitizedName = sanitizeInput(metadata.name, 100);
     const sanitizedDesc = metadata.description ?
-      sanitizeInput(metadata.description, 500) : '';
+      sanitizeInput(metadata.description, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : '';
     const sanitizedContent = content ?
       sanitizeInput(content, 50000) : '';
 
@@ -1094,7 +1094,7 @@ const skillConfig: ElementTypeConfig = {
   },
   validation: {
     namePattern: /^[a-zA-Z0-9-]+$/,
-    descriptionMaxLength: 500,
+    descriptionMaxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
     contentMaxLength: 50000,
     customValidation: (element) => {
       const skill = element as Skill;
@@ -1126,7 +1126,7 @@ const agentConfig: ElementTypeConfig = {
   },
   validation: {
     namePattern: /^[a-zA-Z0-9_-]+$/,
-    descriptionMaxLength: 500,
+    descriptionMaxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
     contentMaxLength: 50000
   },
   fileExtension: '.md',

--- a/docs/architecture/ensemble-system.md
+++ b/docs/architecture/ensemble-system.md
@@ -700,7 +700,7 @@ elements:
 All ensemble metadata is validated and sanitized:
 
 - **Name**: Alphanumeric, hyphens, max 100 chars
-- **Description**: Max 500 chars, HTML stripped
+- **Description**: Bounded by YAML/frontmatter safety limits, HTML stripped
 - **Element Names**: Sanitized, Unicode normalized
 - **Conditions**: Max 500 chars, injection-safe
 - **Dependencies**: Max 10 per element

--- a/docs/reference/element-types.md
+++ b/docs/reference/element-types.md
@@ -96,7 +96,7 @@ Triggers are keywords that help AI assistants discover and activate elements bas
 | Field | Max Length | Required | Description |
 |-------|------------|----------|-------------|
 | `name` | 100 | Yes | Display name for the element |
-| `description` | 500 | No | Brief explanation of purpose |
+| `description` | No description-specific cap | No | Explanation of purpose; bounded by overall YAML/file safety limits |
 | `author` | 100 | No | Creator or maintainer |
 | `version` | 20 | No | Semantic version (e.g., `1.0.0`) |
 | `category` | 50 | No | Grouping category |

--- a/docs/reference/element-types.md
+++ b/docs/reference/element-types.md
@@ -96,7 +96,7 @@ Triggers are keywords that help AI assistants discover and activate elements bas
 | Field | Max Length | Required | Description |
 |-------|------------|----------|-------------|
 | `name` | 100 | Yes | Display name for the element |
-| `description` | No description-specific cap | No | Explanation of purpose; bounded by overall YAML/file safety limits |
+| `description` | No arbitrary 500-character cap | No | Explanation of purpose; bounded by YAML/frontmatter and file safety limits |
 | `author` | 100 | No | Creator or maintainer |
 | `version` | 20 | No | Semantic version (e.g., `1.0.0`) |
 | `category` | 50 | No | Grouping category |

--- a/src/elements/agents/Agent.ts
+++ b/src/elements/agents/Agent.ts
@@ -66,7 +66,7 @@ export class Agent extends BaseElement implements IElement {
     const sanitizedMetadata: Partial<AgentMetadata> = {
       ...metadata,
       name: metadata.name ? sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) : undefined,
-      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
+      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
       specializations: metadata.specializations?.map(s => sanitizeInput(s, 50)),
       decisionFramework: metadata.decisionFramework || AGENT_DEFAULTS.DECISION_FRAMEWORK,
       riskTolerance: metadata.riskTolerance || AGENT_DEFAULTS.RISK_TOLERANCE,

--- a/src/elements/agents/Agent.ts
+++ b/src/elements/agents/Agent.ts
@@ -15,6 +15,7 @@ import { IElement, ElementValidationResult, ValidationError, ValidationWarning }
 import { ElementType } from '../../portfolio/types.js';
 import { randomBytes } from 'node:crypto';
 import { sanitizeInput } from '../../security/InputValidator.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
 import { logger } from '../../utils/logger.js';
@@ -65,7 +66,7 @@ export class Agent extends BaseElement implements IElement {
     const sanitizedMetadata: Partial<AgentMetadata> = {
       ...metadata,
       name: metadata.name ? sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) : undefined,
-      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, 500) : undefined,
+      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
       specializations: metadata.specializations?.map(s => sanitizeInput(s, 50)),
       decisionFramework: metadata.decisionFramework || AGENT_DEFAULTS.DECISION_FRAMEWORK,
       riskTolerance: metadata.riskTolerance || AGENT_DEFAULTS.RISK_TOLERANCE,

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -243,7 +243,7 @@ export class AgentManager extends BaseElementManager<Agent> {
 
       // Sanitize inputs for element creation
       const sanitizedName = sanitizeInput(UnicodeValidator.normalize(name).normalizedContent, 100);
-      const sanitizedDescription = sanitizeInput(UnicodeValidator.normalize(description).normalizedContent, 500);
+      const sanitizedDescription = sanitizeInput(UnicodeValidator.normalize(description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
       // Use ContentValidator for multi-line content to preserve formatting (newlines, tabs)
       // while still detecting prompt injection attacks
       const contentValidation = ContentValidator.validateAndSanitize(content, { maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH, contentContext: 'agent' });
@@ -1874,7 +1874,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     // FIX: Must specify fieldType: 'description' to allow punctuation like colons, semicolons, etc.
     if (metadata.description) {
       const descResult = this.validationService.validateAndSanitizeInput(metadata.description, {
-        maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
         allowSpaces: true,
         fieldType: 'description'
       });
@@ -2421,7 +2421,7 @@ export class AgentManager extends BaseElementManager<Agent> {
 
         const validated: AgentGoalParameter = { name, type, required };
         if (typeof p.description === 'string' && p.description.length > 0) {
-          validated.description = sanitizeInput(p.description, 500);
+          validated.description = sanitizeInput(p.description, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
         }
         if (p.default !== undefined) {
           // Sanitize string defaults to prevent injection when used in goal rendering

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -243,7 +243,7 @@ export class AgentManager extends BaseElementManager<Agent> {
 
       // Sanitize inputs for element creation
       const sanitizedName = sanitizeInput(UnicodeValidator.normalize(name).normalizedContent, 100);
-      const sanitizedDescription = sanitizeInput(UnicodeValidator.normalize(description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
+      const sanitizedDescription = sanitizeInput(UnicodeValidator.normalize(description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH);
       // Use ContentValidator for multi-line content to preserve formatting (newlines, tabs)
       // while still detecting prompt injection attacks
       const contentValidation = ContentValidator.validateAndSanitize(content, { maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH, contentContext: 'agent' });
@@ -1874,7 +1874,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     // FIX: Must specify fieldType: 'description' to allow punctuation like colons, semicolons, etc.
     if (metadata.description) {
       const descResult = this.validationService.validateAndSanitizeInput(metadata.description, {
-        maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
         allowSpaces: true,
         fieldType: 'description'
       });
@@ -2421,7 +2421,7 @@ export class AgentManager extends BaseElementManager<Agent> {
 
         const validated: AgentGoalParameter = { name, type, required };
         if (typeof p.description === 'string' && p.description.length > 0) {
-          validated.description = sanitizeInput(p.description, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
+          validated.description = sanitizeInput(p.description, SECURITY_LIMITS.MAX_YAML_LENGTH);
         }
         if (p.default !== undefined) {
           // Sanitize string defaults to prevent injection when used in goal rendering

--- a/src/elements/base/ElementValidation.ts
+++ b/src/elements/base/ElementValidation.ts
@@ -16,6 +16,7 @@
  */
 
 import { sanitizeInput } from '../../security/InputValidator.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { logger } from '../../utils/logger.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
@@ -25,7 +26,6 @@ import { SecurityMonitor } from '../../security/securityMonitor.js';
  */
 export const VALIDATION_CONSTANTS = {
   MAX_NAME_LENGTH: 100,
-  MAX_DESCRIPTION_LENGTH: 500,
   MAX_CATEGORY_LENGTH: 50,
   MAX_TAG_LENGTH: 50,
   MAX_AUTHOR_LENGTH: 100,
@@ -76,12 +76,12 @@ export class ElementValidation {
    * Validate and sanitize a description field
    *
    * @param description - Raw description value
-   * @param maxLength - Maximum length (default: 500)
+   * @param maxLength - Maximum length (default: global content limit)
    * @returns Sanitized description or undefined
    */
   static validateDescription(
     description: any,
-    maxLength: number = VALIDATION_CONSTANTS.MAX_DESCRIPTION_LENGTH
+    maxLength: number = SECURITY_LIMITS.MAX_CONTENT_LENGTH
   ): string | undefined {
     if (!description) {
       return undefined;

--- a/src/elements/base/ElementValidation.ts
+++ b/src/elements/base/ElementValidation.ts
@@ -76,12 +76,12 @@ export class ElementValidation {
    * Validate and sanitize a description field
    *
    * @param description - Raw description value
-   * @param maxLength - Maximum length (default: global content limit)
+   * @param maxLength - Maximum length (default: YAML/frontmatter limit)
    * @returns Sanitized description or undefined
    */
   static validateDescription(
     description: any,
-    maxLength: number = SECURITY_LIMITS.MAX_CONTENT_LENGTH
+    maxLength: number = SECURITY_LIMITS.MAX_YAML_LENGTH
   ): string | undefined {
     if (!description) {
       return undefined;

--- a/src/elements/ensembles/Ensemble.ts
+++ b/src/elements/ensembles/Ensemble.ts
@@ -172,7 +172,7 @@ export class Ensemble extends BaseElement implements IElement {
       ) : undefined,
       description: metadata.description !== undefined ? (
         metadata.description === '' ? '' :  // Preserve empty string for validation
-        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH)
+        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH)
       ) : undefined
     };
 

--- a/src/elements/ensembles/Ensemble.ts
+++ b/src/elements/ensembles/Ensemble.ts
@@ -31,6 +31,7 @@ import { ElementType } from '../../portfolio/types.js';
 import * as vm from 'vm';
 import { PortfolioManager } from '../../portfolio/PortfolioManager.js';
 import { sanitizeInput } from '../../security/InputValidator.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
 import { logger } from '../../utils/logger.js';
@@ -171,7 +172,7 @@ export class Ensemble extends BaseElement implements IElement {
       ) : undefined,
       description: metadata.description !== undefined ? (
         metadata.description === '' ? '' :  // Preserve empty string for validation
-        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, 500)
+        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH)
       ) : undefined
     };
 

--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -241,7 +241,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
     if (data.description) {
       const descResult = this.validationService.validateMetadataField('description', data.description, {
         required: false,
-        maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
         pattern: VALIDATION_PATTERNS.SAFE_DESCRIPTION
       });
       if (!descResult.isValid) {

--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -241,7 +241,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
     if (data.description) {
       const descResult = this.validationService.validateMetadataField('description', data.description, {
         required: false,
-        maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
         pattern: VALIDATION_PATTERNS.SAFE_DESCRIPTION
       });
       if (!descResult.isValid) {
@@ -438,7 +438,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       let purpose: string | undefined;
       if (elem.purpose) {
         const purposeResult = this.validationService.validateAndSanitizeInput(String(elem.purpose), {
-          maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+          maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
           allowSpaces: true,
           fieldType: 'description'  // Allow full description punctuation (commas, em-dashes, etc.)
         });

--- a/src/elements/memories/Memory.ts
+++ b/src/elements/memories/Memory.ts
@@ -21,6 +21,7 @@ import { UnicodeValidator } from '../../security/validators/unicodeValidator.js'
 import crypto from 'crypto';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
 import { sanitizeInput } from '../../security/InputValidator.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import { MetadataService } from '../../services/MetadataService.js';
 // FIX #1315: ContentValidator no longer used in addEntry (moved to background validation)
 // Import removed to clean up unused dependencies
@@ -251,7 +252,7 @@ export class Memory extends BaseElement implements IElement {
         sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) :
         'Unnamed Memory',
       description: metadata.description ?
-        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, 500) :
+        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) :
         undefined,
       // FIX #1124: Preserve triggers for Enhanced Index
       // SECURITY: Validate BEFORE sanitization to reject invalid characters

--- a/src/elements/memories/Memory.ts
+++ b/src/elements/memories/Memory.ts
@@ -252,7 +252,7 @@ export class Memory extends BaseElement implements IElement {
         sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) :
         'Unnamed Memory',
       description: metadata.description ?
-        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) :
+        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH) :
         undefined,
       // FIX #1124: Preserve triggers for Enhanced Index
       // SECURITY: Validate BEFORE sanitization to reject invalid characters

--- a/src/elements/memories/MemoryManager.ts
+++ b/src/elements/memories/MemoryManager.ts
@@ -1916,7 +1916,7 @@ export class MemoryManager extends BaseElementManager<Memory> {
     let sanitizedDescription = '';
     if (metadataSource.description) {
       const descResult = this.validationService.validateAndSanitizeInput(metadataSource.description, {
-        maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
         allowSpaces: true,
         fieldType: 'description'
       });

--- a/src/elements/memories/MemoryManager.ts
+++ b/src/elements/memories/MemoryManager.ts
@@ -1916,7 +1916,7 @@ export class MemoryManager extends BaseElementManager<Memory> {
     let sanitizedDescription = '';
     if (metadataSource.description) {
       const descResult = this.validationService.validateAndSanitizeInput(metadataSource.description, {
-        maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
         allowSpaces: true,
         fieldType: 'description'
       });

--- a/src/elements/skills/Skill.ts
+++ b/src/elements/skills/Skill.ts
@@ -78,7 +78,7 @@ export class Skill extends BaseElement implements IElement {
     const sanitizedMetadata = {
       ...metadata,
       name: metadata.name ? sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) : undefined,
-      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, 500) : undefined
+      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined
     };
 
     super(ElementType.SKILL, sanitizedMetadata, metadataService);
@@ -112,7 +112,7 @@ export class Skill extends BaseElement implements IElement {
         const sanitized: SkillParameter = {
           ...param,
           name: sanitizeInput(UnicodeValidator.normalize(param.name).normalizedContent, 50),
-          description: sanitizeInput(UnicodeValidator.normalize(param.description).normalizedContent, 200)
+          description: sanitizeInput(UnicodeValidator.normalize(param.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH)
         };
         // Only include options if they exist (avoid undefined)
         if (param.options) {

--- a/src/elements/skills/Skill.ts
+++ b/src/elements/skills/Skill.ts
@@ -78,7 +78,7 @@ export class Skill extends BaseElement implements IElement {
     const sanitizedMetadata = {
       ...metadata,
       name: metadata.name ? sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) : undefined,
-      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined
+      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined
     };
 
     super(ElementType.SKILL, sanitizedMetadata, metadataService);
@@ -112,7 +112,7 @@ export class Skill extends BaseElement implements IElement {
         const sanitized: SkillParameter = {
           ...param,
           name: sanitizeInput(UnicodeValidator.normalize(param.name).normalizedContent, 50),
-          description: sanitizeInput(UnicodeValidator.normalize(param.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH)
+          description: sanitizeInput(UnicodeValidator.normalize(param.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH)
         };
         // Only include options if they exist (avoid undefined)
         if (param.options) {

--- a/src/elements/templates/Template.ts
+++ b/src/elements/templates/Template.ts
@@ -96,7 +96,7 @@ export class Template extends BaseElement implements IElement {
     const sanitizedMetadata = {
       ...metadata,
       name: metadata.name ? sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) : undefined,
-      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
+      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
       category: metadata.category ? sanitizeInput(UnicodeValidator.normalize(metadata.category).normalizedContent, 50) : undefined,
       output_format: metadata.output_format ? sanitizeInput(metadata.output_format, 20) : undefined
     };
@@ -144,7 +144,7 @@ export class Template extends BaseElement implements IElement {
       this.metadata.variables = this.metadata.variables.map(variable => ({
         ...variable,
         name: sanitizeInput(UnicodeValidator.normalize(variable.name).normalizedContent, 50),
-        description: variable.description ? sanitizeInput(UnicodeValidator.normalize(variable.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
+        description: variable.description ? sanitizeInput(UnicodeValidator.normalize(variable.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
         validation: variable.validation ? sanitizeInput(variable.validation, 200) : undefined
       }));
     }

--- a/src/elements/templates/Template.ts
+++ b/src/elements/templates/Template.ts
@@ -18,6 +18,7 @@ import { logger } from '../../utils/logger.js';
 import { ErrorHandler, ErrorCategory } from '../../utils/ErrorHandler.js';
 import { ValidationErrorCodes } from '../../utils/errorCodes.js';
 import { sanitizeInput } from '../../security/InputValidator.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { ContentValidator } from '../../security/contentValidator.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
@@ -95,7 +96,7 @@ export class Template extends BaseElement implements IElement {
     const sanitizedMetadata = {
       ...metadata,
       name: metadata.name ? sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) : undefined,
-      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, 500) : undefined,
+      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
       category: metadata.category ? sanitizeInput(UnicodeValidator.normalize(metadata.category).normalizedContent, 50) : undefined,
       output_format: metadata.output_format ? sanitizeInput(metadata.output_format, 20) : undefined
     };
@@ -143,7 +144,7 @@ export class Template extends BaseElement implements IElement {
       this.metadata.variables = this.metadata.variables.map(variable => ({
         ...variable,
         name: sanitizeInput(UnicodeValidator.normalize(variable.name).normalizedContent, 50),
-        description: variable.description ? sanitizeInput(UnicodeValidator.normalize(variable.description).normalizedContent, 200) : undefined,
+        description: variable.description ? sanitizeInput(UnicodeValidator.normalize(variable.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
         validation: variable.validation ? sanitizeInput(variable.validation, 200) : undefined
       }));
     }

--- a/src/elements/templates/TemplateManager.ts
+++ b/src/elements/templates/TemplateManager.ts
@@ -384,7 +384,7 @@ export class TemplateManager extends BaseElementManager<Template> {
     }
 
     if (data.description) {
-      metadata.description = sanitizeInput(UnicodeValidator.normalize(data.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
+      metadata.description = sanitizeInput(UnicodeValidator.normalize(data.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH);
     }
 
     if (data.category) {
@@ -428,7 +428,7 @@ export class TemplateManager extends BaseElementManager<Template> {
       metadata.variables = data.variables.map((v: any) => ({
         name: sanitizeInput(v.name || '', 50),
         type: sanitizeInput(v.type || 'string', 20),
-        description: v.description ? sanitizeInput(v.description, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
+        description: v.description ? sanitizeInput(v.description, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
         required: Boolean(v.required),
         default: v.default,
         validation: v.validation ? sanitizeInput(v.validation, 200) : undefined,
@@ -440,7 +440,7 @@ export class TemplateManager extends BaseElementManager<Template> {
     if (Array.isArray(data.examples)) {
       metadata.examples = data.examples.map((ex: any) => ({
         title: sanitizeInput(ex.title || '', 100),
-        description: ex.description ? sanitizeInput(ex.description, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
+        description: ex.description ? sanitizeInput(ex.description, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
         variables: ex.variables || {},
         output: ex.output ? sanitizeInput(ex.output, 5000) : undefined
       }));

--- a/src/elements/templates/TemplateManager.ts
+++ b/src/elements/templates/TemplateManager.ts
@@ -384,7 +384,7 @@ export class TemplateManager extends BaseElementManager<Template> {
     }
 
     if (data.description) {
-      metadata.description = sanitizeInput(UnicodeValidator.normalize(data.description).normalizedContent, 500);
+      metadata.description = sanitizeInput(UnicodeValidator.normalize(data.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
     }
 
     if (data.category) {
@@ -428,7 +428,7 @@ export class TemplateManager extends BaseElementManager<Template> {
       metadata.variables = data.variables.map((v: any) => ({
         name: sanitizeInput(v.name || '', 50),
         type: sanitizeInput(v.type || 'string', 20),
-        description: v.description ? sanitizeInput(v.description, 200) : undefined,
+        description: v.description ? sanitizeInput(v.description, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
         required: Boolean(v.required),
         default: v.default,
         validation: v.validation ? sanitizeInput(v.validation, 200) : undefined,
@@ -440,7 +440,7 @@ export class TemplateManager extends BaseElementManager<Template> {
     if (Array.isArray(data.examples)) {
       metadata.examples = data.examples.map((ex: any) => ({
         title: sanitizeInput(ex.title || '', 100),
-        description: ex.description ? sanitizeInput(ex.description, 500) : undefined,
+        description: ex.description ? sanitizeInput(ex.description, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
         variables: ex.variables || {},
         output: ex.output ? sanitizeInput(ex.output, 5000) : undefined
       }));

--- a/src/handlers/element-crud/createElement.ts
+++ b/src/handlers/element-crud/createElement.ts
@@ -10,6 +10,7 @@ import { SECURITY_LIMITS } from '../../security/constants.js';
 import { sanitizeInput, validateContentSize, validateCategory } from '../../security/InputValidator.js';
 import {
   sanitizeMetadata,
+  findOversizedDescriptionFields,
   normalizeElementTypeInput,
   formatValidElementTypesList,
   detectUnknownMetadataProperties,
@@ -166,8 +167,18 @@ export async function createElement(context: ElementCrudContext, args: CreateEle
       };
     }
 
+    const descriptionLengthErrors = findOversizedDescriptionFields({ description, metadata });
+    if (descriptionLengthErrors.length > 0) {
+      return {
+        content: [{
+          type: "text",
+          text: `❌ Description too large:\n${descriptionLengthErrors.map(e => `  • ${e}`).join('\n')}`
+        }]
+      };
+    }
+
     const validatedName = sanitizeInput(name, SECURITY_LIMITS.MAX_FILENAME_LENGTH);
-    const validatedDescription = sanitizeInput(description, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
+    const validatedDescription = sanitizeInput(description, SECURITY_LIMITS.MAX_YAML_LENGTH);
 
     if (content) {
       try {

--- a/src/handlers/element-crud/createElement.ts
+++ b/src/handlers/element-crud/createElement.ts
@@ -167,7 +167,7 @@ export async function createElement(context: ElementCrudContext, args: CreateEle
     }
 
     const validatedName = sanitizeInput(name, SECURITY_LIMITS.MAX_FILENAME_LENGTH);
-    const validatedDescription = sanitizeInput(description, SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH);
+    const validatedDescription = sanitizeInput(description, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
 
     if (content) {
       try {

--- a/src/handlers/element-crud/createElement.ts
+++ b/src/handlers/element-crud/createElement.ts
@@ -169,10 +169,11 @@ export async function createElement(context: ElementCrudContext, args: CreateEle
 
     const descriptionLengthErrors = findOversizedDescriptionFields({ description, metadata });
     if (descriptionLengthErrors.length > 0) {
+      const formattedErrors = descriptionLengthErrors.map(error => `  • ${error}`).join('\n');
       return {
         content: [{
           type: "text",
-          text: `❌ Description too large:\n${descriptionLengthErrors.map(e => `  • ${e}`).join('\n')}`
+          text: `❌ Description too large:\n${formattedErrors}`
         }]
       };
     }

--- a/src/handlers/element-crud/editElement.ts
+++ b/src/handlers/element-crud/editElement.ts
@@ -216,7 +216,7 @@ function validateFieldValue(
 
   // Determine max length based on field type, using system constants
   const maxLength = fieldType === 'name' ? SECURITY_LIMITS.MAX_NAME_LENGTH :
-                    fieldType === 'description' ? SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH :
+                    fieldType === 'description' ? SECURITY_LIMITS.MAX_CONTENT_LENGTH :
                     fieldType === 'content' ? SECURITY_LIMITS.MAX_CONTENT_LENGTH : SECURITY_LIMITS.MAX_COMMAND_ARG_LENGTH;
 
   const result = validationService.validateAndSanitizeInput(value, {

--- a/src/handlers/element-crud/editElement.ts
+++ b/src/handlers/element-crud/editElement.ts
@@ -72,6 +72,19 @@ const READ_ONLY_FIELDS = new Set([
   '_isDirty'
 ]);
 
+function getMaxLengthForFieldType(fieldType: ValidationFieldType): number {
+  switch (fieldType) {
+    case 'name':
+      return SECURITY_LIMITS.MAX_NAME_LENGTH;
+    case 'description':
+      return SECURITY_LIMITS.MAX_YAML_LENGTH;
+    case 'content':
+      return SECURITY_LIMITS.MAX_CONTENT_LENGTH;
+    case 'filename':
+      return SECURITY_LIMITS.MAX_COMMAND_ARG_LENGTH;
+  }
+}
+
 /**
  * Issue #662: Systematic field type validation at the editElement boundary.
  *
@@ -216,9 +229,7 @@ function validateFieldValue(
   }
 
   // Determine max length based on field type, using system constants
-  const maxLength = fieldType === 'name' ? SECURITY_LIMITS.MAX_NAME_LENGTH :
-                    fieldType === 'description' ? SECURITY_LIMITS.MAX_YAML_LENGTH :
-                    fieldType === 'content' ? SECURITY_LIMITS.MAX_CONTENT_LENGTH : SECURITY_LIMITS.MAX_COMMAND_ARG_LENGTH;
+  const maxLength = getMaxLengthForFieldType(fieldType);
 
   const result = validationService.validateAndSanitizeInput(value, {
     maxLength,
@@ -614,7 +625,8 @@ export async function editElement(
 
   const descriptionLengthErrors = findOversizedDescriptionFields(input);
   if (descriptionLengthErrors.length > 0) {
-    return error(`Description length validation failed:\n${descriptionLengthErrors.map(e => `  • ${e}`).join('\n')}`);
+    const formattedErrors = descriptionLengthErrors.map(descriptionError => `  • ${descriptionError}`).join('\n');
+    return error(`Description length validation failed:\n${formattedErrors}`);
   }
 
   // Validate string field values using injected validator

--- a/src/handlers/element-crud/editElement.ts
+++ b/src/handlers/element-crud/editElement.ts
@@ -27,6 +27,7 @@ import {
   formatUnknownPropertyWarnings,
   formatElementResolutionWarnings,
   collectGatekeeperAuthoringErrors,
+  findOversizedDescriptionFields,
   formatGatekeeperValidationMessage,
 } from './helpers.js';
 import type { ResolveElementTypesResult } from '../../utils/elementTypeResolver.js';
@@ -216,7 +217,7 @@ function validateFieldValue(
 
   // Determine max length based on field type, using system constants
   const maxLength = fieldType === 'name' ? SECURITY_LIMITS.MAX_NAME_LENGTH :
-                    fieldType === 'description' ? SECURITY_LIMITS.MAX_CONTENT_LENGTH :
+                    fieldType === 'description' ? SECURITY_LIMITS.MAX_YAML_LENGTH :
                     fieldType === 'content' ? SECURITY_LIMITS.MAX_CONTENT_LENGTH : SECURITY_LIMITS.MAX_COMMAND_ARG_LENGTH;
 
   const result = validationService.validateAndSanitizeInput(value, {
@@ -609,6 +610,11 @@ export async function editElement(
   const gatekeeperErrors = collectGatekeeperAuthoringErrors(input, input.metadata);
   if (gatekeeperErrors.length > 0) {
     return error(formatGatekeeperValidationMessage(gatekeeperErrors));
+  }
+
+  const descriptionLengthErrors = findOversizedDescriptionFields(input);
+  if (descriptionLengthErrors.length > 0) {
+    return error(`Description length validation failed:\n${descriptionLengthErrors.map(e => `  • ${e}`).join('\n')}`);
   }
 
   // Validate string field values using injected validator

--- a/src/handlers/element-crud/helpers.ts
+++ b/src/handlers/element-crud/helpers.ts
@@ -9,6 +9,7 @@ import { slugify } from '../../utils/filesystem.js';
 import { ElementType } from '../../portfolio/PortfolioManager.js';
 import { logger } from '../../utils/logger.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import {
   ELEMENT_TYPE_MAP,
   ALL_ELEMENT_TYPES,
@@ -83,6 +84,47 @@ export function sanitizeMetadata(metadata: Record<string, any> | undefined): Rec
   }
 
   return sanitized;
+}
+
+/**
+ * Find description fields that would exceed the YAML/frontmatter parser limit.
+ *
+ * Element descriptions are metadata and are serialized into YAML frontmatter, so
+ * the real upper bound is the YAML safety limit rather than the content body
+ * limit. This walks nested metadata too because templates, agents, and skills
+ * all have description-like nested fields.
+ */
+export function findOversizedDescriptionFields(
+  value: unknown,
+  path = 'input',
+  maxLength = SECURITY_LIMITS.MAX_YAML_LENGTH,
+  seen = new WeakSet<object>()
+): string[] {
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+
+  if (seen.has(value)) {
+    return [];
+  }
+  seen.add(value);
+
+  const errors: string[] = [];
+  const entries = Array.isArray(value)
+    ? value.map((item, index) => [String(index), item] as const)
+    : Object.entries(value);
+
+  for (const [key, child] of entries) {
+    const childPath = Array.isArray(value) ? `${path}[${key}]` : `${path}.${key}`;
+    if (key === 'description' && typeof child === 'string' && child.length > maxLength) {
+      errors.push(`${childPath} exceeds maximum YAML/frontmatter length of ${maxLength} characters`);
+      continue;
+    }
+
+    errors.push(...findOversizedDescriptionFields(child, childPath, maxLength, seen));
+  }
+
+  return errors;
 }
 
 function asMetadataRecord(value: unknown): Record<string, unknown> | undefined {

--- a/src/security/constants.ts
+++ b/src/security/constants.ts
@@ -20,7 +20,6 @@ export const SECURITY_LIMITS = {
   // Field-level validation limits — used across element managers and validators.
   // Centralized here so a single change applies everywhere and grep finds all usages.
   MAX_NAME_LENGTH: 100,                     // Element name field
-  MAX_DESCRIPTION_LENGTH: 500,              // Element description field
   MAX_ENUM_FIELD_LENGTH: 20,                // Short enum-like fields (strategy, role, activation)
   MAX_TAG_LENGTH: 50,                       // Individual tag / category values
   MAX_COMMAND_ARG_LENGTH: 1000,             // CLI command argument validation

--- a/src/security/contentValidator.ts
+++ b/src/security/contentValidator.ts
@@ -725,9 +725,13 @@ export class ContentValidator {
     // Check all string fields in metadata
     const checkField = (fieldName: string, value: any) => {
       if (typeof value === 'string') {
-        // Check field length first
-        if (value.length > SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH) {
-          detectedPatterns.push(`${fieldName}: Field exceeds maximum length of ${SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH} characters`);
+        // Descriptions can be substantive LLM-authored text; keep them bounded by
+        // the global content limit rather than the short metadata-field limit.
+        const maxFieldLength = fieldName === 'description'
+          ? SECURITY_LIMITS.MAX_CONTENT_LENGTH
+          : SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH;
+        if (value.length > maxFieldLength) {
+          detectedPatterns.push(`${fieldName}: Field exceeds maximum length of ${maxFieldLength} characters`);
           return;
         }
         

--- a/src/security/contentValidator.ts
+++ b/src/security/contentValidator.ts
@@ -726,9 +726,9 @@ export class ContentValidator {
     const checkField = (fieldName: string, value: any) => {
       if (typeof value === 'string') {
         // Descriptions can be substantive LLM-authored text; keep them bounded by
-        // the global content limit rather than the short metadata-field limit.
+        // the YAML/frontmatter limit rather than the short metadata-field limit.
         const maxFieldLength = fieldName === 'description'
-          ? SECURITY_LIMITS.MAX_CONTENT_LENGTH
+          ? SECURITY_LIMITS.MAX_YAML_LENGTH
           : SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH;
         if (value.length > maxFieldLength) {
           detectedPatterns.push(`${fieldName}: Field exceeds maximum length of ${maxFieldLength} characters`);

--- a/src/security/secureYamlParser.ts
+++ b/src/security/secureYamlParser.ts
@@ -69,7 +69,7 @@ export class SecureYamlParser {
   // Additional validation for specific persona fields
   private static readonly FIELD_VALIDATORS: Record<string, (value: any) => boolean> = {
     name: (v) => typeof v === 'string' && v.length <= 100,
-    description: (v) => typeof v === 'string' && v.length <= 500,
+    description: (v) => typeof v === 'string',
     author: (v) => typeof v === 'string' && v.length <= 100,
     version: (v) => typeof v === 'string' && /^\d+\.\d+(\.\d+)?(-[a-zA-Z0-9.-]+)?$/.test(v),
     category: (v) => typeof v === 'string' && v.length <= 50,

--- a/src/services/validation/GenericElementValidator.ts
+++ b/src/services/validation/GenericElementValidator.ts
@@ -428,7 +428,7 @@ export class GenericElementValidator implements ElementValidator {
     }
 
     const result = this.validationService.validateAndSanitizeInput(description, {
-      maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+      maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
       allowSpaces: true,
       fieldType: 'description'
     });

--- a/src/services/validation/GenericElementValidator.ts
+++ b/src/services/validation/GenericElementValidator.ts
@@ -427,8 +427,14 @@ export class GenericElementValidator implements ElementValidator {
       return ValidatorHelpers.fail(["Description must be a string"]);
     }
 
+    if (description.length > SECURITY_LIMITS.MAX_YAML_LENGTH) {
+      return ValidatorHelpers.fail([
+        `Description exceeds maximum YAML/frontmatter length of ${SECURITY_LIMITS.MAX_YAML_LENGTH} characters`
+      ]);
+    }
+
     const result = this.validationService.validateAndSanitizeInput(description, {
-      maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
+      maxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
       allowSpaces: true,
       fieldType: 'description'
     });

--- a/tests/integration/crud/config/agentConfig.ts
+++ b/tests/integration/crud/config/agentConfig.ts
@@ -121,11 +121,11 @@ export const AGENT_CONFIG: ElementTypeTestConfig = {
       required: true,
       validValues: [
         'Updated agent description',
-        'A completely different description'
+        'A completely different description',
+        'Long-form agent description. '.repeat(40)
       ],
       invalidValues: [
-        { value: '', expectedError: 'required|empty' },
-        { value: 'A'.repeat(501), expectedError: 'length|size' }
+        { value: '', expectedError: 'required|empty' }
       ]
     },
     {

--- a/tests/integration/crud/config/ensembleConfig.ts
+++ b/tests/integration/crud/config/ensembleConfig.ts
@@ -151,11 +151,11 @@ export const ENSEMBLE_CONFIG: ElementTypeTestConfig = {
       required: true,
       validValues: [
         'Updated ensemble description',
-        'A completely different description'
+        'A completely different description',
+        'Long-form ensemble description. '.repeat(40)
       ],
       invalidValues: [
-        { value: '', expectedError: 'required|empty' },
-        { value: 'A'.repeat(501), expectedError: 'length|size' }
+        { value: '', expectedError: 'required|empty' }
       ]
     },
     {

--- a/tests/integration/crud/config/memoryConfig.ts
+++ b/tests/integration/crud/config/memoryConfig.ts
@@ -117,11 +117,11 @@ export const MEMORY_CONFIG: ElementTypeTestConfig = {
       required: true,
       validValues: [
         'Updated memory description',
-        'A completely different description'
+        'A completely different description',
+        'Long-form memory description. '.repeat(40)
       ],
       invalidValues: [
-        { value: '', expectedError: 'required|empty' },
-        { value: 'A'.repeat(501), expectedError: 'length|size' }
+        { value: '', expectedError: 'required|empty' }
       ]
     },
     {

--- a/tests/integration/crud/config/personaConfig.ts
+++ b/tests/integration/crud/config/personaConfig.ts
@@ -107,11 +107,11 @@ export const PERSONA_CONFIG: ElementTypeTestConfig = {
       required: true,
       validValues: [
         'Updated description',
-        'A completely different description'
+        'A completely different description',
+        'Long-form persona description. '.repeat(40)
       ],
       invalidValues: [
-        { value: '', expectedError: 'required|empty' },
-        { value: 'A'.repeat(501), expectedError: 'length|size' }
+        { value: '', expectedError: 'required|empty' }
       ]
     },
     {

--- a/tests/integration/crud/config/skillConfig.ts
+++ b/tests/integration/crud/config/skillConfig.ts
@@ -134,11 +134,11 @@ export const SKILL_CONFIG: ElementTypeTestConfig = {
       required: true,
       validValues: [
         'Updated skill description',
-        'A completely different description'
+        'A completely different description',
+        'Long-form skill description. '.repeat(40)
       ],
       invalidValues: [
-        { value: '', expectedError: 'required|empty' },
-        { value: 'A'.repeat(501), expectedError: 'length|size' }
+        { value: '', expectedError: 'required|empty' }
       ]
     },
     {

--- a/tests/integration/crud/config/templateConfig.ts
+++ b/tests/integration/crud/config/templateConfig.ts
@@ -163,11 +163,11 @@ export const TEMPLATE_CONFIG: ElementTypeTestConfig = {
       required: true,
       validValues: [
         'Updated template description',
-        'A completely different description'
+        'A completely different description',
+        'Long-form template description. '.repeat(40)
       ],
       invalidValues: [
-        { value: '', expectedError: 'required|empty' },
-        { value: 'A'.repeat(501), expectedError: 'length|size' }
+        { value: '', expectedError: 'required|empty' }
       ]
     },
     {

--- a/tests/integration/mcp-aql/update.test.ts
+++ b/tests/integration/mcp-aql/update.test.ts
@@ -11,6 +11,7 @@ import { DollhouseMCPServer } from '../../../src/index.js';
 import { DollhouseContainer } from '../../../src/di/Container.js';
 import { MCPAQLHandler } from '../../../src/handlers/mcp-aql/MCPAQLHandler.js';
 import { createPortfolioTestEnvironment, preConfirmAllOperations, type PortfolioTestEnvironment } from '../../helpers/portfolioTestHelper.js';
+import { SecureYamlParser } from '../../../src/security/secureYamlParser.js';
 import path from 'path';
 import fs from 'fs/promises';
 
@@ -521,12 +522,12 @@ describe('MCP-AQL UPDATE Endpoint Integration', () => {
       }
     });
 
-    // TODO: Max length validation not enforced on edit (truncation happens silently)
-    it.skip('should validate field values before setting', async () => {
+    it.each([501, 4096])('should accept %i character descriptions when editing', async (descriptionLength) => {
+      const elementName = `validation-test-skill-${descriptionLength}`;
       const createResult = await mcpAqlHandler.handleCreate({
         operation: 'create_element',
         params: {
-          element_name: 'validation-test-skill',
+          element_name: elementName,
           element_type: 'skills',
           description: 'Skill for validation testing',
           content: '# Test Content\n\nThis is test content that meets minimum length requirements.',
@@ -538,31 +539,35 @@ describe('MCP-AQL UPDATE Endpoint Integration', () => {
       const verifyResult = await mcpAqlHandler.handleRead({
         operation: 'get_element',
         params: {
-          element_name: 'validation-test-skill',
+          element_name: elementName,
           element_type: 'skills',
         },
       });
       expect(verifyResult.success).toBe(true);
 
-      // Try to set a description that exceeds max length (500 chars)
-      const tooLongDescription = 'a'.repeat(501);
+      // Descriptions over 500 chars should be accepted; only global content/YAML
+      // safety limits should apply.
+      const longDescription = `Updated description ${descriptionLength}: `.padEnd(descriptionLength, 'a');
 
       const result = await mcpAqlHandler.handleUpdate({
         operation: 'edit_element',
         params: {
-          element_name: 'validation-test-skill',
+          element_name: elementName,
           element_type: 'skills',
-          input: { description: tooLongDescription },
+          input: { description: longDescription },
         },
       });
 
-      // Handler returns success:true but with error content (❌ in message)
       expect(result.success).toBe(true);
       if (result.success) {
         const data = result.data as any;
-        expect(data.content[0].text).toMatch(/❌/);
-        expect(data.content[0].text).toMatch(/invalid value/i);
+        expect(data.content[0].text).toMatch(/✅/);
       }
+
+      const skillFile = path.join(env.testDir, 'skills', `${elementName}.md`);
+      const fileContent = await fs.readFile(skillFile, 'utf-8');
+      const parsed = SecureYamlParser.parse(fileContent, { validateContent: false });
+      expect(parsed.data.description).toBe(longDescription);
     });
 
     // FIX: Issue #287 - Fixed by removing test-pattern filtering

--- a/tests/security/inputLengthValidation.test.ts
+++ b/tests/security/inputLengthValidation.test.ts
@@ -81,14 +81,25 @@ describe('Input Length Validation', () => {
     test('rejects metadata fields exceeding limit', () => {
       const metadata = {
         name: 'Test',
-        description: 'a'.repeat(SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH + 1)
+        customField: 'a'.repeat(SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH + 1)
       };
       
       const result = ContentValidator.validateMetadata(metadata);
       expect(result.isValid).toBe(false);
       expect(result.detectedPatterns).toEqual(
-        expect.arrayContaining(['description: Field exceeds maximum length of 1024 characters'])
+        expect.arrayContaining(['customField: Field exceeds maximum length of 1024 characters'])
       );
+    });
+
+    test('allows descriptions beyond short metadata field limit', () => {
+      const metadata = {
+        name: 'Test',
+        description: 'a'.repeat(SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH + 1)
+      };
+
+      const result = ContentValidator.validateMetadata(metadata);
+
+      expect(result.isValid).toBe(true);
     });
   });
 
@@ -156,11 +167,12 @@ This is the content of the persona.`;
       expect(contentResult.isValid).toBe(true);
     });
 
-    test('large persona file is rejected early', () => {
-      // Should fail on metadata field length
+    test('large non-description metadata field is rejected early', () => {
+      // Description is allowed to be substantive; other metadata fields still use
+      // the short field-size guard.
       const result = ContentValidator.validateMetadata({
         name: 'Test',
-        description: 'a'.repeat(2000)
+        customField: 'a'.repeat(2000)
       });
       expect(result.isValid).toBe(false);
     });

--- a/tests/security/inputLengthValidation.test.ts
+++ b/tests/security/inputLengthValidation.test.ts
@@ -101,6 +101,22 @@ describe('Input Length Validation', () => {
 
       expect(result.isValid).toBe(true);
     });
+
+    test('rejects descriptions exceeding YAML frontmatter limit', () => {
+      const metadata = {
+        name: 'Test',
+        description: 'a'.repeat(SECURITY_LIMITS.MAX_YAML_LENGTH + 1)
+      };
+
+      const result = ContentValidator.validateMetadata(metadata);
+
+      expect(result.isValid).toBe(false);
+      expect(result.detectedPatterns).toEqual(
+        expect.arrayContaining([
+          `description: Field exceeds maximum length of ${SECURITY_LIMITS.MAX_YAML_LENGTH} characters`
+        ])
+      );
+    });
   });
 
   describe('SecureYamlParser length checks', () => {

--- a/tests/security/secureYamlParser.test.ts
+++ b/tests/security/secureYamlParser.test.ts
@@ -178,7 +178,6 @@ count: 42
     it('should validate field types', () => {
       const invalidFields = [
         { field: 'name', value: 'x'.repeat(101), error: 'Invalid value for field \'name\'' },
-        { field: 'description', value: 'x'.repeat(501), error: 'Invalid value for field \'description\'' },
         { field: 'age_rating', value: 'invalid', error: 'Invalid value for field \'age_rating\'' },
         { field: 'price', value: '$invalid', error: 'Invalid value for field \'price\'' },
         { field: 'version', value: 'not.a.version', error: 'Invalid value for field \'version\'' }
@@ -191,6 +190,19 @@ count: 42
           SecureYamlParser.parse(yaml);
         }).toThrow(error);
       });
+    });
+
+    it('should accept substantive descriptions longer than 500 characters', () => {
+      const longDescription = 'Long-form element description. '.repeat(40).trim();
+      const yaml = `---
+name: Test
+description: ${longDescription}
+---`;
+
+      const result = SecureYamlParser.parse(yaml);
+
+      expect(result.data.description).toBe(longDescription);
+      expect(result.data.description.length).toBeGreaterThan(500);
     });
 
     it('should sanitize content with security threats', () => {

--- a/tests/unit/base/ElementValidation.test.ts
+++ b/tests/unit/base/ElementValidation.test.ts
@@ -35,6 +35,13 @@ describe('ElementValidation', () => {
     expect(ElementValidation.validateDescription('  description ')).toBe('description');
   });
 
+  it('validateDescription should preserve substantive descriptions over 500 characters', () => {
+    const description = 'Long-form element description. '.repeat(40);
+
+    expect(ElementValidation.validateDescription(description)).toBe(description.trim());
+    expect(ElementValidation.validateDescription(description)!.length).toBeGreaterThan(500);
+  });
+
   it('validateTags should filter falsey values and sanitize entries', () => {
     const tags = ElementValidation.validateTags(['Tag One', '', null, 'two', undefined, 'three!']);
     expect(tags).toEqual(['Tag One', 'two', 'three']);

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -1109,6 +1109,7 @@ Content`;
 
     describe('Issue #697: V2 Field Normalization on Load', () => {
       it('should normalize goals (plural) to goal on load', async () => {
+        const longParameterDescription = 'Agent goal parameter description '.padEnd(1024, 'g');
         fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
           if (filePath.includes('.state.yaml')) {
             const error = new Error('ENOENT') as NodeJS.ErrnoException;
@@ -1122,7 +1123,7 @@ goals:
   template: "Do {{task}}"
   parameters:
     - name: task
-      description: The task to do
+      description: ${longParameterDescription}
       required: true
 ---
 Agent with plural goals field`;
@@ -1133,6 +1134,8 @@ Agent with plural goals field`;
         // goal should be set from goals
         expect((agent!.metadata as any).goal).toBeDefined();
         expect((agent!.metadata as any).goal.template).toBe('Do {{task}}');
+        expect((agent!.metadata as any).goal.parameters[0].description).toBe(longParameterDescription);
+        expect((agent!.metadata as any).goal.parameters[0].description.length).toBeGreaterThan(500);
         // goals (plural) should be removed
         expect((agent!.metadata as any).goals).toBeUndefined();
       });

--- a/tests/unit/elements/skills/SkillManager.test.ts
+++ b/tests/unit/elements/skills/SkillManager.test.ts
@@ -129,6 +129,29 @@ This is a test skill.`;
         .rejects.toThrow();
     });
 
+    it('should preserve long parameter descriptions from skill metadata', async () => {
+      const longDescription = 'Skill parameter description '.padEnd(1024, 'a');
+      const skillContent = `---
+name: Parameter Skill
+description: A skill with detailed parameter metadata
+parameters:
+  - name: prompt
+    type: string
+    description: ${longDescription}
+---
+# Parameter Skill
+
+This skill has a parameter with a substantive description.`;
+
+      const skillPath = path.join(portfolioManager.getElementDir(ElementType.SKILL), 'parameter-skill.md');
+      await fs.writeFile(skillPath, skillContent);
+
+      const skill = await skillManager.load('parameter-skill.md');
+
+      expect(skill.metadata.parameters?.[0].description).toBe(longDescription);
+      expect(skill.metadata.parameters?.[0].description.length).toBeGreaterThan(500);
+    });
+
     it('should validate file paths', async () => {
       await expect(skillManager.load('../../../etc/passwd'))
         .rejects.toThrow('Invalid skill path');

--- a/tests/unit/elements/templates/TemplateManager.test.ts
+++ b/tests/unit/elements/templates/TemplateManager.test.ts
@@ -177,6 +177,8 @@ Hello {{name}}!`;
 
   describe('validation methods', () => {
     it('should handle complex metadata during import', async () => {
+      const longVariableDescription = 'Template variable description: '.padEnd(1024, 'v');
+      const longExampleDescription = 'Template example description: '.padEnd(1024, 'e');
       const complexData = JSON.stringify({
         metadata: {
           name: 'Complex Template',
@@ -188,7 +190,7 @@ Hello {{name}}!`;
             {
               name: 'username',
               type: 'string',
-              description: 'User name',
+              description: longVariableDescription,
               required: true,
               validation: '^[a-zA-Z0-9_]+$'
             },
@@ -204,7 +206,7 @@ Hello {{name}}!`;
           examples: [
             {
               title: 'Basic Example',
-              description: 'Shows basic usage',
+              description: longExampleDescription,
               variables: { username: 'john_doe', count: 5 },
               output: 'Hello john_doe, you have 5 items!'
             }
@@ -217,10 +219,14 @@ Hello {{name}}!`;
       
       expect(template.metadata.variables).toHaveLength(2);
       expect(template.metadata.variables![0].name).toBe('username');
+      expect(template.metadata.variables![0].description).toBe(longVariableDescription);
+      expect(template.metadata.variables![0].description!.length).toBeGreaterThan(500);
       // The sanitization removes backslashes, so they won't be in the validation pattern
       expect(template.metadata.variables![0].validation).toBe('^[a-zA-Z0-9_]+');
       expect(template.metadata.variables![1].default).toBe(10);
       expect(template.metadata.examples).toHaveLength(1);
+      expect(template.metadata.examples![0].description).toBe(longExampleDescription);
+      expect(template.metadata.examples![0].description!.length).toBeGreaterThan(500);
       expect(template.metadata.tags).toEqual(['complex', 'advanced', 'features']);
     });
 

--- a/tests/unit/handlers/element-crud/createElement.helper.test.ts
+++ b/tests/unit/handlers/element-crud/createElement.helper.test.ts
@@ -149,6 +149,20 @@ describe('createElement helper', () => {
       expect(call.description).not.toContain('<script>');
     });
 
+    it('should preserve long descriptions when creating elements', async () => {
+      const longDescription = 'Long-form skill description. '.repeat(80);
+
+      await createElement(mockContext, {
+        name: 'test',
+        type: ElementType.SKILL,
+        description: longDescription,
+      });
+
+      const call = (mockContext.skillManager.create as jest.Mock).mock.calls[0][0];
+      expect(call.description).toBe(longDescription.trim());
+      expect(call.description.length).toBeGreaterThan(500);
+    });
+
     it('should sanitize metadata to remove dangerous properties', async () => {
       const metadata = {
         description: 'safe',

--- a/tests/unit/handlers/element-crud/createElement.helper.test.ts
+++ b/tests/unit/handlers/element-crud/createElement.helper.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 
 const { createElement } = await import('../../../../src/handlers/element-crud/createElement.js');
 const { ElementType } = await import('../../../../src/portfolio/PortfolioManager.js');
+const { SECURITY_LIMITS } = await import('../../../../src/security/constants.js');
 import type { ElementCrudContext } from '../../../../src/handlers/element-crud/types.js';
 
 describe('createElement helper', () => {
@@ -161,6 +162,18 @@ describe('createElement helper', () => {
       const call = (mockContext.skillManager.create as jest.Mock).mock.calls[0][0];
       expect(call.description).toBe(longDescription.trim());
       expect(call.description.length).toBeGreaterThan(500);
+    });
+
+    it('should reject descriptions that exceed the YAML frontmatter safety limit', async () => {
+      const result = await createElement(mockContext, {
+        name: 'test',
+        type: ElementType.SKILL,
+        description: 'a'.repeat(SECURITY_LIMITS.MAX_YAML_LENGTH + 1),
+      });
+
+      expect(result.content[0].text).toContain('❌ Description too large');
+      expect(result.content[0].text).toContain('input.description');
+      expect(mockContext.skillManager.create).not.toHaveBeenCalled();
     });
 
     it('should sanitize metadata to remove dangerous properties', async () => {

--- a/tests/unit/handlers/element-crud/editElement.helper.test.ts
+++ b/tests/unit/handlers/element-crud/editElement.helper.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 const { editElement } = await import('../../../../src/handlers/element-crud/editElement.js');
 const { ElementType } = await import('../../../../src/portfolio/PortfolioManager.js');
 const { ElementNotFoundError } = await import('../../../../src/utils/ErrorHandler.js');
+const { SECURITY_LIMITS } = await import('../../../../src/security/constants.js');
 import type { ElementCrudContext } from '../../../../src/handlers/element-crud/types.js';
 
 describe('editElement helper', () => {
@@ -377,6 +378,26 @@ describe('editElement helper', () => {
       const saved = (mockContext.skillManager.save as jest.Mock).mock.calls[0][0];
       expect(saved.metadata.description).toBe(longDescription);
       expect(saved.metadata.description.length).toBeGreaterThan(500);
+    });
+
+    it('should reject description edits that exceed the YAML frontmatter safety limit', async () => {
+      const element = createMockElement('test-skill');
+      mockContext.skillManager.find = jest.fn().mockResolvedValue(element);
+
+      const result = await editElement(mockContext, {
+        name: 'test-skill',
+        type: ElementType.SKILL,
+        input: {
+          metadata: {
+            description: 'a'.repeat(SECURITY_LIMITS.MAX_YAML_LENGTH + 1)
+          }
+        },
+      });
+
+      expect(result.content[0].text).toContain('❌');
+      expect(result.content[0].text).toContain('Description length validation failed');
+      expect(result.content[0].text).toContain('input.metadata.description');
+      expect(mockContext.skillManager.save).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/handlers/element-crud/editElement.helper.test.ts
+++ b/tests/unit/handlers/element-crud/editElement.helper.test.ts
@@ -338,6 +338,46 @@ describe('editElement helper', () => {
       expect(saved.metadata.author).toBe('New Author');
       expect(saved.metadata.tags).toEqual(['tag1', 'tag2']);
     });
+
+    it('should preserve long top-level descriptions instead of rejecting or truncating them', async () => {
+      const element = createMockElement('test-skill');
+      const longDescription = 'Long-form skill description. '.repeat(80);
+      mockContext.skillManager.find = jest.fn().mockResolvedValue(element);
+
+      const result = await editElement(mockContext, {
+        name: 'test-skill',
+        type: ElementType.SKILL,
+        input: {
+          description: longDescription
+        },
+      });
+
+      expect(result.content[0].text).toContain('✅');
+      const saved = (mockContext.skillManager.save as jest.Mock).mock.calls[0][0];
+      expect(saved.metadata.description).toBe(longDescription);
+      expect(saved.metadata.description.length).toBeGreaterThan(500);
+    });
+
+    it('should preserve long nested metadata descriptions instead of rejecting or truncating them', async () => {
+      const element = createMockElement('test-skill');
+      const longDescription = 'Nested long-form skill description. '.repeat(80);
+      mockContext.skillManager.find = jest.fn().mockResolvedValue(element);
+
+      const result = await editElement(mockContext, {
+        name: 'test-skill',
+        type: ElementType.SKILL,
+        input: {
+          metadata: {
+            description: longDescription
+          }
+        },
+      });
+
+      expect(result.content[0].text).toContain('✅');
+      const saved = (mockContext.skillManager.save as jest.Mock).mock.calls[0][0];
+      expect(saved.metadata.description).toBe(longDescription);
+      expect(saved.metadata.description.length).toBeGreaterThan(500);
+    });
   });
 
   describe('persona editing', () => {

--- a/tests/unit/services/SerializationService.test.ts
+++ b/tests/unit/services/SerializationService.test.ts
@@ -807,6 +807,25 @@ description: Pure YAML
         expect(result).toContain('name: test');
         expect(result).toContain('description: Test description');
       });
+
+      it.each([500, 501, 1024, 4096, 16384, 32768])(
+        'should roundtrip a %i character description',
+        (descriptionLength) => {
+          const description = `Description ${descriptionLength}: `.padEnd(descriptionLength, 'x');
+          const metadata = {
+            name: `long-description-${descriptionLength}`,
+            description
+          };
+          const content = '# Long Description Element\n\nElement content stays separate.';
+
+          const result = service.createFrontmatter(metadata, content);
+          const parsed = service.parseFrontmatter(result);
+
+          expect(parsed.data.description).toBe(description);
+          expect(parsed.data.description).toHaveLength(descriptionLength);
+          expect(parsed.content).toBe(content);
+        }
+      );
     });
 
     describe('Method Options', () => {

--- a/tests/unit/services/SerializationService.test.ts
+++ b/tests/unit/services/SerializationService.test.ts
@@ -808,7 +808,7 @@ description: Pure YAML
         expect(result).toContain('description: Test description');
       });
 
-      it.each([500, 501, 1024, 4096, 16384, 32768])(
+      it.each([500, 501, 1024, 4096, 16384, 32768, 60000])(
         'should roundtrip a %i character description',
         (descriptionLength) => {
           const description = `Description ${descriptionLength}: `.padEnd(descriptionLength, 'x');

--- a/tests/unit/services/validation/GenericElementValidator.test.ts
+++ b/tests/unit/services/validation/GenericElementValidator.test.ts
@@ -16,6 +16,7 @@ import { ValidationService } from '../../../../src/services/validation/Validatio
 import { TriggerValidationService } from '../../../../src/services/validation/TriggerValidationService.js';
 import { MetadataService } from '../../../../src/services/MetadataService.js';
 import { ElementType } from '../../../../src/portfolio/types.js';
+import { SECURITY_LIMITS } from '../../../../src/security/constants.js';
 
 // Mock the services
 jest.mock('../../../../src/services/validation/ValidationService.js');
@@ -299,6 +300,28 @@ describe('GenericElementValidator', () => {
         const result = await validator.validateCreate(data);
 
         expect(result.warnings.some(w => w.includes('Description is very long'))).toBe(true);
+      });
+
+      it('should reject descriptions beyond the YAML frontmatter safety limit', async () => {
+        const description = 'a'.repeat(SECURITY_LIMITS.MAX_YAML_LENGTH + 1);
+        const data = {
+          name: 'Test',
+          description,
+          content: 'Content'
+        };
+
+        const result = await validator.validateCreate(data);
+
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toEqual(
+          expect.arrayContaining([
+            `Description exceeds maximum YAML/frontmatter length of ${SECURITY_LIMITS.MAX_YAML_LENGTH} characters`
+          ])
+        );
+        expect(mockValidationService.validateAndSanitizeInput).not.toHaveBeenCalledWith(
+          description,
+          expect.objectContaining({ fieldType: 'description' })
+        );
       });
 
       it('should warn about very long content', async () => {


### PR DESCRIPTION
## Summary

Fixes #2181.

Removes the historical 500-character hard cap from Dollhouse element descriptions and description-like metadata fields. Descriptions are no longer blocked by the short metadata-field limit, but they remain bounded by the existing YAML/frontmatter and file safety limits so create/edit cannot write unloadable elements.

This PR is built from and targets `develop`. It stays focused on length handling only; content-safety pattern checks such as XSS/prompt-injection detection are unchanged.

## What changed

- Removed `MAX_DESCRIPTION_LENGTH` and replaced description-specific validation with the existing YAML/frontmatter safety boundary for metadata descriptions.
- Updated secure YAML parsing, content metadata validation, generic element validation, CRUD create/edit handlers, and element constructors/managers.
- Added recursive create/edit validation for nested `description` fields, including `metadata.description`, template variables/examples, skill parameters, and agent goal parameters.
- Updated tests and docs so >500 character descriptions are valid, while descriptions beyond the frontmatter safety limit are rejected before save.
- Fixed the stale `docs/architecture/ensemble-system.md` reference called out by Claude.

## Validation

- `npm test -- --runInBand tests/unit/handlers/element-crud/createElement.helper.test.ts tests/unit/handlers/element-crud/editElement.helper.test.ts tests/security/inputLengthValidation.test.ts tests/unit/services/SerializationService.test.ts tests/unit/services/validation/GenericElementValidator.test.ts tests/unit/base/ElementValidation.test.ts --modulePathIgnorePatterns='<rootDir>/.worktrees'`
- `npm test -- --runInBand tests/unit/elements/skills/SkillManager.test.ts tests/unit/elements/templates/TemplateManager.test.ts tests/unit/elements/agents/AgentManager.test.ts tests/unit/elements/templates/Template.test.ts tests/unit/elements/agents/Agent.test.ts tests/unit/elements/memories/Memory.test.ts tests/unit/elements/ensembles/Ensemble.test.ts --modulePathIgnorePatterns='<rootDir>/.worktrees'`
- `npm run test:integration -- --runInBand tests/integration/mcp-aql/update.test.ts --modulePathIgnorePatterns='<rootDir>/.worktrees'`
- `npm run test:integration -- --runInBand tests/integration/crud/ElementCRUD.test.ts --modulePathIgnorePatterns='<rootDir>/.worktrees'`
- `npx tsc --noEmit --pretty false`
- `git diff --check`