### PR TITLE
fix: replace uuid dependency with crypto.randomUUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "posthog-node": "^5.24.17",
         "qrcode": "^1.5.4",
         "smol-toml": "^1.6.1",
-        "uuid": "^11.1.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -53,7 +52,6 @@
         "@types/qrcode": "^1.5.6",
         "@types/semver": "^7.7.1",
         "@types/supertest": "^7.2.0",
-        "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.46.2",
         "@typescript-eslint/parser": "^8.48.1",
         "archiver": "^7.0.1",
@@ -4041,11 +4039,6 @@
       "version": "2.0.7",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -11574,17 +11567,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -193,7 +193,6 @@
     "posthog-node": "^5.24.17",
     "qrcode": "^1.5.4",
     "smol-toml": "^1.6.1",
-    "uuid": "^11.1.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -211,7 +210,6 @@
     "@types/qrcode": "^1.5.6",
     "@types/semver": "^7.7.1",
     "@types/supertest": "^7.2.0",
-    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.46.2",
     "@typescript-eslint/parser": "^8.48.1",
     "archiver": "^7.0.1",

--- a/src/elements/BaseElement.ts
+++ b/src/elements/BaseElement.ts
@@ -16,7 +16,7 @@ import {
   UserFeedback
 } from '../types/elements/index.js';
 import { ElementType } from '../portfolio/types.js';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
 import * as yaml from 'js-yaml';
 import { logger } from '../utils/logger.js';
 import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
@@ -106,7 +106,7 @@ export abstract class BaseElement implements IElement {
     });
 
     this.type = type;
-    this.id = metadata.name ? this.generateId(normalized.name) : uuidv4();
+    this.id = metadata.name ? this.generateId(normalized.name) : randomUUID();
     this.version = normalized.version || '1.0.0';  // Guaranteed by normalizeMetadata, but add fallback for type safety
 
     // Spread normalized common metadata

--- a/src/telemetry/OperationalTelemetry.ts
+++ b/src/telemetry/OperationalTelemetry.ts
@@ -36,7 +36,7 @@
 
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
 import { PostHog } from 'posthog-node';
 import { logger } from '../utils/logger.js';
 import { PACKAGE_VERSION as VERSION } from '../generated/version.js';
@@ -220,7 +220,7 @@ export class OperationalTelemetry {
       }
 
       // Generate new UUID v4
-      this.installId = uuidv4();
+      this.installId = randomUUID();
 
       // Ensure directory exists
       await this.fileOperations.createDirectory(path.dirname(config.installIdPath));

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -32,9 +32,8 @@ const GITHUB_REPO = 'DollhouseMCP/mcp-server';
 const MCPB_ASSET_PATTERN = /^dollhousemcp-.*\.mcpb$/;
 import { SlidingWindowRateLimiter } from '../../utils/SlidingWindowRateLimiter.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
-import { randomInt } from 'node:crypto';
+import { randomInt, randomUUID } from 'node:crypto';
 import { PostHog } from 'posthog-node';
-import { v4 as uuidv4 } from 'uuid';
 
 function isMissingPathError(error: unknown): boolean {
   return Boolean(
@@ -454,7 +453,7 @@ async function capturePostHogLicenseEvent(licenseData: Record<string, unknown>):
     const idPath = join(homedir(), '.dollhouse', '.telemetry-id');
     installId = (await readFile(idPath, 'utf-8')).trim();
   } catch {
-    installId = uuidv4();
+    installId = randomUUID();
   }
   const eventType = (licenseData.eventType as string) ?? 'activation';
   posthog.capture({

--- a/tests/e2e/roundtrip-workflow.test.ts
+++ b/tests/e2e/roundtrip-workflow.test.ts
@@ -12,7 +12,7 @@
 import { describe, test, beforeAll, afterAll, beforeEach, expect, jest } from '@jest/globals';
 import path from 'path';
 import fs from 'fs/promises';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
 import { TestServer } from '../helpers/test-server.js';
 import { hasTestCredentials, getTestSkipMessage } from '../../src/config/test-env.js';
 
@@ -33,7 +33,7 @@ describe('Roundtrip Workflow E2E Tests', () => {
     ctx = {
       server: new TestServer(),
       portfolioDir: path.join(process.cwd(), 'test-portfolio'),
-      testRepoName: `test-portfolio-${uuidv4()}`,
+      testRepoName: `test-portfolio-${randomUUID()}`,
       testSkillName: 'roundtrip-test-skill',
       originalConfig: null
     };

--- a/tests/helpers/file-utils.ts
+++ b/tests/helpers/file-utils.ts
@@ -4,8 +4,8 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { randomUUID } from 'node:crypto';
 import matter from 'gray-matter';
-import { v4 as uuidv4 } from 'uuid';
 import { Persona } from '../../src/types/persona.js';
 import { createPersonaFileContent } from './test-fixtures.js';
 
@@ -102,7 +102,7 @@ export async function createTempDir(prefix: string): Promise<string> {
   }
   
   // Use UUID instead of Date.now() for better uniqueness guarantees
-  const tempDir = path.join(baseDir, `${prefix}-${uuidv4()}`);
+  const tempDir = path.join(baseDir, `${prefix}-${randomUUID()}`);
   await fs.mkdir(tempDir, { recursive: true });
   return tempDir;
 }

--- a/tests/unit/elements/version-persistence.test.ts
+++ b/tests/unit/elements/version-persistence.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
 import { SkillManager } from '../../../src/elements/skills/SkillManager.js';
 import { Skill } from '../../../src/elements/skills/Skill.js';
 import { TemplateManager } from '../../../src/elements/templates/TemplateManager.js';
@@ -33,7 +33,7 @@ describe('Version Persistence', () => {
 
   beforeEach(async () => {
     // Create unique test directory
-    testDir = path.join(os.tmpdir(), `test-version-${uuidv4()}`);
+    testDir = path.join(os.tmpdir(), `test-version-${randomUUID()}`);
     await fs.mkdir(testDir, { recursive: true });
     
     // Create subdirectories

--- a/tests/unit/telemetry/OperationalTelemetry.test.ts
+++ b/tests/unit/telemetry/OperationalTelemetry.test.ts
@@ -13,11 +13,9 @@ import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals
 import * as path from 'node:path';
 import * as os from 'node:os';
 
-// Mock dependencies BEFORE imports using ESM approach
-jest.unstable_mockModule('uuid', () => ({
-  v4: jest.fn(() => 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee')
-}));
+const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+// Mock dependencies BEFORE imports using ESM approach
 jest.unstable_mockModule('../../../src/utils/logger.js', () => ({
   logger: {
     debug: jest.fn(),
@@ -209,7 +207,7 @@ describe('OperationalTelemetry', () => {
       // Should write UUID to file
       expect(mockFileOperations.writeFile).toHaveBeenCalledWith(
         expectedPath,
-        testUUID,
+        expect.stringMatching(uuidRegex),
         expect.objectContaining({ source: 'OperationalTelemetry.ensureUUID' })
       );
     });
@@ -228,8 +226,6 @@ describe('OperationalTelemetry', () => {
       expect(uuidCall).toBeDefined();
       const uuid = uuidCall![1];
 
-      // Validate UUID v4 format
-      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
       expect(uuid).toMatch(uuidRegex);
     });
   });
@@ -324,7 +320,7 @@ describe('OperationalTelemetry', () => {
         call => (call[0] as string).includes('.telemetry-id')
       );
       expect(uuidWriteCall).toBeDefined();
-      expect(uuidWriteCall![1]).toBe(testUUID);
+      expect(uuidWriteCall![1]).toMatch(uuidRegex);
     });
 
     it('should reuse cached UUID on second initialize() call', async () => {
@@ -390,10 +386,13 @@ describe('OperationalTelemetry', () => {
 
       const eventLine = logCall![1] as string;
       const event = JSON.parse(eventLine.replace(/\n$/, ''));
+      const uuidWriteCall = mockFileOperations.writeFile.mock.calls.find(
+        call => (call[0] as string).includes('.telemetry-id')
+      );
 
       expect(event).toMatchObject({
         event: 'install',
-        install_id: testUUID,
+        install_id: uuidWriteCall?.[1],
         version: testVersion,
         os: expect.any(String),
         node_version: expect.any(String),


### PR DESCRIPTION
## Summary
- remove the direct `uuid` and `@types/uuid` dependencies
- replace the remaining `uuid.v4()` production calls with Node built-in `crypto.randomUUID()`
- update affected tests/helpers to assert UUID v4 shape instead of mocking the uuid package

This handles Dependabot alert 102 / GHSA-w5hq-g745-h8pq without taking the `uuid@14` Node 20+ support change from Dependabot PR #2169. Supersedes #2169.

## Verification
- `rg -n "from [\'\"]uuid[\'\"]|uuidv4|node_modules/uuid|@types/uuid|\"uuid\"\s*:" package.json package-lock.json src tests -g "!node_modules" -g "!.worktrees"` returned no matches
- `npm exec tsc -- --noEmit`
- `npm test -- --runInBand --modulePathIgnorePatterns=.worktrees --testPathPatterns='tests/unit/telemetry/OperationalTelemetry.test.ts|tests/integration/telemetry.integration.test.ts|tests/unit/elements/version-persistence.test.ts|tests/e2e/roundtrip-workflow.test.ts|tests/unit/web/licenseRoutes.test.ts'`
- `npm ls uuid --all` reports `(empty)`