### PR TITLE
Add opt-in permission audit artifact generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,11 @@ DOLLHOUSE_EMAIL=your-email@example.com
 # DOLLHOUSE_INDICATOR_ENABLED=false
 # DOLLHOUSE_MAX_PERSONA_CACHE_SIZE=100
 
+# Permission audit artifacts (admin/operator controlled; disabled by default)
+# DOLLHOUSE_PERMISSION_AUDIT_FILE_ENABLED=false
+# DOLLHOUSE_PERMISSION_AUDIT_DESTINATION_TYPE=localFile
+# DOLLHOUSE_PERMISSION_AUDIT_FILE_PATH=/var/log/dollhouse/permission-audit.md
+
 # Active element limits (soft limits that trigger cleanup of stale entries)
 # Values are clamped to safety floors and security ceilings.
 # See docs/reference/environment-vars.md for details.

--- a/docs/guides/environment-variables.md
+++ b/docs/guides/environment-variables.md
@@ -55,6 +55,7 @@ That's it! The `.env` file already has all the defaults configured.
   - [Server Configuration](#server-configuration)
   - [MCP Interface Configuration](#mcp-interface-configuration)
   - [Security & Gatekeeper](#security--gatekeeper)
+  - [Permission Audit Artifacts](#permission-audit-artifacts)
   - [Permission Prompt Configuration](#permission-prompt-configuration)
   - [Encryption & Memory Security](#encryption--memory-security)
   - [Activation Persistence](#activation-persistence)
@@ -343,6 +344,26 @@ These variables control the Gatekeeper policy enforcement engine that protects a
 | `DOLLHOUSE_POLICY_EXPORT_ENABLED` | `true` | Policy export opt-in. When `true`, `PolicyExportService` writes the security policy blueprint to `~/.dollhouse/bridge/imports/policies/` on activation changes. The DollhouseBridge permission-prompt server watches this file to evaluate permissions locally. Set to `false` to disable policy file export. |
 | `DOLLHOUSE_DANGER_ZONE_ADMIN_TOKEN` | _(none)_ | Admin token for DangerZone operations. When set, provides an alternative authentication path for danger zone verification. |
 | `DOLLHOUSE_SECURITY_ALERTS` | `false` | When `true`, enables security alert notifications in the security monitor. |
+
+### Permission Audit Artifacts
+
+These admin/operator variables control opt-in permission audit artifact generation. This is disabled by default because permission decisions can include commands, local paths, transcript references, model names, session IDs, and policy matches.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DOLLHOUSE_PERMISSION_AUDIT_FILE_ENABLED` | `false` | Enables admin-controlled permission audit artifact generation. When `true`, captured permission decisions are mirrored to the configured destination. |
+| `DOLLHOUSE_PERMISSION_AUDIT_DESTINATION_TYPE` | `localFile` | Destination type for audit artifacts. `localFile` is supported now; this setting is intentionally extensible for future cloud or enterprise audit sinks. Unsupported values are reported in permissions status without blocking permission decisions. |
+| `DOLLHOUSE_PERMISSION_AUDIT_FILE_PATH` | `~/.dollhouse/audit/permission-audit.md` | Local Markdown file path used when destination type is `localFile`. Use an admin-controlled path. The path must resolve to an absolute `.md` or `.markdown` file. |
+
+Example:
+
+```bash
+DOLLHOUSE_PERMISSION_AUDIT_FILE_ENABLED=true
+DOLLHOUSE_PERMISSION_AUDIT_DESTINATION_TYPE=localFile
+DOLLHOUSE_PERMISSION_AUDIT_FILE_PATH=/var/log/dollhouse/permission-audit.md
+```
+
+The permissions dashboard and `/api/permissions/status` expose whether artifact generation is enabled, where it writes, and the latest write/error state.
 
 ### Permission Prompt Configuration
 

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -69,6 +69,12 @@ display:
     include_emoji: true
   verbose_logging: false
   show_progress: true
+permissionAudit:
+  artifactGeneration:
+    enabled: false
+    destination:
+      type: localFile
+      path: ~/.dollhouse/audit/permission-audit.md
 wizard:
   completed: false
   dismissed: false
@@ -124,6 +130,12 @@ wizard:
 ### `display`
 - `persona_indicators` – toggles and styles for the active persona banner.
 - `verbose_logging`, `show_progress` – adjust console output verbosity.
+
+### `permissionAudit`
+- `artifactGeneration.enabled` – opt-in admin/operator setting for generating persistent permission audit artifacts. Environment override: `DOLLHOUSE_PERMISSION_AUDIT_FILE_ENABLED`.
+- `artifactGeneration.destination.type` – destination type for generated artifacts. `localFile` is supported now; the shape is reserved for future cloud or enterprise audit sinks. Environment override: `DOLLHOUSE_PERMISSION_AUDIT_DESTINATION_TYPE`.
+- `artifactGeneration.destination.path` – local Markdown path for `localFile` destinations. Use an admin-controlled path. Environment override: `DOLLHOUSE_PERMISSION_AUDIT_FILE_PATH`.
+- Generated artifacts can contain sensitive commands, paths, transcript references, model names, session IDs, and policy matches, so generation is disabled by default.
 
 ### `wizard`
 - Records wizard completion state. The wizard uses this to decide whether to prompt again.

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -252,6 +252,17 @@ const envSchema = z.object({
    */
   DOLLHOUSE_POLICY_EXPORT_ENABLED: z.coerce.boolean().default(true),
 
+  /**
+   * Opt-in admin-controlled permission audit artifact generation (#2188).
+   * When enabled, permission decisions can be mirrored to an admin-configured
+   * destination for governance review. The first supported destination is a
+   * local Markdown file; the destination shape is intentionally extensible for
+   * future cloud or enterprise audit sinks.
+   */
+  DOLLHOUSE_PERMISSION_AUDIT_FILE_ENABLED: z.coerce.boolean().default(false),
+  DOLLHOUSE_PERMISSION_AUDIT_DESTINATION_TYPE: z.string().default('localFile'),
+  DOLLHOUSE_PERMISSION_AUDIT_FILE_PATH: z.string().optional(),
+
   // ============================================================================
   // Storage Layer Configuration
   // ============================================================================

--- a/src/utils/permissionAuditArtifacts.ts
+++ b/src/utils/permissionAuditArtifacts.ts
@@ -1,0 +1,257 @@
+import { mkdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import { FileLockManager } from '../security/fileLockManager.js';
+import { logger } from './logger.js';
+
+export type PermissionAuditArtifactDestinationType = 'localFile' | string;
+
+export interface PermissionAuditDecisionDetail {
+  label: string;
+  value: string;
+}
+
+export interface PermissionAuditDecision {
+  id: string;
+  timestamp: string;
+  tool_name: string;
+  command?: string;
+  decision: string;
+  reason?: string;
+  platform?: string;
+  target?: string;
+  targetLabel?: string;
+  details?: PermissionAuditDecisionDetail[];
+}
+
+export interface PermissionAuditArtifactDestination {
+  type: PermissionAuditArtifactDestinationType;
+  path?: string;
+}
+
+export interface PermissionAuditArtifactConfig {
+  enabled: boolean;
+  destination: PermissionAuditArtifactDestination;
+}
+
+export interface PermissionAuditArtifactStatus extends PermissionAuditArtifactConfig {
+  available: boolean;
+  lastWriteAt?: string;
+  lastDecisionId?: string;
+  lastError?: string;
+}
+
+export interface PermissionAuditArtifactEnvironment extends NodeJS.ProcessEnv {
+  DOLLHOUSE_PERMISSION_AUDIT_FILE_ENABLED?: string;
+  DOLLHOUSE_PERMISSION_AUDIT_DESTINATION_TYPE?: string;
+  DOLLHOUSE_PERMISSION_AUDIT_FILE_PATH?: string;
+}
+
+const DEFAULT_AUDIT_FILENAME = 'permission-audit.md';
+const LOCAL_FILE_DESTINATION = 'localFile';
+const MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown']);
+
+export function loadPermissionAuditArtifactConfig(
+  homeDir = homedir(),
+  env: PermissionAuditArtifactEnvironment = process.env,
+): PermissionAuditArtifactConfig {
+  const enabled = parseBoolean(env.DOLLHOUSE_PERMISSION_AUDIT_FILE_ENABLED, false);
+  const destinationType = normalizeDestinationType(env.DOLLHOUSE_PERMISSION_AUDIT_DESTINATION_TYPE);
+  const configuredPath = env.DOLLHOUSE_PERMISSION_AUDIT_FILE_PATH;
+
+  return {
+    enabled,
+    destination: {
+      type: destinationType,
+      ...(destinationType === LOCAL_FILE_DESTINATION
+        ? { path: resolveAuditFilePath(configuredPath, homeDir) }
+        : {}),
+    },
+  };
+}
+
+export function renderPermissionAuditMarkdown(
+  decisions: PermissionAuditDecision[],
+  generatedAt = new Date().toISOString(),
+): string {
+  const lines: string[] = [
+    '# DollhouseMCP Permissions Audit',
+    '',
+    `Generated: ${sanitizeMarkdownValue(generatedAt)}`,
+    `Entries: ${decisions.length}`,
+    '',
+  ];
+
+  if (decisions.length === 0) {
+    lines.push('No permission decisions have been captured yet.', '');
+    return lines.join('\n');
+  }
+
+  decisions.forEach((decision, index) => {
+    lines.push(
+      `## ${index + 1}. ${sanitizeMarkdownValue(decision.tool_name)}`,
+      '',
+      `- Decision: ${sanitizeMarkdownValue(decision.decision.toUpperCase())}`,
+      `- Time: ${sanitizeMarkdownValue(decision.timestamp)}`,
+    );
+
+    if (decision.reason) {
+      lines.push(`- Reason: ${sanitizeMarkdownValue(decision.reason)}`);
+    }
+
+    if (decision.targetLabel && decision.target) {
+      lines.push(`- ${sanitizeMarkdownValue(decision.targetLabel)}: ${sanitizeMarkdownValue(decision.target)}`);
+    }
+
+    if (decision.command) {
+      lines.push(`- Command: ${sanitizeMarkdownValue(decision.command)}`);
+    }
+
+    const details = Array.isArray(decision.details) ? decision.details : [];
+    if (details.length > 0) {
+      lines.push('', '### Details');
+      for (const detail of details) {
+        lines.push(`- ${sanitizeMarkdownValue(detail.label)}: ${sanitizeMarkdownValue(detail.value)}`);
+      }
+    }
+
+    lines.push('');
+  });
+
+  return lines.join('\n');
+}
+
+export class PermissionAuditArtifactWriter {
+  private status: PermissionAuditArtifactStatus;
+  private readonly fileLockManager = new FileLockManager();
+  private readonly configError: string | undefined;
+
+  constructor(config: PermissionAuditArtifactConfig) {
+    this.configError = this.getConfigError(config);
+    this.status = {
+      ...config,
+      available: config.enabled && !this.configError,
+      ...(this.configError ? { lastError: this.configError } : {}),
+    };
+  }
+
+  getStatus(): PermissionAuditArtifactStatus {
+    return { ...this.status, destination: { ...this.status.destination } };
+  }
+
+  async write(decisions: PermissionAuditDecision[]): Promise<void> {
+    if (!this.status.enabled) {
+      return;
+    }
+
+    if (this.configError) {
+      return;
+    }
+
+    if (this.status.destination.type !== LOCAL_FILE_DESTINATION || !this.status.destination.path) {
+      this.recordError(`Unsupported permission audit destination type: ${this.status.destination.type}`);
+      return;
+    }
+
+    try {
+      validateLocalAuditFilePath(this.status.destination.path);
+      await mkdir(path.dirname(this.status.destination.path), { recursive: true });
+      await this.fileLockManager.atomicWriteFile(
+        this.status.destination.path,
+        renderPermissionAuditMarkdown(decisions),
+        { encoding: 'utf-8' },
+      );
+      this.status = {
+        ...this.status,
+        available: true,
+        lastWriteAt: new Date().toISOString(),
+        lastDecisionId: decisions[0]?.id,
+        lastError: undefined,
+      };
+    } catch (err) {
+      this.recordError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  private getConfigError(config: PermissionAuditArtifactConfig): string | undefined {
+    if (!config.enabled) {
+      return undefined;
+    }
+
+    if (config.destination.type !== LOCAL_FILE_DESTINATION) {
+      return `Unsupported permission audit destination type: ${config.destination.type}`;
+    }
+
+    if (!config.destination.path) {
+      return 'Permission audit local file path is required';
+    }
+
+    try {
+      validateLocalAuditFilePath(config.destination.path);
+      return undefined;
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  private recordError(error: string): void {
+    this.status = {
+      ...this.status,
+      available: false,
+      lastError: error,
+    };
+    logger.warn('[PermissionAuditArtifact] Could not write permission audit artifact', {
+      destinationType: this.status.destination.type,
+      path: this.status.destination.path,
+      error,
+    });
+  }
+}
+
+function parseBoolean(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined || value.trim() === '') {
+    return defaultValue;
+  }
+
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
+}
+
+function normalizeDestinationType(value: string | undefined): PermissionAuditArtifactDestinationType {
+  if (value === undefined || value.trim() === '') {
+    return LOCAL_FILE_DESTINATION;
+  }
+
+  return value.trim();
+}
+
+function resolveAuditFilePath(configuredPath: string | undefined, homeDir: string): string {
+  const rawPath = configuredPath && configuredPath.trim() !== ''
+    ? configuredPath.trim()
+    : path.join(homeDir, '.dollhouse', 'audit', DEFAULT_AUDIT_FILENAME);
+  const expanded = rawPath === '~'
+    ? homeDir
+    : rawPath.startsWith(`~${path.sep}`)
+      ? path.join(homeDir, rawPath.slice(2))
+      : rawPath;
+
+  return path.resolve(expanded);
+}
+
+function validateLocalAuditFilePath(filePath: string): void {
+  if (!path.isAbsolute(filePath)) {
+    throw new Error('Permission audit local file path must be absolute');
+  }
+
+  if (filePath.includes('\0')) {
+    throw new Error('Permission audit local file path cannot contain null bytes');
+  }
+
+  const extension = path.extname(filePath).toLowerCase();
+  if (!MARKDOWN_EXTENSIONS.has(extension)) {
+    throw new Error('Permission audit local file path must use .md or .markdown');
+  }
+}
+
+function sanitizeMarkdownValue(value: string): string {
+  return value.normalize('NFC').replace(/[\r\n]+/g, ' ').trim();
+}

--- a/src/web/public/permissions.js
+++ b/src/web/public/permissions.js
@@ -216,7 +216,9 @@
     const serverDot = document.getElementById('perm-dot-server');
     const ensembleDot = document.getElementById('perm-dot-ensemble');
     const hookDot = document.getElementById('perm-dot-hook');
+    const auditDot = document.getElementById('perm-dot-audit-artifact');
     const hookLabel = hookDot ? hookDot.parentElement.querySelector('.perm-status-label') : null;
+    const auditLabel = auditDot ? auditDot.parentElement.querySelector('.perm-status-label') : null;
     const updated = document.getElementById('perm-last-updated');
 
     if (serverDot) {
@@ -261,6 +263,26 @@
       } else {
         hookDot.dataset.status = 'warning';
         hookLabel.textContent = 'Policies loaded, not enforced';
+      }
+    }
+    if (auditDot && auditLabel) {
+      const artifact = data.permissionAuditArtifact;
+      if (!artifact || !artifact.enabled) {
+        auditDot.dataset.status = 'inactive';
+        auditLabel.textContent = 'Audit file off';
+        auditLabel.removeAttribute('title');
+      } else if (artifact.available) {
+        auditDot.dataset.status = 'active';
+        auditLabel.textContent = 'Audit file active';
+        if (artifact.destination?.path) {
+          auditLabel.setAttribute('title', artifact.destination.path);
+        }
+      } else {
+        auditDot.dataset.status = 'warning';
+        auditLabel.textContent = 'Audit file needs attention';
+        if (artifact.lastError) {
+          auditLabel.setAttribute('title', artifact.lastError);
+        }
       }
     }
     if (updated) {
@@ -834,6 +856,10 @@
           <div class="perm-status-indicator">
             <span class="perm-status-dot" id="perm-dot-hook" data-status="inactive"></span>
             <span class="perm-status-label">Policies</span>
+          </div>
+          <div class="perm-status-indicator">
+            <span class="perm-status-dot" id="perm-dot-audit-artifact" data-status="inactive"></span>
+            <span class="perm-status-label">Audit file off</span>
           </div>
         <span class="perm-status-spacer"></span>
         <span class="perm-status-updated">Updated: <span id="perm-last-updated">--:--:--</span></span>

--- a/src/web/routes/permissionRoutes.ts
+++ b/src/web/routes/permissionRoutes.ts
@@ -31,6 +31,10 @@ import {
   readPermissionAuthorityState,
   setPermissionAuthorityMode,
 } from '../../utils/permissionAuthority.js';
+import {
+  loadPermissionAuditArtifactConfig,
+  PermissionAuditArtifactWriter,
+} from '../../utils/permissionAuditArtifacts.js';
 
 // ── Permission Decision Tracking ─────────────────────────────────────────────
 // Ring buffer of recent permission decisions for the live dashboard feed.
@@ -126,7 +130,7 @@ interface PermissionDecisionTracker {
     input: PermissionDecisionInput,
     result: Record<string, unknown>,
     platform: string,
-  ): void;
+  ): PermissionDecision;
   getRecentDecisions(): PermissionDecision[];
 }
 
@@ -303,7 +307,7 @@ function createPermissionDecisionTracker(bufferSize = DECISION_BUFFER_SIZE): Per
       input: PermissionDecisionInput,
       result: Record<string, unknown>,
       platform: string,
-    ): void {
+    ): PermissionDecision {
       const detailState = buildDecisionDetails(toolName, input, result, platform, metadata);
       const entry: PermissionDecision = {
         id: `d-${++decisionCounter}`,
@@ -327,6 +331,7 @@ function createPermissionDecisionTracker(bufferSize = DECISION_BUFFER_SIZE): Per
       if (recentDecisions.length > bufferSize) {
         recentDecisions.length = bufferSize;
       }
+      return entry;
     },
     getRecentDecisions(): PermissionDecision[] {
       return recentDecisions;
@@ -449,6 +454,9 @@ export function registerPermissionRoutes(
   const authorityHomeDir = options.homeDir ?? homedir();
   const autoRepairHookAssets = options.autoRepairHookAssets ?? process.env.NODE_ENV !== 'test';
   const decisionTracker = createPermissionDecisionTracker();
+  const auditArtifactWriter = new PermissionAuditArtifactWriter(
+    loadPermissionAuditArtifactConfig(authorityHomeDir),
+  );
   /**
    * POST /api/evaluate_permission
    * Permission evaluation endpoint for PreToolUse hooks.
@@ -526,8 +534,9 @@ export function registerPermissionRoutes(
       const decision = extractDecision(trackedResult, platform);
       logger.debug(`[WebUI/Gateway] evaluate_permission: ${tool_name} → ${decision} (${elapsedMs}ms)`);
 
-      // Track decision for live dashboard feed
+      // Track decision for live dashboard feed and optional admin-configured artifact generation.
       decisionTracker.trackDecision(requestMetadata, tool_name, input || {}, trackedResult, platform);
+      await auditArtifactWriter.write(decisionTracker.getRecentDecisions());
 
       res.json(responseData);
     } catch (err) {
@@ -630,6 +639,7 @@ export function registerPermissionRoutes(
         authoritySupportedHosts: installedAuthorityHosts,
         authoritySupportedModes: [...PERMISSION_AUTHORITY_MODES],
         authorityAiMutable: false,
+        permissionAuditArtifact: auditArtifactWriter.getStatus(),
         enforcementReady: data.enforcementReady,
         invalidPolicyElementCount: data.invalidPolicyElementCount ?? 0,
         advisory: data.advisory,

--- a/tests/unit/utils/permissionAuditArtifacts.test.ts
+++ b/tests/unit/utils/permissionAuditArtifacts.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from '@jest/globals';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  loadPermissionAuditArtifactConfig,
+  PermissionAuditArtifactWriter,
+  renderPermissionAuditMarkdown,
+} from '../../../src/utils/permissionAuditArtifacts.js';
+
+describe('permissionAuditArtifacts', () => {
+  it('loads disabled local-file config with a safe default path', () => {
+    const homeDir = path.join(tmpdir(), 'dollhouse-audit-home');
+    const config = loadPermissionAuditArtifactConfig(homeDir, {});
+
+    expect(config).toEqual({
+      enabled: false,
+      destination: {
+        type: 'localFile',
+        path: path.join(homeDir, '.dollhouse', 'audit', 'permission-audit.md'),
+      },
+    });
+  });
+
+  it('expands admin-controlled local file destinations', () => {
+    const homeDir = path.join(tmpdir(), 'dollhouse-audit-home');
+    const config = loadPermissionAuditArtifactConfig(homeDir, {
+      DOLLHOUSE_PERMISSION_AUDIT_FILE_ENABLED: 'true',
+      DOLLHOUSE_PERMISSION_AUDIT_FILE_PATH: '~/.dollhouse/audit/team-permissions.md',
+    });
+
+    expect(config.enabled).toBe(true);
+    expect(config.destination).toEqual({
+      type: 'localFile',
+      path: path.join(homeDir, '.dollhouse', 'audit', 'team-permissions.md'),
+    });
+  });
+
+  it('renders captured decisions as markdown', () => {
+    const markdown = renderPermissionAuditMarkdown([
+      {
+        id: 'd-1',
+        timestamp: '2026-05-06T20:00:00.000Z',
+        tool_name: 'Bash',
+        command: 'npm test',
+        decision: 'allow',
+        reason: 'Allowed by policy',
+        targetLabel: 'Command',
+        target: 'npm test',
+        details: [
+          { label: 'Platform', value: 'codex' },
+          { label: 'Session', value: 'session-1' },
+        ],
+      },
+    ], '2026-05-06T20:01:00.000Z');
+
+    expect(markdown).toContain('# DollhouseMCP Permissions Audit');
+    expect(markdown).toContain('Generated: 2026-05-06T20:01:00.000Z');
+    expect(markdown).toContain('## 1. Bash');
+    expect(markdown).toContain('- Decision: ALLOW');
+    expect(markdown).toContain('- Reason: Allowed by policy');
+    expect(markdown).toContain('- Platform: codex');
+  });
+
+  it('writes enabled local audit artifacts and records status', async () => {
+    const tempHome = await mkdtemp(path.join(tmpdir(), 'permission-audit-home-'));
+    const auditPath = path.join(tempHome, '.dollhouse', 'audit', 'permissions.md');
+    const writer = new PermissionAuditArtifactWriter({
+      enabled: true,
+      destination: { type: 'localFile', path: auditPath },
+    });
+
+    await writer.write([
+      {
+        id: 'd-1',
+        timestamp: '2026-05-06T20:00:00.000Z',
+        tool_name: 'Read',
+        decision: 'allow',
+        details: [{ label: 'File', value: '/workspace/README.md' }],
+      },
+    ]);
+
+    const content = await readFile(auditPath, 'utf-8');
+    expect(content).toContain('## 1. Read');
+    expect(content).toContain('- File: /workspace/README.md');
+    expect(writer.getStatus()).toEqual(expect.objectContaining({
+      enabled: true,
+      available: true,
+      lastDecisionId: 'd-1',
+      lastWriteAt: expect.any(String),
+    }));
+
+    await rm(tempHome, { recursive: true, force: true });
+  });
+
+  it('keeps unsupported destination types fail-soft and visible in status', async () => {
+    const writer = new PermissionAuditArtifactWriter({
+      enabled: true,
+      destination: { type: 'cloudStorage' },
+    });
+
+    await writer.write([
+      {
+        id: 'd-1',
+        timestamp: '2026-05-06T20:00:00.000Z',
+        tool_name: 'Bash',
+        decision: 'deny',
+      },
+    ]);
+
+    expect(writer.getStatus()).toEqual(expect.objectContaining({
+      enabled: true,
+      available: false,
+      destination: { type: 'cloudStorage' },
+      lastError: expect.stringContaining('Unsupported permission audit destination type'),
+    }));
+  });
+});

--- a/tests/unit/web/console-ui-regressions.test.ts
+++ b/tests/unit/web/console-ui-regressions.test.ts
@@ -1214,6 +1214,59 @@ describe('Web console cleanup regressions', () => {
     cleanup();
   });
 
+  it('shows admin-configured permission audit artifact status in the permissions header', async () => {
+    const { window: win, cleanup } = createDom(`
+      <div id="console-tabs"><button class="console-tab" data-tab="permissions">Permissions</button></div>
+      <div id="permissions-dashboard-root"></div>
+    `);
+
+    win.DollhouseAuth.apiFetch = jest.fn((url: string) => {
+      if (url === '/api/permissions/status') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            activeElementCount: 0,
+            hasAllowlist: false,
+            denyPatterns: [],
+            allowPatterns: [],
+            confirmPatterns: [],
+            denyRules: [],
+            allowRules: [],
+            confirmRules: [],
+            elements: [],
+            knownSessions: [],
+            recentDecisions: [],
+            permissionPromptActive: false,
+            permissionAuditArtifact: {
+              enabled: true,
+              available: true,
+              destination: {
+                type: 'localFile',
+                path: '/Users/admin/.dollhouse/audit/permission-audit.md',
+              },
+              lastWriteAt: '2026-05-06T20:00:00.000Z',
+            },
+          }),
+        });
+      }
+
+      return Promise.reject(new Error(`unexpected url ${url}`));
+    });
+
+    win.eval(permissionsSource);
+    win.document.dispatchEvent(new win.Event('DOMContentLoaded'));
+    win.DollhouseConsole.permissions.init();
+    await wait(DEFAULT_WAIT_MS);
+
+    const auditDot = win.document.getElementById('perm-dot-audit-artifact') as HTMLElement | null;
+    const auditLabel = auditDot?.parentElement?.querySelector('.perm-status-label') as HTMLElement | null;
+    expect(auditDot?.dataset.status).toBe('active');
+    expect(auditLabel?.textContent).toBe('Audit file active');
+    expect(auditLabel?.getAttribute('title')).toBe('/Users/admin/.dollhouse/audit/permission-audit.md');
+
+    cleanup();
+  });
+
   it('surfaces malformed permissions JSON through the dashboard error boundary', async () => {
     const { window: win, cleanup } = createDom(`
       <div id="console-tabs"><button class="console-tab" data-tab="permissions">Permissions</button></div>

--- a/tests/unit/web/permissionRoutes.test.ts
+++ b/tests/unit/web/permissionRoutes.test.ts
@@ -55,6 +55,9 @@ describe('permissionRoutes', () => {
   });
 
   afterEach(async () => {
+    delete process.env.DOLLHOUSE_PERMISSION_AUDIT_FILE_ENABLED;
+    delete process.env.DOLLHOUSE_PERMISSION_AUDIT_DESTINATION_TYPE;
+    delete process.env.DOLLHOUSE_PERMISSION_AUDIT_FILE_PATH;
     _resetPermissionHookStartupRepairSummaryForTests();
     await unlink(latestPortFile).catch(() => {});
     await rm(tempHome, { recursive: true, force: true });
@@ -323,6 +326,14 @@ describe('permissionRoutes', () => {
       expect(res.body.enforcementReady).toBe(false);
       expect(res.body.advisory).toContain('NOT enforced');
       expect(Array.isArray(res.body.recentDecisions)).toBe(true);
+      expect(res.body.permissionAuditArtifact).toEqual(expect.objectContaining({
+        enabled: false,
+        available: false,
+        destination: {
+          type: 'localFile',
+          path: join(tempHome, '.dollhouse', 'audit', 'permission-audit.md'),
+        },
+      }));
       expect(handler.handleRead).toHaveBeenCalledWith({
         operation: 'get_effective_cli_policies',
         params: {
@@ -837,6 +848,104 @@ describe('permissionRoutes', () => {
         { label: 'File', value: '/opt/dollhouse/example.txt', monospace: true },
         { label: 'Matched Pattern', value: 'Edit:*', monospace: true },
       ]));
+    });
+
+    it('should generate an admin-enabled local permission audit artifact', async () => {
+      const auditPath = join(tempHome, '.dollhouse', 'audit', 'permission-decisions.md');
+      process.env.DOLLHOUSE_PERMISSION_AUDIT_FILE_ENABLED = 'true';
+      process.env.DOLLHOUSE_PERMISSION_AUDIT_FILE_PATH = auditPath;
+
+      const handler = {
+        handleRead: jest
+          .fn()
+          .mockResolvedValueOnce([{
+            success: true,
+            data: {
+              decision: 'deny',
+              reason: 'Blocked by policy',
+              matched_pattern: 'Bash:git push --force*',
+            },
+          }])
+          .mockResolvedValueOnce([{
+            success: true,
+            data: {
+              activeElementCount: 0,
+              hasAllowlist: false,
+              combinedDenyPatterns: [],
+              combinedAllowPatterns: [],
+              combinedConfirmPatterns: [],
+              elements: [],
+              permissionPromptActive: false,
+            },
+          }]),
+      } as any;
+      const app = createApp(handler, { homeDir: tempHome });
+
+      const evaluate = await request(app)
+        .post('/api/evaluate_permission')
+        .send({
+          tool_name: 'Bash',
+          input: { command: 'git push --force' },
+          platform: 'codex',
+          session_id: 'session-audit-file',
+        });
+      expect(evaluate.status).toBe(200);
+
+      const artifact = await readFile(auditPath, 'utf-8');
+      expect(artifact).toContain('# DollhouseMCP Permissions Audit');
+      expect(artifact).toContain('## 1. Bash');
+      expect(artifact).toContain('- Decision: DENY');
+      expect(artifact).toContain('- Reason: Blocked by policy');
+      expect(artifact).toContain('- Session: session-audit-file');
+      expect(artifact).toContain('- Matched Pattern: Bash:git push --force*');
+
+      const status = await request(app).get('/api/permissions/status');
+      expect(status.body.permissionAuditArtifact).toEqual(expect.objectContaining({
+        enabled: true,
+        available: true,
+        destination: { type: 'localFile', path: auditPath },
+        lastDecisionId: 'd-1',
+        lastWriteAt: expect.any(String),
+      }));
+    });
+
+    it('should report audit artifact configuration errors without blocking permission evaluation', async () => {
+      const invalidAuditPath = join(tempHome, '.dollhouse', 'audit', 'permission-decisions.txt');
+      process.env.DOLLHOUSE_PERMISSION_AUDIT_FILE_ENABLED = 'true';
+      process.env.DOLLHOUSE_PERMISSION_AUDIT_FILE_PATH = invalidAuditPath;
+
+      const handler = {
+        handleRead: jest
+          .fn()
+          .mockResolvedValueOnce([{ success: true, data: { decision: 'allow' } }])
+          .mockResolvedValueOnce([{
+            success: true,
+            data: {
+              activeElementCount: 0,
+              hasAllowlist: false,
+              combinedDenyPatterns: [],
+              combinedAllowPatterns: [],
+              combinedConfirmPatterns: [],
+              elements: [],
+              permissionPromptActive: false,
+            },
+          }]),
+      } as any;
+      const app = createApp(handler, { homeDir: tempHome });
+
+      const evaluate = await request(app)
+        .post('/api/evaluate_permission')
+        .send({ tool_name: 'Read', input: { file_path: './README.md' }, platform: 'codex' });
+      expect(evaluate.status).toBe(200);
+
+      const status = await request(app).get('/api/permissions/status');
+      expect(status.body.recentDecisions).toHaveLength(1);
+      expect(status.body.permissionAuditArtifact).toEqual(expect.objectContaining({
+        enabled: true,
+        available: false,
+        destination: { type: 'localFile', path: invalidAuditPath },
+        lastError: expect.stringContaining('.md or .markdown'),
+      }));
     });
   });
 


### PR DESCRIPTION
## Summary

Adds opt-in, admin-controlled permission audit artifact generation for issue #2188.

This PR keeps the first destination local-file based while making the destination model explicit and future-friendly for cloud or enterprise audit sinks.

## Changes

- Adds `PermissionAuditArtifactWriter` for local Markdown artifact generation from captured permission decisions.
- Adds admin/operator environment controls:
  - `DOLLHOUSE_PERMISSION_AUDIT_FILE_ENABLED`
  - `DOLLHOUSE_PERMISSION_AUDIT_DESTINATION_TYPE`
  - `DOLLHOUSE_PERMISSION_AUDIT_FILE_PATH`
- Mirrors the recent decision feed to the configured Markdown artifact when enabled.
- Surfaces artifact status through `/api/permissions/status` and the permissions dashboard header.
- Documents the new admin controls in the env guide, config schema reference, and `.env.example`.
- Adds unit/UI coverage for disabled config, enabled local file writing, invalid path fail-soft behavior, unsupported destination types, and dashboard status display.

## Safety Notes

- Disabled by default.
- Local path must resolve to an absolute `.md` or `.markdown` file.
- Write failures are reported in status but do not block permission evaluation.
- Artifact content stays local and is not uploaded or synced by this implementation.

## Validation

- `npm test -- --runInBand tests/unit/utils/permissionAuditArtifacts.test.ts tests/unit/web/permissionRoutes.test.ts tests/unit/web/console-ui-regressions.test.ts`
- `npx eslint src/utils/permissionAuditArtifacts.ts src/web/routes/permissionRoutes.ts src/web/public/permissions.js tests/unit/utils/permissionAuditArtifacts.test.ts tests/unit/web/permissionRoutes.test.ts tests/unit/web/console-ui-regressions.test.ts`
- `npm run build`
- `npm run security:audit`
- `git diff --check`

Closes #2188
