### PR TITLE
fix: pin patched fast-uri, hono, ip-address via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6640,7 +6640,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -7199,9 +7201,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -7412,9 +7414,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
+      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -239,7 +239,9 @@
     "@istanbuljs/load-nyc-config": {
       "js-yaml": "3.14.2"
     },
-    "hono": "4.12.14",
-    "@hono/node-server": "1.19.13"
+    "hono": "4.12.18",
+    "@hono/node-server": "1.19.13",
+    "fast-uri": "3.1.2",
+    "ip-address": "10.1.1"
   }
 }


### PR DESCRIPTION
## Summary

Clears 8 open Dependabot alerts on transitive dependencies pulled in via `@modelcontextprotocol/sdk`. All three packages are bumped via `npm` `overrides` (the pattern already in use for `hono` / `@hono/node-server`).

| Pkg | Was | Now | Path | Alerts cleared |
|---|---|---|---|---|
| `fast-uri` | 3.1.0 | **3.1.2** | sdk → ajv → fast-uri | #108, #110 (2 high) |
| `hono` | 4.12.14 | **4.12.18** | sdk → hono | #106, #107, #109, #111, #112 (4 med + 1 low) |
| `ip-address` | 10.1.0 | **10.1.1** | sdk → express-rate-limit → ip-address | #105 (1 med) |

`uuid` (#104) is handled separately in #2186.

## CVEs

- **fast-uri 3.1.2** — CVE-2026-6321 (path traversal via percent-encoded dot segments), CVE-2026-6322 (host confusion via percent-encoded authority delimiters)
- **hono 4.12.18** — CVE-2026-44455 (JSX HTML injection via unvalidated tag names), CVE-2026-44456 (`bodyLimit()` bypass for chunked/unknown-length requests), CVE-2026-44457 (cache middleware ignores `Vary: Authorization`/`Vary: Cookie`), CVE-2026-44458 (CSS declaration injection via style object values in JSX SSR), CVE-2026-44459 (improper validation of NumericDate JWT claims)
- **ip-address 10.1.1** — CVE-2026-42338 (XSS in `Address6` HTML-emitting methods)

## Supply-chain check

Given recent ecosystem hijack activity, verified each patched version's publisher before bumping:

- `fast-uri@3.1.2` — published by `matteo.collina`, long-time Fastify maintainer (published v2.0.0 in 2022, v2.4.0 in 2024). Repo: `github.com/fastify/fast-uri`.
- `hono@4.12.18` — published by `yusukebe`, Hono's original author and primary maintainer.
- `ip-address@10.1.1` — published by `beaugunderson`, same maintainer as 10.1.0.

All three publish dates (April 27 – May 6, 2026) align with the CVE disclosure timeline.

## Why overrides and not just bumping `@modelcontextprotocol/sdk`

SDK 1.27.1 and 1.29.0 declare the same caret ranges (`^4.11.4`, `^8.17.1`, etc.) that already permit the patched versions. The vulnerability isn't that SDK pins to old versions — it's that the existing lockfile resolved them to old versions at install time. An SDK bump alone wouldn't deterministically force the patched transitives without also regenerating the lockfile, and even then npm's resolver could pick differently next time. Overrides make the pin explicit and surgical.

## Test plan

- [x] `npm install` — overrides apply cleanly, lockfile updated
- [x] `npm ls fast-uri hono ip-address` — all three resolve to patched versions, marked `overridden`
- [x] `npm run build` — TypeScript compiles
- [x] `npm test` — 10367 of 10377 tests pass. The unrelated failures are pre-existing timing flakes in permission server tests (different test fails each run; nothing in `web/` or `di/` modules consumes hono/fast-uri/ip-address APIs whose semantics changed at the patch level).
- [ ] CI on this PR

## Out of scope

- `uuid` (#104) — handled by #2186
- npm-audit-only findings (lodash, picomatch, tar, brace-expansion, path-to-regexp via dev deps) — separate PR