### PR TITLE
fix: HTTP per-user isolation, config schema validation, auth metrics

### DIFF
--- a/docs/guides/deployment-configuration.md
+++ b/docs/guides/deployment-configuration.md
@@ -1018,7 +1018,7 @@ For deployments running multiple replicas behind a load balancer, set the signin
 ```
 DOLLHOUSE_COOKIE_SIGNING_SECRET=<64+ hex chars>   # generate via:
                                                    # node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
-DOLLHOUSE_INVITE_TOKEN_SECRET=<base64 secret>     # for invite + magic-link tokens
+DOLLHOUSE_INVITE_TOKEN_SECRET=<hex secret>        # for invite + magic-link tokens; openssl rand -hex 32
 ```
 
 Without these, each replica generates its own keys at first run and stores them in the run directory. Single-replica deployments are unaffected; multi-replica without env-var secrets produces non-deterministic JWKS and revoked refresh-token sessions on rotation. Multi-replica HA has additional limitations beyond signing-secret sharing (rate limits are per-replica; mode-switch invalidation can race across replicas; key rotation is not coordinated) — these are documented separately and tracked as follow-up work.
@@ -1078,7 +1078,7 @@ See `/dollhouse/docs/SECTION-8.1-DR-RUNBOOK.md` (filesystem-only) for backup/res
 | `DOLLHOUSE_AUTH_STORAGE_BACKEND` | `filesystem` | One of `memory`, `filesystem`, `postgres`. `postgres` requires `DOLLHOUSE_STORAGE_BACKEND=database` and `DOLLHOUSE_DATABASE_URL` to be set. |
 | `DOLLHOUSE_ALLOW_MEMORY_AUTH_STORAGE` | `false` | Required to be `true` for `BACKEND=memory` when durable methods (`local-password`, `magic-link`) are configured — otherwise refused at startup, since password hashes and pending invites would silently disappear on restart. Dev/test only. |
 | `DOLLHOUSE_COOKIE_SIGNING_SECRET` | *(per-replica random)* | 64+ hex chars used to sign /interaction session cookies AND as the HMAC salt for IP/UA hashes. **Required for multi-replica HA** — without it, each replica generates its own key, so cross-replica session cookies fail to verify. Generate via `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`. |
-| `DOLLHOUSE_INVITE_TOKEN_SECRET` | *(per-replica random)* | Base64 secret used to sign invite + magic-link tokens. **Required for multi-replica HA** — without it, an invite issued by replica A can't be redeemed on replica B. |
+| `DOLLHOUSE_INVITE_TOKEN_SECRET` | *(per-replica random)* | Hex-encoded secret (decodes to ≥16 bytes) used to sign invite + magic-link tokens. Generate via `openssl rand -hex 32`. **Required for multi-replica HA** — without it, an invite issued by replica A can't be redeemed on replica B. |
 | `DOLLHOUSE_AUTH_GITHUB_CLIENT_ID` | *(unset)* | GitHub OAuth app client ID for the embedded-AS user-auth flow. **Required when `github` is in `DOLLHOUSE_AUTH_METHODS`.** Register a web-flow OAuth app at <https://github.com/settings/developers> with the callback URL `<DOLLHOUSE_PUBLIC_BASE_URL>/auth/social/github/callback`. Falls back to the legacy `DOLLHOUSE_GITHUB_CLIENT_ID` (with a deprecation warning) when unset, so existing deployments don't break. |
 | `DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET` | *(unset)* | GitHub OAuth app client secret for the embedded-AS user-auth flow. **Required when `github` is in `DOLLHOUSE_AUTH_METHODS`.** Treat as a deployment secret. Falls back to the legacy `DOLLHOUSE_GITHUB_CLIENT_SECRET` when unset. |
 | `DOLLHOUSE_GITHUB_CLIENT_ID` | *(unset)* | Legacy GitHub OAuth client ID. Originally introduced for the portfolio-sync feature (server → GitHub, device flow). Still used by `setup_github_auth`; also serves as the user-auth fallback when `DOLLHOUSE_AUTH_GITHUB_CLIENT_ID` is unset. |
@@ -1397,7 +1397,7 @@ All variables are optional unless marked **required**. Variables with no default
 | `DOLLHOUSE_ALLOW_MEMORY_AUTH_STORAGE` | `false` | Embedded AS only. Required to be `true` for `BACKEND=memory` with durable methods. Dev/test only. |
 | `DOLLHOUSE_PUBLIC_BASE_URL` | *(derived)* | Embedded AS only. Public-facing base URL. Required behind a reverse proxy. |
 | `DOLLHOUSE_COOKIE_SIGNING_SECRET` | *(per-replica random)* | Embedded AS only. 64+ hex chars. Required for multi-replica HA. |
-| `DOLLHOUSE_INVITE_TOKEN_SECRET` | *(per-replica random)* | Embedded AS only. Base64 secret for invite + magic-link tokens. Required for multi-replica HA. |
+| `DOLLHOUSE_INVITE_TOKEN_SECRET` | *(per-replica random)* | Embedded AS only. Hex-encoded secret (≥16 bytes) for invite + magic-link tokens. Required for multi-replica HA. |
 | `DOLLHOUSE_AUTH_GITHUB_CLIENT_ID` | *(unset)* | Embedded AS only. User-auth (web flow). Required when `github` is in `DOLLHOUSE_AUTH_METHODS`. |
 | `DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET` | *(unset)* | Embedded AS only. User-auth secret. Required when `github` is in `DOLLHOUSE_AUTH_METHODS`. Deployment secret. |
 | `DOLLHOUSE_GITHUB_CLIENT_ID` | *(unset)* | Legacy: portfolio-sync device flow. Also user-auth fallback when the AUTH-prefixed var is unset. |

--- a/docs/guides/postgres-dr-runbook.md
+++ b/docs/guides/postgres-dr-runbook.md
@@ -1,0 +1,229 @@
+# Postgres Disaster Recovery Runbook
+
+**Audience:** operators running DollhouseMCP with `DOLLHOUSE_STORAGE_BACKEND=database` (Postgres).
+**Scope:** what to back up, how to restore to a scratch host, recovery targets, secret reconstruction, and the verification checklist.
+
+This runbook assumes you have already followed [`deployment-configuration.md`](./deployment-configuration.md) and [`production-hosting-runbook.md`](./production-hosting-runbook.md) for initial setup. It picks up at *"the database is gone or corrupt — now what?"*.
+
+---
+
+## Recovery targets
+
+Set these explicitly with your stakeholders before you need them. The defaults below are the minimum a production deployment should tolerate.
+
+| Metric | Default target | Notes |
+|---|---|---|
+| **RPO** (recovery point objective — max acceptable data loss) | 24 hours | Daily `pg_dump`. Drop to 5 minutes with WAL archiving / PITR. |
+| **RTO** (recovery time objective — max acceptable downtime) | 4 hours | Manual restore on scratch host + secret reconstruction. Drop to <30 min with hot-standby replica. |
+| **Verification cadence** | Quarterly restore drill | Untested backups aren't backups. |
+
+If your deployment can't tolerate 24-hour RPO, use a managed Postgres provider with PITR (RDS, Cloud SQL, Crunchy Bridge, Neon, Supabase) — most offer 5-minute RPO out of the box.
+
+---
+
+## Critical state — what to back up
+
+A complete deployment depends on **two backup tracks** that must be kept synchronised. Lose one and you lose either user data or the ability to verify tokens against the data you restored.
+
+### Track 1 — Postgres data
+
+A `pg_dump` of the application database covers everything user-facing:
+
+```bash
+pg_dump \
+  -U dollhouse \
+  -h "$DB_HOST" \
+  -d dollhousemcp \
+  --no-owner --no-privileges \
+  --format=custom \
+  --file="dollhousemcp-$(date -u +%Y%m%dT%H%M%SZ).dump"
+```
+
+Or, when in-compose, run inside the container:
+
+```bash
+docker exec dollhousemcp-postgres pg_dump \
+  -U dollhouse dollhousemcp \
+  --format=custom > "dollhousemcp-$(date -u +%Y%m%dT%H%M%SZ).dump"
+```
+
+Tables this captures (the ones that matter for DR):
+
+| Table | Contains | Reconstructable? |
+|---|---|---|
+| `auth_accounts` | User identities (sub, email, github_username, displayName) | No — would have to re-register everyone |
+| `auth_allowlist` | Sign-in allowlist entries | Recreatable from `dollhouse-allowlist add` if you have the source list |
+| `auth_kv` | Interactions, grants, refresh tokens, sessions, bootstrap state | Tokens / sessions expire naturally; not critical for DR but users have to re-auth |
+| `auth_identity_events` | Audit log (append-only) | Lost = lost — audit gap |
+| `signing_keys` | Active + rotated JWKS keys (encrypted at rest if cookie-secret rotation is on) | No — every outstanding access token becomes unverifiable |
+| `operator_settings`, `user_settings` | `dollhouse_config` JSONB blobs | Recreatable from operator memory if simple |
+| `element_*`, `memories`, `agents`, `ensembles`, `personas` | User portfolio content | No — user data |
+| `agent_states` | Agent runtime state | Resets to default on restore — acceptable |
+
+**Backup retention:** keep at least 7 dailies + 4 weeklies + 12 monthlies. Storage is cheap; old dumps are the only way to recover from corruption you didn't notice for a month.
+
+### Track 2 — Secrets
+
+These live outside Postgres and must be backed up separately. Lose them and the restored database is unverifiable.
+
+| Secret | Source | Loss impact |
+|---|---|---|
+| `DOLLHOUSE_COOKIE_SIGNING_SECRET` | Env var (per-replica random if unset) | All active interaction cookies invalidated; users mid-OAuth must restart. Refresh-token IP/UA hash binding breaks. |
+| `DOLLHOUSE_INVITE_TOKEN_SECRET` | Env var (per-replica random if unset) | All outstanding invite + magic-link tokens become unverifiable. |
+| `DOLLHOUSE_DATABASE_ADMIN_URL` password | Env var | Admin role connection broken until rotated in Postgres. |
+| `DOLLHOUSE_DATABASE_URL` password | Env var | App role connection broken until rotated in Postgres. |
+| OAuth client secrets (`DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET`, `DOLLHOUSE_SMTP_PASSWORD`, etc.) | Env var | Re-issue from the upstream provider; doesn't invalidate existing user data, but the AS can't initiate new sign-ins until rotated. |
+| Signing-key encryption envelope (when DB-store mode is on) | Bound to `DOLLHOUSE_COOKIE_SIGNING_SECRET` | If lost, `signing_keys` table is undecryptable — same effect as losing JWKS. |
+
+**Store secrets encrypted, in a different location than the database backups.** A single compromised bucket should not yield both. Common options: `age` / `gpg`-encrypted file in a separate bucket, Vault / AWS Secrets Manager / Doppler / 1Password, or your CI/CD secrets store.
+
+---
+
+## Restore-to-scratch-host procedure
+
+This is the standard recovery path: production is gone, you have a recent `pg_dump` + secrets, you need to bring it back somewhere new.
+
+### 1. Provision a scratch host
+
+A clean machine or container with:
+- Postgres 15+ matching your production version
+- Node.js matching the version in `package.json`'s `engines` field
+- Network access to your IdP (GitHub, SMTP) and to whoever needs to reach the MCP endpoint
+- Docker if you're restoring in-compose
+
+### 2. Restore the database
+
+```bash
+# Create the empty database
+createdb -h "$DB_HOST" -U "$ADMIN_USER" dollhousemcp
+
+# Apply the role grants (use the same init script the original deployment used)
+psql -h "$DB_HOST" -U "$ADMIN_USER" -d dollhousemcp -f docker/init-db.sql
+
+# Restore the dump
+pg_restore \
+  -h "$DB_HOST" -U "$ADMIN_USER" -d dollhousemcp \
+  --no-owner --no-privileges \
+  --jobs=4 \
+  dollhousemcp-2026-05-20T120000Z.dump
+
+# Re-apply grants so they cover any newly-restored objects
+psql -h "$DB_HOST" -U "$ADMIN_USER" -d dollhousemcp -f docker/init-db.sql
+```
+
+If the dump is plain SQL instead of custom format, swap `pg_restore` for `psql -f`.
+
+### 3. Reconstruct secrets
+
+The order matters — set everything before starting the server so the AS doesn't generate fresh per-replica random secrets that would conflict with the restored data.
+
+```bash
+# From your secret manager — exact same values as the lost deployment
+export DOLLHOUSE_COOKIE_SIGNING_SECRET=<from backup>
+export DOLLHOUSE_INVITE_TOKEN_SECRET=<from backup>
+export DOLLHOUSE_DATABASE_URL=<rewrite for new host>
+export DOLLHOUSE_DATABASE_ADMIN_URL=<rewrite for new host>
+
+# Auth provider secrets (re-fetch from upstream if you didn't back these up)
+export DOLLHOUSE_AUTH_GITHUB_CLIENT_ID=<from GitHub OAuth app>
+export DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET=<from GitHub OAuth app>
+# ... etc for magic-link / local-password / etc.
+```
+
+If you lost `DOLLHOUSE_COOKIE_SIGNING_SECRET` AND signing-key envelope encryption was on, the `signing_keys` table rows are undecryptable. The server will mint fresh keys on startup and every outstanding access token becomes invalid — users must re-authenticate. This is the "key envelope reconstruction" case below.
+
+### 4. Start the server
+
+```bash
+npm run start:http
+```
+
+Watch the startup logs for:
+- `[AuthStorage] backend=postgres` — confirms the DB connection works
+- `[persistKeys] Loaded signing key from store (kid=...)` — confirms the signing-key envelope decrypted
+- `[EmbeddedAuthorizationServer] initialized` — confirms the AS came up
+
+If you see `[persistKeys] active jwks key in store is malformed; regenerating` or `[persistKeys] Generated new signing key in store`, that's the cookie-secret envelope mismatch — see "Key envelope reconstruction" below.
+
+### 5. Verify with the health endpoints
+
+```bash
+curl -s https://<new-host>/healthz | jq .
+curl -s https://<new-host>/readyz | jq .
+```
+
+`/healthz` should return `{"ok": true, ...}` with session telemetry. `/readyz` should return 200 (or 503 with `reason: 'bootstrap_required'` if the admin pre-claim was lost — re-run `dollhouse-admin-bootstrap` to restore admin access).
+
+### 6. End-to-end smoke test
+
+Sign in as a known user and verify their portfolio loads:
+
+```bash
+# From a client machine — exercise the full auth flow
+mcp call dollhouse list_elements --transport=http --url=https://<new-host>/mcp
+```
+
+You should see the same elements that were in the database backup.
+
+---
+
+## Point-in-time recovery (managed Postgres)
+
+If you're on a managed provider with PITR (RDS, Cloud SQL, Crunchy Bridge, Supabase Pro, Neon), use the provider's UI / CLI to restore to a target timestamp instead of `pg_restore`. The procedure differs per provider:
+
+| Provider | Command |
+|---|---|
+| **AWS RDS** | `aws rds restore-db-instance-to-point-in-time --restore-time <ISO8601> --source-db-instance-identifier <prod> --target-db-instance-identifier <restored>` |
+| **GCP Cloud SQL** | `gcloud sql backups restore <BACKUP_ID> --restore-instance=<target> --backup-instance=<source>` (uses the most recent automated backup) or use Console for PITR |
+| **Crunchy Bridge** | `cb cluster restore-pitr <id> --target-time '2026-05-20 12:00:00 UTC'` |
+| **Supabase / Neon** | Use their dashboard — both support branch-from-point-in-time |
+
+The secret-reconstruction step (3) is identical regardless of the data restore method.
+
+---
+
+## Key envelope reconstruction
+
+When `DOLLHOUSE_COOKIE_SIGNING_SECRET` is lost but the `signing_keys` table is restored, the AS cannot decrypt the rows. On startup it will mint a fresh signing key and:
+
+- All outstanding access tokens become unverifiable — every user must re-authenticate
+- The new `kid` will appear at `/jwks` — external resource servers must refresh their cached JWKS (most do this automatically)
+- Refresh tokens stamped before the rotation are also invalidated
+
+There is no recovery path for the encrypted rows without the original secret. The mitigation is to ensure cookie-secret backups are restored *before* the database, OR to accept the user re-auth event as part of the DR scenario.
+
+**Operationally:** notify users that they'll be signed out and need to sign in again. Plan a maintenance window if possible.
+
+---
+
+## Verification checklist
+
+After any restore, run through this before declaring DR complete:
+
+- [ ] `/healthz` returns 200 with session telemetry
+- [ ] `/readyz` returns 200 (not 503/bootstrap_required)
+- [ ] `/jwks` exposes the expected `kid` (matches the original if cookie secret was restored intact)
+- [ ] At least one known user can sign in via the configured auth method (GitHub OAuth, magic link, local password)
+- [ ] Signed-in user sees their portfolio elements (personas, memories, etc.)
+- [ ] `dollhouse-allowlist list` returns the expected entries (if allowlist is in use)
+- [ ] Audit log query returns recent events (verifies `auth_identity_events` is intact and writable)
+- [ ] `auth_kv` size is consistent with active session count (no stale data from a previous restore)
+- [ ] `npm audit` or your dep-scanning tool reports no new high-severity issues (helps catch deps that drifted during the restore-host setup)
+- [ ] Monitoring is re-pointed at the new host (Prometheus / Datadog / etc.)
+- [ ] DNS / load balancer is re-pointed to the new host
+
+---
+
+## Quarterly drill
+
+Run the full restore procedure quarterly against a scratch host that you tear down afterward. Time it — that's your real RTO. Use the most recent production backup; if it can't restore cleanly, that's a P0 backup-pipeline incident, not a DR exercise outcome.
+
+Record drill results in your runbook log: date, RTO achieved, anomalies found, action items.
+
+---
+
+## See also
+
+- [`production-hosting-runbook.md`](./production-hosting-runbook.md) — initial deployment, ongoing operations, secret rotation
+- [`secret-rotation-runbook.md`](./secret-rotation-runbook.md) — secret rotation procedures (cookie signing, invite tokens, JWKS)
+- [`deployment-configuration.md`](./deployment-configuration.md) — env var reference

--- a/src/auth/AuthProviderFactory.ts
+++ b/src/auth/AuthProviderFactory.ts
@@ -35,6 +35,9 @@ import {
 } from './embedded-as/AuthMethodFactory.js';
 import type { IAuthStorageLayer } from './embedded-as/storage/IAuthStorageLayer.js';
 import type { DatabaseInstance } from '../database/connection.js';
+import type { PerformanceMonitor } from '../utils/PerformanceMonitor.js';
+import { instrumentAuthMethod } from './embedded-as/instrumentAuthMethod.js';
+import { instrumentAuthProvider } from './instrumentAuthProvider.js';
 
 export type AuthProviderMode = 'embedded' | 'oidc-bridge';
 
@@ -83,6 +86,13 @@ export interface AuthConfig {
    * Forwarded to EmbeddedAuthorizationServer; ignored by other providers.
    */
   signingKeyStore?: import('../storage/signingKeys/ISigningKeyStore.js').ISigningKeyStore;
+  /**
+   * Optional PerformanceMonitor for instrumenting auth-flow timing.
+   * When present, each method's beginInteraction / completeInteraction /
+   * findAccount calls record into `recordAuthOp` so operators can see
+   * per-method latency in /healthz. When absent, calls run uninstrumented.
+   */
+  performanceMonitor?: PerformanceMonitor;
 }
 
 /**
@@ -141,12 +151,12 @@ export async function createAuthProvider(config: AuthConfig): Promise<IAuthProvi
   });
 
   if (config.provider === 'oidc') {
-    return createOidcProvider(config);
+    return instrumentAuthProvider(await createOidcProvider(config), config.performanceMonitor);
   }
   if (config.provider === 'embedded') {
-    return createEmbeddedProvider(config, methods);
+    return instrumentAuthProvider(await createEmbeddedProvider(config, methods), config.performanceMonitor);
   }
-  return createLocalDevProvider(config);
+  return instrumentAuthProvider(await createLocalDevProvider(config), config.performanceMonitor);
 }
 
 /**
@@ -219,7 +229,11 @@ async function createEmbeddedProvider(
   // simultaneously and let the LoginChooser pick at /interaction time.
   const builtMethods: import('./embedded-as/IAuthMethod.js').IAuthMethod[] = [];
   for (const id of methods) {
-    builtMethods.push(await buildAuthMethod(id, { storage, baseUrl, ensureInvites, config }));
+    const raw = await buildAuthMethod(id, { storage, baseUrl, ensureInvites, config });
+    // Wrap with PerformanceMonitor instrumentation when one was injected.
+    // No-op when monitor is undefined; otherwise records per-method timing
+    // for the three IAuthMethod entry points.
+    builtMethods.push(instrumentAuthMethod(raw, config.performanceMonitor));
   }
 
   return new EmbeddedAuthorizationServer({

--- a/src/auth/LocalDevAuthProvider.ts
+++ b/src/auth/LocalDevAuthProvider.ts
@@ -50,6 +50,81 @@ function extractScopes(payload: Record<string, unknown>): string[] | undefined {
   return undefined;
 }
 
+/**
+ * Build an AuthResult from a successfully-verified JWT payload. Returns
+ * an error result when required claims (typ, sub, mcp scope) are
+ * missing or wrong-shaped. Extracted from validate() to keep that
+ * function's cognitive complexity ≤15 (S3776).
+ */
+function buildLocalAuthResult(
+  payload: Record<string, unknown>,
+  protectedHeader: { typ?: string },
+): AuthResult {
+  // RFC 9068: access tokens carry `typ: at+jwt` so an id_token (or any
+  // other JWT signed by the same key) can't be replayed as an access
+  // token. Mirror the embedded AS's enforcement.
+  if (protectedHeader.typ && protectedHeader.typ !== 'at+jwt') {
+    return { ok: false, reason: 'invalid token type' };
+  }
+  if (!payload.sub || typeof payload.sub !== 'string') {
+    return { ok: false, reason: 'token missing sub claim' };
+  }
+
+  // Cycle-16 fix: validate the spec-standard `scope` (RFC 8693 §4.2,
+  // space-separated string) AND legacy `scopes` (array) for tokens
+  // issued by older versions of this provider. Both forms decode to
+  // the same string array internally. New issuance uses `scope`
+  // exclusively so a token issued under DOLLHOUSE_AUTH_PROVIDER=local
+  // can be verified by the embedded AS (which requires `scope`).
+  const scopes = extractScopes(payload);
+  if (!scopes?.includes('mcp')) {
+    return { ok: false, reason: 'token missing mcp scope' };
+  }
+
+  const claims: AuthClaims = {
+    sub: payload.sub,
+    displayName: typeof payload.display_name === 'string' ? payload.display_name : undefined,
+    email: typeof payload.email === 'string' ? payload.email : undefined,
+    tenantId: typeof payload.tenant_id === 'string' ? payload.tenant_id : null,
+    scopes,
+    roles: Array.isArray(payload.roles)
+      ? payload.roles.filter((r): r is string => typeof r === 'string')
+      : undefined,
+    exp: typeof payload.exp === 'number' ? payload.exp : undefined,
+  };
+  return { ok: true, claims };
+}
+
+/**
+ * Map a jose JWT-verification error to a stable, operator-friendly
+ * reason string. Cycle-10 fix (H10-3): use jose's typed errors rather
+ * than substring-matching .message — substrings like 'exp' / 'signature'
+ * collide with unrelated error text and produce misleading reasons in
+ * operator logs. Extracted from validate() for the cognitive-complexity
+ * refactor; behaviour is identical to the inline cascade it replaced.
+ */
+function mapJwtVerifyError(error: unknown): string {
+  if (error instanceof joseErrors.JWTExpired) {
+    return 'token expired';
+  }
+  if (error instanceof joseErrors.JWSSignatureVerificationFailed) {
+    return 'invalid signature';
+  }
+  // Cycle-13 fix: parity with OidcAuthProvider — distinct reason for
+  // alg-rejection so operator triage doesn't fold it into the generic
+  // "token validation failed" bucket.
+  if (error instanceof joseErrors.JOSEAlgNotAllowed) {
+    return 'algorithm not allowed';
+  }
+  if (error instanceof joseErrors.JWTClaimValidationFailed) {
+    const claim = error.claim;
+    if (claim === 'aud') return 'invalid audience';
+    if (claim === 'iss') return 'invalid issuer';
+    return `claim validation failed: ${claim ?? 'unknown'}`;
+  }
+  return 'token validation failed';
+}
+
 export class LocalDevAuthProvider implements IAuthProvider {
   readonly name = 'local-dev';
 
@@ -71,69 +146,9 @@ export class LocalDevAuthProvider implements IAuthProvider {
         audience: AUDIENCE,
         algorithms: [ALGORITHM],
       });
-
-      // RFC 9068: access tokens carry `typ: at+jwt` so an id_token
-      // (or any other JWT signed by the same key) can't be replayed
-      // as an access token. Mirror the embedded AS's enforcement.
-      if (protectedHeader.typ && protectedHeader.typ !== 'at+jwt') {
-        return { ok: false, reason: 'invalid token type' };
-      }
-
-      if (!payload.sub) {
-        return { ok: false, reason: 'token missing sub claim' };
-      }
-
-      // Cycle-16 fix: validate the spec-standard `scope` (RFC 8693 §4.2,
-      // space-separated string) AND legacy `scopes` (array) for tokens
-      // issued by older versions of this provider. Both forms decode to
-      // the same string array internally. New issuance uses `scope`
-      // exclusively so a token issued under DOLLHOUSE_AUTH_PROVIDER=local
-      // can be verified by the embedded AS (which requires `scope`).
-      const scopes = extractScopes(payload);
-      if (!scopes?.includes('mcp')) {
-        return { ok: false, reason: 'token missing mcp scope' };
-      }
-
-      const claims: AuthClaims = {
-        sub: payload.sub,
-        displayName: typeof payload.display_name === 'string' ? payload.display_name : undefined,
-        email: typeof payload.email === 'string' ? payload.email : undefined,
-        tenantId: typeof payload.tenant_id === 'string' ? payload.tenant_id : null,
-        scopes,
-        roles: Array.isArray(payload.roles)
-          ? payload.roles.filter((r): r is string => typeof r === 'string')
-          : undefined,
-        exp: payload.exp,
-      };
-
-      return { ok: true, claims };
+      return buildLocalAuthResult(payload, protectedHeader);
     } catch (error) {
-      // Cycle-10 fix (H10-3): use jose's typed errors instead of
-      // substring-matching .message. Substrings like 'exp' / 'signature'
-      // collide with unrelated error text ('issuer' contains 'iss',
-      // 'expected' contains 'exp', 'unexpected signal' contains
-      // 'signature') and produce misleading reasons in operator logs.
-      // Cycle 8 made the same fix in EmbeddedAuthorizationServer.validate;
-      // this is the sibling site that was missed at the time.
-      if (error instanceof joseErrors.JWTExpired) {
-        return { ok: false, reason: 'token expired' };
-      }
-      if (error instanceof joseErrors.JWSSignatureVerificationFailed) {
-        return { ok: false, reason: 'invalid signature' };
-      }
-      // Cycle-13 fix: parity with OidcAuthProvider — distinct reason
-      // for alg-rejection so operator triage doesn't fold it into the
-      // generic "token validation failed" bucket.
-      if (error instanceof joseErrors.JOSEAlgNotAllowed) {
-        return { ok: false, reason: 'algorithm not allowed' };
-      }
-      if (error instanceof joseErrors.JWTClaimValidationFailed) {
-        const claim = error.claim;
-        if (claim === 'aud') return { ok: false, reason: 'invalid audience' };
-        if (claim === 'iss') return { ok: false, reason: 'invalid issuer' };
-        return { ok: false, reason: `claim validation failed: ${claim ?? 'unknown'}` };
-      }
-      return { ok: false, reason: 'token validation failed' };
+      return { ok: false, reason: mapJwtVerifyError(error) };
     }
   }
 

--- a/src/auth/OidcAuthProvider.ts
+++ b/src/auth/OidcAuthProvider.ts
@@ -115,91 +115,87 @@ export class OidcAuthProvider implements IAuthProvider {
 
   async validate(token: string): Promise<AuthResult> {
     try {
-      // Cycle-12 fix (M12-1): pin algorithms explicitly. The peer
-      // providers do this; OIDC bridge mode was missing the parity
-      // hardening. jose's default is permissive (any alg the JWKS
-      // keys support); explicit allowlist refuses `none`/HMAC even
-      // if the upstream JWKS were ever compromised in a way that
-      // included symmetric keys.
+      // Cycle-12 fix (M12-1): pin algorithms explicitly. jose's default
+      // is permissive (any alg the JWKS keys support); explicit allowlist
+      // refuses `none`/HMAC even if the upstream JWKS were ever
+      // compromised in a way that included symmetric keys.
+      // Cycle 19 / security-#6: opt-in RFC 9068 typ enforcement — default
+      // off for compat with IdPs that don't stamp typ; on closes the
+      // id-token-as-access-token gap.
       const { payload } = await jwtVerify(token, this.jwks, {
         issuer: this.issuer,
         audience: this.audience,
         algorithms: [...this.algorithms],
-        // Cycle 19 / security-#6: opt-in RFC 9068 typ enforcement.
-        // Default off for compat with IdPs that don't stamp typ; on
-        // closes the id-token-as-access-token gap.
         ...(this.requireAccessTokenTyp ? { typ: 'at+jwt' } : {}),
       });
-
-      if (!payload.sub) {
-        return { ok: false, reason: 'token missing sub claim' };
-      }
-
-      const scopes = extractScopes(payload);
-      // Defense in depth: the bridge must enforce the same `mcp` scope
-      // requirement as the embedded AS — an external IdP token issued
-      // for our audience but lacking `mcp` represents a different
-      // permission surface (e.g. an admin console token) and must not
-      // satisfy the resource-server check here.
-      if (!scopes?.includes('mcp')) {
-        return { ok: false, reason: 'token missing mcp scope' };
-      }
-
-      const claims: AuthClaims = {
-        sub: payload.sub,
-        displayName: extractStringClaim(payload, 'name', 'display_name', 'preferred_username'),
-        email: extractStringClaim(payload, 'email'),
-        tenantId: extractStringClaim(payload, 'tenant_id', 'org_id') ?? null,
-        scopes,
-        roles: Array.isArray(payload.roles)
-          ? payload.roles.filter((r): r is string => typeof r === 'string')
-          : undefined,
-        exp: payload.exp,
-      };
-
-      return { ok: true, claims };
+      return buildOidcAuthResult(payload);
     } catch (error) {
-      // Cycle-11 fix (H11-1 / M11-1): use jose's typed errors instead of
-      // substring-matching on .message. The earlier substring-matching
-      // pattern was a sibling of the same bug class cycle 8 fixed in
-      // EmbeddedAuthorizationServer.validate and cycle 10 fixed in
-      // LocalDevAuthProvider.validate. This is the third site —
-      // missed both times — exactly the recurring drift class user
-      // memory `feedback_scan_for_class_when_fixing` flags.
-      //
-      // Reason text aligned across all three providers (M11-1):
-      // 'token expired', 'invalid signature', 'invalid issuer',
-      // 'invalid audience'. Operator log-grep stays consistent
-      // regardless of which provider is mounted.
-      if (error instanceof joseErrors.JWTExpired) {
-        return { ok: false, reason: 'token expired' };
-      }
-      if (error instanceof joseErrors.JWSSignatureVerificationFailed) {
-        return { ok: false, reason: 'invalid signature' };
-      }
-      // Cycle-13 fix: JOSEAlgNotAllowed gets its own reason string so
-      // operator log triage can distinguish "token had a forbidden alg"
-      // from generic "token validation failed". Sibling of the M11-1
-      // alignment work — that round caught aud/iss/expired/signature
-      // but not alg.
-      if (error instanceof joseErrors.JOSEAlgNotAllowed) {
-        return { ok: false, reason: 'algorithm not allowed' };
-      }
-      if (error instanceof joseErrors.JWTClaimValidationFailed) {
-        const claim = error.claim;
-        if (claim === 'aud') return { ok: false, reason: 'invalid audience' };
-        if (claim === 'iss') return { ok: false, reason: 'invalid issuer' };
-        // Cycle 22 / cycle-21 security-LOW-1: align typ-rejection
-        // reason with EmbeddedAuthorizationServer.validate so operator
-        // log-grep sees consistent strings across providers when an
-        // upstream typ check fails. Same drift class as M11-1
-        // alignment work.
-        if (claim === 'typ') return { ok: false, reason: 'wrong token type' };
-        return { ok: false, reason: `claim validation failed: ${claim ?? 'unknown'}` };
-      }
-      return { ok: false, reason: 'token validation failed' };
+      return { ok: false, reason: mapOidcVerifyError(error) };
     }
   }
+}
+
+/**
+ * Build an AuthResult from a verified OIDC JWT payload. Enforces the
+ * required `mcp` scope (defence-in-depth: an external IdP token issued
+ * for our audience but lacking `mcp` represents a different permission
+ * surface and must not satisfy the resource-server check here).
+ * Extracted from validate() to keep its cognitive complexity ≤15 (S3776).
+ */
+function buildOidcAuthResult(payload: Record<string, unknown>): AuthResult {
+  if (!payload.sub || typeof payload.sub !== 'string') {
+    return { ok: false, reason: 'token missing sub claim' };
+  }
+
+  const scopes = extractScopes(payload);
+  if (!scopes?.includes('mcp')) {
+    return { ok: false, reason: 'token missing mcp scope' };
+  }
+
+  const claims: AuthClaims = {
+    sub: payload.sub,
+    displayName: extractStringClaim(payload, 'name', 'display_name', 'preferred_username'),
+    email: extractStringClaim(payload, 'email'),
+    tenantId: extractStringClaim(payload, 'tenant_id', 'org_id') ?? null,
+    scopes,
+    roles: Array.isArray(payload.roles)
+      ? payload.roles.filter((r): r is string => typeof r === 'string')
+      : undefined,
+    exp: typeof payload.exp === 'number' ? payload.exp : undefined,
+  };
+  return { ok: true, claims };
+}
+
+/**
+ * Map a jose JWT-verification error to a stable, operator-friendly
+ * reason string. Cycle-11 / M11-1 fix: use jose's typed errors instead
+ * of substring-matching .message — substrings like 'exp' / 'signature'
+ * collide with unrelated error text and produce misleading reasons in
+ * operator logs. Reasons aligned across all three providers so
+ * operator log-grep is consistent regardless of which provider is
+ * mounted. Extracted from validate() for the cognitive-complexity
+ * refactor; behaviour is identical to the inline cascade it replaced.
+ */
+function mapOidcVerifyError(error: unknown): string {
+  if (error instanceof joseErrors.JWTExpired) {
+    return 'token expired';
+  }
+  if (error instanceof joseErrors.JWSSignatureVerificationFailed) {
+    return 'invalid signature';
+  }
+  if (error instanceof joseErrors.JOSEAlgNotAllowed) {
+    return 'algorithm not allowed';
+  }
+  if (error instanceof joseErrors.JWTClaimValidationFailed) {
+    const claim = error.claim;
+    if (claim === 'aud') return 'invalid audience';
+    if (claim === 'iss') return 'invalid issuer';
+    // Cycle 22 / cycle-21 security-LOW-1: align typ-rejection reason
+    // with the embedded AS so operator log-grep sees consistent strings.
+    if (claim === 'typ') return 'wrong token type';
+    return `claim validation failed: ${claim ?? 'unknown'}`;
+  }
+  return 'token validation failed';
 }
 
 function extractStringClaim(payload: Record<string, unknown>, ...keys: string[]): string | undefined {

--- a/src/auth/embedded-as/EmbeddedAuthorizationServer.ts
+++ b/src/auth/embedded-as/EmbeddedAuthorizationServer.ts
@@ -311,60 +311,9 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
         typ: 'at+jwt',
         crit: {},
       });
-
-      if (!protectedHeader.kid) {
-        return { ok: false, reason: 'token missing kid header' };
-      }
-      if (protectedHeader.kid !== keyset.kid) {
-        return { ok: false, reason: 'unknown key id' };
-      }
-      if (!payload.sub) {
-        return { ok: false, reason: 'token missing sub claim' };
-      }
-
-      // Defense in depth (H6): require the `mcp` scope on the token.
-      // Tokens we issue always carry it (resource server scope wired in
-      // the resourceIndicators config), but a key-rotation bug or a
-      // future code path that accidentally minted a token without scope
-      // would otherwise pass everything else here. Reject unconditionally.
-      const scopeClaim = typeof payload.scope === 'string' ? payload.scope : '';
-      const scopes = new Set(scopeClaim.split(/\s+/).filter(Boolean));
-      if (!scopes.has('mcp')) {
-        return { ok: false, reason: 'token missing mcp scope' };
-      }
-
-      return { ok: true, claims: claimsFromPayload(payload) };
+      return buildEmbeddedAsAuthResult(payload, protectedHeader, keyset.kid);
     } catch (error) {
-      // Use jose's typed errors instead of substring-matching .message —
-      // substrings like 'iss' or 'typ' collide with unrelated error text
-      // ('issuer', 'unexpected', 'cryptographic', 'type'), producing
-      // misleading reasons in operator logs.
-      //
-      // Cycle-11 fix (M11-1): added JWSSignatureVerificationFailed
-      // branch for parity with LocalDevAuthProvider and OidcAuthProvider
-      // — without it, tampered tokens fell through to the generic
-      // "token validation failed" reason while the other two providers
-      // returned "invalid signature". Operator log triage now sees
-      // consistent reason text across all three IAuthProvider impls.
-      if (error instanceof joseErrors.JWTExpired) {
-        return { ok: false, reason: 'token expired' };
-      }
-      if (error instanceof joseErrors.JWSSignatureVerificationFailed) {
-        return { ok: false, reason: 'invalid signature' };
-      }
-      // Cycle-13 fix: distinct reason for alg-rejection across all 3
-      // providers (M11-1 alignment + cycle-13 follow-up).
-      if (error instanceof joseErrors.JOSEAlgNotAllowed) {
-        return { ok: false, reason: 'algorithm not allowed' };
-      }
-      if (error instanceof joseErrors.JWTClaimValidationFailed) {
-        const claim = error.claim;
-        if (claim === 'aud') return { ok: false, reason: 'invalid audience' };
-        if (claim === 'iss') return { ok: false, reason: 'invalid issuer' };
-        if (claim === 'typ') return { ok: false, reason: 'wrong token type' };
-        return { ok: false, reason: `claim validation failed: ${claim ?? 'unknown'}` };
-      }
-      return { ok: false, reason: 'token validation failed' };
+      return { ok: false, reason: mapEmbeddedAsVerifyError(error) };
     }
   }
 
@@ -935,7 +884,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
       methodIds: this.methods.map((m) => m.id),
       issuer: this.issuer,
       primaryKid: keyset.kid,
-      primaryCookieKey: cookieKeys[0]!,
+      primaryCookieKey: cookieKeys[0],
     };
     const fingerprintResult = await checkModeFingerprint(this.storage, fingerprintInputs);
 
@@ -980,7 +929,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
       await persistModeFingerprint(this.storage, {
         ...fingerprintInputs,
         primaryKid: keyset.kid,
-        primaryCookieKey: cookieKeys[0]!,
+        primaryCookieKey: cookieKeys[0],
       });
       await this.storage.recordIdentityEvent({
         type: 'auth.mode_switch_invalidation',
@@ -1315,6 +1264,69 @@ function claimsFromPayload(payload: Record<string, unknown>): AuthClaims {
       : undefined,
     exp: typeof payload.exp === 'number' ? payload.exp : undefined,
   };
+}
+
+/**
+ * Build an AuthResult from a successfully-verified embedded-AS JWT.
+ * Enforces kid presence, kid match against the active keyset (so a
+ * token signed with a rotated-out key can't validate), sub presence,
+ * and the `mcp` scope (defence-in-depth: H6 — tokens we issue always
+ * carry it, but a key-rotation bug or a future code path that
+ * accidentally minted a token without scope would otherwise pass
+ * everything else here). Extracted from validate() to keep its
+ * cognitive complexity ≤15 (S3776).
+ */
+function buildEmbeddedAsAuthResult(
+  payload: Record<string, unknown>,
+  protectedHeader: { kid?: string },
+  activeKid: string,
+): AuthResult {
+  if (!protectedHeader.kid) {
+    return { ok: false, reason: 'token missing kid header' };
+  }
+  if (protectedHeader.kid !== activeKid) {
+    return { ok: false, reason: 'unknown key id' };
+  }
+  if (!payload.sub) {
+    return { ok: false, reason: 'token missing sub claim' };
+  }
+  const scopeClaim = typeof payload.scope === 'string' ? payload.scope : '';
+  const scopes = new Set(scopeClaim.split(/\s+/).filter(Boolean));
+  if (!scopes.has('mcp')) {
+    return { ok: false, reason: 'token missing mcp scope' };
+  }
+  return { ok: true, claims: claimsFromPayload(payload) };
+}
+
+/**
+ * Map a jose JWT-verification error to a stable reason string. Uses
+ * jose's typed errors instead of substring-matching .message —
+ * substrings like 'iss' or 'typ' collide with unrelated error text
+ * ('issuer', 'unexpected', 'cryptographic', 'type'). Cycle-11 (M11-1)
+ * added the JWSSignatureVerificationFailed branch for parity with the
+ * other two providers; cycle-13 added JOSEAlgNotAllowed. Reason
+ * strings are aligned across all three providers so operator log-grep
+ * sees consistent text regardless of which provider is mounted.
+ * Extracted from validate() for the cognitive-complexity refactor.
+ */
+function mapEmbeddedAsVerifyError(error: unknown): string {
+  if (error instanceof joseErrors.JWTExpired) {
+    return 'token expired';
+  }
+  if (error instanceof joseErrors.JWSSignatureVerificationFailed) {
+    return 'invalid signature';
+  }
+  if (error instanceof joseErrors.JOSEAlgNotAllowed) {
+    return 'algorithm not allowed';
+  }
+  if (error instanceof joseErrors.JWTClaimValidationFailed) {
+    const claim = error.claim;
+    if (claim === 'aud') return 'invalid audience';
+    if (claim === 'iss') return 'invalid issuer';
+    if (claim === 'typ') return 'wrong token type';
+    return `claim validation failed: ${claim ?? 'unknown'}`;
+  }
+  return 'token validation failed';
 }
 
 /**

--- a/src/auth/embedded-as/instrumentAuthMethod.ts
+++ b/src/auth/embedded-as/instrumentAuthMethod.ts
@@ -1,0 +1,44 @@
+/**
+ * Auth method instrumentation decorator.
+ *
+ * Wraps an IAuthMethod with PerformanceMonitor timing on each async
+ * entry point so operators can see how long each phase of the auth
+ * flow takes (per-method, separately) in `/healthz`. The decorator
+ * lives here rather than inside each method class so:
+ *   1. Each method file stays single-purpose (auth logic, not metrics).
+ *   2. Adding a new method automatically gets instrumented when its
+ *      registration runs through AuthProviderFactory.buildAuthMethod.
+ *   3. SonarCloud complexity findings on existing method files are not
+ *      re-flagged by adding metrics — the wrapper sits outside them.
+ *
+ * When `monitor` is undefined, returns the original method untouched
+ * (zero overhead).
+ *
+ * @module auth/embedded-as/instrumentAuthMethod
+ */
+
+import type { IAuthMethod } from './IAuthMethod.js';
+import type { PerformanceMonitor } from '../../utils/PerformanceMonitor.js';
+
+const OP_BEGIN = 'auth.beginInteraction';
+const OP_COMPLETE = 'auth.completeInteraction';
+const OP_FIND_ACCOUNT = 'auth.findAccount';
+
+export function instrumentAuthMethod(
+  method: IAuthMethod,
+  monitor?: PerformanceMonitor,
+): IAuthMethod {
+  if (!monitor) return method;
+
+  return {
+    id: method.id,
+    displayName: method.displayName,
+    beginInteraction: (ctx) =>
+      monitor.timeAuthOp(OP_BEGIN, () => method.beginInteraction(ctx), method.id),
+    completeInteraction: (ctx, input) =>
+      monitor.timeAuthOp(OP_COMPLETE, () => method.completeInteraction(ctx, input), method.id),
+    findAccount: (sub) =>
+      monitor.timeAuthOp(OP_FIND_ACCOUNT, () => method.findAccount(sub), method.id),
+    contributeRoutes: method.contributeRoutes?.bind(method),
+  };
+}

--- a/src/auth/instrumentAuthProvider.ts
+++ b/src/auth/instrumentAuthProvider.ts
@@ -1,0 +1,46 @@
+/**
+ * IAuthProvider instrumentation decorator.
+ *
+ * Wraps `validate(token)` with PerformanceMonitor timing so operators
+ * can see token-validation latency in `/healthz`. For OIDC bridge mode
+ * this includes the JWKS fetch + JWT signature verify; for the local-dev
+ * provider it's just the local signing-key check. Separate from
+ * `instrumentAuthMethod` (which decorates IAuthMethod entry points)
+ * because IAuthProvider is the outer abstraction the HTTP middleware
+ * calls on every request.
+ *
+ * Same design intent as instrumentAuthMethod: wrap from outside so the
+ * concrete provider class file is untouched (no SonarCloud complexity
+ * re-flag on the existing validate() bodies).
+ *
+ * When `monitor` is undefined, returns the original provider untouched.
+ *
+ * @module auth/instrumentAuthProvider
+ */
+
+import type { IAuthProvider, AuthResult } from './IAuthProvider.js';
+import type { PerformanceMonitor } from '../utils/PerformanceMonitor.js';
+
+const OP_VALIDATE = 'auth.validateToken';
+
+export function instrumentAuthProvider(
+  provider: IAuthProvider,
+  monitor?: PerformanceMonitor,
+): IAuthProvider {
+  if (!monitor) return provider;
+
+  // Use a Proxy so optional methods (issue, getProtectedResourceMetadataUrl,
+  // isReadyForTraffic, etc.) and properties (name) pass through unchanged.
+  // Only validate() is wrapped — that's the per-request hot path the
+  // metrics target.
+  return new Proxy(provider, {
+    get(target, prop, receiver) {
+      if (prop === 'validate') {
+        return (token: string): Promise<AuthResult> =>
+          monitor.timeAuthOp(OP_VALIDATE, () => target.validate(token), target.name);
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}

--- a/src/config/ConfigManager.ts
+++ b/src/config/ConfigManager.ts
@@ -1040,7 +1040,7 @@ export class ConfigManager {
     }
 
     // Set the value using secure property setter
-    const lastKey = keys[keys.length - 1];
+    const lastKey = keys.at(-1)!;
     safeSetProperty(current, lastKey, value);
 
     // Persist to both stores (split + parallel save).
@@ -1120,7 +1120,7 @@ export class ConfigManager {
       }
       current = current[key];
     }
-    const lastKey = keys[keys.length - 1];
+    const lastKey = keys.at(-1)!;
     if (safeHasOwnProperty(current, lastKey)) {
       delete current[lastKey];
     }
@@ -1429,7 +1429,7 @@ export class ConfigManager {
           defaultSection = defaultSection[sectionKeys[i]];
         }
 
-        const lastKey = sectionKeys[sectionKeys.length - 1];
+        const lastKey = sectionKeys.at(-1)!;
         // SECURITY: Use secure property setter to avoid prototype chain pollution
         safeSetProperty(current, lastKey, defaultSection[lastKey]);
       } else {

--- a/src/config/ConfigManager.ts
+++ b/src/config/ConfigManager.ts
@@ -45,6 +45,7 @@ import {
   safeHasOwnProperty
 } from '../utils/securityUtils.js';
 import { env } from './env.js';
+import { isKnownConfigPath, validateConfigPath } from './configSchema.js';
 import { IFileOperationsService } from '../services/FileOperationsService.js';
 import type { IOperatorConfigStore, OperatorConfig } from '../storage/operatorConfig/IOperatorConfigStore.js';
 import type { IUserConfigStore, UserConfig as UserConfigPayload } from '../storage/userConfig/IUserConfigStore.js';
@@ -1010,6 +1011,20 @@ export class ConfigManager {
       value = validated;
     }
 
+    // Schema validation: reject unknown paths and type mismatches so typos
+    // and renamed-key drift surface as errors instead of silently writing
+    // phantom keys into the JSONB blob. Strict-by-default; operators can
+    // set DOLLHOUSE_CONFIG_STRICT_PATHS=false to opt back to "anything goes"
+    // for back-compat with workflows that still rely on old/unenumerated paths.
+    const validation = validateConfigPath(path, value, { strict: env.DOLLHOUSE_CONFIG_STRICT_PATHS });
+    if (!validation.ok) {
+      logger.warn('[ConfigManager] Rejected config write (schema violation)', {
+        path,
+        error: validation.error,
+      });
+      return { success: false, message: validation.error };
+    }
+
     const keys = path.split('.');
     let current: any = this.config;
     const previousValue = this.getSetting(path);
@@ -1042,6 +1057,83 @@ export class ConfigManager {
       message: `Setting '${path}' updated successfully`,
       previousValue,
       newValue: value,
+    };
+  }
+
+  /**
+   * Remove a setting from the config so the consumer sees the schema
+   * default. Useful for cleaning up phantom keys (typos from before
+   * schema validation existed, or paths from renamed/removed features).
+   *
+   * Returns success=false when:
+   *   - the path is server-wide (per-host) and the caller lacks 'admin'
+   *   - the path doesn't currently have a stored value (nothing to delete)
+   *
+   * Prototype-pollution guards mirror `updateSetting`.
+   */
+  public async deleteSetting(path: string): Promise<ConfigUpdateResult> {
+    const userId = this.resolveUserId();
+    if (!this.config) {
+      await this.initialize();
+    }
+
+    validatePropertyPath(path, 'path');
+
+    // Same admin gate as updateSetting — per-host paths require 'admin'.
+    if (ConfigManager.isPerHostPath(path) && this.contextTracker) {
+      const callerRoles = this.contextTracker.getSessionContext()?.roles ?? [];
+      if (!callerRoles.includes('admin')) {
+        const reason = `Configuration path '${path}' is server-wide and requires the 'admin' role.`;
+        logger.warn('[ConfigManager] Rejected non-admin operator-config delete', {
+          path,
+          callerUserId: userId,
+        });
+        return {
+          success: false,
+          message: `${reason} Per-host settings can only be changed by an admin operator.`,
+        };
+      }
+    }
+
+    const previousValue = this.getSetting(path);
+    if (previousValue === undefined) {
+      return {
+        success: false,
+        message: `Configuration path '${path}' has no stored value to delete.`,
+      };
+    }
+    if (!isKnownConfigPath(path) && isPlainObject(previousValue)) {
+      return {
+        success: false,
+        message: `Configuration path '${path}' is a section, not a leaf setting. Delete a specific setting path instead.`,
+      };
+    }
+
+    const keys = path.split('.');
+    let current: any = this.config;
+    // Navigate to the parent
+    for (let i = 0; i < keys.length - 1; i++) {
+      const key = keys[i];
+      if (!safeHasOwnProperty(current, key)) {
+        // Parent missing — nothing to delete; return idempotently
+        return { success: true, message: `Setting '${path}' was already unset`, previousValue };
+      }
+      current = current[key];
+    }
+    const lastKey = keys[keys.length - 1];
+    if (safeHasOwnProperty(current, lastKey)) {
+      delete current[lastKey];
+    }
+
+    await this.persistMerged(userId, this.config!);
+
+    logger.info('Configuration setting deleted', { path, previousValue });
+
+    return {
+      success: true,
+      message: `Setting '${path}' deleted (consumer will now see schema default)`,
+      previousValue,
+      newValue: undefined,
     };
   }
 
@@ -1473,4 +1565,10 @@ export class ConfigManager {
       sortKeys: false
     });
   }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
 }

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -1,0 +1,357 @@
+/**
+ * dollhouse_config schema registry.
+ *
+ * Canonical list of valid configuration paths and their expected value
+ * types. ConfigManager.updateSetting validates against this on every
+ * write so typos (`sync.enabled = "tru"`), schema drift (renamed keys
+ * silently writing into the JSONB blob), and type mismatches surface as
+ * errors instead of "✅ saved" lies.
+ *
+ * The schema mirrors the TypeScript interfaces in ConfigManager.ts
+ * (UserConfig, GitHubConfig, SyncConfig, CollectionConfig, etc.). When
+ * those interfaces gain a new field, add the corresponding path entry
+ * here too — both should change together.
+ *
+ * Strictness is controlled by `DOLLHOUSE_CONFIG_STRICT_PATHS` env var:
+ *   - default `true`  — reject unknown paths with a clear error
+ *   - `false`         — log a warning and allow (back-compat for old
+ *                       operator workflows that may have stored phantom
+ *                       keys that the schema hasn't catalogued yet)
+ *
+ * @module config/configSchema
+ */
+
+/**
+ * Allowed value shape for a single configuration path. `enum` is used
+ * for string-literal unions; `nullable` for `string | null` fields;
+ * `arrayOf` for typed array fields.
+ */
+export type ConfigFieldType =
+  | 'boolean'
+  | 'number'
+  | 'string'
+  | 'array'
+  | 'object';
+
+export interface ConfigFieldSpec {
+  type: ConfigFieldType;
+  /** When type='string', the set of acceptable literal values. */
+  enum?: readonly string[];
+  /** When true, `null` is an acceptable value (e.g. user.username before setup). */
+  nullable?: boolean;
+  /** When type='array', the element type for items in the array. */
+  arrayOf?: 'string' | 'number';
+  /** When type='number', the inclusive minimum. */
+  min?: number;
+  /** When type='number', the inclusive maximum. */
+  max?: number;
+  /** Human-readable description, surfaced in error messages. */
+  description: string;
+}
+
+/**
+ * The schema registry. Keys are dot-notation paths exactly as
+ * `dollhouse_config set <path>` accepts them.
+ */
+export const CONFIG_SCHEMA: Readonly<Record<string, ConfigFieldSpec>> = {
+  // ── User identity ──────────────────────────────────────────────────
+  'user.username': { type: 'string', nullable: true, description: 'Display username for portfolio attribution' },
+  'user.email': { type: 'string', nullable: true, description: 'Contact email (only used for verification / license attestation)' },
+  'user.display_name': { type: 'string', nullable: true, description: 'Human-readable display name' },
+
+  // ── GitHub integration ─────────────────────────────────────────────
+  'github.portfolio.repository_url': { type: 'string', nullable: true, description: 'Full URL to the operator\'s GitHub portfolio repo' },
+  'github.portfolio.repository_name': { type: 'string', description: 'Repository name (e.g. "dollhouse-portfolio")' },
+  'github.portfolio.default_branch': { type: 'string', description: 'Default branch for portfolio commits' },
+  'github.portfolio.auto_create': { type: 'boolean', description: 'Auto-create the portfolio repo on first sync if missing' },
+  'github.auth.use_oauth': { type: 'boolean', description: 'Use OAuth device flow for portfolio sync (vs personal access token)' },
+  'github.auth.token_source': { type: 'string', enum: ['environment', 'oauth', 'config'], description: 'Where to source the GitHub token from' },
+  'github.auth.client_id': { type: 'string', description: 'GitHub OAuth app client ID (for device flow)' },
+
+  // ── Sync ───────────────────────────────────────────────────────────
+  'sync.enabled': { type: 'boolean', description: 'Master toggle for portfolio sync' },
+  'sync.individual.require_confirmation': { type: 'boolean', description: 'Require confirm before single-element sync' },
+  'sync.individual.show_diff_before_sync': { type: 'boolean', description: 'Show a diff before pushing a single element' },
+  'sync.individual.track_versions': { type: 'boolean', description: 'Keep version history for individual elements' },
+  'sync.individual.keep_history': { type: 'number', min: 0, description: 'Number of historical versions to keep per element' },
+  'sync.bulk.upload_enabled': { type: 'boolean', description: 'Allow bulk upload operations' },
+  'sync.bulk.download_enabled': { type: 'boolean', description: 'Allow bulk download operations' },
+  'sync.bulk.require_preview': { type: 'boolean', description: 'Show preview before bulk operations' },
+  'sync.bulk.respect_local_only': { type: 'boolean', description: 'Honor the local-only flag on elements during bulk sync' },
+  'sync.privacy.scan_for_secrets': { type: 'boolean', description: 'Scan element content for secrets before sync' },
+  'sync.privacy.scan_for_pii': { type: 'boolean', description: 'Scan element content for PII before sync' },
+  'sync.privacy.warn_on_sensitive': { type: 'boolean', description: 'Warn (don\'t block) when sync content matches sensitive patterns' },
+  'sync.privacy.excluded_patterns': { type: 'array', arrayOf: 'string', description: 'Glob patterns to exclude from sync entirely' },
+
+  // ── Collection ─────────────────────────────────────────────────────
+  'collection.auto_submit': { type: 'boolean', description: 'Auto-submit new elements to the public collection' },
+  'collection.require_review': { type: 'boolean', description: 'Require human review before collection submission' },
+  'collection.add_attribution': { type: 'boolean', description: 'Stamp portfolio attribution onto collection submissions' },
+
+  // ── Elements ───────────────────────────────────────────────────────
+  'elements.auto_activate.personas': { type: 'array', arrayOf: 'string', description: 'Personas auto-activated at startup' },
+  'elements.auto_activate.skills': { type: 'array', arrayOf: 'string', description: 'Skills auto-activated at startup' },
+  'elements.auto_activate.templates': { type: 'array', arrayOf: 'string', description: 'Templates auto-activated at startup' },
+  'elements.auto_activate.agents': { type: 'array', arrayOf: 'string', description: 'Agents auto-activated at startup' },
+  'elements.auto_activate.memories': { type: 'array', arrayOf: 'string', description: 'Memories auto-activated at startup' },
+  'elements.auto_activate.ensembles': { type: 'array', arrayOf: 'string', description: 'Ensembles auto-activated at startup' },
+  'elements.default_element_dir': { type: 'string', description: 'Override for the element root directory' },
+  'elements.enhanced_index.enabled': { type: 'boolean', description: 'Master toggle for the enhanced verb-trigger index' },
+  'elements.enhanced_index.limits.maxTriggersPerElement': { type: 'number', min: 0, description: 'Cap on triggers extracted per element' },
+  'elements.enhanced_index.limits.maxTriggerLength': { type: 'number', min: 1, description: 'Max characters per trigger string' },
+  'elements.enhanced_index.limits.maxKeywordsToCheck': { type: 'number', min: 0, description: 'Cap on keywords scanned per trigger evaluation' },
+  'elements.enhanced_index.telemetry.enabled': { type: 'boolean', description: 'Emit enhanced-index telemetry events' },
+  'elements.enhanced_index.telemetry.sampleRate': { type: 'number', min: 0, max: 1, description: 'Sampling rate for telemetry (0..1)' },
+  'elements.enhanced_index.telemetry.metricsInterval': { type: 'number', min: 1000, description: 'Metrics flush interval in ms' },
+  'elements.enhanced_index.verbPatterns.customPrefixes': { type: 'array', arrayOf: 'string', description: 'Operator-defined verb prefixes' },
+  'elements.enhanced_index.verbPatterns.customSuffixes': { type: 'array', arrayOf: 'string', description: 'Operator-defined verb suffixes' },
+  'elements.enhanced_index.verbPatterns.excludedNouns': { type: 'array', arrayOf: 'string', description: 'Nouns excluded from trigger extraction' },
+  'elements.enhanced_index.backgroundAnalysis.enabled': { type: 'boolean', description: 'Run trigger analysis on a background schedule' },
+  'elements.enhanced_index.backgroundAnalysis.scanInterval': { type: 'number', min: 1000, description: 'Background scan interval in ms' },
+  'elements.enhanced_index.backgroundAnalysis.maxConcurrentScans': { type: 'number', min: 1, description: 'Concurrency cap for background scans' },
+  'elements.enhanced_index.resources.advertise_resources': { type: 'boolean', description: 'Expose enhanced-index data via MCP resources' },
+  'elements.enhanced_index.resources.variants.summary': { type: 'boolean', description: 'Include the summary resource variant' },
+  'elements.enhanced_index.resources.variants.full': { type: 'boolean', description: 'Include the full resource variant' },
+  'elements.enhanced_index.resources.variants.stats': { type: 'boolean', description: 'Include the stats resource variant' },
+
+  // ── Display ────────────────────────────────────────────────────────
+  'display.persona_indicators.enabled': { type: 'boolean', description: 'Show persona-indicator prefix on tool output' },
+  'display.persona_indicators.style': { type: 'string', enum: ['full', 'minimal', 'compact', 'custom'], description: 'Indicator render style' },
+  'display.persona_indicators.include_emoji': { type: 'boolean', description: 'Include the persona emoji in the indicator' },
+  'display.verbose_logging': { type: 'boolean', description: 'Verbose log output for operator debugging' },
+  'display.show_progress': { type: 'boolean', description: 'Render progress for long-running operations' },
+  // display.indicator.* maps to PersonaIndicatorService (separate from persona_indicators)
+  'display.indicator.enabled': { type: 'boolean', description: 'Enable the runtime persona indicator' },
+  'display.indicator.style': { type: 'string', enum: ['full', 'minimal', 'compact', 'custom'], description: 'Runtime indicator render style' },
+  'display.indicator.customFormat': { type: 'string', description: 'Custom format string for style="custom"' },
+  'display.indicator.showEmoji': { type: 'boolean', description: 'Render the emoji in the runtime indicator' },
+  'display.indicator.showName': { type: 'boolean', description: 'Render the name in the runtime indicator' },
+  'display.indicator.showVersion': { type: 'boolean', description: 'Render the version in the runtime indicator' },
+  'display.indicator.showAuthor': { type: 'boolean', description: 'Render the author in the runtime indicator' },
+  'display.indicator.showCategory': { type: 'boolean', description: 'Render the category in the runtime indicator' },
+  'display.indicator.separator': { type: 'string', description: 'Separator between indicator fields' },
+  'display.indicator.emoji': { type: 'string', description: 'Emoji override for the runtime indicator' },
+  'display.indicator.bracketStyle': { type: 'string', enum: ['square', 'round', 'curly', 'angle', 'none'], description: 'Bracket style around the indicator' },
+
+  // ── Wizard ─────────────────────────────────────────────────────────
+  'wizard.completed': { type: 'boolean', description: 'True when the operator finished the setup wizard' },
+  'wizard.dismissed': { type: 'boolean', description: 'True when the operator chose "don\'t show again"' },
+  'wizard.completedAt': { type: 'string', description: 'ISO-8601 timestamp the wizard was completed at' },
+  'wizard.version': { type: 'string', description: 'Wizard schema version (deprecated; prefer lastSeenVersion)' },
+  'wizard.lastSeenVersion': { type: 'string', description: 'Last wizard version shown to the operator' },
+  'wizard.skippedSections': { type: 'array', arrayOf: 'string', description: 'Sections the operator skipped' },
+
+  // ── Auto-load ──────────────────────────────────────────────────────
+  'autoLoad.enabled': { type: 'boolean', description: 'Auto-load configured memories at session start' },
+  'autoLoad.maxTokenBudget': { type: 'number', min: 0, description: 'Cap on total tokens loaded by auto-load' },
+  'autoLoad.maxSingleMemoryTokens': { type: 'number', min: 0, description: 'Cap on a single memory\'s contribution' },
+  'autoLoad.suppressLargeMemoryWarnings': { type: 'boolean', description: 'Suppress the "memory exceeded budget" warning' },
+  'autoLoad.memories': { type: 'array', arrayOf: 'string', description: 'Memory names to load automatically' },
+
+  // ── Retention policy ───────────────────────────────────────────────
+  'retentionPolicy.enabled': { type: 'boolean', description: 'Master switch for memory retention enforcement' },
+  'retentionPolicy.enforcement_mode': { type: 'string', enum: ['disabled', 'manual', 'on_load', 'scheduled'], description: 'When retention runs' },
+  'retentionPolicy.safety.require_confirmation': { type: 'boolean', description: 'Require confirm before any retention deletion' },
+  'retentionPolicy.safety.dry_run_first': { type: 'boolean', description: 'Always preview before deletion' },
+  'retentionPolicy.safety.warn_on_expiring': { type: 'boolean', description: 'Warn when entries approach expiration' },
+  'retentionPolicy.safety.warning_threshold_days': { type: 'number', min: 0, description: 'Days before expiration to warn' },
+  'retentionPolicy.audit.log_deletions': { type: 'boolean', description: 'Log retention deletions to the audit trail' },
+  'retentionPolicy.audit.backup_before_delete': { type: 'boolean', description: 'Keep a backup before permanent removal' },
+  'retentionPolicy.audit.backup_retention_days': { type: 'number', min: 0, description: 'Days to keep deletion backups' },
+  'retentionPolicy.defaults.ttl_days': { type: 'number', min: 0, description: 'Default TTL (days) for new memory entries' },
+  'retentionPolicy.defaults.max_entries': { type: 'number', min: 0, description: 'Default cap on entries per memory' },
+
+  // ── License ────────────────────────────────────────────────────────
+  'license.tier': { type: 'string', enum: ['agpl', 'free-commercial', 'paid-commercial'], description: 'Active license tier' },
+  'license.email': { type: 'string', description: 'License contact email (required for commercial tiers)' },
+  'license.attestedAt': { type: 'string', description: 'ISO-8601 timestamp of license attestation' },
+  'license.telemetryRequired': { type: 'boolean', description: 'True for commercial tiers (license condition)' },
+  'license.revenueScale': { type: 'string', description: 'Paid commercial revenue band' },
+  'license.companyName': { type: 'string', description: 'Paid commercial: required company name' },
+  'license.useCase': { type: 'string', description: 'Paid commercial: required use case' },
+
+  // ── Console ────────────────────────────────────────────────────────
+  'console.port': { type: 'number', min: 1024, max: 65535, description: 'Web console port (1024..65535)' },
+
+  // ── Source priority (top-level path also accepted but handled by source_priority handler) ──
+  'source_priority.order': { type: 'array', arrayOf: 'string', description: 'Source resolution order (local, github, collection)' },
+  'source_priority.stop_on_first': { type: 'boolean', description: 'Stop at the first source that returns a hit' },
+  'source_priority.check_all_for_updates': { type: 'boolean', description: 'Always check all sources for updates' },
+  'source_priority.fallback_on_error': { type: 'boolean', description: 'Fall back to next source on error' },
+};
+
+/**
+ * Result of validating a single `set` operation.
+ */
+export type ValidationResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+/**
+ * Validate a `dollhouse_config set <path> <value>` invocation against
+ * the schema. Returns ok=false with a human-readable error when:
+ *   - path is unknown (and strict mode is on)
+ *   - value type does not match the schema entry's type
+ *   - enum constraint is violated
+ *   - numeric min/max is violated
+ *   - array element type is wrong
+ *
+ * `strict` defaults to true; pass false to allow unknown paths through
+ * (for back-compat with operator workflows storing phantom keys).
+ */
+export function validateConfigPath(
+  path: string,
+  value: unknown,
+  options: { strict?: boolean } = {},
+): ValidationResult {
+  const strict = options.strict ?? true;
+  const spec = CONFIG_SCHEMA[path];
+
+  if (!spec) {
+    if (!strict) return { ok: true };
+    const suggestion = suggestNearestPath(path);
+    const hint = suggestion ? ` Did you mean '${suggestion}'?` : '';
+    return {
+      ok: false,
+      error: `Unknown configuration path '${path}'.${hint} Run \`dollhouse_config action: "get"\` to see valid paths, or set DOLLHOUSE_CONFIG_STRICT_PATHS=false to allow unknown paths.`,
+    };
+  }
+
+  return checkValueAgainstSpec(spec, value, path);
+}
+
+/** True when the path is a schema-known leaf setting. */
+export function isKnownConfigPath(path: string): boolean {
+  return CONFIG_SCHEMA[path] !== undefined;
+}
+
+function checkValueAgainstSpec(spec: ConfigFieldSpec, value: unknown, path: string): ValidationResult {
+  if (value === null) {
+    return spec.nullable
+      ? { ok: true }
+      : { ok: false, error: `Configuration path '${path}' does not accept null.` };
+  }
+
+  switch (spec.type) {
+    case 'boolean':
+      return typeof value === 'boolean'
+        ? { ok: true }
+        : { ok: false, error: `Configuration path '${path}' expects boolean, got ${describeValue(value)}.` };
+
+    case 'number':
+      return checkNumber(spec, value, path);
+
+    case 'string':
+      return checkString(spec, value, path);
+
+    case 'array':
+      return checkArray(spec, value, path);
+
+    case 'object':
+      return typeof value === 'object' && !Array.isArray(value)
+        ? { ok: true }
+        : { ok: false, error: `Configuration path '${path}' expects object, got ${describeValue(value)}.` };
+  }
+}
+
+function checkNumber(spec: ConfigFieldSpec, value: unknown, path: string): ValidationResult {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return { ok: false, error: `Configuration path '${path}' expects number, got ${describeValue(value)}.` };
+  }
+  if (spec.min !== undefined && value < spec.min) {
+    return { ok: false, error: `Configuration path '${path}' must be ≥ ${spec.min}, got ${value}.` };
+  }
+  if (spec.max !== undefined && value > spec.max) {
+    return { ok: false, error: `Configuration path '${path}' must be ≤ ${spec.max}, got ${value}.` };
+  }
+  return { ok: true };
+}
+
+function checkString(spec: ConfigFieldSpec, value: unknown, path: string): ValidationResult {
+  if (typeof value !== 'string') {
+    return { ok: false, error: `Configuration path '${path}' expects string, got ${describeValue(value)}.` };
+  }
+  if (spec.enum && !spec.enum.includes(value)) {
+    return {
+      ok: false,
+      error: `Configuration path '${path}' must be one of: ${spec.enum.map(v => `'${v}'`).join(', ')}. Got '${value}'.`,
+    };
+  }
+  return { ok: true };
+}
+
+function checkArray(spec: ConfigFieldSpec, value: unknown, path: string): ValidationResult {
+  if (!Array.isArray(value)) {
+    return { ok: false, error: `Configuration path '${path}' expects array, got ${describeValue(value)}.` };
+  }
+  if (!spec.arrayOf) return { ok: true };
+
+  for (let i = 0; i < value.length; i++) {
+    const item = value[i];
+    if (spec.arrayOf === 'string' && typeof item !== 'string') {
+      return { ok: false, error: `Configuration path '${path}'[${i}] expects string, got ${describeValue(item)}.` };
+    }
+    if (spec.arrayOf === 'number' && (typeof item !== 'number' || !Number.isFinite(item))) {
+      return { ok: false, error: `Configuration path '${path}'[${i}] expects number, got ${describeValue(item)}.` };
+    }
+  }
+  return { ok: true };
+}
+
+function describeValue(value: unknown): string {
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+  if (Array.isArray(value)) return `array (${value.length} item${value.length === 1 ? '' : 's'})`;
+  return `${typeof value} (${JSON.stringify(value).slice(0, 40)})`;
+}
+
+/**
+ * Return the schema's nearest path to `candidate` by Levenshtein
+ * distance, or undefined if nothing is close (distance > 5). Used to
+ * power "did you mean" suggestions for typos.
+ */
+export function suggestNearestPath(candidate: string): string | undefined {
+  const knownPaths = Object.keys(CONFIG_SCHEMA);
+  let best: { path: string; distance: number } | undefined;
+  for (const path of knownPaths) {
+    const distance = levenshtein(candidate, path);
+    if (best === undefined || distance < best.distance) {
+      best = { path, distance };
+    }
+  }
+  if (best && best.distance <= 5) return best.path;
+  return undefined;
+}
+
+/**
+ * Return all schema paths matching an optional prefix. Used by the
+ * `dollhouse_config list-paths` UX so operators can discover what's
+ * available.
+ */
+export function listKnownPaths(prefix?: string): string[] {
+  const all = Object.keys(CONFIG_SCHEMA).sort();
+  if (!prefix) return all;
+  return all.filter(p => p.startsWith(prefix));
+}
+
+// ── Levenshtein distance for path suggestions ─────────────────────
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  const prev: number[] = new Array(b.length + 1);
+  const curr: number[] = new Array(b.length + 1);
+  for (let j = 0; j <= b.length; j++) prev[j] = j;
+
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a.charCodeAt(i - 1) === b.charCodeAt(j - 1) ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    for (let j = 0; j <= b.length; j++) prev[j] = curr[j];
+  }
+  return prev[b.length];
+}

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -272,9 +272,10 @@ function checkString(spec: ConfigFieldSpec, value: unknown, path: string): Valid
     return { ok: false, error: `Configuration path '${path}' expects string, got ${describeValue(value)}.` };
   }
   if (spec.enum && !spec.enum.includes(value)) {
+    const allowed = spec.enum.map(v => `'${v}'`).join(', ');
     return {
       ok: false,
-      error: `Configuration path '${path}' must be one of: ${spec.enum.map(v => `'${v}'`).join(', ')}. Got '${value}'.`,
+      error: `Configuration path '${path}' must be one of: ${allowed}. Got '${value}'.`,
     };
   }
   return { ok: true };
@@ -329,7 +330,7 @@ export function suggestNearestPath(candidate: string): string | undefined {
  * available.
  */
 export function listKnownPaths(prefix?: string): string[] {
-  const all = Object.keys(CONFIG_SCHEMA).sort();
+  const all = Object.keys(CONFIG_SCHEMA).sort((a, b) => a.localeCompare(b));
   if (!prefix) return all;
   return all.filter(p => p.startsWith(prefix));
 }
@@ -348,7 +349,7 @@ function levenshtein(a: string, b: string): number {
   for (let i = 1; i <= a.length; i++) {
     curr[0] = i;
     for (let j = 1; j <= b.length; j++) {
-      const cost = a.charCodeAt(i - 1) === b.charCodeAt(j - 1) ? 0 : 1;
+      const cost = a.codePointAt(i - 1) === b.codePointAt(j - 1) ? 0 : 1;
       curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
     }
     for (let j = 0; j <= b.length; j++) prev[j] = curr[j];

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -222,6 +222,16 @@ const envSchema = z.object({
    */
   DOLLHOUSE_ALLOW_MEMORY_AUTH_STORAGE: envBool(false),
 
+  /**
+   * Strict-mode toggle for `dollhouse_config set <path> <value>`. When
+   * true (default), unknown paths and type mismatches are rejected with
+   * a clear error. When false, unknown paths produce a warning but are
+   * accepted — preserves back-compat for operator workflows that may
+   * have stored config paths the schema registry hasn't catalogued yet.
+   * See src/config/configSchema.ts for the path registry.
+   */
+  DOLLHOUSE_CONFIG_STRICT_PATHS: envBool(true),
+
   // ============================================================================
   // Shared Pool Configuration (Step 4.6)
   // ============================================================================

--- a/src/di/registrars/AuthServiceRegistrar.ts
+++ b/src/di/registrars/AuthServiceRegistrar.ts
@@ -17,6 +17,7 @@ import { logger } from '../../utils/logger.js';
 import type { DiContainerFacade } from '../DiContainerFacade.js';
 import type { IAuthProvider } from '../../auth/IAuthProvider.js';
 import type { DatabaseInstance } from '../../database/connection.js';
+import type { PerformanceMonitor } from '../../utils/PerformanceMonitor.js';
 
 interface ProtectedResourceMetadataProvider extends IAuthProvider {
   getProtectedResourceMetadataUrl(): string;
@@ -106,6 +107,14 @@ export class AuthServiceRegistrar {
       // Phase 4.5: signing key store (filesystem or postgres backend
       // selected per DOLLHOUSE_AUTH_STORAGE_BACKEND inside the factory).
       signingKeyStore,
+      // PerformanceMonitor for auth-flow timing. Optional — when present,
+      // each method's three IAuthMethod entry points (beginInteraction /
+      // completeInteraction / findAccount) record per-call duration into
+      // recordAuthOp so operators can see latency in /healthz. Resolved
+      // from the root container which ObservabilityServiceRegistrar wires.
+      performanceMonitor: container.hasRegistration('PerformanceMonitor')
+        ? container.resolve<PerformanceMonitor>('PerformanceMonitor')
+        : undefined,
     });
 
     if (!provider) return;

--- a/src/elements/base/BaseElementManager.ts
+++ b/src/elements/base/BaseElementManager.ts
@@ -819,19 +819,20 @@ export abstract class BaseElementManager<T extends IElement> implements IElement
       return 'unnamed';
     }
 
-    // Anchored leading/trailing dash trim split into two separate replaceAll
-    // calls. Combined as `/^-+|-+$/g` it tripped sonarjs S5852 (super-linear
-    // backtracking) even though the alternation is anchored to disjoint
-    // positions and not actually exploitable. Two single-anchor regexes
-    // sidestep the analysis without changing behaviour.
+    // The `/-+/g` collapse above reduces any run of dashes to a single
+    // dash, so the trims below only ever need to remove ONE leading or
+    // trailing dash — no `+` quantifier needed. The quantifier-free
+    // form also sidesteps sonarjs S5852, which flagged `/-+$/g` as
+    // super-linear even though it's O(n) when anchored to a disjoint
+    // position.
     return name
       .replaceAll(/([a-z])([A-Z])/g, '$1-$2')
       .replaceAll(/[\s_]+/g, '-')
       .toLowerCase()
       .replaceAll(/[^a-z0-9-]/g, '-')
       .replaceAll(/-+/g, '-')
-      .replaceAll(/^-+/g, '')
-      .replaceAll(/-+$/g, '');
+      .replaceAll(/^-/g, '')
+      .replaceAll(/-$/g, '');
   }
 
   /**

--- a/src/elements/base/BaseElementManager.ts
+++ b/src/elements/base/BaseElementManager.ts
@@ -819,13 +819,19 @@ export abstract class BaseElementManager<T extends IElement> implements IElement
       return 'unnamed';
     }
 
+    // Anchored leading/trailing dash trim split into two separate replaceAll
+    // calls. Combined as `/^-+|-+$/g` it tripped sonarjs S5852 (super-linear
+    // backtracking) even though the alternation is anchored to disjoint
+    // positions and not actually exploitable. Two single-anchor regexes
+    // sidestep the analysis without changing behaviour.
     return name
       .replaceAll(/([a-z])([A-Z])/g, '$1-$2')
       .replaceAll(/[\s_]+/g, '-')
       .toLowerCase()
       .replaceAll(/[^a-z0-9-]/g, '-')
       .replaceAll(/-+/g, '-')
-      .replaceAll(/^-+|-+$/g, '');
+      .replaceAll(/^-+/g, '')
+      .replaceAll(/-+$/g, '');
   }
 
   /**

--- a/src/elements/base/BaseElementManager.ts
+++ b/src/elements/base/BaseElementManager.ts
@@ -587,6 +587,15 @@ export abstract class BaseElementManager<T extends IElement> implements IElement
     return this._cache.getScopedValues();
   }
 
+  /**
+   * Record an access on a cached element by ID. Exposes ElementCache.touchById
+   * so subclasses doing name- or filename-based iteration (which can't go
+   * through `get(id)`) can keep the LRU ordering and hit metrics honest.
+   */
+  protected touchCachedElement(id: string): T | undefined {
+    return this._cache.touchById(id);
+  }
+
   protected getCacheStats(): { elementCount: number; pathMappings: number } {
     return this._cache.getCacheStats();
   }
@@ -811,12 +820,12 @@ export abstract class BaseElementManager<T extends IElement> implements IElement
     }
 
     return name
-      .replace(/([a-z])([A-Z])/g, '$1-$2')
-      .replace(/[\s_]+/g, '-')
+      .replaceAll(/([a-z])([A-Z])/g, '$1-$2')
+      .replaceAll(/[\s_]+/g, '-')
       .toLowerCase()
-      .replace(/[^a-z0-9-]/g, '-')
-      .replace(/-+/g, '-')
-      .replace(/^-+|-+$/g, '');
+      .replaceAll(/[^a-z0-9-]/g, '-')
+      .replaceAll(/-+/g, '-')
+      .replaceAll(/^-+|-+$/g, '');
   }
 
   /**

--- a/src/elements/base/ElementCache.ts
+++ b/src/elements/base/ElementCache.ts
@@ -158,6 +158,17 @@ export class ElementCache<T extends IElement> {
     return this.getCachedByAbsolutePath(filePath);
   }
 
+  /**
+   * Trigger LRU bookkeeping for an element ID already known to be cached.
+   * Promotes the entry to most-recently-used and bumps the LRU's internal
+   * hit counter. Use after a `getScopedValues()`-based iteration when the
+   * caller has identified the matching element but still needs the LRU to
+   * see the access.
+   */
+  touchById(id: string): T | undefined {
+    return this.elements.get(this.key(id));
+  }
+
   getScopedValues(): T[] {
     const prefix = this.keyPrefix();
     return this.elements

--- a/src/handlers/ConfigHandler.ts
+++ b/src/handlers/ConfigHandler.ts
@@ -49,7 +49,7 @@ const INDICATOR_PATH_MAP: Record<string, keyof IndicatorConfig> = {
 };
 
 export interface ConfigOperationOptions {
-  action: 'get' | 'set' | 'reset' | 'export' | 'import' | 'wizard';
+  action: 'get' | 'set' | 'reset' | 'export' | 'import' | 'wizard' | 'delete';
   setting?: string;
   value?: any;
   section?: string;
@@ -103,28 +103,31 @@ export class ConfigHandler {
       switch (options.action) {
         case 'get':
           return this.handleGet(options, indicator);
-        
+
         case 'set':
           return this.handleSet(options, indicator);
-        
+
+        case 'delete':
+          return this.handleDelete(options, indicator);
+
         case 'reset':
           return this.handleReset(options, indicator);
-        
+
         case 'export':
           return this.handleExport(options, indicator);
-        
+
         case 'import':
           return this.handleImport(options, indicator);
-        
+
         case 'wizard':
           return await this.handleWizard(indicator);
-        
+
         default:
           return {
             content: [{
               type: "text",
               text: `${indicator}❌ Invalid action '${options.action}'.\n\n` +
-                    `Valid actions: get, set, reset, export, import, wizard`
+                    `Valid actions: get, set, delete, reset, export, import, wizard`
             }]
           };
       }
@@ -239,7 +242,19 @@ export class ConfigHandler {
       }
     }
 
-    await this.configManager.updateSetting(options.setting, coercedValue);
+    const result = await this.configManager.updateSetting(options.setting, coercedValue);
+
+    if (!result.success) {
+      // ConfigManager rejected the write — schema violation, admin gate, or
+      // type validation. Surface the rejection to the caller rather than
+      // emitting a false "Configuration Updated" success.
+      return {
+        content: [{
+          type: "text",
+          text: `${indicator}❌ ${result.message}`
+        }]
+      };
+    }
 
     return {
       content: [{
@@ -251,6 +266,38 @@ export class ConfigHandler {
     };
   }
   
+  private async handleDelete(options: ConfigOperationOptions, indicator: string) {
+    if (!options.setting) {
+      return {
+        content: [{
+          type: "text",
+          text: `${indicator}❌ 'setting' is required for delete operation.\n\n` +
+                `Example: \`dollhouse_config action: "delete", setting: "sync.privacy.excluded_patterns"\``
+        }]
+      };
+    }
+
+    const result = await this.configManager.deleteSetting(options.setting);
+
+    if (!result.success) {
+      return {
+        content: [{
+          type: "text",
+          text: `${indicator}❌ ${result.message}`
+        }]
+      };
+    }
+
+    return {
+      content: [{
+        type: "text",
+        text: `${indicator}🗑️ **Configuration Setting Deleted**\n\n` +
+              `**${options.setting}** removed. Consumer will now see the schema default.\n\n` +
+              `Previous value: ${JSON.stringify(result.previousValue, null, 2)}`
+      }]
+    };
+  }
+
   private async handleReset(options: ConfigOperationOptions, indicator: string) {
     // Reset configuration to defaults
     if (options.section) {
@@ -294,10 +341,18 @@ export class ConfigHandler {
   }
   
   private async handleExport(options: ConfigOperationOptions, indicator: string) {
-    // Export configuration
+    // Serialize the in-memory config for the MCP response. Previously this
+    // called configManager.exportConfig(format) which takes a *filePath*,
+    // not a format — so it was writing a file at path './yaml' and
+    // returning a ConfigActionResult that interpolated as `[object Object]`
+    // in the text below. Inlining the serializer keeps the operator-facing
+    // export side-effect-free and surfaces the actual content.
     const format = options.format || 'yaml';
-    const exported = await this.configManager.exportConfig(format);
-    
+    const config = this.configManager.getConfig();
+    const exported = format === 'yaml'
+      ? yaml.dump(config, { lineWidth: -1 })
+      : JSON.stringify(config, null, 2);
+
     return {
       content: [{
         type: "text",
@@ -452,12 +507,9 @@ Customize how DollhouseMCP shows information.
       }
     }
 
-    // Display settings
-    if (friendly.display) {
-      // These are typically booleans, but handle nulls just in case
-      if (friendly.display.show_persona_indicator === null) {
-        friendly.display.show_persona_indicator = true; // Default value
-      }
+    // Display settings — these are typically booleans, but handle nulls just in case
+    if (friendly.display?.show_persona_indicator === null) {
+      friendly.display.show_persona_indicator = true; // Default value
     }
 
     // Collection settings

--- a/src/handlers/mcp-aql/OperationSchema.ts
+++ b/src/handlers/mcp-aql/OperationSchema.ts
@@ -60,13 +60,13 @@ export interface ParamDef {
    * Checked in order before falling back to the primary param name.
    *
    * Supports dot notation for nested access:
-   * - 'input.elementType' - checks input.elementType
+   * - SRC.INPUT_ELEMENT_TYPE_CAMEL - checks input.elementType
    * - 'params.type' - checks params.type (same as just checking the param)
    *
    * Use case: elementType can come from input.elementType OR params.type
    *
    * @example
-   * type: { type: 'string', sources: ['input.elementType', 'params.type'] }
+   * type: { type: 'string', sources: [SRC.INPUT_ELEMENT_TYPE_CAMEL, 'params.type'] }
    */
   sources?: string[];
 }
@@ -141,7 +141,7 @@ export interface OperationDef {
   /**
    * Whether this operation needs access to the full OperationInput.
    * When true, SchemaDispatcher passes the full input for source resolution.
-   * Required for operations that use param sources like 'input.elementType'.
+   * Required for operations that use param sources like SRC.INPUT_ELEMENT_TYPE_CAMEL.
    */
   needsFullInput?: boolean;
   /**
@@ -199,6 +199,42 @@ export type OperationSchemaMap = Record<string, OperationDef>;
 // Collection Operations Schema (Proof of Concept)
 // ============================================================================
 
+// ──────────────────────────────────────────────────────────────────────────
+// Shared string constants — extracted to satisfy `sonarjs/no-duplicate-string`
+// and to make the operation schema easier to navigate. When adding a new
+// operation, prefer reusing these over inlining the same literal again.
+// ──────────────────────────────────────────────────────────────────────────
+
+const CATEGORY = {
+  AGENT_EXECUTION: 'Agent Execution',
+  COMMUNITY: 'Community Collection',
+  CONFIG: 'Configuration & Diagnostics',
+  ELEMENT_DISCOVERY: 'Element Discovery',
+  ELEMENT_LIFECYCLE: 'Element Lifecycle',
+  GITHUB_AUTH: 'GitHub Authentication',
+  MANAGEMENT_CONSOLE: 'Management Console',
+  PORTFOLIO: 'Portfolio Management',
+  SECURITY: 'Security & Permissions',
+} as const;
+
+const DESC = {
+  ELEMENT_TYPE: 'Element type',
+  ELEMENT_NAME: 'Element name',
+  SEARCH_QUERY: 'Search query',
+  FIELDS_INCLUDE: 'Fields to include: array like ["element_name", "description"] OR preset: "minimal", "standard", "full"',
+  BROWSER_OPEN_RESULT: 'Confirmation with the URL of the opened browser',
+} as const;
+
+const SRC = {
+  INPUT_ELEMENT_TYPE_CAMEL: 'input.elementType',
+  INPUT_ELEMENT_TYPE_SNAKE: 'input.element_type',
+  PARAMS_ELEMENT_TYPE: 'params.element_type',
+} as const;
+
+/** Schema-param `type:` string for fields accepting either a single string
+ *  or an array of strings (e.g. element selectors, fields-to-include). */
+const TYPE_STRING_OR_STRING_ARRAY = 'string | string[]';
+
 /**
  * Collection operations schema
  *
@@ -214,7 +250,7 @@ export const COLLECTION_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'collectionHandler',
     method: 'browseCollection',
-    category: 'Community Collection',
+    category: CATEGORY.COMMUNITY,
     description: 'Browse the DollhouseMCP community collection by section and type',
     optional: true,
     params: {
@@ -228,11 +264,11 @@ export const COLLECTION_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'collectionHandler',
     method: 'searchCollection',
-    category: 'Community Collection',
+    category: CATEGORY.COMMUNITY,
     description: 'Search the community collection for elements by keywords',
     optional: true,
     params: {
-      query: { type: 'string', required: true, description: 'Search query' },
+      query: { type: 'string', required: true, description: DESC.SEARCH_QUERY },
     },
     returns: { name: 'CollectionSearchResult', kind: 'object', description: 'Matching elements from collection' },
     examples: ['{ operation: "search_collection", params: { query: "code review" } }'],
@@ -241,12 +277,12 @@ export const COLLECTION_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'collectionHandler',
     method: 'searchCollectionEnhanced',
-    category: 'Community Collection',
+    category: CATEGORY.COMMUNITY,
     description: 'Advanced search with pagination, filtering, and sorting',
     optional: true,
     argBuilder: 'spread',
     params: {
-      query: { type: 'string', required: true, description: 'Search query' },
+      query: { type: 'string', required: true, description: DESC.SEARCH_QUERY },
     },
     returns: { name: 'EnhancedSearchResult', kind: 'object', description: 'Paginated search results with metadata' },
     examples: ['{ operation: "search_collection_enhanced", params: { query: "assistant", limit: 10 } }'],
@@ -255,7 +291,7 @@ export const COLLECTION_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'collectionHandler',
     method: 'getCollectionContent',
-    category: 'Community Collection',
+    category: CATEGORY.COMMUNITY,
     description: 'Get detailed information about content from the collection',
     optional: true,
     params: {
@@ -268,7 +304,7 @@ export const COLLECTION_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'collectionHandler',
     method: 'getCollectionCacheHealth',
-    category: 'Community Collection',
+    category: CATEGORY.COMMUNITY,
     description: 'Get health status and statistics for the collection cache',
     optional: true,
     params: {},
@@ -279,7 +315,7 @@ export const COLLECTION_OPERATIONS: OperationSchemaMap = {
     endpoint: 'CREATE',
     handler: 'collectionHandler',
     method: 'installContent',
-    category: 'Community Collection',
+    category: CATEGORY.COMMUNITY,
     description: 'Install an element from the collection to your local portfolio',
     optional: true,
     params: {
@@ -292,7 +328,7 @@ export const COLLECTION_OPERATIONS: OperationSchemaMap = {
     endpoint: 'CREATE',
     handler: 'collectionHandler',
     method: 'submitContent',
-    category: 'Community Collection',
+    category: CATEGORY.COMMUNITY,
     description: 'Submit a local element to the community collection via GitHub',
     optional: true,
     params: {
@@ -312,7 +348,7 @@ export const AUTH_OPERATIONS: OperationSchemaMap = {
     endpoint: 'CREATE',
     handler: 'authHandler',
     method: 'setupGitHubAuth',
-    category: 'GitHub Authentication',
+    category: CATEGORY.GITHUB_AUTH,
     description: 'Set up GitHub authentication using device flow',
     optional: true,
     params: {},
@@ -323,7 +359,7 @@ export const AUTH_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'authHandler',
     method: 'checkGitHubAuth',
-    category: 'GitHub Authentication',
+    category: CATEGORY.GITHUB_AUTH,
     description: 'Check current GitHub authentication status',
     optional: true,
     params: {},
@@ -334,7 +370,7 @@ export const AUTH_OPERATIONS: OperationSchemaMap = {
     endpoint: 'DELETE',
     handler: 'authHandler',
     method: 'clearGitHubAuth',
-    category: 'GitHub Authentication',
+    category: CATEGORY.GITHUB_AUTH,
     description: 'Remove GitHub authentication and disconnect',
     optional: true,
     params: {},
@@ -345,7 +381,7 @@ export const AUTH_OPERATIONS: OperationSchemaMap = {
     endpoint: 'CREATE',
     handler: 'authHandler',
     method: 'configureOAuth',
-    category: 'GitHub Authentication',
+    category: CATEGORY.GITHUB_AUTH,
     description: 'Configure GitHub OAuth client ID',
     optional: true,
     params: {
@@ -358,7 +394,7 @@ export const AUTH_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'authHandler',
     method: 'getOAuthHelperStatus',
-    category: 'GitHub Authentication',
+    category: CATEGORY.GITHUB_AUTH,
     description: 'Get diagnostic information about OAuth helper process',
     optional: true,
     params: {
@@ -513,7 +549,7 @@ export const PERSONA_OPERATIONS: OperationSchemaMap = {
     endpoint: 'CREATE',
     handler: 'personaHandler',
     method: 'importPersona',
-    category: 'Element Lifecycle',
+    category: CATEGORY.ELEMENT_LIFECYCLE,
     description: 'Import a persona from a file path or JSON string',
     optional: true,
     params: {
@@ -534,12 +570,12 @@ export const CONFIG_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'configHandler',
     method: 'handleConfigOperation',
-    category: 'Configuration & Diagnostics',
+    category: CATEGORY.CONFIG,
     description: 'Manage DollhouseMCP configuration settings',
     optional: true,
     argBuilder: 'named',
     params: {
-      action: { type: 'string', required: true, description: 'get, set, reset, export, import, wizard' },
+      action: { type: 'string', required: true, description: 'get, set, delete, reset, export, import, wizard' },
       setting: { type: 'string' },
       value: { type: 'string' },
       section: { type: 'string' },
@@ -556,7 +592,7 @@ export const CONFIG_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'configHandler',
     method: 'convertSkillFormat',
-    category: 'Configuration & Diagnostics',
+    category: CATEGORY.CONFIG,
     description: 'Convert between current Agent Skill and Dollhouse Skill formats (both directions) with structured warnings and optional roundtrip state for lossless supported-field restoration',
     optional: true,
     argBuilder: 'named',
@@ -572,16 +608,16 @@ export const CONFIG_OPERATIONS: OperationSchemaMap = {
     },
     returns: { name: 'SkillConversionResult', kind: 'object', description: 'Converted artifact plus machine-readable conversion report and warnings' },
     examples: [
-      '{ operation: "convert_skill_format", params: { direction: "agent_to_dollhouse", agent_skill: { "SKILL.md": "---\\nname: my-skill\\ndescription: test\\n---\\n\\nUse this skill." } } }',
-      '{ operation: "convert_skill_format", params: { direction: "agent_to_dollhouse", security_mode: "warn", path_mode: "lossless", agent_skill: { "SKILL.md": "---\\nname: my-skill\\ndescription: test\\n---\\n\\nUse this skill." } } }',
-      '{ operation: "convert_skill_format", params: { direction: "dollhouse_to_agent", path_mode: "lossless", dollhouse_markdown: "---\\nname: my-skill\\ndescription: test\\ninstructions: Use this skill.\\n---\\n\\nReference content" } }',
+      String.raw`{ operation: "convert_skill_format", params: { direction: "agent_to_dollhouse", agent_skill: { "SKILL.md": "---\nname: my-skill\ndescription: test\n---\n\nUse this skill." } } }`,
+      String.raw`{ operation: "convert_skill_format", params: { direction: "agent_to_dollhouse", security_mode: "warn", path_mode: "lossless", agent_skill: { "SKILL.md": "---\nname: my-skill\ndescription: test\n---\n\nUse this skill." } } }`,
+      String.raw`{ operation: "convert_skill_format", params: { direction: "dollhouse_to_agent", path_mode: "lossless", dollhouse_markdown: "---\nname: my-skill\ndescription: test\ninstructions: Use this skill.\n---\n\nReference content" } }`,
     ],
   },
   get_build_info: {
     endpoint: 'READ',
     handler: 'buildInfoService',
     method: '__buildInfo__', // Special marker for build info
-    category: 'Configuration & Diagnostics',
+    category: CATEGORY.CONFIG,
     description: 'Get comprehensive build and runtime information',
     optional: true,
     params: {},
@@ -592,7 +628,7 @@ export const CONFIG_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'cacheMemoryBudget',
     method: '__cacheBudget__',
-    category: 'Configuration & Diagnostics',
+    category: CATEGORY.CONFIG,
     description: 'Get global cache memory budget report with per-cache diagnostics',
     optional: true,
     params: {},
@@ -625,7 +661,7 @@ export const PORTFOLIO_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'portfolioHandler',
     method: 'portfolioStatus',
-    category: 'Portfolio Management',
+    category: CATEGORY.PORTFOLIO,
     description: 'Check GitHub portfolio repository status and element counts',
     optional: true,
     argBuilder: 'single',
@@ -639,7 +675,7 @@ export const PORTFOLIO_OPERATIONS: OperationSchemaMap = {
     endpoint: 'CREATE',
     handler: 'portfolioHandler',
     method: 'initPortfolio',
-    category: 'Portfolio Management',
+    category: CATEGORY.PORTFOLIO,
     description: 'Initialize a new GitHub portfolio repository',
     optional: true,
     argBuilder: 'named',
@@ -656,7 +692,7 @@ export const PORTFOLIO_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'portfolioHandler',
     method: 'portfolioConfig',
-    category: 'Portfolio Management',
+    category: CATEGORY.PORTFOLIO,
     description: 'Configure portfolio settings (auto-sync, visibility, etc.)',
     optional: true,
     argBuilder: 'named',
@@ -674,7 +710,7 @@ export const PORTFOLIO_OPERATIONS: OperationSchemaMap = {
     endpoint: 'CREATE',
     handler: 'portfolioHandler',
     method: 'syncPortfolio',
-    category: 'Portfolio Management',
+    category: CATEGORY.PORTFOLIO,
     description: 'Sync local portfolio with GitHub repository',
     optional: true,
     argBuilder: 'named',
@@ -706,13 +742,13 @@ export const PORTFOLIO_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'portfolioHandler',
     method: 'searchAll',
-    category: 'Element Discovery',
+    category: CATEGORY.ELEMENT_DISCOVERY,
     description: 'Unified search across local, GitHub, and collection sources with flexible scope',
     optional: true,
     normalizer: 'searchParams',
     argBuilder: 'named',
     params: {
-      query: { type: 'string', required: true, description: 'Search query' },
+      query: { type: 'string', required: true, description: DESC.SEARCH_QUERY },
       scope: { type: 'unknown', description: 'Search scope: "local", "github", "collection", "all", or array of scopes' },
       type: { type: 'string', description: 'Filter by element type' },
       page: { type: 'number', description: 'Page number for pagination' },
@@ -721,8 +757,8 @@ export const PORTFOLIO_OPERATIONS: OperationSchemaMap = {
       filters: { type: 'object', description: 'Filter options: { tags, author, createdAfter, createdBefore }' },
       options: { type: 'object', description: 'Search options: { fuzzyMatch, includeKeywords, includeTags }' },
       fields: {
-        type: 'string | string[]',
-        description: 'Fields to include: array like ["element_name", "description"] OR preset: "minimal", "standard", "full"',
+        type: TYPE_STRING_OR_STRING_ARRAY,
+        description: DESC.FIELDS_INCLUDE,
       },
     },
     returns: { name: 'UnifiedSearchResult', kind: 'object', description: 'Paginated search results from specified scopes' },
@@ -740,13 +776,13 @@ export const PORTFOLIO_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'portfolioHandler',
     method: 'searchPortfolio',
-    category: 'Element Discovery',
+    category: CATEGORY.ELEMENT_DISCOVERY,
     description: 'Search local portfolio by content name, keywords, or tags',
     optional: true,
     argBuilder: 'named',
     paramStyle: 'snakeToCamel',
     params: {
-      query: { type: 'string', required: true, description: 'Search query' },
+      query: { type: 'string', required: true, description: DESC.SEARCH_QUERY },
       type: { type: 'string', mapTo: 'elementType', description: 'Filter by element type' },
       fuzzy_match: { type: 'boolean', description: 'Enable fuzzy matching' },
       max_results: { type: 'number', description: 'Maximum number of results' },
@@ -755,8 +791,8 @@ export const PORTFOLIO_OPERATIONS: OperationSchemaMap = {
       include_triggers: { type: 'boolean', description: 'Search in triggers' },
       include_descriptions: { type: 'boolean', description: 'Search in descriptions' },
       fields: {
-        type: 'string | string[]',
-        description: 'Fields to include: array like ["element_name", "description"] OR preset: "minimal", "standard", "full"',
+        type: TYPE_STRING_OR_STRING_ARRAY,
+        description: DESC.FIELDS_INCLUDE,
       },
     },
     returns: { name: 'PortfolioSearchResult', kind: 'object', description: 'Matching elements from local portfolio' },
@@ -769,21 +805,21 @@ export const PORTFOLIO_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'portfolioHandler',
     method: 'searchAll',
-    category: 'Element Discovery',
+    category: CATEGORY.ELEMENT_DISCOVERY,
     description: 'Unified search across local, GitHub, and collection sources',
     optional: true,
     argBuilder: 'named',
     paramStyle: 'snakeToCamel',
     params: {
-      query: { type: 'string', required: true, description: 'Search query' },
+      query: { type: 'string', required: true, description: DESC.SEARCH_QUERY },
       sources: { type: 'string[]', description: 'Sources to search: local, github, collection' },
       type: { type: 'string', mapTo: 'elementType', description: 'Filter by element type' },
       page: { type: 'number', description: 'Page number for pagination' },
       page_size: { type: 'number', description: 'Results per page' },
       sort_by: { type: 'string', description: 'Sort field' },
       fields: {
-        type: 'string | string[]',
-        description: 'Fields to include: array like ["element_name", "description"] OR preset: "minimal", "standard", "full"',
+        type: TYPE_STRING_OR_STRING_ARRAY,
+        description: DESC.FIELDS_INCLUDE,
       },
     },
     returns: { name: 'UnifiedSearchResult', kind: 'object', description: 'Search results from all sources with source attribution' },
@@ -796,14 +832,14 @@ export const PORTFOLIO_OPERATIONS: OperationSchemaMap = {
     endpoint: 'CREATE',
     handler: 'syncHandler',
     method: 'handleSyncOperation',
-    category: 'Portfolio Management',
+    category: CATEGORY.PORTFOLIO,
     description: 'Manage individual elements between local and GitHub',
     optional: true,
     argBuilder: 'named',
     params: {
       operation: { type: 'string', required: true, description: 'list-remote, download, upload, compare' },
       element_name: { type: 'string', description: 'Element name to operate on' },
-      element_type: { type: 'string', description: 'Element type' },
+      element_type: { type: 'string', description: DESC.ELEMENT_TYPE },
       filter: { type: 'object', description: 'Filter options for list operations' },
       options: { type: 'object', description: 'Operation options (force, dry_run, etc.)' },
     },
@@ -835,18 +871,18 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
     endpoint: 'CREATE',
     handler: 'elementCRUD',
     method: 'createElement',
-    category: 'Element Lifecycle',
+    category: CATEGORY.ELEMENT_LIFECYCLE,
     description: 'Create a new element of any type. Note: Gatekeeper may return a confirmation prompt instead of creating immediately — use confirm_operation to approve, then retry.',
     needsFullInput: true,
     argBuilder: 'namedWithType',
     params: {
-      element_name: { type: 'string', required: true, mapTo: 'elementName', description: 'Element name' },
+      element_name: { type: 'string', required: true, mapTo: 'elementName', description: DESC.ELEMENT_NAME },
       element_type: {
         type: 'string',
         required: true,
         mapTo: 'elementType',
         description: 'Element type (persona, skill, template, agent, memory, ensemble)',
-        sources: ['input.element_type', 'input.elementType', 'params.element_type'],
+        sources: [SRC.INPUT_ELEMENT_TYPE_SNAKE, SRC.INPUT_ELEMENT_TYPE_CAMEL, SRC.PARAMS_ELEMENT_TYPE],
       },
       description: { type: 'string', required: true, description: 'Element description' },
       // Issue #602 resolved: Both 'instructions' and 'content' are first-class fields with distinct semantic roles.
@@ -881,9 +917,9 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
       // Issue #602: Dual-field examples showing both 'instructions' (behavioral) and 'content' (reference)
       '{ operation: "create_element", element_type: "persona", params: { element_name: "MyPersona", description: "A helpful assistant", instructions: "You ARE a helpful assistant. ALWAYS provide clear, accurate responses." } }',
       '{ operation: "create_element", element_type: "agent", params: { element_name: "CodeReviewer", description: "Automated code review agent", instructions: "You are methodical and thorough. ALWAYS check security first. Report issues by severity.", goal: { template: "Review {files} for {review_type} issues", parameters: [{ name: "files", type: "string", required: true }, { name: "review_type", type: "string", required: true }], successCriteria: ["Review completed", "Issues documented"] } } }',
-      '{ operation: "create_element", element_type: "skill", params: { element_name: "CodeReview", description: "Reviews code for quality", instructions: "ANALYZE code systematically. CHECK security patterns FIRST. Report findings by severity.", content: "# Code Review Reference\\n\\n## Common Patterns\\n- OWASP Top 10\\n- CWE/SANS Top 25" } }',
+      String.raw`{ operation: "create_element", element_type: "skill", params: { element_name: "CodeReview", description: "Reviews code for quality", instructions: "ANALYZE code systematically. CHECK security patterns FIRST. Report findings by severity.", content: "# Code Review Reference\n\n## Common Patterns\n- OWASP Top 10\n- CWE/SANS Top 25" } }`,
       '{ operation: "create_element", element_type: "skill", params: { element_name: "read-only-review", description: "Review session with write restrictions", instructions: "When active, ALLOW browsing and analysis but REQUIRE confirmation for edits.", gatekeeper: { allow: ["read_*", "list_*", "search_*", "get_*"], confirm: ["create_*", "edit_*", "update_*"], deny: ["delete_*"], externalRestrictions: { description: "Review shell guardrails", allowPatterns: ["Read:*", "Glob:*", "Grep:*"], confirmPatterns: ["Edit:*", "Write:*", "Bash:git push*"], denyPatterns: ["Bash:rm *", "WebSearch:*"] } } } }',
-      '{ operation: "create_element", element_type: "template", params: { element_name: "BugReport", description: "Bug report template", content: "## Bug Report\\n\\n**Summary:** {{summary}}\\n**Steps:** {{steps}}\\n**Expected:** {{expected}}", instructions: "Render all sections. NEVER omit required fields." } }',
+      String.raw`{ operation: "create_element", element_type: "template", params: { element_name: "BugReport", description: "Bug report template", content: "## Bug Report\n\n**Summary:** {{summary}}\n**Steps:** {{steps}}\n**Expected:** {{expected}}", instructions: "Render all sections. NEVER omit required fields." } }`,
       // Memory relationship patterns - naming conventions for element-linked memories:
       // agent-{name}-context: Agent execution state and learned behaviors
       '{ operation: "create_element", element_type: "memory", params: { element_name: "agent-code-reviewer-context", description: "Stores context and learned preferences for code-reviewer agent" } }',
@@ -901,7 +937,7 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'elementCRUD',
     method: 'listElements',
-    category: 'Element Discovery',
+    category: CATEGORY.ELEMENT_DISCOVERY,
     description: 'List elements with pagination, filtering, sorting, and aggregation. Returns structured JSON: { items, pagination, sorting, element_type }. Default: page 1, pageSize 20, sorted by name ascending. TIP: If the user wants to browse, explore, or view their portfolio visually, prefer open_portfolio_browser instead — it opens a full web UI with search, filters, and detail views.',
     needsFullInput: true,
     argBuilder: 'typeWithParams', // (type, fullParams) for pagination support
@@ -911,7 +947,7 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
         required: true,
         mapTo: 'elementType',
         description: 'Element type to list (persona, skill, template, agent, memory, ensemble)',
-        sources: ['input.element_type', 'input.elementType', 'params.element_type'],
+        sources: [SRC.INPUT_ELEMENT_TYPE_SNAKE, SRC.INPUT_ELEMENT_TYPE_CAMEL, SRC.PARAMS_ELEMENT_TYPE],
       },
       page: { type: 'number', default: 1, description: 'Page number (1-indexed)' },
       pageSize: { type: 'number', default: 20, description: 'Items per page (max 100)' },
@@ -932,7 +968,7 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
       },
       aggregate: { type: 'object', description: "Aggregation: { count: true } returns count only (~50 tokens). { count: true, group_by: 'category' } returns grouped counts. Allowed group_by fields: author, category, status, tags, version." },
       fields: {
-        type: 'string | string[]',
+        type: TYPE_STRING_OR_STRING_ARRAY,
         description: 'Fields to include: preset ("minimal", "standard", "full") or array of field names',
       },
     },
@@ -955,22 +991,22 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'elementCRUD',
     method: 'getElementDetails',
-    category: 'Element Lifecycle',
+    category: CATEGORY.ELEMENT_LIFECYCLE,
     description: 'Get a specific element by name. TIP: If the user wants to browse or explore multiple elements rather than retrieve one specific element, prefer open_portfolio_browser instead.',
     needsFullInput: true,
     argBuilder: 'single', // (elementName, elementType)
     params: {
-      element_name: { type: 'string', required: true, mapTo: 'elementName', description: 'Element name' },
+      element_name: { type: 'string', required: true, mapTo: 'elementName', description: DESC.ELEMENT_NAME },
       element_type: {
         type: 'string',
         required: true,
         mapTo: 'elementType',
-        description: 'Element type',
-        sources: ['input.element_type', 'input.elementType', 'params.element_type'],
+        description: DESC.ELEMENT_TYPE,
+        sources: [SRC.INPUT_ELEMENT_TYPE_SNAKE, SRC.INPUT_ELEMENT_TYPE_CAMEL, SRC.PARAMS_ELEMENT_TYPE],
       },
       fields: {
-        type: 'string | string[]',
-        description: 'Fields to include: array like ["element_name", "description"] OR preset: "minimal", "standard", "full"',
+        type: TYPE_STRING_OR_STRING_ARRAY,
+        description: DESC.FIELDS_INCLUDE,
       },
     },
     returns: { name: 'Element', kind: 'object', description: 'Full element details' },
@@ -988,22 +1024,22 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'elementCRUD',
     method: 'getElementDetails',
-    category: 'Element Lifecycle',
+    category: CATEGORY.ELEMENT_LIFECYCLE,
     description: 'Get detailed information about a specific element including extended metadata. TIP: If the user wants to browse or explore multiple elements rather than retrieve one specific element, prefer open_portfolio_browser instead.',
     needsFullInput: true,
     argBuilder: 'single', // (elementName, elementType)
     params: {
-      element_name: { type: 'string', required: true, mapTo: 'elementName', description: 'Element name' },
+      element_name: { type: 'string', required: true, mapTo: 'elementName', description: DESC.ELEMENT_NAME },
       element_type: {
         type: 'string',
         required: true,
         mapTo: 'elementType',
-        description: 'Element type',
-        sources: ['input.element_type', 'input.elementType', 'params.element_type'],
+        description: DESC.ELEMENT_TYPE,
+        sources: [SRC.INPUT_ELEMENT_TYPE_SNAKE, SRC.INPUT_ELEMENT_TYPE_CAMEL, SRC.PARAMS_ELEMENT_TYPE],
       },
       fields: {
-        type: 'string | string[]',
-        description: 'Fields to include: array like ["element_name", "description"] OR preset: "minimal", "standard", "full"',
+        type: TYPE_STRING_OR_STRING_ARRAY,
+        description: DESC.FIELDS_INCLUDE,
       },
     },
     returns: { name: 'ElementDetails', kind: 'object', description: 'Complete element with all metadata' },
@@ -1016,18 +1052,18 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
     endpoint: 'UPDATE',
     handler: 'elementCRUD',
     method: 'editElement',
-    category: 'Element Lifecycle',
+    category: CATEGORY.ELEMENT_LIFECYCLE,
     description: 'Edit an element using GraphQL-aligned nested input objects',
     needsFullInput: true,
     argBuilder: 'namedWithType',
     params: {
-      element_name: { type: 'string', required: true, mapTo: 'elementName', description: 'Element name' },
+      element_name: { type: 'string', required: true, mapTo: 'elementName', description: DESC.ELEMENT_NAME },
       element_type: {
         type: 'string',
         required: true,
         mapTo: 'elementType',
-        description: 'Element type',
-        sources: ['input.element_type', 'input.elementType', 'params.element_type'],
+        description: DESC.ELEMENT_TYPE,
+        sources: [SRC.INPUT_ELEMENT_TYPE_SNAKE, SRC.INPUT_ELEMENT_TYPE_CAMEL, SRC.PARAMS_ELEMENT_TYPE],
       },
       input: { type: 'object', required: true, description: 'Nested object with fields to update (deep-merged with existing element). Common fields (all types): instructions, content, description, tags, triggers, category, gatekeeper. Agent fields: goal, activates, tools, systemPrompt (or system_prompt), autonomy, resilience. Ensemble fields: elements (array of { element_name, element_type, role, priority?, activation? } — merges by name; use _remove: true to remove). Gatekeeper: { allow?, confirm?, deny?, scopeRestrictions?: { allowedTypes?, blockedTypes? } } — dynamic security policy that takes effect when the element is active. Snake_case keys are auto-normalized to camelCase.' },
     },
@@ -1045,7 +1081,7 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
     endpoint: 'UPDATE',
     handler: 'elementCRUD',
     method: 'upgradeElement',
-    category: 'Element Lifecycle',
+    category: CATEGORY.ELEMENT_LIFECYCLE,
     description: 'Upgrade element from v1 single-body format to v2.0 dual-field format (instructions + content). Reads existing body text, assigns to instructions or content based on element type, saves in new format with instructions in YAML frontmatter.',
     needsFullInput: true,
     argBuilder: 'namedWithType',
@@ -1055,8 +1091,8 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
         type: 'string',
         required: true,
         mapTo: 'elementType',
-        description: 'Element type',
-        sources: ['input.element_type', 'input.elementType', 'params.element_type'],
+        description: DESC.ELEMENT_TYPE,
+        sources: [SRC.INPUT_ELEMENT_TYPE_SNAKE, SRC.INPUT_ELEMENT_TYPE_CAMEL, SRC.PARAMS_ELEMENT_TYPE],
       },
       dry_run: { type: 'boolean', description: 'Preview changes without writing to disk (default: false)' },
       instructions_override: { type: 'string', description: 'Manually specify instructions (overrides auto-detection from body text)' },
@@ -1072,18 +1108,18 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'elementCRUD',
     method: 'validateElement',
-    category: 'Element Lifecycle',
+    category: CATEGORY.ELEMENT_LIFECYCLE,
     description: 'Validate an existing element by name',
     needsFullInput: true,
     argBuilder: 'namedWithType',
     params: {
-      element_name: { type: 'string', required: true, mapTo: 'elementName', description: 'Element name' },
+      element_name: { type: 'string', required: true, mapTo: 'elementName', description: DESC.ELEMENT_NAME },
       element_type: {
         type: 'string',
         required: true,
         mapTo: 'elementType',
-        description: 'Element type',
-        sources: ['input.element_type', 'input.elementType', 'params.element_type'],
+        description: DESC.ELEMENT_TYPE,
+        sources: [SRC.INPUT_ELEMENT_TYPE_SNAKE, SRC.INPUT_ELEMENT_TYPE_CAMEL, SRC.PARAMS_ELEMENT_TYPE],
       },
       strict: { type: 'boolean', description: 'Use strict validation' },
     },
@@ -1094,18 +1130,18 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
     endpoint: 'DELETE',
     handler: 'elementCRUD',
     method: 'deleteElement',
-    category: 'Element Lifecycle',
+    category: CATEGORY.ELEMENT_LIFECYCLE,
     description: 'Delete an element',
     needsFullInput: true,
     argBuilder: 'namedWithType',
     params: {
-      element_name: { type: 'string', required: true, mapTo: 'elementName', description: 'Element name' },
+      element_name: { type: 'string', required: true, mapTo: 'elementName', description: DESC.ELEMENT_NAME },
       element_type: {
         type: 'string',
         required: true,
         mapTo: 'elementType',
-        description: 'Element type',
-        sources: ['input.element_type', 'input.elementType', 'params.element_type'],
+        description: DESC.ELEMENT_TYPE,
+        sources: [SRC.INPUT_ELEMENT_TYPE_SNAKE, SRC.INPUT_ELEMENT_TYPE_CAMEL, SRC.PARAMS_ELEMENT_TYPE],
       },
       deleteData: { type: 'boolean', description: 'Also delete associated data' },
     },
@@ -1116,18 +1152,18 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'elementCRUD',
     method: '__export__', // Special marker - uses internal handler
-    category: 'Element Lifecycle',
+    category: CATEGORY.ELEMENT_LIFECYCLE,
     description: 'Export an element to a portable format',
     needsFullInput: true,
     argBuilder: 'single', // (elementName, elementType, format)
     params: {
-      element_name: { type: 'string', required: true, mapTo: 'elementName', description: 'Element name' },
+      element_name: { type: 'string', required: true, mapTo: 'elementName', description: DESC.ELEMENT_NAME },
       element_type: {
         type: 'string',
         required: true,
         mapTo: 'elementType',
-        description: 'Element type',
-        sources: ['input.element_type', 'input.elementType', 'params.element_type'],
+        description: DESC.ELEMENT_TYPE,
+        sources: [SRC.INPUT_ELEMENT_TYPE_SNAKE, SRC.INPUT_ELEMENT_TYPE_CAMEL, SRC.PARAMS_ELEMENT_TYPE],
       },
       format: { type: 'string', default: 'json', description: 'Export format (json or yaml)' },
     },
@@ -1138,7 +1174,7 @@ export const ELEMENT_CRUD_OPERATIONS: OperationSchemaMap = {
     endpoint: 'CREATE',
     handler: 'elementCRUD',
     method: '__import__', // Special marker - uses internal handler
-    category: 'Element Lifecycle',
+    category: CATEGORY.ELEMENT_LIFECYCLE,
     description: 'Import an element from exported data',
     argBuilder: 'named',
     params: {
@@ -1220,7 +1256,7 @@ export const EXECUTION_SCHEMAS: OperationSchemaMap = {
     endpoint: 'EXECUTE',
     handler: 'mcpAqlHandler',
     method: 'dispatchExecute',
-    category: 'Agent Execution',
+    category: CATEGORY.AGENT_EXECUTION,
     description: 'Start execution of an agent. The agent must have a goal.template defined (set during create_element). Pass values for the template placeholders in parameters. ' +
       'Canonical loop: call execute_agent once to start, then use mcp_aql_create record_execution_step after each work chunk, inspect autonomy.continue and autonomy.notifications, and call complete_execution when done. continue_execution is only for resuming an already-paused execution and is not the normal next call after execute_agent. ' +
       'Lifecycle: Elements listed in the agent\'s activates field (e.g., activates: { personas: ["Reviewer"], skills: ["code-analysis"] }) are automatically activated when execution begins — their gatekeeper policies, instructions, and capabilities become active for the duration. ' +
@@ -1241,7 +1277,7 @@ export const EXECUTION_SCHEMAS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'mcpAqlHandler',
     method: 'dispatchExecute',
-    category: 'Agent Execution',
+    category: CATEGORY.AGENT_EXECUTION,
     description: 'Query current execution state including progress and findings. Use the same element_name you passed to execute_agent for this execution.',
     params: {
       element_name: { type: 'string', required: true, description: 'Agent or executable element name. Reuse the same element_name from execute_agent.' },
@@ -1257,7 +1293,7 @@ export const EXECUTION_SCHEMAS: OperationSchemaMap = {
     endpoint: 'CREATE',
     handler: 'mcpAqlHandler',
     method: 'dispatchExecute',
-    category: 'Agent Execution',
+    category: CATEGORY.AGENT_EXECUTION,
     description: 'Record execution progress, step completion, or findings. This is the normal follow-up call after execute_agent. Returns autonomy directive with continue/pause decision and notifications.',
     params: {
       element_name: { type: 'string', required: true, description: 'Agent or executable element name' },
@@ -1278,7 +1314,7 @@ export const EXECUTION_SCHEMAS: OperationSchemaMap = {
     endpoint: 'EXECUTE',
     handler: 'mcpAqlHandler',
     method: 'dispatchExecute',
-    category: 'Agent Execution',
+    category: CATEGORY.AGENT_EXECUTION,
     description: 'Signal that execution finished successfully with summary',
     params: {
       element_name: { type: 'string', required: true, description: 'Agent or executable element name' },
@@ -1295,7 +1331,7 @@ export const EXECUTION_SCHEMAS: OperationSchemaMap = {
     endpoint: 'EXECUTE',
     handler: 'mcpAqlHandler',
     method: 'dispatchExecute',
-    category: 'Agent Execution',
+    category: CATEGORY.AGENT_EXECUTION,
     description: 'Resume a previously paused execution from saved state. Use only after a pause or handoff boundary, not as the normal next call after execute_agent. Pass the same goal parameters used for execute_agent so the goal template can be revalidated before resuming.',
     params: {
       element_name: { type: 'string', required: true, description: 'Agent or executable element name' },
@@ -1311,7 +1347,7 @@ export const EXECUTION_SCHEMAS: OperationSchemaMap = {
     endpoint: 'EXECUTE',
     handler: 'mcpAqlHandler',
     method: 'dispatchExecute',
-    category: 'Agent Execution',
+    category: CATEGORY.AGENT_EXECUTION,
     description: 'Abort a running agent execution, rejecting further operations for the goalId',
     params: {
       element_name: { type: 'string', required: true, description: 'Agent or executable element name to abort' },
@@ -1327,7 +1363,7 @@ export const EXECUTION_SCHEMAS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'mcpAqlHandler',
     method: 'dispatchExecute',
-    category: 'Agent Execution',
+    category: CATEGORY.AGENT_EXECUTION,
     description: 'Get aggregated execution data (steps, decisions, findings, and summary statistics) for a specific goal',
     params: {
       element_name: { type: 'string', required: true, description: 'Agent name' },
@@ -1343,7 +1379,7 @@ export const EXECUTION_SCHEMAS: OperationSchemaMap = {
     endpoint: 'EXECUTE',
     handler: 'mcpAqlHandler',
     method: 'dispatchExecute',
-    category: 'Agent Execution',
+    category: CATEGORY.AGENT_EXECUTION,
     description: 'Serialize goal progress into a portable handoff block for session transfer',
     params: {
       element_name: { type: 'string', required: true, description: 'Agent name to prepare handoff for' },
@@ -1361,7 +1397,7 @@ export const EXECUTION_SCHEMAS: OperationSchemaMap = {
     endpoint: 'EXECUTE',
     handler: 'mcpAqlHandler',
     method: 'dispatchExecute',
-    category: 'Agent Execution',
+    category: CATEGORY.AGENT_EXECUTION,
     description: 'Resume agent execution from a handoff block with integrity validation',
     params: {
       element_name: { type: 'string', required: true, description: 'Agent name to resume (must match handoff block)' },
@@ -1393,7 +1429,7 @@ export const GATEKEEPER_SCHEMAS: OperationSchemaMap = {
     endpoint: 'EXECUTE',
     handler: 'mcpAqlHandler',
     method: 'dispatchGatekeeper',
-    category: 'Security & Permissions',
+    category: CATEGORY.SECURITY,
     description: 'Confirm a pending operation that requires user approval (Gatekeeper flow)',
     params: {
       operation: { type: 'string', required: true, description: 'Operation name to confirm (e.g., "create_element")' },
@@ -1409,7 +1445,7 @@ export const GATEKEEPER_SCHEMAS: OperationSchemaMap = {
     endpoint: 'CREATE',
     handler: 'mcpAqlHandler',
     method: 'dispatchGatekeeper',
-    category: 'Security & Permissions',
+    category: CATEGORY.SECURITY,
     description: 'Submit verification code to unblock a danger zone operation',
     params: {
       challenge_id: { type: 'string', required: true, description: 'UUID v4 challenge ID from danger zone trigger' },
@@ -1425,7 +1461,7 @@ export const GATEKEEPER_SCHEMAS: OperationSchemaMap = {
     endpoint: 'CREATE',
     handler: 'mcpAqlHandler',
     method: 'dispatchGatekeeper',
-    category: 'Security & Permissions',
+    category: CATEGORY.SECURITY,
     description: 'Recover from a restrictive permission deadlock by showing a human-only verification code, then deactivating all active elements and clearing current-session activation state',
     params: {
       challenge_id: { type: 'string', description: 'Challenge ID from the first release_deadlock call' },
@@ -1441,7 +1477,7 @@ export const GATEKEEPER_SCHEMAS: OperationSchemaMap = {
     endpoint: 'CREATE',
     handler: 'mcpAqlHandler',
     method: 'dispatchGatekeeper',
-    category: 'Security & Permissions',
+    category: CATEGORY.SECURITY,
     description: 'Safe-trigger the full danger zone verification pipeline for testing purposes',
     params: {
       agent_name: { type: 'string', description: 'Agent to block (defaults to "beetlejuice-test-agent")' },
@@ -1459,7 +1495,7 @@ export const GATEKEEPER_SCHEMAS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'mcpAqlHandler',
     method: 'dispatchGatekeeper',
-    category: 'Security & Permissions',
+    category: CATEGORY.SECURITY,
     description: 'Evaluate a CLI-level permission prompt (Bash, Edit, Write, MCP tools). Returns allow/deny decision for non-interactive Claude Code sessions using --permission-prompt-tool.',
     params: {
       tool_name: { type: 'string', required: true, description: 'The tool requesting permission (e.g., "Bash", "Edit", "Write", "mcp__server__tool")' },
@@ -1477,7 +1513,7 @@ export const GATEKEEPER_SCHEMAS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'mcpAqlHandler',
     method: 'dispatchGatekeeper',
-    category: 'Security & Permissions',
+    category: CATEGORY.SECURITY,
     description: 'Evaluate CLI permission for a tool via HTTP/hook. Returns platform-formatted response (claude_code, gemini, cursor, windsurf, codex). Alternative to permission_prompt for interactive sessions using PreToolUse hooks.',
     params: {
       tool_name: { type: 'string', required: true, description: 'The tool requesting permission (e.g., "Bash", "Edit", "Write")' },
@@ -1496,7 +1532,7 @@ export const GATEKEEPER_SCHEMAS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'mcpAqlHandler',
     method: 'dispatchGatekeeper',
-    category: 'Security & Permissions',
+    category: CATEGORY.SECURITY,
     description: 'Get effective CLI-level permission policies across all active elements',
     params: {
       tool_name: { type: 'string', description: 'Optional: evaluate a specific tool (e.g., "Bash", "Edit:src/index.ts")' },
@@ -1512,7 +1548,7 @@ export const GATEKEEPER_SCHEMAS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'mcpAqlHandler',
     method: 'dispatchGatekeeper',
-    category: 'Security & Permissions',
+    category: CATEGORY.SECURITY,
     description: 'Get the current permission-authority mode for supported hosts. Read-only: AI can inspect authority state but cannot change it.',
     params: {
       host: { type: 'string', description: 'Optional host to inspect (e.g., "claude-code", "codex")' },
@@ -1528,7 +1564,7 @@ export const GATEKEEPER_SCHEMAS: OperationSchemaMap = {
     endpoint: 'EXECUTE',
     handler: 'mcpAqlHandler',
     method: 'dispatchGatekeeper',
-    category: 'Security & Permissions',
+    category: CATEGORY.SECURITY,
     description: 'Approve a pending CLI tool permission request. Used by bridges (Zulip, Slack) to relay human approval for tools that require it.',
     params: {
       request_id: { type: 'string', required: true, description: 'Approval request ID from permission_prompt deny response (format: cli-<UUID>)' },
@@ -1544,7 +1580,7 @@ export const GATEKEEPER_SCHEMAS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'mcpAqlHandler',
     method: 'dispatchGatekeeper',
-    category: 'Security & Permissions',
+    category: CATEGORY.SECURITY,
     description: 'Get all pending CLI tool approval requests for this session. Returns unapproved requests that are waiting for human authorization.',
     params: {},
     returns: { name: 'PendingApprovals', kind: 'object', description: '{ pending: CliApprovalRecord[], count: number }' },
@@ -1571,7 +1607,7 @@ export const LOGGING_SCHEMAS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'mcpAqlHandler',
     method: 'dispatchLogging',
-    category: 'Configuration & Diagnostics',
+    category: CATEGORY.CONFIG,
     description: 'Query recent log entries from the in-memory buffer. Returns filtered, paginated results sorted newest-first. Only queries the hot tier (in-memory); evicted entries exist only in disk log files.',
     params: {
       category: { type: 'string', description: "Log category filter: 'application', 'security', 'performance', 'telemetry', or 'all'. Default: 'all'" },
@@ -1609,7 +1645,7 @@ export const METRICS_SCHEMAS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'mcpAqlHandler',
     method: 'dispatchMetrics',
-    category: 'Configuration & Diagnostics',
+    category: CATEGORY.CONFIG,
     description: 'Query collected metrics snapshots. Returns filtered, paginated results sorted newest-first. Supports filtering by metric name (prefix or exact), source, type, and time range.',
     params: {
       names: { type: 'string[]', description: "Metric name filters. Exact match or prefix match with trailing '.' or '.*' (e.g., 'system.memory.*')" },
@@ -1714,7 +1750,7 @@ export const SEARCH_SCHEMAS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'mcpAqlHandler',
     method: 'dispatchSearch',
-    category: 'Element Discovery',
+    category: CATEGORY.ELEMENT_DISCOVERY,
     description: 'Full-text search across element names, descriptions, and content with pagination and sorting. TIP: If the user wants to browse or explore their portfolio visually rather than get text results, prefer open_portfolio_browser with a q parameter instead — it opens a web UI with the search pre-populated.',
     params: {
       query: { type: 'string', required: true, description: 'Search query string (max 1000 characters)' },
@@ -1723,8 +1759,8 @@ export const SEARCH_SCHEMAS: OperationSchemaMap = {
       pageSize: { type: 'number', description: 'Results per page' },
       sort: { type: 'object', description: 'Sort options: { sortBy, sortOrder }' },
       fields: {
-        type: 'string | string[]',
-        description: 'Fields to include: array like ["element_name", "description"] OR preset: "minimal", "standard", "full"',
+        type: TYPE_STRING_OR_STRING_ARRAY,
+        description: DESC.FIELDS_INCLUDE,
       },
     },
     returns: { name: 'SearchResult', kind: 'object', description: 'Search results: { items: [{ type, name, description, matchedIn }], pagination: { page, pageSize, totalItems, totalPages }, sorting }' },
@@ -1739,7 +1775,7 @@ export const SEARCH_SCHEMAS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'mcpAqlHandler',
     method: 'dispatchSearch',
-    category: 'Element Discovery',
+    category: CATEGORY.ELEMENT_DISCOVERY,
     description: 'Query elements with filters, sorting, pagination, and count aggregation. Returns structured JSON.',
     params: {
       element_type: { type: 'string', required: true, description: 'Element type to query (required)' },
@@ -1748,8 +1784,8 @@ export const SEARCH_SCHEMAS: OperationSchemaMap = {
       pagination: { type: 'object', description: 'Pagination: { page, pageSize }' },
       aggregate: { type: 'object', description: 'Aggregation: { count?: boolean, group_by?: string }. group_by groups results by a metadata field and returns counts per group. Allowed group_by fields: category, author, tags, status, version. Use group_by: "category" to discover existing categories in the portfolio.' },
       fields: {
-        type: 'string | string[]',
-        description: 'Fields to include: array like ["element_name", "description"] OR preset: "minimal", "standard", "full"',
+        type: TYPE_STRING_OR_STRING_ARRAY,
+        description: DESC.FIELDS_INCLUDE,
       },
     },
     returns: { name: 'QueryResult', kind: 'object', description: 'Query results: { items: [{ name, description, type, version, tags }], pagination, sorting, filters }. With aggregate: adds count (total), groups (if group_by used, e.g. { development: 5, security: 3 }).' },
@@ -1802,7 +1838,7 @@ export const BROWSER_SCHEMAS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'mcpAqlHandler',
     method: 'dispatchBrowser',
-    category: 'Management Console',
+    category: CATEGORY.MANAGEMENT_CONSOLE,
     description: `Start the portfolio web UI and open it in the system browser. The web server runs on localhost:${env.DOLLHOUSE_WEB_CONSOLE_PORT} and shows all portfolio elements with search, filtering, and detail views. Supports URL parameters for deep-linking with pre-populated search, filters, and element navigation. Aliases: open_console, open_management_console, open_dollhouse_mcp.`,
     params: {
       tab: { type: 'string', description: 'Tab to open (portfolio, logs, metrics, permissions, setup). Default: last-used tab.', required: false },
@@ -1813,7 +1849,7 @@ export const BROWSER_SCHEMAS: OperationSchemaMap = {
       category: { type: 'string', description: 'Filter by category on logs tab (application, security, performance).' },
       since: { type: 'string', description: 'Time range filter (ISO 8601 or relative: 5m, 1h, 24h, 7d) on logs/metrics tabs.' },
     },
-    returns: { name: 'BrowserResult', kind: 'object', description: 'Confirmation with the URL of the opened browser' },
+    returns: { name: 'BrowserResult', kind: 'object', description: DESC.BROWSER_OPEN_RESULT },
     examples: [
       '{ operation: "open_portfolio_browser" }',
       '{ operation: "open_portfolio_browser", params: { tab: "logs" } }',
@@ -1825,7 +1861,7 @@ export const BROWSER_SCHEMAS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'mcpAqlHandler',
     method: 'dispatchBrowser',
-    category: 'Management Console',
+    category: CATEGORY.MANAGEMENT_CONSOLE,
     description: 'Open the management console directly on the logs tab. Supports URL parameters for pre-filtered views. Aliases: open_dollhouse_logs, open_dollhouse_mcp_logs.',
     params: {
       level: { type: 'string', description: 'Filter by minimum log level (debug, info, warn, error).' },
@@ -1834,7 +1870,7 @@ export const BROWSER_SCHEMAS: OperationSchemaMap = {
       q: { type: 'string', description: 'Search log messages.' },
       since: { type: 'string', description: 'Time range (ISO 8601 or relative: 5m, 1h, 24h, 7d).' },
     },
-    returns: { name: 'BrowserResult', kind: 'object', description: 'Confirmation with the URL of the opened browser' },
+    returns: { name: 'BrowserResult', kind: 'object', description: DESC.BROWSER_OPEN_RESULT },
     examples: [
       '{ operation: "open_logs" }',
       '{ operation: "open_logs", params: { level: "error", since: "1h" } }',
@@ -1844,13 +1880,13 @@ export const BROWSER_SCHEMAS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'mcpAqlHandler',
     method: 'dispatchBrowser',
-    category: 'Management Console',
+    category: CATEGORY.MANAGEMENT_CONSOLE,
     description: 'Open the management console directly on the metrics tab. Supports URL parameters for filtered views. Aliases: open_dollhouse_metrics, open_dollhouse_mcp_metrics.',
     params: {
       since: { type: 'string', description: 'Time range (15m, 30m, 1h).' },
       refresh: { type: 'number', description: 'Auto-refresh interval in seconds. 0 disables.' },
     },
-    returns: { name: 'BrowserResult', kind: 'object', description: 'Confirmation with the URL of the opened browser' },
+    returns: { name: 'BrowserResult', kind: 'object', description: DESC.BROWSER_OPEN_RESULT },
     examples: [
       '{ operation: "open_metrics" }',
       '{ operation: "open_metrics", params: { since: "1h", refresh: 5 } }',
@@ -1860,20 +1896,20 @@ export const BROWSER_SCHEMAS: OperationSchemaMap = {
     endpoint: 'READ',
     handler: 'mcpAqlHandler',
     method: 'dispatchBrowser',
-    category: 'Management Console',
+    category: CATEGORY.MANAGEMENT_CONSOLE,
     description: 'Open the management console directly on the permissions tab. Aliases: open_dollhouse_permissions.',
     params: {},
-    returns: { name: 'BrowserResult', kind: 'object', description: 'Confirmation with the URL of the opened browser' },
+    returns: { name: 'BrowserResult', kind: 'object', description: DESC.BROWSER_OPEN_RESULT },
     examples: ['{ operation: "open_permissions" }'],
   },
   open_setup: {
     endpoint: 'READ',
     handler: 'mcpAqlHandler',
     method: 'dispatchBrowser',
-    category: 'Management Console',
+    category: CATEGORY.MANAGEMENT_CONSOLE,
     description: 'Open the management console directly on the setup/install tab. Aliases: open_dollhouse_setup, open_installer.',
     params: {},
-    returns: { name: 'BrowserResult', kind: 'object', description: 'Confirmation with the URL of the opened browser' },
+    returns: { name: 'BrowserResult', kind: 'object', description: DESC.BROWSER_OPEN_RESULT },
     examples: ['{ operation: "open_setup" }'],
   },
 } as const;
@@ -1959,7 +1995,7 @@ export function schemaToParameterInfo(schema: ParamSchema | undefined): Paramete
     type: def.type,
     required: def.required ?? false,
     description: def.description ?? `${name} parameter`,
-    ...(def.default !== undefined ? { default: def.default } : {}),
+    ...(def.default === undefined ? {} : { default: def.default }),
   }));
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { env } from './config/env.js';
 
 import * as path from 'path';
 import { realpathSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { ErrorHandler } from "./utils/ErrorHandler.js";
@@ -40,6 +41,7 @@ import type { EnhancedIndexHandler } from "./handlers/EnhancedIndexHandler.js";
 import { ConfigManager } from "./config/ConfigManager.js";
 import * as os from "os";
 import type { EnsembleElement } from "./elements/ensembles/types.js";
+import { validateUserId } from './paths/validateUserId.js';
 
 // Transport-aware error handlers.
 // Issue #1948: Process lifecycle managed by LifecycleService singleton.
@@ -66,6 +68,27 @@ export function setHttpModeActive(active: boolean): void {
 // Only log execution environment in debug mode
 if (env.DOLLHOUSE_DEBUG) {
   console.error('[DollhouseMCP] Debug mode enabled');
+}
+
+/**
+ * Convert an authenticated subject into a path-safe internal user id for
+ * file-mode HTTP sessions. Embedded/local providers already issue safe
+ * subjects (e.g. github_123), but generic OIDC subjects often contain
+ * provider separators, URLs, or exceed our path segment limits. Preserve
+ * safe subjects for readability; hash unsafe ones into a stable ID.
+ */
+function toPathSafeAuthUserId(subject: string, providerName: string | undefined): string {
+  try {
+    return validateUserId(subject);
+  } catch {
+    const digest = createHash('sha256')
+      .update(providerName ?? 'auth')
+      .update('\0')
+      .update(subject)
+      .digest('base64url')
+      .slice(0, 43);
+    return `auth_${digest}`;
+  }
 }
 
 export class DollhouseMCPServer implements IToolHandler {
@@ -857,18 +880,42 @@ async function bootstrapHttpContainer(): Promise<DollhouseContainer> {
  *
  * @returns IngestRoutesResult for wiring HTTP session lifecycle into the console
  */
+const HTTP_CONSOLE_LOG_PREFIX = '[HTTP Console]';
+
+/**
+ * Try to resolve an optional service from the container, logging a
+ * debug message with the shared prefix when the registration is absent.
+ * Extracted to bring `startHttpConsole` cognitive complexity ≤15 (S3776)
+ * and to keep all "not registered → use fallback" warnings on one line.
+ */
+function tryResolveOptional<T>(
+  container: DollhouseContainer,
+  registration: string,
+  description: string,
+): T | undefined {
+  try {
+    return container.resolve<T>(registration);
+  } catch (e) {
+    logger.debug(`${HTTP_CONSOLE_LOG_PREFIX} ${description}`, { error: (e as Error).message });
+    return undefined;
+  }
+}
+
 async function startHttpConsole(
   container: DollhouseContainer,
 ): Promise<import('./web/console/IngestRoutes.js').IngestRoutesResult> {
   const portfolioDir = path.join(os.homedir(), '.dollhouse', 'portfolio');
 
   // Resolve sinks from the shared container
-  let memorySink: import('./logging/sinks/MemoryLogSink.js').MemoryLogSink | undefined;
-  let metricsSink: import('./metrics/sinks/MemoryMetricsSink.js').MemoryMetricsSink | undefined;
-  let logManager: import('./logging/LogManager.js').LogManager | undefined;
-  try { memorySink = container.resolve<import('./logging/sinks/MemoryLogSink.js').MemoryLogSink>('MemoryLogSink'); } catch (e) { logger.debug('[HTTP Console] MemoryLogSink not registered, using fallback', { error: (e as Error).message }); }
-  try { metricsSink = container.resolve<import('./metrics/sinks/MemoryMetricsSink.js').MemoryMetricsSink>('MemoryMetricsSink'); } catch (e) { logger.debug('[HTTP Console] MemoryMetricsSink not registered, using fallback', { error: (e as Error).message }); }
-  try { logManager = container.resolve<import('./logging/LogManager.js').LogManager>('LogManager'); } catch (e) { logger.debug('[HTTP Console] LogManager not registered', { error: (e as Error).message }); }
+  let memorySink = tryResolveOptional<import('./logging/sinks/MemoryLogSink.js').MemoryLogSink>(
+    container, 'MemoryLogSink', 'MemoryLogSink not registered, using fallback',
+  );
+  let metricsSink = tryResolveOptional<import('./metrics/sinks/MemoryMetricsSink.js').MemoryMetricsSink>(
+    container, 'MemoryMetricsSink', 'MemoryMetricsSink not registered, using fallback',
+  );
+  const logManager = tryResolveOptional<import('./logging/LogManager.js').LogManager>(
+    container, 'LogManager', 'LogManager not registered',
+  );
 
   // Fallback sinks if not available from the container
   if (!memorySink) {
@@ -894,15 +941,16 @@ async function startHttpConsole(
   try {
     await tokenStore.ensureInitialized(pickRandomTokenName());
   } catch (err) {
-    logger.warn('[HTTP Console] Failed to initialize console token store', err);
+    logger.warn(`${HTTP_CONSOLE_LOG_PREFIX} Failed to initialize console token store`, err);
   }
 
   // Resolve web console port
   const resolvedPort = await resolvePortFromConfig() ?? env.DOLLHOUSE_WEB_CONSOLE_PORT;
 
   // Resolve MCP-AQL handler for gateway routes
-  let mcpAqlHandler: import('./handlers/mcp-aql/MCPAQLHandler.js').MCPAQLHandler | undefined;
-  try { mcpAqlHandler = container.resolve<import('./handlers/mcp-aql/MCPAQLHandler.js').MCPAQLHandler>('mcpAqlHandler'); } catch (e) { logger.debug('[HTTP Console] MCPAQLHandler not registered', { error: (e as Error).message }); }
+  const mcpAqlHandler = tryResolveOptional<import('./handlers/mcp-aql/MCPAQLHandler.js').MCPAQLHandler>(
+    container, 'mcpAqlHandler', 'MCPAQLHandler not registered',
+  );
 
   // Wire unified auth into the console when DOLLHOUSE_AUTH_ENABLED is on
   // (Phase 9 M4/Q7). Without this, MCP transport routes are protected
@@ -975,6 +1023,13 @@ async function startStreamableHttpServer(
   const authProvider = container.hasRegistration('AuthProvider')
     ? container.resolve<unknown>('AuthProvider')
     : undefined;
+  const authProviderName = (() => {
+    if (typeof authProvider !== 'object' || authProvider === null || !('name' in authProvider)) {
+      return undefined;
+    }
+    const rawName = (authProvider as { name?: unknown }).name;
+    return typeof rawName === 'string' ? rawName : 'auth';
+  })();
   const oauthProvider = isEmbeddedOAuthProvider(authProvider) ? authProvider : undefined;
 
   // Fallback userId for unauthenticated sessions (DB mode bootstrap user)
@@ -992,17 +1047,33 @@ async function startStreamableHttpServer(
     : undefined;
 
   return createStreamableHttpRuntime(async (transport, authClaims) => {
-    // When auth is active, resolve the DB user UUID BEFORE creating the
-    // session — the session's userId must be a UUID, not a username string.
+    // SECURITY: fail-closed per-user isolation. Authenticated HTTP
+    // sessions must never collapse onto the unauthenticated fallback user.
+    //
+    // Resolution order:
+    //   1. DB mode + UserIdentityService.resolveOrCreateUser succeeds → UUID.
+    //   2. DB mode + resolve fails → abort session setup; continuing with a
+    //      non-UUID subject would poison RLS-scoped state.
+    //   3. File mode → path-safe stable id derived from authClaims.sub.
+    //   4. No authClaims at all (auth disabled) → fallbackUserId.
     let sessionUserId = fallbackUserId;
-    if (authClaims?.sub && userIdentityService) {
-      try {
-        sessionUserId = await userIdentityService.resolveOrCreateUser(
-          authClaims.sub,
-          authClaims.displayName,
-        );
-      } catch (err) {
-        logger.error(`[HTTP] Failed to resolve DB user for '${authClaims.sub}': ${err instanceof Error ? err.message : String(err)}`);
+    let resolvedDbUserId = false;
+    if (authClaims?.sub) {
+      if (userIdentityService) {
+        try {
+          sessionUserId = await userIdentityService.resolveOrCreateUser(
+            authClaims.sub,
+            authClaims.displayName,
+          );
+          resolvedDbUserId = true;
+        } catch (err) {
+          logger.error(`[HTTP] Failed to resolve DB user for '${authClaims.sub}': ${err instanceof Error ? err.message : String(err)}`);
+          throw new Error('Failed to resolve database user for authenticated HTTP session');
+        }
+      } else {
+        // File mode: no DB UUID resolution layer. Use a stable path-safe
+        // internal ID so generic OIDC subjects cannot break path resolution.
+        sessionUserId = toPathSafeAuthUserId(authClaims.sub, authProviderName);
       }
     }
 
@@ -1021,7 +1092,7 @@ async function startStreamableHttpServer(
 
     // Store the resolved DB UUID on the session activation state so
     // UserIdResolver picks it up for RLS-scoped queries.
-    if (authClaims?.sub && activationRegistry && sessionUserId !== fallbackUserId) {
+    if (resolvedDbUserId && activationRegistry) {
       const state = activationRegistry.getOrCreate(sessionContext.sessionId);
       state.dbUserId = sessionUserId;
     }
@@ -1044,6 +1115,12 @@ async function startStreamableHttpServer(
     oauthProvider,
     tlsConfig: container.hasRegistration('TlsConfig')
       ? container.resolve<import('./server/TlsConfig.js').TlsConfig>('TlsConfig')
+      : undefined,
+    // Forward PerformanceMonitor so /healthz can surface auth-flow timing
+    // aggregates alongside session telemetry. Resolved from the container
+    // which ObservabilityServiceRegistrar wires unconditionally.
+    performanceMonitor: container.hasRegistration('PerformanceMonitor')
+      ? container.resolve<import('./utils/PerformanceMonitor.js').PerformanceMonitor>('PerformanceMonitor')
       : undefined,
     registerSignalHandlers: true,
     onSessionCreated: (sessionId) => {

--- a/src/persona/PersonaManager.ts
+++ b/src/persona/PersonaManager.ts
@@ -56,6 +56,137 @@ export interface PersonaManagerDeps extends ElementManagerDeps {
   contextTracker?: ContextTracker;
 }
 
+/**
+ * Validate + sanitize an edit-value through the security pipeline
+ * (Unicode normalization → ContentValidator). Logs a CONTENT_INJECTION_ATTEMPT
+ * security event on rejection. Throws on any validation failure; returns
+ * the sanitized value on success. Extracted from editPersona to keep its
+ * cognitive complexity ≤15 (S3776).
+ */
+function validateAndSanitizeEditValue(value: string, fieldName: string): string {
+  const unicodeResult = UnicodeValidator.normalize(value);
+  if (!unicodeResult.isValid && unicodeResult.severity === 'critical') {
+    throw new Error(`Value contains dangerous Unicode patterns: ${unicodeResult.detectedIssues?.join(', ')}`);
+  }
+  const valueValidation = ContentValidator.validateAndSanitize(unicodeResult.normalizedContent);
+  if (!valueValidation.isValid) {
+    SecurityMonitor.logSecurityEvent({
+      type: 'CONTENT_INJECTION_ATTEMPT',
+      severity: 'MEDIUM',
+      source: 'PersonaManager.editPersona',
+      details: `Edit value validation failed: ${valueValidation.detectedPatterns?.join(', ')}`,
+      additionalData: {
+        field: fieldName,
+        severity: valueValidation.severity,
+      },
+    });
+    throw new Error(`Security Validation Failed: The new value contains prohibited content: ${valueValidation.detectedPatterns?.join(', ')}`);
+  }
+  return valueValidation.sanitizedContent || unicodeResult.normalizedContent;
+}
+
+/**
+ * Dispatch a sanitized edit value into the matching persona field.
+ * Mutates `persona` in place. Extracted from editPersona to keep its
+ * cognitive complexity ≤15 (S3776).
+ */
+function applyEditValueToPersona(
+  persona: PersonaElement,
+  field: string,
+  sanitizedValue: string,
+): void {
+  if (field === 'instructions') {
+    persona.instructions = sanitizedValue;
+    return;
+  }
+  if (field === 'triggers') {
+    persona.metadata.triggers = sanitizedValue
+      .split(',')
+      .map(t => sanitizeInput(t.trim(), 50))
+      .filter(t => t.length > 0);
+    return;
+  }
+  if (field === 'name') {
+    persona.metadata.name = sanitizeInput(sanitizedValue, 100);
+    return;
+  }
+  if (field === 'category') {
+    persona.metadata.category = sanitizeInput(sanitizedValue, 50)?.toLowerCase() || 'general';
+    return;
+  }
+  if (field === 'description') {
+    persona.metadata.description = sanitizedValue;
+    return;
+  }
+  if (field === 'version') {
+    persona.metadata.version = sanitizedValue;
+    persona.version = sanitizedValue;
+  }
+}
+
+/**
+ * Auto-increment a persona's version following semver rules. Pre-release
+ * versions bump the pre-release counter; standard versions bump patch.
+ * Returns the new version string. Extracted from editPersona to keep
+ * its cognitive complexity ≤15 (S3776).
+ */
+function bumpPatchVersion(currentVersion: string | undefined): string {
+  if (!currentVersion) return '1.0.0';
+  const normalized = normalizeVersion(String(currentVersion));
+  const versionMatch = normalized.match(/^(\d+)\.(\d+)\.(\d+)(-.*)?$/);
+  if (!versionMatch) return '1.0.1';
+
+  const [, major, minor, patch, preRelease] = versionMatch;
+  if (!preRelease) {
+    return `${major}.${minor}.${Number.parseInt(patch) + 1}`;
+  }
+
+  const preReleaseMatch = preRelease.match(/^-([a-zA-Z]+)\.?(\d+)?$/);
+  if (!preReleaseMatch) {
+    return `${major}.${minor}.${Number.parseInt(patch) + 1}`;
+  }
+  const [, preReleaseType, preReleaseNum] = preReleaseMatch;
+  const nextNum = Number.parseInt(preReleaseNum || '0') + 1;
+  return `${major}.${minor}.${patch}-${preReleaseType}.${nextNum}`;
+}
+
+/**
+ * Validate and sanitize a username for setUserIdentity. Applies Unicode
+ * normalization, refuses critical Unicode patterns, enforces the
+ * project-wide username format (3-50 chars, alphanumeric + `-` + `_`),
+ * and returns the sanitized value. Throws on any rejection. Extracted
+ * from setUserIdentity for the cognitive-complexity refactor.
+ */
+function validateAndSanitizeUsername(username: string): string {
+  const usernameUnicode = UnicodeValidator.normalize(username);
+  if (!usernameUnicode.isValid && usernameUnicode.severity === 'critical') {
+    throw new Error(`Username contains dangerous Unicode patterns: ${usernameUnicode.detectedIssues?.join(', ')}`);
+  }
+  const usernameRegex = /^[a-zA-Z0-9\-_]{3,50}$/;
+  if (!usernameRegex.test(usernameUnicode.normalizedContent)) {
+    throw new Error(
+      'Invalid username format. Must be 3-50 characters, alphanumeric with hyphens/underscores only'
+    );
+  }
+  return sanitizeInput(usernameUnicode.normalizedContent, 50);
+}
+
+/**
+ * Validate an email's Unicode normalization + format. Throws on any
+ * rejection. Caller is responsible for storing the normalized value.
+ * Extracted from setUserIdentity for the cognitive-complexity refactor.
+ */
+function validateEmail(email: string): void {
+  const emailUnicode = UnicodeValidator.normalize(email);
+  if (!emailUnicode.isValid && emailUnicode.severity === 'critical') {
+    throw new Error(`Email contains dangerous Unicode patterns: ${emailUnicode.detectedIssues?.join(', ')}`);
+  }
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(emailUnicode.normalizedContent)) {
+    throw new Error('Invalid email format');
+  }
+}
+
 export class PersonaManager extends BaseElementManager<PersonaElement> {
   // Fallback for tests/callers that don't inject the registry
   private readonly _localActivePersonas: Set<string> = new Set();
@@ -376,7 +507,23 @@ export class PersonaManager extends BaseElementManager<PersonaElement> {
       return undefined;
     }
 
-    return this.getCachedElementsForCurrentNamespace().find(p => this.matchesIdentifier(p, identifier));
+    const candidate = this.getCachedElementsForCurrentNamespace()
+      .find(p => this.matchesIdentifier(p, identifier));
+
+    if (candidate) {
+      // Issue #843 follow-up: the iteration above scans cache values
+      // without going through LRUCache.get(), so the LRU never sees the
+      // access — hits don't get recorded and frequently-read personas
+      // can be evicted before stale ones under memory pressure. Touch
+      // the entry by ID so the LRU promotes it to MRU and bumps its
+      // internal hit counter.
+      this.touchCachedElement(candidate.id);
+      this.cacheMissMetrics.cacheHits++;
+    } else {
+      this.cacheMissMetrics.cacheMisses++;
+    }
+
+    return candidate;
   }
 
   /** In-flight disk lookups to prevent duplicate reads for the same identifier */
@@ -395,14 +542,13 @@ export class PersonaManager extends BaseElementManager<PersonaElement> {
    * share a single disk read to avoid redundant I/O in bridge/swarm scenarios.
    */
   async findPersonaAsync(identifier: string): Promise<PersonaElement | undefined> {
-    // Fast path: check LRU cache (synchronous, O(cache size))
+    // Fast path: check LRU cache (synchronous, O(cache size)).
+    // findPersona() now records hit/miss in cacheMissMetrics and touches
+    // the LRU on hit, so we don't double-count here.
     const cached = this.findPersona(identifier);
     if (cached) {
-      this.cacheMissMetrics.cacheHits++;
       return cached;
     }
-
-    this.cacheMissMetrics.cacheMisses++;
 
     // Deduplicate concurrent disk lookups for the same identifier
     const lookupKey = identifier.trim().toLowerCase();
@@ -676,37 +822,51 @@ export class PersonaManager extends BaseElementManager<PersonaElement> {
     };
 
     if (metadataOverrides) {
-      if (typeof metadataOverrides.category === 'string') {
-        // SECURITY FIX: Use ValidationService to validate BEFORE sanitization
-        const categoryResult = this.validationService.validateCategory(metadataOverrides.category);
-        if (categoryResult.isValid && categoryResult.sanitizedValue) {
-          metadata.category = categoryResult.sanitizedValue.toLowerCase();
-        }
-      }
-
-      if (Array.isArray(metadataOverrides.triggers) && metadataOverrides.triggers.length > 0) {
-        // Use TriggerValidationService to apply proper validation
-        const validationResult = this.triggerValidationService.validateTriggers(
-          metadataOverrides.triggers,
-          ElementType.PERSONA,
-          metadata.name
-        );
-        // CRITICAL: Preserve undefined behavior
-        metadata.triggers = validationResult.validTriggers.length > 0
-          ? validationResult.validTriggers
-          : undefined;
-      }
-
-      if (typeof metadataOverrides.age_rating === 'string') {
-        const sanitizedAgeRating = sanitizeInput(metadataOverrides.age_rating, 10);
-        if (sanitizedAgeRating) {
-          metadata.age_rating = sanitizedAgeRating.toLowerCase();
-        }
-      }
+      this.applyMetadataOverrideSanitization(metadata, metadataOverrides);
     }
 
     // Convert legacy PersonaMetadata to PersonaElementMetadata before returning
     return this.toPersonaElementMetadata(metadata);
+  }
+
+  /**
+   * Apply override-specific sanitization (category, triggers, age_rating)
+   * to a partially-built metadata object. Extracted from
+   * buildPersonaMetadata to keep its cognitive complexity ≤15 (S3776);
+   * each override case applies independent validation and would inflate
+   * the host function otherwise.
+   */
+  private applyMetadataOverrideSanitization(
+    metadata: PersonaMetadata,
+    metadataOverrides: Partial<PersonaMetadata>,
+  ): void {
+    if (typeof metadataOverrides.category === 'string') {
+      // SECURITY FIX: Use ValidationService to validate BEFORE sanitization
+      const categoryResult = this.validationService.validateCategory(metadataOverrides.category);
+      if (categoryResult.isValid && categoryResult.sanitizedValue) {
+        metadata.category = categoryResult.sanitizedValue.toLowerCase();
+      }
+    }
+
+    if (Array.isArray(metadataOverrides.triggers) && metadataOverrides.triggers.length > 0) {
+      // Use TriggerValidationService to apply proper validation
+      const validationResult = this.triggerValidationService.validateTriggers(
+        metadataOverrides.triggers,
+        ElementType.PERSONA,
+        metadata.name
+      );
+      // CRITICAL: Preserve undefined behavior
+      metadata.triggers = validationResult.validTriggers.length > 0
+        ? validationResult.validTriggers
+        : undefined;
+    }
+
+    if (typeof metadataOverrides.age_rating === 'string') {
+      const sanitizedAgeRating = sanitizeInput(metadataOverrides.age_rating, 10);
+      if (sanitizedAgeRating) {
+        metadata.age_rating = sanitizedAgeRating.toLowerCase();
+      }
+    }
   }
 
   /**
@@ -1032,81 +1192,12 @@ export class PersonaManager extends BaseElementManager<PersonaElement> {
     let editablePersona = this.clonePersona(persona, { writableCopy: isDefault });
 
     try {
-      // SECURITY: Phase 4.3 - Apply Unicode validation to edit values
-      const unicodeResult = UnicodeValidator.normalize(value);
-      if (!unicodeResult.isValid && unicodeResult.severity === 'critical') {
-        throw new Error(`Value contains dangerous Unicode patterns: ${unicodeResult.detectedIssues?.join(', ')}`);
-      }
+      const sanitizedValue = validateAndSanitizeEditValue(value, normalizedField);
+      applyEditValueToPersona(editablePersona, normalizedField, sanitizedValue);
 
-      const valueValidation = ContentValidator.validateAndSanitize(unicodeResult.normalizedContent);
-      // SECURITY: Phase 4.1 - Block ALL invalid content, not just critical
-      if (!valueValidation.isValid) {
-        // SECURITY: Phase 4.4 - Log validation failures
-        SecurityMonitor.logSecurityEvent({
-          type: 'CONTENT_INJECTION_ATTEMPT',
-          severity: 'MEDIUM',
-          source: 'PersonaManager.editPersona',
-          details: `Edit value validation failed: ${valueValidation.detectedPatterns?.join(', ')}`,
-          additionalData: {
-            field: normalizedField,
-            severity: valueValidation.severity
-          }
-        });
-        throw new Error(`Security Validation Failed: The new value contains prohibited content: ${valueValidation.detectedPatterns?.join(', ')}`);
-      }
-
-      let sanitizedValue = valueValidation.sanitizedContent || unicodeResult.normalizedContent;
-      
-      if (normalizedField === 'instructions') {
-        editablePersona.instructions = sanitizedValue;
-      } else if (normalizedField === 'triggers') {
-        editablePersona.metadata.triggers = sanitizedValue
-          .split(',')
-          .map(t => sanitizeInput(t.trim(), 50))
-          .filter(t => t.length > 0);
-      } else if (normalizedField === 'name') {
-        editablePersona.metadata.name = sanitizeInput(sanitizedValue, 100);
-      } else if (normalizedField === 'category') {
-        editablePersona.metadata.category =
-          sanitizeInput(sanitizedValue, 50)?.toLowerCase() || 'general';
-      } else if (normalizedField === 'description') {
-        editablePersona.metadata.description = sanitizedValue;
-      } else if (normalizedField === 'version') {
-        editablePersona.metadata.version = sanitizedValue;
-        editablePersona.version = sanitizedValue;
-      }
-
-      // Auto-increment version if not explicitly setting version field
+      // Auto-increment version when an unrelated field changed
       if (normalizedField !== 'version') {
-        if (editablePersona.version) {
-          // Normalize to 3-part format first (handles legacy "1.0" format)
-          const normalized = normalizeVersion(String(editablePersona.version));
-          const versionMatch = normalized.match(/^(\d+)\.(\d+)\.(\d+)(-.*)?$/);
-
-          if (versionMatch) {
-            const [, major, minor, patch, preRelease] = versionMatch;
-
-            if (preRelease) {
-              // Increment pre-release version
-              const preReleaseMatch = preRelease.match(/^-([a-zA-Z]+)\.?(\d+)?$/);
-              if (preReleaseMatch) {
-                const [, preReleaseType, preReleaseNum] = preReleaseMatch;
-                const nextNum = Number.parseInt(preReleaseNum || '0') + 1;
-                editablePersona.version = `${major}.${minor}.${patch}-${preReleaseType}.${nextNum}`;
-              } else {
-                editablePersona.version = `${major}.${minor}.${Number.parseInt(patch) + 1}`;
-              }
-            } else {
-              // Standard version, bump patch
-              editablePersona.version = `${major}.${minor}.${Number.parseInt(patch) + 1}`;
-            }
-          } else {
-            editablePersona.version = '1.0.1';
-          }
-        } else {
-          editablePersona.version = '1.0.0';
-        }
-        // Sync to metadata
+        editablePersona.version = bumpPatchVersion(editablePersona.version);
         editablePersona.metadata.version = editablePersona.version;
       }
 
@@ -1231,56 +1322,28 @@ export class PersonaManager extends BaseElementManager<PersonaElement> {
    * SECURITY: Phase 4.6 - Added username and email validation
    */
   setUserIdentity(username: string | null, email?: string): void {
-    if (username) {
-      // SECURITY: Phase 4.3 - Apply Unicode normalization FIRST
-      const usernameUnicode = UnicodeValidator.normalize(username);
-      if (!usernameUnicode.isValid && usernameUnicode.severity === 'critical') {
-        throw new Error(`Username contains dangerous Unicode patterns: ${usernameUnicode.detectedIssues?.join(', ')}`);
-      }
-
-      // SECURITY: Phase 4.6 - Validate username format AFTER normalization (alphanumeric, hyphens, underscores)
-      const usernameRegex = /^[a-zA-Z0-9\-_]{3,50}$/;
-      if (!usernameRegex.test(usernameUnicode.normalizedContent)) {
-        throw new Error(
-          'Invalid username format. Must be 3-50 characters, alphanumeric with hyphens/underscores only'
-        );
-      }
-
-      // Sanitize username
-      const validUsername = sanitizeInput(usernameUnicode.normalizedContent, 50);
-
-      if (email) {
-        // SECURITY: Phase 4.3 - Apply Unicode normalization FIRST
-        const emailUnicode = UnicodeValidator.normalize(email);
-        if (!emailUnicode.isValid && emailUnicode.severity === 'critical') {
-          throw new Error(`Email contains dangerous Unicode patterns: ${emailUnicode.detectedIssues?.join(', ')}`);
-        }
-
-        // SECURITY: Phase 4.6 - Validate email format AFTER normalization
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        if (!emailRegex.test(emailUnicode.normalizedContent)) {
-          throw new Error('Invalid email format');
-        }
-
-        // Email validation passed — it will be stored in session state below
-      }
-
-      // Issue #1946: Write identity to session-scoped state only (no singleton, no process.env)
-      const previous = this.getSessionUserIdentity()?.username ?? null;
-      this.setSessionUserIdentity({
-        username: validUsername,
-        ...(email ? { email: sanitizeInput(UnicodeValidator.normalize(email).normalizedContent, 100) } : {}),
-      });
-
-      logger.info('User identity set', { username: validUsername });
-      this.notifyPersonaChange('user-changed', previous, validUsername);
-    } else {
+    if (!username) {
       const previous = this.getSessionUserIdentity()?.username ?? null;
       this.setSessionUserIdentity(undefined);
-
       logger.info('User identity cleared');
       this.notifyPersonaChange('user-changed', previous, null);
+      return;
     }
+
+    const validUsername = validateAndSanitizeUsername(username);
+    if (email) {
+      validateEmail(email);  // throws on bad format; value is sanitized below
+    }
+
+    // Issue #1946: Write identity to session-scoped state only (no singleton, no process.env)
+    const previous = this.getSessionUserIdentity()?.username ?? null;
+    this.setSessionUserIdentity({
+      username: validUsername,
+      ...(email ? { email: sanitizeInput(UnicodeValidator.normalize(email).normalizedContent, 100) } : {}),
+    });
+
+    logger.info('User identity set', { username: validUsername });
+    this.notifyPersonaChange('user-changed', previous, validUsername);
   }
   
   /**

--- a/src/server/StreamableHttpServer.ts
+++ b/src/server/StreamableHttpServer.ts
@@ -16,6 +16,11 @@ import { createHttpOrHttpsServer } from './createHttpOrHttpsServer.js';
 import { TlsConfig } from './TlsConfig.js';
 
 export type RuntimeTransportName = 'stdio' | 'streamable-http';
+
+/** Constant form of the streamable-http transport name. Used in /healthz,
+ *  /readyz, and runtime selection — extracted so changes (or typos) can't
+ *  drift across the multiple emission sites. */
+const STREAMABLE_HTTP: RuntimeTransportName = 'streamable-http';
 export type DeferredSetupMode = 'full' | 'sink-only' | 'none';
 
 export interface AttachTransportOptions {
@@ -59,6 +64,13 @@ export interface StreamableHttpRuntimeOptions {
   onSessionCreated?: (sessionId: string) => void;
   /** Called when an HTTP session is disposed (disconnect, expiry, or shutdown). */
   onSessionDisposed?: (sessionId: string) => void;
+  /**
+   * Optional PerformanceMonitor. When provided, /healthz includes
+   * per-op auth timing aggregates (latency p50/p95/p99, success rate)
+   * under the `auth` key so operators can spot slow OAuth round-trips,
+   * JWKS misses, etc.
+   */
+  performanceMonitor?: import('../utils/PerformanceMonitor.js').PerformanceMonitor;
 }
 
 export interface StreamableHttpRuntimeHandle {
@@ -213,7 +225,7 @@ function getProcessMemorySnapshot(): Record<string, number> {
 
 export function getRequestedTransportName(): RuntimeTransportName {
   if (process.argv.includes('--streamable-http') || process.argv.includes('--http')) {
-    return 'streamable-http';
+    return STREAMABLE_HTTP;
   }
 
   return env.DOLLHOUSE_TRANSPORT;
@@ -656,7 +668,7 @@ export async function createStreamableHttpRuntime(
     res.json({
       name: 'dollhousemcp',
       version: PACKAGE_VERSION,
-      transport: 'streamable-http',
+      transport: STREAMABLE_HTTP,
       mcpPath,
       connectorUrl: publicBaseUrl ? `${publicBaseUrl.replace(/\/$/, '')}${mcpPath}` : mcpPath,
       health: '/healthz',
@@ -669,13 +681,14 @@ export async function createStreamableHttpRuntime(
   app.get('/healthz', (_req, res) => {
     res.status(200).json({
       ok: true,
-      transport: 'streamable-http',
+      transport: STREAMABLE_HTTP,
       version: PACKAGE_VERSION,
       sessions: {
         active: sessions.size,
         pooled: pooledSessions.length,
         ...sessionTelemetry,
       },
+      auth: options.performanceMonitor?.getAuthOpStats() ?? {},
       memory: getProcessMemorySnapshot(),
     });
   });
@@ -696,14 +709,14 @@ export async function createStreamableHttpRuntime(
             res.status(503).json({
               ready: false,
               reason: 'bootstrap_required',
-              transport: 'streamable-http',
+              transport: STREAMABLE_HTTP,
             });
             return;
           }
         }
         res.status(200).json({
           ready: true,
-          transport: 'streamable-http',
+          transport: STREAMABLE_HTTP,
           activeSessions: sessions.size,
           pooledSessions: pooledSessions.length,
           sessionTelemetry,

--- a/src/server/tools/ConfigToolsV2.ts
+++ b/src/server/tools/ConfigToolsV2.ts
@@ -22,12 +22,12 @@ export function getConfigToolsV2(server: ConfigToolsHandler): Array<{ tool: Tool
           properties: {
             action: {
               type: "string",
-              enum: ["get", "set", "reset", "export", "import", "wizard"],
+              enum: ["get", "set", "delete", "reset", "export", "import", "wizard"],
               description: "The configuration action to perform"
             },
             setting: {
               type: "string",
-              description: "Dot-notation path to setting (e.g., 'user.username', 'sync.enabled'). Required for 'set' action, optional for 'get'."
+              description: "Dot-notation path to setting (e.g., 'user.username', 'sync.enabled'). Required for 'set' and 'delete' actions, optional for 'get'."
             },
             value: {
               description: "Value to set (required for 'set' action). Can be string, number, boolean, or object."

--- a/src/utils/PerformanceMonitor.ts
+++ b/src/utils/PerformanceMonitor.ts
@@ -61,15 +61,55 @@ export interface SlowQuery {
   timestamp: Date;
 }
 
+/**
+ * Wall-clock timing for a single auth-flow operation. Operators read
+ * these from /healthz to distinguish whether sign-in latency is in
+ * GitHub's token endpoint, JWKS validation, DB lookups, or signing.
+ */
+export interface AuthOpMetrics {
+  /**
+   * Identifier of the timed operation, e.g. `'token-exchange'`,
+   * `'jwks-load'`, `'find-account'`, `'refresh-rotate'`. Free-form but
+   * should stay stable across releases for dashboarding.
+   */
+  op: string;
+  /** Duration in milliseconds. */
+  duration: number;
+  /** True if the op completed normally; false if it threw / errored. */
+  success: boolean;
+  /**
+   * Optional method identifier for multi-method auth flows: `'github'`,
+   * `'magic-link'`, `'local-password'`, `'trivial-consent'`, `'oidc'`.
+   */
+  method?: string;
+  timestamp: Date;
+}
+
+/**
+ * Aggregate per-op stats for a single auth op, surfaced via /healthz.
+ */
+export interface AuthOpAggregate {
+  count: number;
+  successCount: number;
+  errorCount: number;
+  successRate: number;
+  avgMs: number;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+}
+
 export class PerformanceMonitor {
   private searchMetrics: SearchMetrics[] = [];
   private slowQueries: SlowQuery[] = [];
   private memorySnapshots: MemoryUsage[] = [];
   private cacheMetrics: Map<string, CachePerformance> = new Map();
+  private authOpMetrics: AuthOpMetrics[] = [];
 
   // Configuration
   private readonly maxMetricsHistory = 1000;
   private readonly slowQueryThreshold = 100; // ms
+  private readonly slowAuthOpThreshold = 1000; // ms — auth round-trips are slower
   private readonly memorySnapshotInterval = 30000; // 30 seconds
   private readonly maxSlowQueries = 100;
 
@@ -184,6 +224,107 @@ export class PerformanceMonitor {
         sources: normalizedMetrics.sources
       });
     }
+  }
+
+  /**
+   * Record a single auth-flow operation timing. Silently no-ops when
+   * monitoring is off, so call sites can wrap unconditionally without
+   * a check.
+   */
+  recordAuthOp(metrics: AuthOpMetrics): void {
+    if (!this.isMonitoring) {
+      return;
+    }
+
+    this.authOpMetrics.push(metrics);
+
+    if (metrics.duration > this.slowAuthOpThreshold) {
+      this.logListener?.('warn', 'Detect slow auth op', {
+        op: metrics.op,
+        method: metrics.method,
+        duration: metrics.duration,
+        success: metrics.success,
+      });
+      logger.warn('Slow auth op detected', {
+        op: metrics.op,
+        method: metrics.method,
+        duration: metrics.duration,
+        success: metrics.success,
+      });
+    }
+
+    // Trim history to bound memory
+    if (this.authOpMetrics.length > this.maxMetricsHistory) {
+      this.authOpMetrics = this.authOpMetrics.slice(-this.maxMetricsHistory);
+    }
+  }
+
+  /**
+   * Time an auth op, recording success/failure automatically. Returns
+   * whatever the wrapped function returns; rethrows on error after
+   * recording the timing. Use this when the call site is async and you
+   * want the metrics without manual try/catch.
+   */
+  async timeAuthOp<T>(op: string, fn: () => Promise<T>, method?: string): Promise<T> {
+    const start = Date.now();
+    try {
+      const result = await fn();
+      this.recordAuthOp({
+        op,
+        duration: Date.now() - start,
+        success: true,
+        method,
+        timestamp: new Date(),
+      });
+      return result;
+    } catch (err) {
+      this.recordAuthOp({
+        op,
+        duration: Date.now() - start,
+        success: false,
+        method,
+        timestamp: new Date(),
+      });
+      throw err;
+    }
+  }
+
+  /**
+   * Aggregate per-op auth statistics for /healthz exposure. Empty map
+   * when monitoring is off or no ops have been recorded.
+   */
+  getAuthOpStats(): Record<string, AuthOpAggregate> {
+    if (this.authOpMetrics.length === 0) {
+      return {};
+    }
+
+    const byOp = new Map<string, AuthOpMetrics[]>();
+    for (const m of this.authOpMetrics) {
+      const bucket = byOp.get(m.op);
+      if (bucket) {
+        bucket.push(m);
+      } else {
+        byOp.set(m.op, [m]);
+      }
+    }
+
+    const result: Record<string, AuthOpAggregate> = {};
+    for (const [op, entries] of byOp.entries()) {
+      const durations = entries.map(e => e.duration).sort((a, b) => a - b);
+      const successCount = entries.filter(e => e.success).length;
+      const sum = durations.reduce((acc, d) => acc + d, 0);
+      result[op] = {
+        count: entries.length,
+        successCount,
+        errorCount: entries.length - successCount,
+        successRate: successCount / entries.length,
+        avgMs: sum / entries.length,
+        p50Ms: durations[Math.floor(durations.length * 0.5)],
+        p95Ms: durations[Math.floor(durations.length * 0.95)],
+        p99Ms: durations[Math.floor(durations.length * 0.99)],
+      };
+    }
+    return result;
   }
 
   /**
@@ -397,7 +538,8 @@ export class PerformanceMonitor {
     this.slowQueries = [];
     this.memorySnapshots = [];
     this.cacheMetrics.clear();
-    
+    this.authOpMetrics = [];
+
     logger.info('Performance metrics reset');
   }
 

--- a/src/utils/PerformanceMonitor.ts
+++ b/src/utils/PerformanceMonitor.ts
@@ -430,7 +430,7 @@ export class PerformanceMonitor {
       };
     }
 
-    const current = this.memorySnapshots[this.memorySnapshots.length - 1];
+    const current = this.memorySnapshots.at(-1)!;
     const peak = this.memorySnapshots.reduce((max, snapshot) =>
       snapshot.heapUsed > max.heapUsed ? snapshot : max,
       this.memorySnapshots[0]

--- a/tests/integration/transport/http-transport-parity.test.ts
+++ b/tests/integration/transport/http-transport-parity.test.ts
@@ -220,6 +220,9 @@ describe('HTTP Transport — Session Context Propagation', () => {
 
   beforeAll(async () => {
     env = await createHttpTestEnvironment();
+    // create_element is gatekeeper-gated; pre-confirm so the mutations
+    // below proceed without an approval prompt.
+    preConfirmAllOperations(env.container);
     handle = await connectHttpClient(env.runtime);
   }, ENV_STARTUP_TIMEOUT);
 
@@ -228,9 +231,24 @@ describe('HTTP Transport — Session Context Propagation', () => {
     await env?.cleanup();
   });
 
+  // These tests use mutations (create_element) rather than READ operations
+  // because READ ops only emit debug-level logs, which production
+  // LOG_LEVEL=info filters out. Mutations route through
+  // SecurityMonitor.OPERATION_COMPLETED at info level, exercising the
+  // session-attribution path at the log level operators actually run with.
+  const sessionTestPersona = (suffix: string): Record<string, unknown> => ({
+    operation: 'create_element',
+    params: {
+      element_name: `session-ctx-${suffix}-${Date.now()}`,
+      element_type: 'persona',
+      description: 'Session context propagation test fixture',
+      instructions: 'Test persona used to verify HTTP session attribution in logs.',
+    },
+  });
+
   it('should propagate HTTP session identity to logs', async () => {
-    // Trigger an operation that generates log entries
-    await read(handle.client, { operation: 'get_build_info' });
+    // Trigger a mutation that generates info-level log entries
+    await create(handle.client, sessionTestPersona('propagate'));
 
     // Query logs to inspect session attribution
     const logsText = await read(handle.client, {
@@ -247,9 +265,9 @@ describe('HTTP Transport — Session Context Propagation', () => {
     const handle2 = await connectHttpClient(env.runtime);
 
     try {
-      // Both clients perform an operation
-      await read(handle.client, { operation: 'get_build_info' });
-      await read(handle2.client, { operation: 'get_build_info' });
+      // Both clients perform a mutation (info-level log emission)
+      await create(handle.client, sessionTestPersona('unique-1'));
+      await create(handle2.client, sessionTestPersona('unique-2'));
 
       // query_logs is session-scoped: each session sees only its own entries.
       // Query from both sessions and extract their session UUIDs.
@@ -279,7 +297,7 @@ describe('HTTP Transport — Session Context Propagation', () => {
   });
 
   it('should use http-user identity (not stdio local-user)', async () => {
-    await read(handle.client, { operation: 'introspect' });
+    await create(handle.client, sessionTestPersona('identity'));
 
     const logsText = await read(handle.client, {
       operation: 'query_logs',

--- a/tests/unit/config/ConfigHandler.test.ts
+++ b/tests/unit/config/ConfigHandler.test.ts
@@ -324,7 +324,10 @@ describe('ConfigHandler', () => {
 
   describe('handleIndicatorSet (immediate + persistent config)', () => {
     beforeEach(() => {
-      mockConfigManager.updateSetting = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+      // Real ConfigManager.updateSetting returns Promise<ConfigUpdateResult>;
+      // the handler now checks .success to surface validation rejections.
+      mockConfigManager.updateSetting = jest.fn<() => Promise<{ success: boolean; message: string }>>()
+        .mockResolvedValue({ success: true, message: 'Setting updated' });
     });
 
     it('should update indicator style with both persistence and runtime effect', async () => {

--- a/tests/unit/config/ConfigManager-admin-role-gate.test.ts
+++ b/tests/unit/config/ConfigManager-admin-role-gate.test.ts
@@ -19,6 +19,9 @@
 
 import { describe, it, expect, beforeEach } from '@jest/globals';
 import { ConfigManager } from '../../../src/config/ConfigManager.js';
+
+const CONSOLE_PORT_PATH = 'console.port';
+const SYNC_ENABLED_PATH = 'sync.enabled';
 import { InMemoryOperatorConfigStore } from '../../../src/storage/operatorConfig/InMemoryOperatorConfigStore.js';
 import { InMemoryUserConfigStore } from '../../../src/storage/userConfig/InMemoryUserConfigStore.js';
 import { ContextTracker } from '../../../src/security/encryption/ContextTracker.js';
@@ -86,7 +89,7 @@ describe('ConfigManager admin-role gate on per-host writes', () => {
   describe('isPerHostPath classifier', () => {
     it.each([
       'version',
-      'console.port',
+      CONSOLE_PORT_PATH,
       'console',
       'license.tier',
       'license',
@@ -100,7 +103,7 @@ describe('ConfigManager admin-role gate on per-host writes', () => {
     it.each([
       'user.username',
       'github.auth.use_oauth',
-      'sync.enabled',
+      SYNC_ENABLED_PATH,
       'autoLoad.token_budget',
       'retentionPolicy.defaults.ttl_days',
       'wizard.completed',
@@ -117,10 +120,10 @@ describe('ConfigManager admin-role gate on per-host writes', () => {
     it('rejects per-host write with a clear message naming the path', async () => {
       const session = makeSession({ roles: [] });
       const result = await runWithSession(contextTracker, session, () =>
-        manager.updateSetting('console.port', 41716),
+        manager.updateSetting(CONSOLE_PORT_PATH, 41716),
       );
       expect(result.success).toBe(false);
-      expect(result.message).toContain('console.port');
+      expect(result.message).toContain(CONSOLE_PORT_PATH);
       expect(result.message).toContain("'admin' role");
       // operator_settings was NOT mutated
       const operator = await operatorStore.load();
@@ -146,7 +149,7 @@ describe('ConfigManager admin-role gate on per-host writes', () => {
     it('still allows per-user writes (RLS-scoped, no admin needed)', async () => {
       const session = makeSession({ roles: [] });
       const result = await runWithSession(contextTracker, session, () =>
-        manager.updateSetting('sync.enabled', true),
+        manager.updateSetting(SYNC_ENABLED_PATH, true),
       );
       expect(result.success).toBe(true);
     });
@@ -156,7 +159,7 @@ describe('ConfigManager admin-role gate on per-host writes', () => {
     it('allows per-host writes', async () => {
       const session = makeSession({ roles: ['admin'] });
       const result = await runWithSession(contextTracker, session, () =>
-        manager.updateSetting('console.port', 41717),
+        manager.updateSetting(CONSOLE_PORT_PATH, 41717),
       );
       expect(result.success).toBe(true);
       const operator = await operatorStore.load();
@@ -166,11 +169,36 @@ describe('ConfigManager admin-role gate on per-host writes', () => {
     it('allows per-host writes alongside per-user writes (no surprise blocking)', async () => {
       const session = makeSession({ roles: ['admin'] });
       await runWithSession(contextTracker, session, async () => {
-        const a = await manager.updateSetting('license.tier', 'pro');
-        const b = await manager.updateSetting('sync.enabled', true);
+        const a = await manager.updateSetting('license.tier', 'paid-commercial');
+        const b = await manager.updateSetting(SYNC_ENABLED_PATH, true);
         expect(a.success).toBe(true);
         expect(b.success).toBe(true);
       });
+    });
+  });
+
+  describe('deleteSetting leaf safety', () => {
+    it('rejects deleting an entire config section', async () => {
+      const session = makeSession({ roles: ['admin'] });
+      const result = await runWithSession(contextTracker, session, () =>
+        manager.deleteSetting('sync'),
+      );
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('section');
+      expect(manager.getSetting(SYNC_ENABLED_PATH)).toBe(false);
+    });
+
+    it('allows deleting a specific leaf setting', async () => {
+      const session = makeSession({ roles: [] });
+      await runWithSession(contextTracker, session, () =>
+        manager.updateSetting(SYNC_ENABLED_PATH, true),
+      );
+      const result = await runWithSession(contextTracker, session, () =>
+        manager.deleteSetting(SYNC_ENABLED_PATH),
+      );
+      expect(result.success).toBe(true);
+      expect(result.previousValue).toBe(true);
+      expect(manager.getSetting(SYNC_ENABLED_PATH)).toBe(false);
     });
   });
 
@@ -180,7 +208,7 @@ describe('ConfigManager admin-role gate on per-host writes', () => {
       // common pattern for buggy callers or background tasks. The gate
       // defaults to "no roles" so privilege escalation via forgetting to
       // scope is not possible.
-      const result = await manager.updateSetting('console.port', 41718);
+      const result = await manager.updateSetting(CONSOLE_PORT_PATH, 41718);
       expect(result.success).toBe(false);
       expect(result.message).toContain("'admin' role");
     });
@@ -203,7 +231,7 @@ describe('ConfigManager admin-role gate on per-host writes', () => {
         null, // no ContextTracker
       );
       await standaloneManager.initialize();
-      const result = await standaloneManager.updateSetting('console.port', 41719);
+      const result = await standaloneManager.updateSetting(CONSOLE_PORT_PATH, 41719);
       expect(result.success).toBe(true);
     });
   });

--- a/tests/unit/config/configSchema.test.ts
+++ b/tests/unit/config/configSchema.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for the dollhouse_config schema validator. Covers the key
+ * decision rules: known-path acceptance, unknown-path rejection (with
+ * suggestion), type checking per spec, enum constraint, numeric range,
+ * array element type, and non-strict mode back-compat.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import {
+  validateConfigPath,
+  suggestNearestPath,
+  listKnownPaths,
+  CONFIG_SCHEMA,
+} from '../../../src/config/configSchema.js';
+
+const SYNC_ENABLED = 'sync.enabled';
+const LICENSE_TIER = 'license.tier';
+
+describe('validateConfigPath — known paths and types', () => {
+  it('accepts a boolean value for a boolean-typed path', () => {
+    expect(validateConfigPath(SYNC_ENABLED, true)).toEqual({ ok: true });
+    expect(validateConfigPath(SYNC_ENABLED, false)).toEqual({ ok: true });
+  });
+
+  it('rejects a string value for a boolean-typed path', () => {
+    const result = validateConfigPath(SYNC_ENABLED, 'true');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('boolean');
+      expect(result.error).toContain('string');
+    }
+  });
+
+  it('accepts a number within range for console.port', () => {
+    expect(validateConfigPath('console.port', 41716)).toEqual({ ok: true });
+  });
+
+  it('rejects a number below min for console.port', () => {
+    const result = validateConfigPath('console.port', 80);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('≥');
+      expect(result.error).toContain('1024');
+    }
+  });
+
+  it('rejects a number above max for console.port', () => {
+    const result = validateConfigPath('console.port', 99999);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('≤');
+      expect(result.error).toContain('65535');
+    }
+  });
+
+  it('accepts an enum value for license.tier', () => {
+    expect(validateConfigPath(LICENSE_TIER, 'agpl')).toEqual({ ok: true });
+    expect(validateConfigPath(LICENSE_TIER, 'free-commercial')).toEqual({ ok: true });
+    expect(validateConfigPath(LICENSE_TIER, 'paid-commercial')).toEqual({ ok: true });
+  });
+
+  it('rejects a string outside the enum for license.tier', () => {
+    const result = validateConfigPath(LICENSE_TIER, 'pro');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('must be one of');
+      expect(result.error).toContain("'agpl'");
+    }
+  });
+
+  it('accepts null for nullable user fields', () => {
+    expect(validateConfigPath('user.username', null)).toEqual({ ok: true });
+    expect(validateConfigPath('user.email', null)).toEqual({ ok: true });
+  });
+
+  it('rejects null for non-nullable fields', () => {
+    const result = validateConfigPath(SYNC_ENABLED, null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('null');
+  });
+
+  it('accepts an array of strings for elements.auto_activate.personas', () => {
+    expect(validateConfigPath('elements.auto_activate.personas', ['creative-writer'])).toEqual({ ok: true });
+    expect(validateConfigPath('elements.auto_activate.personas', [])).toEqual({ ok: true });
+  });
+
+  it('rejects an array with a wrong element type', () => {
+    const result = validateConfigPath('elements.auto_activate.personas', ['ok-name', 42]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('[1]');
+      expect(result.error).toContain('string');
+    }
+  });
+
+  it('rejects a non-array value for an array-typed path', () => {
+    const result = validateConfigPath('autoLoad.memories', 'just-one-memory');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('array');
+  });
+});
+
+describe('validateConfigPath — strict mode (unknown paths)', () => {
+  it('rejects unknown paths by default', () => {
+    const result = validateConfigPath('totally.made.up.path', 'value');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Unknown configuration path");
+      expect(result.error).toContain('totally.made.up.path');
+      expect(result.error).toContain('DOLLHOUSE_CONFIG_STRICT_PATHS=false');
+    }
+  });
+
+  it('suggests a nearest match when the typo is close', () => {
+    const result = validateConfigPath('sync.enable', true);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Did you mean 'sync.enabled'");
+    }
+  });
+
+  it('allows unknown paths when strict=false', () => {
+    expect(validateConfigPath('legacy.unknown.path', 'anything', { strict: false })).toEqual({ ok: true });
+  });
+});
+
+describe('suggestNearestPath', () => {
+  it('returns the nearest known path for a close typo', () => {
+    expect(suggestNearestPath('sync.enable')).toBe(SYNC_ENABLED);
+    expect(suggestNearestPath('wizard.complted')).toBe('wizard.completed');
+  });
+
+  it('returns undefined when no close match exists', () => {
+    expect(suggestNearestPath('totally-unrelated-xyz-abc-123')).toBeUndefined();
+  });
+});
+
+describe('listKnownPaths', () => {
+  it('returns all schema paths when no prefix is given', () => {
+    const paths = listKnownPaths();
+    expect(paths.length).toBe(Object.keys(CONFIG_SCHEMA).length);
+    // Sorted
+    const sorted = [...paths].sort();
+    expect(paths).toEqual(sorted);
+  });
+
+  it('filters by prefix', () => {
+    const syncPaths = listKnownPaths('sync.');
+    expect(syncPaths.length).toBeGreaterThan(0);
+    for (const p of syncPaths) {
+      expect(p.startsWith('sync.')).toBe(true);
+    }
+  });
+});
+
+describe('CONFIG_SCHEMA — coverage spot checks', () => {
+  // These are the paths most likely to be set by operators in production —
+  // failing this case = operator hit a path the schema didn't know about.
+  it.each([
+    'user.username',
+    'user.email',
+    SYNC_ENABLED,
+    'collection.auto_submit',
+    'wizard.completed',
+    'console.port',
+    LICENSE_TIER,
+    'display.persona_indicators.enabled',
+    'display.indicator.style',
+    'elements.default_element_dir',
+    'elements.auto_activate.personas',
+    'autoLoad.enabled',
+    'retentionPolicy.enabled',
+    'retentionPolicy.defaults.ttl_days',
+  ])('schema covers %s', (path) => {
+    expect(CONFIG_SCHEMA[path]).toBeDefined();
+  });
+});

--- a/tests/unit/config/configSchema.test.ts
+++ b/tests/unit/config/configSchema.test.ts
@@ -139,8 +139,8 @@ describe('listKnownPaths', () => {
   it('returns all schema paths when no prefix is given', () => {
     const paths = listKnownPaths();
     expect(paths.length).toBe(Object.keys(CONFIG_SCHEMA).length);
-    // Sorted
-    const sorted = [...paths].sort();
+    // Sorted with explicit comparator (matches listKnownPaths implementation)
+    const sorted = [...paths].sort((a, b) => a.localeCompare(b));
     expect(paths).toEqual(sorted);
   });
 


### PR DESCRIPTION
## Summary

Targeted improvements across the auth, config, and observability surfaces, with supporting test and doc updates.

### Security / correctness

- **HTTP per-user isolation.** File-mode authenticated sessions previously collapsed onto a shared `http-user` identity at the filesystem layer because `UserIdentityService` is DB-mode-only. Now resolves a path-safe internal user id from the auth claims via a stable provider+sub derivation — preserves readable subs (`github_42`, `local_alice`) and hashes generic OIDC subjects that can't satisfy the userId regex.
- **DB-mode auth resolution fails closed.** If `resolveOrCreateUser` throws, the session aborts at handshake time rather than continuing with a non-UUID `dbUserId` that would corrupt downstream RLS-scoped queries. `state.dbUserId` is only written when resolution actually succeeded.
- **PersonaManager LRU bypass fix.** `findPersona` was iterating cache values without going through `.get()`, so cache hits weren't recorded and frequently-read personas could be evicted before stale ones. New `touchById` API on `ElementCache` lets name-based lookups keep the LRU honest.
- **HTTP transport session-context tests** no longer depend on `LOG_LEVEL=debug`. The fixtures now exercise the session-attribution path through a mutation that emits at `info` level (the level operators actually run with).

### New features

- **`dollhouse_config` schema validation.** Writes are validated against a path/type registry; unknown paths and type mismatches are rejected with clear errors and near-match suggestions (e.g. `sync.enable` → "did you mean `sync.enabled`?"). Strict by default; operators can set `DOLLHOUSE_CONFIG_STRICT_PATHS=false` for back-compat with workflows that store legacy keys not yet in the registry.
- **`dollhouse_config delete` action.** Removes a stored value so consumers see the schema default. Leaf-only safety check rejects attempts to delete entire sections.
- **Per-operation auth-flow timing in `/healthz`.** `PerformanceMonitor` gained `recordAuthOp` / `timeAuthOp` / `getAuthOpStats`; auth methods and providers are wrapped via decorators (`instrumentAuthMethod`, `instrumentAuthProvider`) so timing is captured without touching the concrete classes. `/healthz` JSON surfaces per-op p50/p95/p99 + success rate alongside the existing session telemetry.

### Refactors

- `LocalDevAuthProvider.validate`, `OidcAuthProvider.validate`, and `EmbeddedAuthorizationServer.validate` split into focused helpers (`buildXxxAuthResult` + `mapXxxVerifyError`). Public API unchanged; cognitive complexity brought within target.
- `ConfigHandler.handleExport` was passing the format string as a filePath argument to `exportConfig`, writing files at literal paths `'yaml'`/`'json'` and rendering `[object Object]` in the response. Now serializes the in-memory config inline (no side effects, no missing content).
- `ConfigHandler.handleSet` now surfaces `ConfigManager` rejections instead of always reporting success.

### Documentation

- New **Postgres-mode DR runbook** (`docs/guides/postgres-dr-runbook.md`): backup tracks (DB + secrets), restore-to-scratch-host procedure, RTO/RPO targets, PITR for managed Postgres, key-envelope reconstruction, quarterly drill checklist.
- `DOLLHOUSE_INVITE_TOKEN_SECRET` format in `deployment-configuration.md` corrected (hex, not base64).

## Test plan

- [x] `npm run build`
- [x] `npm run lint` — zero warnings
- [x] `npm test` — 11,216 passed, 9 skipped
- [x] `npm run test:integration` — 2,433 passed, 160 skipped, 120/122 suites
- [x] `npm run test:e2e` — 186 passed, 10/10 suites