### PR TITLE
refactor: extract helpers from high-complexity functions

### DIFF
--- a/src/auth/GitHubAuthManager.ts
+++ b/src/auth/GitHubAuthManager.ts
@@ -279,120 +279,142 @@ export class GitHubAuthManager {
     logger.debug('OAUTH_STEP_2: Initiating device flow', { url: this.DEVICE_CODE_URL });
     
     try {
-      const response = await this.fetchWithRetry(this.DEVICE_CODE_URL, {
-        method: 'POST',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          client_id: clientId,
-          scope: 'public_repo read:user'
-        })
-      });
-      
-      logger.debug('OAUTH_STEP_3: GitHub response', { 
-        status: response.status, 
-        statusText: response.statusText,
-        headers: {
-          'x-github-request-id': response.headers.get('x-github-request-id'),
-          'x-ratelimit-remaining': response.headers.get('x-ratelimit-remaining')
-        }
-      });
-      
+      const response = await this.requestDeviceCode(clientId);
+      this.logDeviceFlowResponse(response);
       if (!response.ok) {
-        const responseText = await response.text();
-        logger.error('GitHub OAuth endpoint error', { 
-          status: response.status,
-          statusText: response.statusText,
-          responseBody: responseText,
-          clientId: clientId?.substring(0, 8) + '...'
-        });
-        
-        // Parse GitHub's error response for specific error codes
-        try {
-          const errorData = JSON.parse(responseText);
-          
-          if (errorData.error === 'unauthorized_client') {
-            throw new Error(`OAUTH_CLIENT_UNAUTHORIZED: OAuth app '${clientId?.substring(0, 8)}...' is not authorized for device flow. The app may need reconfiguration.`);
-          }
-          
-          if (errorData.error === 'invalid_client') {
-            throw new Error(`OAUTH_CLIENT_INVALID: GitHub rejected OAuth client ID '${clientId?.substring(0, 8)}...'. The app may not exist or be disabled.`);
-          }
-          
-          if (errorData.error_description) {
-            throw new Error(`OAUTH_API_ERROR: ${errorData.error_description}`);
-          }
-        } catch {
-          // If we can't parse the error, provide HTTP status specific error
-          if (response.status === 401) {
-            throw new Error(`OAUTH_CLIENT_INVALID: GitHub rejected OAuth client ID '${clientId?.substring(0, 8)}...'. The app may not exist or be disabled.`);
-          }
-          
-          if (response.status === 403) {
-            throw new Error(`OAUTH_DEVICE_FLOW_DISABLED: This OAuth app doesn't have device flow enabled. Contact administrator.`);
-          }
-          
-          if (response.status === 429) {
-            throw new Error(`OAUTH_RATE_LIMITED: Too many authentication attempts. Please wait before trying again.`);
-          }
-          
-          throw new Error(`OAUTH_HTTP_${response.status}: GitHub OAuth failed - ${response.statusText}`);
-        }
+        await this.handleDeviceFlowHttpError(response, clientId);
       }
       
       const data = await response.json();
-      
-      // Validate response
-      if (!data.device_code || !data.user_code || !data.verification_uri) {
-        logger.error('Invalid device flow response structure', { 
-          hasDeviceCode: !!data.device_code,
-          hasUserCode: !!data.user_code,
-          hasVerificationUri: !!data.verification_uri
-        });
-        throw new Error('OAUTH_INVALID_RESPONSE: Invalid device flow response from GitHub - missing required fields');
-      }
-      
-      // Log security event for audit trail
-      SecurityMonitor.logSecurityEvent({
-        type: 'TOKEN_VALIDATION_SUCCESS',
-        severity: 'LOW',
-        source: 'GitHubAuthManager.initiateDeviceFlow',
-        details: 'GitHub OAuth device flow initiated successfully',
-        metadata: {
-          userCode: data.user_code,
-          expiresIn: data.expires_in,
-          interval: data.interval
-        }
-      });
-      
+      this.validateDeviceFlowResponse(data);
+      this.logDeviceFlowSuccess(data as DeviceCodeResponse);
       return data as DeviceCodeResponse;
     } catch (error) {
-      ErrorHandler.logError('GitHubAuthManager.initiateDeviceFlow', error);
-      
-      // Check if it's a network error
-      if (error instanceof Error) {
-        // Re-throw if it's already a properly formatted error with code
-        if (error.message.startsWith('OAUTH_')) {
-          throw error;
-        }
-        
-        // Format network errors
-        if (error.message.includes('ECONNREFUSED') || 
-            error.message.includes('ETIMEDOUT') || 
-            error.message.includes('ENOTFOUND')) {
-          throw new Error(`OAUTH_NETWORK_ERROR: Unable to reach GitHub servers (https://github.com/login/device/code). Check your internet connection.`);
-        }
-        
-        if (error.message.includes('network')) {
-          throw new Error(`OAUTH_NETWORK_ERROR: Network error while connecting to GitHub. Please check your internet connection.`);
-        }
-      }
-      
-      // Generic fallback (should rarely happen)
-      throw new Error(`OAUTH_UNKNOWN_ERROR: Failed to start GitHub authentication - ${error instanceof Error ? error.message : 'Unknown error'}`);
+      this.handleDeviceFlowError(error);
     }
+  }
+
+  private async requestDeviceCode(clientId: string): Promise<Response> {
+    return this.fetchWithRetry(this.DEVICE_CODE_URL, {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        client_id: clientId,
+        scope: 'public_repo read:user'
+      })
+    });
+  }
+
+  private logDeviceFlowResponse(response: Response): void {
+    logger.debug('OAUTH_STEP_3: GitHub response', {
+      status: response.status,
+      statusText: response.statusText,
+      headers: {
+        'x-github-request-id': response.headers.get('x-github-request-id'),
+        'x-ratelimit-remaining': response.headers.get('x-ratelimit-remaining')
+      }
+    });
+  }
+
+  private async handleDeviceFlowHttpError(response: Response, clientId: string): Promise<void> {
+    const responseText = await response.text();
+    logger.error('GitHub OAuth endpoint error', {
+      status: response.status,
+      statusText: response.statusText,
+      responseBody: responseText,
+      clientId: clientId?.substring(0, 8) + '...'
+    });
+
+    try {
+      const errorData = JSON.parse(responseText);
+      this.throwDeviceFlowApiError(errorData, clientId);
+    } catch {
+      this.throwDeviceFlowStatusError(response, clientId);
+    }
+  }
+
+  private throwDeviceFlowApiError(errorData: { error?: string; error_description?: string }, clientId: string): void {
+    if (errorData.error === 'unauthorized_client') {
+      throw new Error(`OAUTH_CLIENT_UNAUTHORIZED: OAuth app '${clientId?.substring(0, 8)}...' is not authorized for device flow. The app may need reconfiguration.`);
+    }
+
+    if (errorData.error === 'invalid_client') {
+      throw new Error(`OAUTH_CLIENT_INVALID: GitHub rejected OAuth client ID '${clientId?.substring(0, 8)}...'. The app may not exist or be disabled.`);
+    }
+
+    if (errorData.error_description) {
+      throw new Error(`OAUTH_API_ERROR: ${errorData.error_description}`);
+    }
+  }
+
+  private throwDeviceFlowStatusError(response: Response, clientId: string): never {
+    if (response.status === 401) {
+      throw new Error(`OAUTH_CLIENT_INVALID: GitHub rejected OAuth client ID '${clientId?.substring(0, 8)}...'. The app may not exist or be disabled.`);
+    }
+
+    if (response.status === 403) {
+      throw new Error(`OAUTH_DEVICE_FLOW_DISABLED: This OAuth app doesn't have device flow enabled. Contact administrator.`);
+    }
+
+    if (response.status === 429) {
+      throw new Error(`OAUTH_RATE_LIMITED: Too many authentication attempts. Please wait before trying again.`);
+    }
+
+    throw new Error(`OAUTH_HTTP_${response.status}: GitHub OAuth failed - ${response.statusText}`);
+  }
+
+  private validateDeviceFlowResponse(data: any): void {
+    if (!data.device_code || !data.user_code || !data.verification_uri) {
+      logger.error('Invalid device flow response structure', {
+        hasDeviceCode: !!data.device_code,
+        hasUserCode: !!data.user_code,
+        hasVerificationUri: !!data.verification_uri
+      });
+      throw new Error('OAUTH_INVALID_RESPONSE: Invalid device flow response from GitHub - missing required fields');
+    }
+  }
+
+  private logDeviceFlowSuccess(data: DeviceCodeResponse): void {
+    SecurityMonitor.logSecurityEvent({
+      type: 'TOKEN_VALIDATION_SUCCESS',
+      severity: 'LOW',
+      source: 'GitHubAuthManager.initiateDeviceFlow',
+      details: 'GitHub OAuth device flow initiated successfully',
+      metadata: {
+        userCode: data.user_code,
+        expiresIn: data.expires_in,
+        interval: data.interval
+      }
+    });
+  }
+
+  private handleDeviceFlowError(error: unknown): never {
+    ErrorHandler.logError('GitHubAuthManager.initiateDeviceFlow', error);
+
+    if (error instanceof Error) {
+      if (error.message.startsWith('OAUTH_')) {
+        throw error;
+      }
+
+      if (this.isConnectionError(error.message)) {
+        throw new Error(`OAUTH_NETWORK_ERROR: Unable to reach GitHub servers (https://github.com/login/device/code). Check your internet connection.`);
+      }
+
+      if (error.message.includes('network')) {
+        throw new Error(`OAUTH_NETWORK_ERROR: Network error while connecting to GitHub. Please check your internet connection.`);
+      }
+    }
+
+    throw new Error(`OAUTH_UNKNOWN_ERROR: Failed to start GitHub authentication - ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+
+  private isConnectionError(message: string): boolean {
+    return message.includes('ECONNREFUSED') ||
+      message.includes('ETIMEDOUT') ||
+      message.includes('ENOTFOUND');
   }
   
   /**

--- a/src/cli/admin-bootstrap.ts
+++ b/src/cli/admin-bootstrap.ts
@@ -46,6 +46,11 @@ interface GithubUser {
   login: string;
 }
 
+interface BootstrapIdentity {
+  adminSub: string;
+  adminMethod: 'magic-link' | 'github';
+}
+
 /**
  * Resolve a GitHub username to its numeric ID via the public API. We
  * record the numeric ID rather than the username because GitHub allows
@@ -109,7 +114,7 @@ function isValidEmail(value: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value); // NOSONAR — anchored email regex; quantifiers separated by literal anchors (@ and .); CLI input bounded by operator-typed length
 }
 
-async function main(): Promise<void> {
+function parseAndValidateOptions(): BootstrapOptions {
   const program = new Command();
   program
     .name('dollhouse-admin-bootstrap')
@@ -124,44 +129,13 @@ async function main(): Promise<void> {
     .option('--email <email>', 'admin email address (for magic-link method)')
     .parse(process.argv);
 
-  const opts = program.opts<BootstrapOptions>();
+  return program.opts<BootstrapOptions>();
+}
 
-  let adminSub: string;
-  let adminMethod: 'magic-link' | 'github';
-
-  if (opts.method === 'github') {
-    adminMethod = 'github';
-    let id: number;
-    if (opts.githubId) {
-      const parsed = Number.parseInt(opts.githubId, 10);
-      if (!Number.isFinite(parsed) || parsed <= 0) {
-        process.stderr.write(`Invalid --github-id '${opts.githubId}': must be a positive integer.\n`);
-        process.exit(1);
-      }
-      id = parsed;
-    } else if (opts.githubUsername) {
-      try {
-        id = await resolveGithubUserId(opts.githubUsername);
-        process.stderr.write(`[admin bootstrap] Resolved GitHub user '${opts.githubUsername}' to id=${id}.\n`);
-      } catch (err) {
-        process.stderr.write(
-          `Failed to resolve GitHub username: ${err instanceof Error ? err.message : String(err)}\n`,
-        );
-        process.exit(2);
-      }
-    } else {
-      process.stderr.write('--method github requires either --github-username or --github-id.\n');
-      process.exit(1);
-    }
-    adminSub = `github_${id}`;
-  } else if (opts.method === 'magic-link') {
-    adminMethod = 'magic-link';
-    if (!opts.email || !isValidEmail(opts.email)) {
-      process.stderr.write(`--method magic-link requires a valid --email '<addr>'.\n`);
-      process.exit(1);
-    }
-    adminSub = magicLinkSubFromEmail(opts.email);
-  } else if (opts.method === 'local-password' || opts.method === 'local-account') {
+async function resolveBootstrapIdentity(opts: BootstrapOptions): Promise<BootstrapIdentity> {
+  if (opts.method === 'github') return bootstrapGithubAdmin(opts);
+  if (opts.method === 'magic-link') return bootstrapMagicLinkAdmin(opts);
+  if (opts.method === 'local-password' || opts.method === 'local-account') {
     process.stderr.write(
       "Local-account deployments bootstrap implicitly via 'dollhouse-create-user'. " +
       "Run that command instead — the first invite issued is automatically the admin invite.\n",
@@ -173,6 +147,54 @@ async function main(): Promise<void> {
     );
     process.exit(1);
   }
+}
+
+async function bootstrapGithubAdmin(opts: BootstrapOptions): Promise<BootstrapIdentity> {
+  const id = await resolveBootstrapGithubId(opts);
+  return { adminSub: `github_${id}`, adminMethod: 'github' };
+}
+
+async function resolveBootstrapGithubId(opts: BootstrapOptions): Promise<number> {
+  if (opts.githubId) return parseGithubId(opts.githubId);
+  if (opts.githubUsername) return resolveBootstrapGithubUsername(opts.githubUsername);
+
+  process.stderr.write('--method github requires either --github-username or --github-id.\n');
+  process.exit(1);
+}
+
+function parseGithubId(githubId: string): number {
+  const parsed = Number.parseInt(githubId, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    process.stderr.write(`Invalid --github-id '${githubId}': must be a positive integer.\n`);
+    process.exit(1);
+  }
+  return parsed;
+}
+
+async function resolveBootstrapGithubUsername(githubUsername: string): Promise<number> {
+  try {
+    const id = await resolveGithubUserId(githubUsername);
+    process.stderr.write(`[admin bootstrap] Resolved GitHub user '${githubUsername}' to id=${id}.\n`);
+    return id;
+  } catch (err) {
+    process.stderr.write(
+      `Failed to resolve GitHub username: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(2);
+  }
+}
+
+function bootstrapMagicLinkAdmin(opts: BootstrapOptions): BootstrapIdentity {
+  if (!opts.email || !isValidEmail(opts.email)) {
+    process.stderr.write(`--method magic-link requires a valid --email '<addr>'.\n`);
+    process.exit(1);
+  }
+  return { adminSub: magicLinkSubFromEmail(opts.email), adminMethod: 'magic-link' };
+}
+
+async function main(): Promise<void> {
+  const opts = parseAndValidateOptions();
+  const { adminSub, adminMethod } = await resolveBootstrapIdentity(opts);
 
   // Round 5 post-triage HIGH-1: openCliAuthStorage handles all three
   // backends including postgres (which the previous direct

--- a/src/collection/CollectionIndexManager.ts
+++ b/src/collection/CollectionIndexManager.ts
@@ -490,60 +490,70 @@ export class CollectionIndexManager {
    * the dispatch.
    */
   private async loadFromDisk(): Promise<void> {
-    let cached: CollectionIndexCacheEntry | null = null;
-
-    if (this.sharedCache) {
-      try {
-        const entry = await this.sharedCache.get(CollectionIndexManager.CACHE_KEY);
-        if (entry) {
-          // Map SharedCacheEntry → CollectionIndexCacheEntry. payload is the
-          // CollectionIndex; fetchedAt becomes timestamp; HTTP-conditional
-          // fields and version/checksum are preserved verbatim.
-          cached = {
-            data: entry.payload as CollectionIndex,
-            timestamp: entry.fetchedAt,
-            etag: entry.etag,
-            lastModified: entry.lastModified,
-            version: entry.version ?? 'unknown',
-            checksum: entry.checksum ?? '',
-          };
-        }
-      } catch (error) {
-        logger.debug('Failed to load cache from shared store', { error: this.getErrorMessage(error) });
-      }
-    } else {
-      try {
-        const data = await this.fileOperations.readFile(this.CACHE_FILE, {
-          source: 'CollectionIndexManager.loadFromDisk',
-        });
-        cached = JSON.parse(data) as CollectionIndexCacheEntry;
-      } catch (error) {
-        if ((error as any).code !== 'ENOENT') {
-          logger.debug('Failed to load cache from disk', { error: this.getErrorMessage(error) });
-        }
-        return;
-      }
-    }
-
+    const cached = this.sharedCache
+      ? await this.loadFromSharedCache()
+      : await this.loadFromLegacyDisk();
     if (!cached) return;
+    if (!this.validateCacheEntry(cached)) return;
 
-    // Validate cache structure
+    this.cachedIndex = cached;
+    this.logLoadedCache(cached);
+  }
+
+  private async loadFromSharedCache(): Promise<CollectionIndexCacheEntry | null> {
+    try {
+      const entry = await this.sharedCache?.get(CollectionIndexManager.CACHE_KEY);
+      if (!entry) return null;
+
+      // Map SharedCacheEntry → CollectionIndexCacheEntry. payload is the
+      // CollectionIndex; fetchedAt becomes timestamp; HTTP-conditional
+      // fields and version/checksum are preserved verbatim.
+      return {
+        data: entry.payload as CollectionIndex,
+        timestamp: entry.fetchedAt,
+        etag: entry.etag,
+        lastModified: entry.lastModified,
+        version: entry.version ?? 'unknown',
+        checksum: entry.checksum ?? '',
+      };
+    } catch (error) {
+      logger.debug('Failed to load cache from shared store', { error: this.getErrorMessage(error) });
+      return null;
+    }
+  }
+
+  private async loadFromLegacyDisk(): Promise<CollectionIndexCacheEntry | null> {
+    try {
+      const data = await this.fileOperations.readFile(this.CACHE_FILE, {
+        source: 'CollectionIndexManager.loadFromDisk',
+      });
+      return JSON.parse(data) as CollectionIndexCacheEntry;
+    } catch (error) {
+      if ((error as any).code !== 'ENOENT') {
+        logger.debug('Failed to load cache from disk', { error: this.getErrorMessage(error) });
+      }
+      return null;
+    }
+  }
+
+  private validateCacheEntry(cached: CollectionIndexCacheEntry): boolean {
     if (!cached.data || !cached.timestamp || !cached.version) {
       logger.debug('Invalid cache structure, ignoring');
-      return;
+      return false;
     }
 
-    // Verify checksum if available
     if (cached.checksum) {
       const expectedChecksum = this.calculateChecksum(cached.data);
       if (cached.checksum !== expectedChecksum) {
         logger.debug('Cache checksum mismatch, ignoring cached data');
-        return;
+        return false;
       }
     }
 
-    this.cachedIndex = cached;
+    return true;
+  }
 
+  private logLoadedCache(cached: CollectionIndexCacheEntry): void {
     const age = Date.now() - cached.timestamp;
     const isExpired = age > this.TTL_MS;
 

--- a/src/handlers/GitHubAuthHandler.ts
+++ b/src/handlers/GitHubAuthHandler.ts
@@ -19,6 +19,8 @@ import { SecurityMonitor } from '../security/securityMonitor.js';
 import { FileOperationsService } from '../services/FileOperationsService.js';
 import type { PathService } from '../paths/PathService.js';
 
+const UNKNOWN_ERROR = 'Unknown error';
+
 export class GitHubAuthHandler {
     constructor(
         private readonly githubAuthManager: GitHubAuthManager,
@@ -40,174 +42,17 @@ export class GitHubAuthHandler {
     async setupGitHubAuth() {
         await this.ensureInitialized();
         try {
-          // Check current auth status first
           const currentStatus = await this.githubAuthManager.getAuthStatus();
-          
           if (currentStatus.isAuthenticated) {
-            return {
-              content: [{
-                type: "text",
-                text: this.prefix(
-                  `✅ **Already Connected to GitHub**\n\n` +
-                  `👤 **Username:** ${currentStatus.username}\n` +
-                  `🔑 **Permissions:** ${currentStatus.scopes?.join(', ') || 'basic access'}\n\n` +
-                  `You're all set! You can:\n` +
-                  `• Browse the collection\n` +
-                  `• Install content\n` +
-                  `• Submit your creations\n\n` +
-                  `To disconnect, say "disconnect from GitHub"`
-                )
-              }]
-            };
+            return this.alreadyConnectedResponse(currentStatus);
           }
           
-          // FIX: DMCP-SEC-006 - Add security audit logging for authentication initiation
-          SecurityMonitor.logSecurityEvent({
-            type: 'AUTH_FLOW_INITIATED',
-            severity: 'LOW',
-            source: 'GitHubAuthHandler.setupGitHubAuth',
-            details: 'GitHub authentication flow initiated via device code',
-            additionalData: { authFlow: 'device-code' }
-          });
-
-          // Initiate device flow
-          let deviceResponse: DeviceCodeResponse;
-          try {
-            deviceResponse = await this.githubAuthManager.initiateDeviceFlow();
-          } catch (deviceFlowError) {
-            logger.error('OAUTH_INDEX_2681: Failed to initiate device flow', { error: deviceFlowError });
-            throw new Error(`OAUTH_INDEX_2681: Device flow initiation failed - ${deviceFlowError instanceof Error ? deviceFlowError.message : 'Unknown error'}`);
-          }
-          
-          // CRITICAL FIX: Use helper process approach from PR #518
-          // MCP servers are stateless and terminate after returning response
-          // The helper process survives MCP termination and can complete OAuth polling
-          
-          // Get the OAuth client ID - use the same method that has the default fallback
-          // This ensures we get the default client ID if no env/config is set
-          logger.debug('OAUTH_STEP_4: Getting client ID for helper process');
-          const clientId = await this.githubAuthManager.resolveClientId();
-          logger.debug('OAUTH_STEP_5: Client ID obtained', { clientId: clientId?.substring(0, 8) + '...' });
-          
-          if (!clientId) {
-            return {
-              content: [{
-                type: "text",
-                text: this.prefix(
-                  `❌ **GitHub OAuth Configuration Error**\n\n` +
-                  `Unable to obtain GitHub OAuth client ID.\n\n` +
-                  `This is unexpected - please report this issue.\n\n` +
-                  `**Workaround:**\n` +
-                  `• Set environment variable: DOLLHOUSE_GITHUB_CLIENT_ID\n` +
-                  `• Or use GitHub CLI: gh auth login --web`
-                )
-              }]
-            };
-          }
-          
-          let helperPath: string | null = null;
-          try {
-            const locator = new PackageResourceLocator();
-            const pkgRoot = locator.getPackageRoot();
-
-            const overrideHelper = process.env.DOLLHOUSE_OAUTH_HELPER;
-            const possiblePaths = [
-              path.join(pkgRoot, 'dist', 'oauth-helper.mjs'),
-              path.join(pkgRoot, 'src', 'oauth-helper.mjs'),
-              path.join(pkgRoot, 'oauth-helper.mjs'),
-            ];
-            if (overrideHelper) {
-              possiblePaths.unshift(overrideHelper);
-            }
-            
-            helperPath = null;
-            for (const testPath of possiblePaths) {
-              if (await this.fileOperations.exists(testPath)) {
-                helperPath = testPath;
-                break;
-              }
-            }
-            
-            if (!helperPath) {
-              logger.error('OAUTH_INDEX_2734: oauth-helper.mjs not found', {
-                searchedPaths: possiblePaths,
-                packageRoot: pkgRoot,
-              });
-              throw new Error(`OAUTH_HELPER_NOT_FOUND: oauth-helper.mjs not found at line 2734. Searched: ${possiblePaths.join(', ')}`);
-            }
-            
-            logger.debug('OAUTH_STEP_6: Spawning helper process', { 
-              helperPath,
-              clientId: clientId?.substring(0, 8) + '...',
-              deviceCode: deviceResponse.device_code.substring(0, 8) + '...' 
-            });
-            
-            const helper = this.spawnHelperProcess(helperPath, deviceResponse, clientId);
-            
-            helper.unref();
-            
-            logger.debug('OAUTH_STEP_7: Helper process spawned successfully', { pid: helper.pid });
-            
-            logger.info('OAuth helper process spawned', {
-              pid: helper.pid,
-              expiresIn: deviceResponse.expires_in,
-              userCode: deviceResponse.user_code
-            });
-            
-            const stateFile = this.getOAuthHelperStateFile();
-            const stateDir = path.dirname(stateFile);
-            await this.fileOperations.createDirectory(stateDir);
-            
-            const state = {
-              pid: helper.pid,
-              deviceCode: deviceResponse.device_code,
-              userCode: deviceResponse.user_code,
-              startTime: new Date().toISOString(),
-              expiresAt: new Date(Date.now() + deviceResponse.expires_in * 1000).toISOString()
-            };
-
-            await this.fileOperations.writeFile(stateFile, JSON.stringify(state, null, 2), {
-              source: 'GitHubAuthHandler.setupGitHubAuth'
-            });
-            
-          } catch (spawnError) {
-            logger.error('OAUTH_INDEX_2774: Failed to spawn OAuth helper process', { 
-              error: spawnError,
-              helperPath,
-              clientId: clientId?.substring(0, 8) + '...',
-              errorCode: (spawnError as any)?.code,
-              syscall: (spawnError as any)?.syscall
-            });
-            
-            let errorDetail = '';
-            if (spawnError instanceof Error) {
-              if (spawnError.message.includes('ENOENT')) {
-                errorDetail = `OAUTH_HELPER_SPAWN_ENOENT: Node.js executable not found or helper script missing at ${helperPath}`;
-              } else if (spawnError.message.includes('EACCES')) {
-                errorDetail = `OAUTH_HELPER_SPAWN_EACCES: Permission denied when trying to execute ${helperPath}`;
-              } else if (spawnError.message.includes('E2BIG')) {
-                errorDetail = `OAUTH_HELPER_SPAWN_E2BIG: Argument list too long for helper process`;
-              } else {
-                errorDetail = `OAUTH_HELPER_SPAWN_FAILED: Could not start background authentication process at line 2774 - ${spawnError.message}`;
-              }
-            } else {
-              errorDetail = `OAUTH_HELPER_SPAWN_UNKNOWN: Unknown spawn error at line 2774`;
-            }
-            
-            return {
-              content: [{
-                type: "text",
-                text: this.prefix(
-                  `⚠️ **OAuth Helper Launch Failed**\n\n` +
-                  `${errorDetail}\n\n` +
-                  `**Alternative Options:**\n` +
-                  `1. Try again: Run setup_github_auth again\n` +
-                  `2. Use GitHub CLI: gh auth login --web\n` +
-                  `3. Set token manually: export GITHUB_TOKEN=your_token`
-                )
-              }]
-            };
-          }
+          this.logAuthFlowInitiated();
+          const deviceResponse = await this.initiateDeviceFlowForSetup();
+          const clientId = await this.resolveHelperClientId();
+          if (!clientId) return this.missingClientIdResponse();
+          const spawnFailure = await this.startOAuthHelper(deviceResponse, clientId);
+          if (spawnFailure) return spawnFailure;
           
           return {
             content: [{
@@ -224,20 +69,206 @@ export class GitHubAuthHandler {
             errorMessage: error instanceof Error ? error.message : 'Unknown'
           });
           
-          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-          const hasErrorCode = errorMessage.includes('OAUTH_');
+          const errorMessage = error instanceof Error ? error.message : UNKNOWN_ERROR;
           
           return {
             content: [{
               type: "text",
-              text: this.prefix(
-                `❌ **Authentication Setup Failed**\n\n` +
-                `${hasErrorCode ? errorMessage : `OAUTH_INDEX_2806: Unable to start GitHub authentication - ${errorMessage}`}\n\n` +
-                `${!errorMessage.includes('OAUTH_NETWORK') ? 'Please check your internet connection and try again.' : ''}`
-              )
+              text: this.prefix(this.formatAuthenticationSetupFailure(errorMessage))
             }]
           };
         }
+    }
+
+    private formatAuthenticationSetupFailure(errorMessage: string): string {
+        const message = errorMessage.includes('OAUTH_')
+          ? errorMessage
+          : `OAUTH_INDEX_2806: Unable to start GitHub authentication - ${errorMessage}`;
+        const retryHint = errorMessage.includes('OAUTH_NETWORK')
+          ? ''
+          : 'Please check your internet connection and try again.';
+
+        return `❌ **Authentication Setup Failed**\n\n` +
+          `${message}\n\n` +
+          retryHint;
+    }
+
+    private alreadyConnectedResponse(currentStatus: Awaited<ReturnType<GitHubAuthManager['getAuthStatus']>>) {
+        return {
+          content: [{
+            type: "text",
+            text: this.prefix(
+              `✅ **Already Connected to GitHub**\n\n` +
+              `👤 **Username:** ${currentStatus.username}\n` +
+              `🔑 **Permissions:** ${currentStatus.scopes?.join(', ') || 'basic access'}\n\n` +
+              `You're all set! You can:\n` +
+              `• Browse the collection\n` +
+              `• Install content\n` +
+              `• Submit your creations\n\n` +
+              `To disconnect, say "disconnect from GitHub"`
+            )
+          }]
+        };
+    }
+
+    private logAuthFlowInitiated(): void {
+        SecurityMonitor.logSecurityEvent({
+          type: 'AUTH_FLOW_INITIATED',
+          severity: 'LOW',
+          source: 'GitHubAuthHandler.setupGitHubAuth',
+          details: 'GitHub authentication flow initiated via device code',
+          additionalData: { authFlow: 'device-code' }
+        });
+    }
+
+    private async initiateDeviceFlowForSetup(): Promise<DeviceCodeResponse> {
+        try {
+          return await this.githubAuthManager.initiateDeviceFlow();
+        } catch (deviceFlowError) {
+          logger.error('OAUTH_INDEX_2681: Failed to initiate device flow', { error: deviceFlowError });
+          throw new Error(`OAUTH_INDEX_2681: Device flow initiation failed - ${deviceFlowError instanceof Error ? deviceFlowError.message : UNKNOWN_ERROR}`);
+        }
+    }
+
+    private async resolveHelperClientId(): Promise<string | null> {
+        logger.debug('OAUTH_STEP_4: Getting client ID for helper process');
+        const clientId = await this.githubAuthManager.resolveClientId();
+        logger.debug('OAUTH_STEP_5: Client ID obtained', { clientId: clientId?.substring(0, 8) + '...' });
+        return clientId;
+    }
+
+    private missingClientIdResponse() {
+        return {
+          content: [{
+            type: "text",
+            text: this.prefix(
+              `❌ **GitHub OAuth Configuration Error**\n\n` +
+              `Unable to obtain GitHub OAuth client ID.\n\n` +
+              `This is unexpected - please report this issue.\n\n` +
+              `**Workaround:**\n` +
+              `• Set environment variable: DOLLHOUSE_GITHUB_CLIENT_ID\n` +
+              `• Or use GitHub CLI: gh auth login --web`
+            )
+          }]
+        };
+    }
+
+    private async startOAuthHelper(deviceResponse: DeviceCodeResponse, clientId: string) {
+        let helperPath: string | null = null;
+        try {
+          helperPath = await this.findOAuthHelperPath();
+          this.logSpawningOAuthHelper(helperPath, clientId, deviceResponse);
+          const helper = this.spawnHelperProcess(helperPath, deviceResponse, clientId);
+          helper.unref();
+          this.logOAuthHelperSpawned(helper.pid, deviceResponse);
+          await this.writeOAuthHelperState(helper.pid, deviceResponse);
+          return null;
+        } catch (spawnError) {
+          return this.oauthHelperLaunchFailedResponse(spawnError, helperPath, clientId);
+        }
+    }
+
+    private async findOAuthHelperPath(): Promise<string> {
+        const locator = new PackageResourceLocator();
+        const pkgRoot = locator.getPackageRoot();
+        const possiblePaths = this.getOAuthHelperCandidatePaths(pkgRoot);
+
+        for (const testPath of possiblePaths) {
+          if (await this.fileOperations.exists(testPath)) return testPath;
+        }
+
+        logger.error('OAUTH_INDEX_2734: oauth-helper.mjs not found', {
+          searchedPaths: possiblePaths,
+          packageRoot: pkgRoot,
+        });
+        throw new Error(`OAUTH_HELPER_NOT_FOUND: oauth-helper.mjs not found at line 2734. Searched: ${possiblePaths.join(', ')}`);
+    }
+
+    private getOAuthHelperCandidatePaths(pkgRoot: string): string[] {
+        const possiblePaths = [
+          path.join(pkgRoot, 'dist', 'oauth-helper.mjs'),
+          path.join(pkgRoot, 'src', 'oauth-helper.mjs'),
+          path.join(pkgRoot, 'oauth-helper.mjs'),
+        ];
+        const overrideHelper = process.env.DOLLHOUSE_OAUTH_HELPER;
+        if (overrideHelper) possiblePaths.unshift(overrideHelper);
+        return possiblePaths;
+    }
+
+    private logSpawningOAuthHelper(helperPath: string, clientId: string, deviceResponse: DeviceCodeResponse): void {
+        logger.debug('OAUTH_STEP_6: Spawning helper process', {
+          helperPath,
+          clientId: clientId?.substring(0, 8) + '...',
+          deviceCode: deviceResponse.device_code.substring(0, 8) + '...'
+        });
+    }
+
+    private logOAuthHelperSpawned(pid: number | undefined, deviceResponse: DeviceCodeResponse): void {
+        logger.debug('OAUTH_STEP_7: Helper process spawned successfully', { pid });
+        logger.info('OAuth helper process spawned', {
+          pid,
+          expiresIn: deviceResponse.expires_in,
+          userCode: deviceResponse.user_code
+        });
+    }
+
+    private async writeOAuthHelperState(pid: number | undefined, deviceResponse: DeviceCodeResponse): Promise<void> {
+        const stateFile = this.getOAuthHelperStateFile();
+        const stateDir = path.dirname(stateFile);
+        await this.fileOperations.createDirectory(stateDir);
+
+        const state = {
+          pid,
+          deviceCode: deviceResponse.device_code,
+          userCode: deviceResponse.user_code,
+          startTime: new Date().toISOString(),
+          expiresAt: new Date(Date.now() + deviceResponse.expires_in * 1000).toISOString()
+        };
+
+        await this.fileOperations.writeFile(stateFile, JSON.stringify(state, null, 2), {
+          source: 'GitHubAuthHandler.setupGitHubAuth'
+        });
+    }
+
+    private oauthHelperLaunchFailedResponse(spawnError: unknown, helperPath: string | null, clientId: string) {
+        logger.error('OAUTH_INDEX_2774: Failed to spawn OAuth helper process', {
+          error: spawnError,
+          helperPath,
+          clientId: clientId?.substring(0, 8) + '...',
+          errorCode: (spawnError as any)?.code,
+          syscall: (spawnError as any)?.syscall
+        });
+
+        const errorDetail = this.formatOAuthHelperSpawnError(spawnError, helperPath);
+        return {
+          content: [{
+            type: "text",
+            text: this.prefix(
+              `⚠️ **OAuth Helper Launch Failed**\n\n` +
+              `${errorDetail}\n\n` +
+              `**Alternative Options:**\n` +
+              `1. Try again: Run setup_github_auth again\n` +
+              `2. Use GitHub CLI: gh auth login --web\n` +
+              `3. Set token manually: export GITHUB_TOKEN=your_token`
+            )
+          }]
+        };
+    }
+
+    private formatOAuthHelperSpawnError(spawnError: unknown, helperPath: string | null): string {
+        if (!(spawnError instanceof Error)) {
+          return `OAUTH_HELPER_SPAWN_UNKNOWN: Unknown spawn error at line 2774`;
+        }
+        if (spawnError.message.includes('ENOENT')) {
+          return `OAUTH_HELPER_SPAWN_ENOENT: Node.js executable not found or helper script missing at ${helperPath}`;
+        }
+        if (spawnError.message.includes('EACCES')) {
+          return `OAUTH_HELPER_SPAWN_EACCES: Permission denied when trying to execute ${helperPath}`;
+        }
+        if (spawnError.message.includes('E2BIG')) {
+          return `OAUTH_HELPER_SPAWN_E2BIG: Argument list too long for helper process`;
+        }
+        return `OAUTH_HELPER_SPAWN_FAILED: Could not start background authentication process at line 2774 - ${spawnError.message}`;
     }
 
     async checkGitHubAuth() {
@@ -247,104 +278,121 @@ export class GitHubAuthHandler {
           const status = await this.githubAuthManager.getAuthStatus();
           
           if (status.isAuthenticated) {
-            if (helperHealth.exists) {
-              const stateFile = this.getOAuthHelperStateFile();
-              // FileOperationsService.deleteFile already handles ENOENT gracefully
-              await this.fileOperations.deleteFile(stateFile).catch(() => {}); // Preserve error swallowing pattern
-            }
-            
-            return {
-              content: [{
-                type: "text",
-                text: this.prefix(
-                  `✅ **GitHub Connected**\n\n` +
-                  `👤 **Username:** ${status.username}\n` +
-                  `🔑 **Permissions:** ${status.scopes?.join(', ') || 'basic access'}\n\n` +
-                  `**Available Actions:**\n` +
-                  `✅ Browse collection\n` +
-                  `✅ Install content\n` +
-                  `✅ Submit content\n\n` +
-                  `Everything is working properly!`
-                )
-              }]
-            };
-          } else if (helperHealth.isActive) {
-            return {
-              content: [{
-                type: "text",
-                text: this.prefix(
-                  `⏳ **GitHub Authentication In Progress**\n\n` +
-                  `🔑 **User Code:** ${helperHealth.userCode}\n` +
-                  `⏱️ **Time Remaining:** ${Math.floor(helperHealth.timeRemaining / 60)}m ${helperHealth.timeRemaining % 60}s\n` +
-                  `🔄 **Process Status:** ${helperHealth.processAlive ? '✅ Running' : '⚠️ May have stopped'}\n` +
-                  `📁 **Log Available:** ${helperHealth.hasLog ? 'Yes' : 'No'}\n\n` +
-                  `**Waiting for you to:**\n` +
-                  `1. Go to: https://github.com/login/device\n` +
-                  `2. Enter code: **${helperHealth.userCode}**\n` +
-                  `3. Authorize the application\n\n` +
-                  `The authentication will complete automatically once you authorize.\n` +
-                  `Run this command again to check status.`
-                )
-              }]
-            };
-          } else if (helperHealth.exists && helperHealth.expired) {
-            const lines = [
-              '⏱️ **Authentication Expired**',
-              '',
-              'The GitHub authentication request has expired.',
-              `User code: ${helperHealth.userCode} (expired)`,
-              '',
-              '**To try again:**',
-              'Run: `setup_github_auth` to get a new code',
-              ''
-            ];
-
-            if (helperHealth.errorLog) {
-              lines.push('**Error Log:**', '```', helperHealth.errorLog, '```', '');
-            }
-
-            return {
-              content: [{
-                type: "text",
-                text: this.prefix(lines.join('\n'))
-              }]
-            };
-          } else if (status.hasToken) {
-            return {
-              content: [{
-                type: "text",
-                text: this.prefix(`⚠️ **GitHub Token Invalid**\n\n`) +
-                      `A GitHub token was found but it appears to be invalid or expired.\n\n` +
-                      `**To fix this:**\n` +
-                      `1. Say "set up GitHub" to authenticate again\n` +
-                      `2. Or check your GITHUB_TOKEN environment variable\n\n` +
-                      `Note: Browse and install still work without authentication!`
-              }]
-            };
-          } else {
-            return {
-              content: [{
-                type: "text",
-                text: this.prefix(`🔒 **Not Connected to GitHub**\n\n`) +
-                      `You're not currently authenticated with GitHub.\n\n` +
-                      `**What works without auth:**\n` +
-                      `✅ Browse the public collection\n` +
-                      `✅ Install community content\n` +
-                      `❌ Submit your own content (requires auth)\n\n` +
-                      `To connect, just say "set up GitHub" or "connect to GitHub"`
-              }]
-            };
+            await this.cleanupOAuthHelperStateIfPresent(helperHealth.exists);
+            return this.githubConnectedResponse(status);
           }
+          if (helperHealth.isActive) return this.githubAuthInProgressResponse(helperHealth);
+          if (helperHealth.exists && helperHealth.expired) return this.githubAuthExpiredResponse(helperHealth);
+          if (status.hasToken) return this.invalidTokenResponse();
+          return this.notConnectedResponse();
         } catch (error) {
           logger.error('Failed to check GitHub auth', { error });
           return {
             content: [{
               type: "text",
               text: this.prefix(`❌ **Unable to Check Authentication**\n\n`) +
-                    `Error: ${error instanceof Error ? error.message : 'Unknown error'}`
+                    `Error: ${error instanceof Error ? error.message : UNKNOWN_ERROR}`
             }]
           };
         }
+    }
+
+    private async cleanupOAuthHelperStateIfPresent(exists: boolean): Promise<void> {
+        if (!exists) return;
+        const stateFile = this.getOAuthHelperStateFile();
+        await this.fileOperations.deleteFile(stateFile).catch(() => {}); // Preserve error swallowing pattern
+    }
+
+    private githubConnectedResponse(status: Awaited<ReturnType<GitHubAuthManager['getAuthStatus']>>) {
+        return {
+          content: [{
+            type: "text",
+            text: this.prefix(
+              `✅ **GitHub Connected**\n\n` +
+              `👤 **Username:** ${status.username}\n` +
+              `🔑 **Permissions:** ${status.scopes?.join(', ') || 'basic access'}\n\n` +
+              `**Available Actions:**\n` +
+              `✅ Browse collection\n` +
+              `✅ Install content\n` +
+              `✅ Submit content\n\n` +
+              `Everything is working properly!`
+            )
+          }]
+        };
+    }
+
+    private githubAuthInProgressResponse(helperHealth: Awaited<ReturnType<GitHubAuthHandler['checkOAuthHelperHealth']>>) {
+        return {
+          content: [{
+            type: "text",
+            text: this.prefix(
+              `⏳ **GitHub Authentication In Progress**\n\n` +
+              `🔑 **User Code:** ${helperHealth.userCode}\n` +
+              `⏱️ **Time Remaining:** ${Math.floor(helperHealth.timeRemaining / 60)}m ${helperHealth.timeRemaining % 60}s\n` +
+              `🔄 **Process Status:** ${helperHealth.processAlive ? '✅ Running' : '⚠️ May have stopped'}\n` +
+              `📁 **Log Available:** ${helperHealth.hasLog ? 'Yes' : 'No'}\n\n` +
+              `**Waiting for you to:**\n` +
+              `1. Go to: https://github.com/login/device\n` +
+              `2. Enter code: **${helperHealth.userCode}**\n` +
+              `3. Authorize the application\n\n` +
+              `The authentication will complete automatically once you authorize.\n` +
+              `Run this command again to check status.`
+            )
+          }]
+        };
+    }
+
+    private githubAuthExpiredResponse(helperHealth: Awaited<ReturnType<GitHubAuthHandler['checkOAuthHelperHealth']>>) {
+        const lines = [
+          '⏱️ **Authentication Expired**',
+          '',
+          'The GitHub authentication request has expired.',
+          `User code: ${helperHealth.userCode} (expired)`,
+          '',
+          '**To try again:**',
+          'Run: `setup_github_auth` to get a new code',
+          ''
+        ];
+
+        if (helperHealth.errorLog) {
+          lines.push('**Error Log:**', '```', helperHealth.errorLog, '```', '');
+        }
+
+        return {
+          content: [{
+            type: "text",
+            text: this.prefix(lines.join('\n'))
+          }]
+        };
+    }
+
+    private invalidTokenResponse() {
+        return {
+          content: [{
+            type: "text",
+            text: this.prefix(`⚠️ **GitHub Token Invalid**\n\n`) +
+                  `A GitHub token was found but it appears to be invalid or expired.\n\n` +
+                  `**To fix this:**\n` +
+                  `1. Say "set up GitHub" to authenticate again\n` +
+                  `2. Or check your GITHUB_TOKEN environment variable\n\n` +
+                  `Note: Browse and install still work without authentication!`
+          }]
+        };
+    }
+
+    private notConnectedResponse() {
+        return {
+          content: [{
+            type: "text",
+            text: this.prefix(`🔒 **Not Connected to GitHub**\n\n`) +
+                  `You're not currently authenticated with GitHub.\n\n` +
+                  `**What works without auth:**\n` +
+                  `✅ Browse the public collection\n` +
+                  `✅ Install community content\n` +
+                  `❌ Submit your own content (requires auth)\n\n` +
+                  `To connect, just say "set up GitHub" or "connect to GitHub"`
+          }]
+        };
     }
 
     async getOAuthHelperStatus(verbose: boolean = false) {
@@ -355,83 +403,11 @@ export class GitHubAuthHandler {
           const logFile = this.getOAuthHelperLogFile();
           const pidFile = this.getOAuthHelperPidFile();
           
-          let statusText = `📊 **OAuth Helper Process Diagnostics**\n\n`;
-          
-          if (!health.exists) {
-            statusText += `**Status:** No OAuth process detected\n`
-            statusText += `**State File:** Not found\n\n`
-            statusText += `No active authentication process. Run \`setup_github_auth\` to start one.\n`;
-          } else if (health.isActive) {
-            statusText += `**Status:** 🟢 ACTIVE - Authentication in progress\n`
-            statusText += `**User Code:** ${health.userCode}\n`
-            statusText += `**Process ID:** ${health.pid}\n`
-            statusText += `**Process Alive:** ${health.processAlive ? '✅ Yes' : '❌ No (may have crashed)'}\n`
-            statusText += `**Started:** ${health.startTime?.toLocaleString()}\n`
-            statusText += `**Expires:** ${health.expiresAt?.toLocaleString()}\n`
-            statusText += `**Time Remaining:** ${Math.floor(health.timeRemaining / 60)}m ${health.timeRemaining % 60}s\n\n`
-            
-            if (!health.processAlive) {
-              statusText += `⚠️ **WARNING:** Process appears to have stopped!\n`
-              statusText += `The helper process (PID ${health.pid}) is not responding.\n`
-              statusText += `You may need to run 
-setup_github_auth
- again.\n\n`
-            }
-          } else if (health.expired) {
-            statusText += `**Status:** 🔴 EXPIRED\n`
-            statusText += `**User Code:** ${health.userCode} (expired)\n`
-            statusText += `**Process ID:** ${health.pid}\n`
-            statusText += `**Started:** ${health.startTime?.toLocaleString()}\n`
-            statusText += `**Expired:** ${health.expiresAt?.toLocaleString()}\n\n`
-            statusText += `The authentication request has expired. Run 
-setup_github_auth
- to try again.\n\n`
-          }
-          
-          statusText += `**📁 File Locations:**\n`
-          statusText += `• State: ${stateFile}\n`
-          statusText += `• Log: ${logFile} ${health.hasLog ? '(exists)' : '(not found)'}\n`
-          statusText += `• PID: ${pidFile}\n\n`
-          
-          if (health.errorLog) {
-            statusText += `**⚠️ Recent Errors:**\n\`\`\`\n${health.errorLog}\n\`\`\`\n\n`;
-          }
-          
-          if (verbose && health.hasLog) {
-            try {
-              const fullLog = await this.fileOperations.readFile(logFile, {
-                source: 'GitHubAuthHandler.getOAuthHelperStatus'
-              });
-              const lines = fullLog.split('\n').filter(line => line.trim());
-              const recentLines = lines.slice(-20);
-
-              statusText += `**📜 Recent Log Output (last 20 lines):**\n\`\`\`\n`;
-              statusText += recentLines.join('\n');
-              statusText += `\n\`\`\`\n\n`;
-            } catch {
-              statusText += `**📜 Log:** Unable to read log file\n\n`;
-            }
-          }
-          
-          if (health.exists && !health.processAlive && !health.expired) {
-            statusText += `**🔧 Troubleshooting Tips:**\n`
-            statusText += `1. The helper process may have crashed\n`
-            statusText += `2. Check the log file for errors: ${logFile}\n`
-            statusText += `3. Try running 
-setup_github_auth
- again\n`
-            statusText += `4. Ensure DOLLHOUSE_GITHUB_CLIENT_ID is set\n`
-            statusText += `5. Check your internet connection\n`
-          }
-          
-          if (health.exists && (health.expired || !health.processAlive)) {
-            statusText += `\n**🧹 Manual Cleanup (if needed):**\n`
-            statusText += '```bash'
-            statusText += `rm "${stateFile}"\n`
-            statusText += `rm "${logFile}"\n`
-            statusText += `rm "${pidFile}"\n`
-            statusText += '```';
-          }
+          let statusText = this.formatOAuthHelperStatus(health);
+          statusText += this.formatOAuthHelperFileLocations(health, stateFile, logFile, pidFile);
+          statusText += await this.formatVerboseOAuthHelperLog(verbose, health.hasLog, logFile);
+          statusText += this.formatOAuthHelperTroubleshooting(health, logFile);
+          statusText += this.formatOAuthHelperCleanup(health, stateFile, logFile, pidFile);
           
           return {
             content: [{
@@ -446,17 +422,138 @@ setup_github_auth
             content: [{
               type: "text",
               text: this.prefix(`❌ **Failed to Get OAuth Helper Status**\n\n`) +
-                    `Error: ${error instanceof Error ? error.message : 'Unknown error'}`
+                    `Error: ${error instanceof Error ? error.message : UNKNOWN_ERROR}`
             }]
           };
         }
     }
 
+    private formatOAuthHelperStatus(health: Awaited<ReturnType<GitHubAuthHandler['checkOAuthHelperHealth']>>): string {
+        let statusText = `📊 **OAuth Helper Process Diagnostics**\n\n`;
+        if (!health.exists) return statusText + this.formatNoOAuthHelperStatus();
+        if (health.isActive) return statusText + this.formatActiveOAuthHelperStatus(health);
+        if (health.expired) return statusText + this.formatExpiredOAuthHelperStatus(health);
+        return statusText;
+    }
+
+    private formatNoOAuthHelperStatus(): string {
+        return `**Status:** No OAuth process detected\n` +
+          `**State File:** Not found\n\n` +
+          `No active authentication process. Run \`setup_github_auth\` to start one.\n`;
+    }
+
+    private formatActiveOAuthHelperStatus(health: Awaited<ReturnType<GitHubAuthHandler['checkOAuthHelperHealth']>>): string {
+        let statusText = `**Status:** 🟢 ACTIVE - Authentication in progress\n` +
+          `**User Code:** ${health.userCode}\n` +
+          `**Process ID:** ${health.pid}\n` +
+          `**Process Alive:** ${health.processAlive ? '✅ Yes' : '❌ No (may have crashed)'}\n` +
+          `**Started:** ${health.startTime?.toLocaleString()}\n` +
+          `**Expires:** ${health.expiresAt?.toLocaleString()}\n` +
+          `**Time Remaining:** ${Math.floor(health.timeRemaining / 60)}m ${health.timeRemaining % 60}s\n\n`;
+
+        if (!health.processAlive) {
+          statusText += `⚠️ **WARNING:** Process appears to have stopped!\n` +
+            `The helper process (PID ${health.pid}) is not responding.\n` +
+            `You may need to run 
+setup_github_auth
+ again.\n\n`;
+        }
+        return statusText;
+    }
+
+    private formatExpiredOAuthHelperStatus(health: Awaited<ReturnType<GitHubAuthHandler['checkOAuthHelperHealth']>>): string {
+        return `**Status:** 🔴 EXPIRED\n` +
+          `**User Code:** ${health.userCode} (expired)\n` +
+          `**Process ID:** ${health.pid}\n` +
+          `**Started:** ${health.startTime?.toLocaleString()}\n` +
+          `**Expired:** ${health.expiresAt?.toLocaleString()}\n\n` +
+          `The authentication request has expired. Run 
+setup_github_auth
+ to try again.\n\n`;
+    }
+
+    private formatOAuthHelperFileLocations(
+        health: Awaited<ReturnType<GitHubAuthHandler['checkOAuthHelperHealth']>>,
+        stateFile: string,
+        logFile: string,
+        pidFile: string,
+    ): string {
+        let statusText = `**📁 File Locations:**\n` +
+          `• State: ${stateFile}\n` +
+          `• Log: ${logFile} ${health.hasLog ? '(exists)' : '(not found)'}\n` +
+          `• PID: ${pidFile}\n\n`;
+
+        if (health.errorLog) {
+          statusText += `**⚠️ Recent Errors:**\n\`\`\`\n${health.errorLog}\n\`\`\`\n\n`;
+        }
+        return statusText;
+    }
+
+    private async formatVerboseOAuthHelperLog(verbose: boolean, hasLog: boolean, logFile: string): Promise<string> {
+        if (!verbose || !hasLog) return '';
+        try {
+          const fullLog = await this.fileOperations.readFile(logFile, {
+            source: 'GitHubAuthHandler.getOAuthHelperStatus'
+          });
+          const lines = fullLog.split('\n').filter(line => line.trim());
+          const recentLines = lines.slice(-20);
+
+          return `**📜 Recent Log Output (last 20 lines):**\n\`\`\`\n` +
+            recentLines.join('\n') +
+            `\n\`\`\`\n\n`;
+        } catch {
+          return `**📜 Log:** Unable to read log file\n\n`;
+        }
+    }
+
+    private formatOAuthHelperTroubleshooting(
+        health: Awaited<ReturnType<GitHubAuthHandler['checkOAuthHelperHealth']>>,
+        logFile: string,
+    ): string {
+        if (!health.exists || health.processAlive || health.expired) return '';
+        return `**🔧 Troubleshooting Tips:**\n` +
+          `1. The helper process may have crashed\n` +
+          `2. Check the log file for errors: ${logFile}\n` +
+          `3. Try running 
+setup_github_auth
+ again\n` +
+          `4. Ensure DOLLHOUSE_GITHUB_CLIENT_ID is set\n` +
+          `5. Check your internet connection\n`;
+    }
+
+    private formatOAuthHelperCleanup(
+        health: Awaited<ReturnType<GitHubAuthHandler['checkOAuthHelperHealth']>>,
+        stateFile: string,
+        logFile: string,
+        pidFile: string,
+    ): string {
+        if (!health.exists || (!health.expired && health.processAlive)) return '';
+        return `\n**🧹 Manual Cleanup (if needed):**\n` +
+          '```bash' +
+          `rm "${stateFile}"\n` +
+          `rm "${logFile}"\n` +
+          `rm "${pidFile}"\n` +
+          '```';
+    }
+
     private async checkOAuthHelperHealth() {
-        const stateFile = this.getOAuthHelperStateFile();
         const logFile = this.getOAuthHelperLogFile();
+        const health = this.emptyOAuthHelperHealth();
         
-        const health = {
+        try {
+          this.populateOAuthHelperHealth(health, await this.readOAuthHelperState());
+          this.updateOAuthHelperActivity(health);
+          health.hasLog = await this.fileOperations.exists(logFile);
+          health.errorLog = await this.readOAuthHelperErrorLogIfNeeded(health, logFile);
+        } catch (error) {
+          this.logOAuthHelperHealthReadError(error);
+        }
+        
+        return health;
+    }
+
+    private emptyOAuthHelperHealth() {
+        return {
           exists: false,
           isActive: false,
           expired: false,
@@ -469,76 +566,77 @@ setup_github_auth
           expiresAt: null as Date | null,
           errorLog: ''
         };
-        
+    }
+
+    private async readOAuthHelperState() {
+        const stateFile = this.getOAuthHelperStateFile();
+        const stateData = await this.fileOperations.readFile(stateFile, {
+          source: 'GitHubAuthHandler.checkOAuthHelperHealth'
+        });
+        return JSON.parse(stateData);
+    }
+
+    private populateOAuthHelperHealth(
+        health: ReturnType<GitHubAuthHandler['emptyOAuthHelperHealth']>,
+        state: any,
+    ): void {
+        health.exists = true;
+        health.pid = state.pid;
+        health.userCode = state.userCode;
+        health.startTime = new Date(state.startTime);
+        health.expiresAt = new Date(state.expiresAt);
+    }
+
+    private updateOAuthHelperActivity(health: ReturnType<GitHubAuthHandler['emptyOAuthHelperHealth']>): void {
+        const now = new Date();
+        if (health.expiresAt && health.expiresAt > now) {
+          health.isActive = true;
+          health.timeRemaining = Math.ceil((health.expiresAt.getTime() - now.getTime()) / 1000);
+          health.processAlive = this.isOAuthHelperProcessAlive(health.pid);
+          return;
+        }
+        health.expired = true;
+    }
+
+    private isOAuthHelperProcessAlive(pid: number): boolean {
+        if (process.platform === 'win32') return true;
         try {
-          const stateData = await this.fileOperations.readFile(stateFile, {
+          process.kill(pid, 0);
+          return true;
+        } catch {
+          return false;
+        }
+    }
+
+    private async readOAuthHelperErrorLogIfNeeded(
+        health: ReturnType<GitHubAuthHandler['emptyOAuthHelperHealth']>,
+        logFile: string,
+    ): Promise<string> {
+        if (!health.hasLog || (health.processAlive && !health.expired)) return '';
+        try {
+          const logContent = await this.fileOperations.readFile(logFile, {
             source: 'GitHubAuthHandler.checkOAuthHelperHealth'
           });
-          const state = JSON.parse(stateData);
-          health.exists = true;
-          health.pid = state.pid;
-          health.userCode = state.userCode;
-          health.startTime = new Date(state.startTime);
-          health.expiresAt = new Date(state.expiresAt);
-
-          const now = new Date();
-          if (health.expiresAt > now) {
-            health.isActive = true;
-            health.timeRemaining = Math.ceil((health.expiresAt.getTime() - now.getTime()) / 1000);
-
-            // Check if process is alive (only reliable on non-Windows platforms)
-            if (process.platform !== 'win32') {
-              try {
-                process.kill(health.pid, 0); // Signal 0 checks existence without killing
-                health.processAlive = true;
-              } catch {
-                health.processAlive = false;
-              }
-            } else {
-              // On Windows, process.kill(pid, 0) is not reliable for checking existence.
-              // We'll assume it's alive if the state file exists and hasn't expired.
-              // A more robust check would involve platform-specific process management.
-              health.processAlive = true;
-            }
-          } else {
-            health.expired = true;
-          }
-
-          // Check if log file exists
-          health.hasLog = await this.fileOperations.exists(logFile);
-
-          // Read error log if process is dead or expired, or if verbose mode is on
-          if (health.hasLog && (!health.processAlive || health.expired)) {
-            try {
-              const logContent = await this.fileOperations.readFile(logFile, {
-                source: 'GitHubAuthHandler.checkOAuthHelperHealth'
-              });
-              const lines = logContent.split('\n');
-              const importantLines = lines.filter(line =>
-                line.toLowerCase().includes('error') ||
-                line.toLowerCase().includes('fail') ||
-                line.includes('❌') ||
-                line.includes('⚠️')
-              ).slice(-10); // Get last 10 relevant lines
-
-              if (importantLines.length > 0) {
-                health.errorLog = importantLines.join('\n');
-              }
-            } catch {
-              // Intentionally empty - ignore if log file read fails
-            }
-          }
-
-        } catch (error) {
-          // If state file is not found (ENOENT), it's expected, so don't log as debug
-          if (error instanceof Error && error.message.includes('ENOENT')) {
-            // Intentionally empty - ENOENT is expected when state file doesn't exist yet
-          } else {
-            logger.debug('Error reading OAuth helper state', { error });
-          }
+          return this.extractImportantOAuthHelperLogLines(logContent);
+        } catch {
+          return '';
         }
-        
-        return health;
+    }
+
+    private extractImportantOAuthHelperLogLines(logContent: string): string {
+        const importantLines = logContent.split('\n').filter(line =>
+          line.toLowerCase().includes('error') ||
+          line.toLowerCase().includes('fail') ||
+          line.includes('❌') ||
+          line.includes('⚠️')
+        ).slice(-10);
+
+        return importantLines.length > 0 ? importantLines.join('\n') : '';
+    }
+
+    private logOAuthHelperHealthReadError(error: unknown): void {
+        if (error instanceof Error && error.message.includes('ENOENT')) return;
+        logger.debug('Error reading OAuth helper state', { error });
     }
 
     async clearGitHubAuth() {
@@ -573,7 +671,7 @@ setup_github_auth
             content: [{
               type: "text",
               text: this.prefix(`❌ **Failed to Clear Authentication**\n\n`) +
-                    `Error: ${error instanceof Error ? error.message : 'Unknown error'}`
+                    `Error: ${error instanceof Error ? error.message : UNKNOWN_ERROR}`
             }]
           };
         }
@@ -586,80 +684,15 @@ setup_github_auth
           await configManager.initialize();
           
           if (!client_id) {
-            const currentClientId = await this.githubAuthManager.resolveClientId();
-            
-            if (currentClientId) {
-              const configuredClientId = configManager.getGitHubClientId();
-              const isUsingDefault = !configuredClientId;
-              
-              const maskedClientId = currentClientId.substring(0, 10) + '...';
-              
-              return {
-                content: [{
-                  type: "text",
-                  text: this.prefix(`✅ **GitHub OAuth Configuration**\n\n`) +
-                        `**Current Status:** ${isUsingDefault ? 'Using Default' : 'Configured'}\n` +
-                        `**Client ID:** ${maskedClientId}\n` +
-                        `**Source:** ${isUsingDefault ? 'Built-in DollhouseMCP OAuth App' : 'Custom Configuration'}\n\n` +
-                        `Your GitHub OAuth is ready to use! You can now:\n` +
-                        `• Run setup_github_auth to connect\n` +
-                        `• Submit content to the collection\n` +
-                        `• Access authenticated features\n\n` +
-                        (isUsingDefault ? 
-                          `**Note:** Using the default DollhouseMCP OAuth app.\n` +
-                          `To use your own OAuth app, provide a client_id parameter.\n\n` : 
-                          `To update the configuration, provide a new client_id parameter.\n\n`)
-                }]
-              };
-            } else {
-              return {
-                content: [{
-                  type: "text",
-                  text: this.prefix(`⚠️ **GitHub OAuth Not Configured**\n\n`) +
-                        `No GitHub OAuth client ID is currently configured.\n\n` +
-                        `**To set up OAuth:**\n` +
-                        `1. Create a GitHub OAuth app at: https://github.com/settings/applications/new\n` +
-                        `2. Use these settings:\n` +
-                        `   • Homepage URL: https://github.com/DollhouseMCP\n` +
-                        `   • Authorization callback URL: http://localhost:3000/callback\n` +
-                        `3. Copy your Client ID (starts with "Ov23li")\n` +
-                        `4. Run: configure_oauth with your client_id parameter\n\n` +
-                        `**Need help?** Check the documentation for detailed setup instructions.`
-                }]
-              };
-            }
+            return this.currentOAuthConfigResponse(configManager);
           }
           
           if (!ConfigManager.validateClientId(client_id)) {
-            return {
-              content: [{
-                type: "text",
-                text: this.prefix(`❌ **Invalid Client ID Format**\n\n`) +
-                      `GitHub OAuth Client IDs must:\n` +
-                      `• Start with "Ov23li"\n` +
-                      `• Be followed by at least 14 alphanumeric characters\n\n` +
-                      `**Example:** Ov23liABCDEFGHIJKLMN\n\n` +
-                      `Please check your client ID and try again.`
-              }]
-            };
+            return this.invalidClientIdResponse();
           }
           
           await configManager.setGitHubClientId(client_id);
-          
-          const maskedClientId = client_id.substring(0, 10) + '...';
-          return {
-            content: [{
-              type: "text",
-              text: this.prefix(`✅ **GitHub OAuth Configured Successfully**\n\n`) +
-                    `**Client ID:** ${maskedClientId}\n` +
-                    `**Saved to:** ~/.dollhouse/config.json\n\n` +
-                    `Your GitHub OAuth is now ready! Next steps:\n` +
-                    `• Run setup_github_auth to connect your account\n` +
-                    `• Start submitting content to the collection\n` +
-                    `• Access authenticated features\n\n` +
-                    `**Note:** Your client ID is securely stored in your local config file.`
-            }]
-          };
+          return this.oauthConfiguredResponse(client_id);
           
         } catch (error) {
           logger.error('Failed to configure OAuth', { error });
@@ -667,7 +700,7 @@ setup_github_auth
             content: [{
               type: "text",
               text: this.prefix(`❌ **OAuth Configuration Failed**\n\n`) +
-                    `Error: ${error instanceof Error ? error.message : 'Unknown error'}\n\n` +
+                    `Error: ${error instanceof Error ? error.message : UNKNOWN_ERROR}\n\n` +
                     `Please check:\n` +
                     `• File permissions for ~/.dollhouse/config.json\n` +
                     `• Valid client ID format (starts with "Ov23li")\n` +
@@ -675,6 +708,84 @@ setup_github_auth
             }]
           };
         }
+    }
+
+    private async currentOAuthConfigResponse(configManager: ConfigManager) {
+        const currentClientId = await this.githubAuthManager.resolveClientId();
+        if (!currentClientId) return this.oauthNotConfiguredResponse();
+
+        const configuredClientId = configManager.getGitHubClientId();
+        const isUsingDefault = !configuredClientId;
+        const maskedClientId = currentClientId.substring(0, 10) + '...';
+        const source = isUsingDefault ? 'Built-in DollhouseMCP OAuth App' : 'Custom Configuration';
+        const note = isUsingDefault
+          ? `**Note:** Using the default DollhouseMCP OAuth app.\n` +
+            `To use your own OAuth app, provide a client_id parameter.\n\n`
+          : `To update the configuration, provide a new client_id parameter.\n\n`;
+
+        return {
+          content: [{
+            type: "text",
+            text: this.prefix(`✅ **GitHub OAuth Configuration**\n\n`) +
+                  `**Current Status:** ${isUsingDefault ? 'Using Default' : 'Configured'}\n` +
+                  `**Client ID:** ${maskedClientId}\n` +
+                  `**Source:** ${source}\n\n` +
+                  `Your GitHub OAuth is ready to use! You can now:\n` +
+                  `• Run setup_github_auth to connect\n` +
+                  `• Submit content to the collection\n` +
+                  `• Access authenticated features\n\n` +
+                  note
+          }]
+        };
+    }
+
+    private oauthNotConfiguredResponse() {
+        return {
+          content: [{
+            type: "text",
+            text: this.prefix(`⚠️ **GitHub OAuth Not Configured**\n\n`) +
+                  `No GitHub OAuth client ID is currently configured.\n\n` +
+                  `**To set up OAuth:**\n` +
+                  `1. Create a GitHub OAuth app at: https://github.com/settings/applications/new\n` +
+                  `2. Use these settings:\n` +
+                  `   • Homepage URL: https://github.com/DollhouseMCP\n` +
+                  `   • Authorization callback URL: http://localhost:3000/callback\n` +
+                  `3. Copy your Client ID (starts with "Ov23li")\n` +
+                  `4. Run: configure_oauth with your client_id parameter\n\n` +
+                  `**Need help?** Check the documentation for detailed setup instructions.`
+          }]
+        };
+    }
+
+    private invalidClientIdResponse() {
+        return {
+          content: [{
+            type: "text",
+            text: this.prefix(`❌ **Invalid Client ID Format**\n\n`) +
+                  `GitHub OAuth Client IDs must:\n` +
+                  `• Start with "Ov23li"\n` +
+                  `• Be followed by at least 14 alphanumeric characters\n\n` +
+                  `**Example:** Ov23liABCDEFGHIJKLMN\n\n` +
+                  `Please check your client ID and try again.`
+          }]
+        };
+    }
+
+    private oauthConfiguredResponse(clientId: string) {
+        const maskedClientId = clientId.substring(0, 10) + '...';
+        return {
+          content: [{
+            type: "text",
+            text: this.prefix(`✅ **GitHub OAuth Configured Successfully**\n\n`) +
+                  `**Client ID:** ${maskedClientId}\n` +
+                  `**Saved to:** ~/.dollhouse/config.json\n\n` +
+                  `Your GitHub OAuth is now ready! Next steps:\n` +
+                  `• Run setup_github_auth to connect your account\n` +
+                  `• Start submitting content to the collection\n` +
+                  `• Access authenticated features\n\n` +
+                  `**Note:** Your client ID is securely stored in your local config file.`
+          }]
+        };
     }
 
     private spawnHelperProcess(helperPath: string, deviceResponse: DeviceCodeResponse, clientId: string) {

--- a/src/portfolio/PortfolioIndexManager.ts
+++ b/src/portfolio/PortfolioIndexManager.ts
@@ -85,6 +85,22 @@ export interface SearchResult {
   score: number; // For future ranking
 }
 
+interface SearchAccumulator {
+  results: SearchResult[];
+  seenPaths: Set<string>;
+  maxResults: number;
+}
+
+interface BuildStats {
+  totalFiles: number;
+  processedFiles: number;
+}
+
+interface DirectoryEntries {
+  directories: string[];
+  yamlFiles: string[];
+}
+
 export class PortfolioIndexManager {
   private readonly indexByNamespace = new Map<string, PortfolioIndex>();
   private readonly lastBuiltByNamespace = new Map<string, Date>();
@@ -218,107 +234,116 @@ export class PortfolioIndexManager {
    */
   public async search(query: string, options: SearchOptions = {}): Promise<SearchResult[]> {
     const index = await this.getIndex();
-    
-    // Normalize query for security
-    const normalizedQuery = UnicodeValidator.normalize(query);
-    if (!normalizedQuery.isValid) {
-      logger.warn('Invalid Unicode in search query', {
-        issues: normalizedQuery.detectedIssues
-      });
-      return [];
-    }
-    
-    const safeQuery = normalizedQuery.normalizedContent.toLowerCase().trim();
-    const queryTokens = safeQuery.split(/\s+/).filter(token => token.length > 0);
+    const safeQuery = this.normalizeSearchQuery(query);
+    if (!safeQuery) return [];
+
+    const queryTokens = this.tokenizeSearchQuery(safeQuery);
     
     if (queryTokens.length === 0) {
       return [];
     }
     
-    const results: SearchResult[] = [];
-    const seenPaths = new Set<string>();
-    const maxResults = options.maxResults || 20;
-    
-    // Helper to add unique results
-    const addResult = (entry: IndexEntry, matchType: SearchResult['matchType'], score: number = 1) => {
-      if (!seenPaths.has(entry.filePath) && results.length < maxResults) {
-        // Filter by element type if specified
-        if (options.elementType && entry.elementType !== options.elementType) {
-          return;
-        }
-        
-        seenPaths.add(entry.filePath);
-        results.push({ entry, matchType, score });
-      }
+    const accumulator: SearchAccumulator = {
+      results: [],
+      seenPaths: new Set<string>(),
+      maxResults: options.maxResults || 20,
     };
     
-    // 1. Search by name (highest priority)
-    for (const [name, entry] of index.byName) {
-      if (this.matchesQuery(name, queryTokens)) {
-        addResult(entry, 'name', 3);
-      }
-    }
-    
-    // 2. Search by filename
-    for (const [filename, entry] of index.byFilename) {
-      if (this.matchesQuery(filename, queryTokens)) {
-        addResult(entry, 'filename', 2.5);
-      }
-    }
-    
-    // 3. Search by keywords
-    if (options.includeKeywords !== false) {
-      for (const [keyword, entries] of index.byKeyword) {
-        if (this.matchesQuery(keyword, queryTokens)) {
-          for (const entry of entries) {
-            addResult(entry, 'keyword', 2);
-          }
-        }
-      }
-    }
-    
-    // 4. Search by tags
-    if (options.includeTags !== false) {
-      for (const [tag, entries] of index.byTag) {
-        if (this.matchesQuery(tag, queryTokens)) {
-          for (const entry of entries) {
-            addResult(entry, 'tag', 2);
-          }
-        }
-      }
-    }
-    
-    // 5. Search by triggers
-    if (options.includeTriggers !== false) {
-      for (const [trigger, entries] of index.byTrigger) {
-        if (this.matchesQuery(trigger, queryTokens)) {
-          for (const entry of entries) {
-            addResult(entry, 'trigger', 1.8);
-          }
-        }
-      }
-    }
-    
-    // 6. Search by description
-    if (options.includeDescriptions !== false) {
-      for (const [, entry] of index.byName) {
-        if (entry.metadata.description && 
-            this.matchesQuery(entry.metadata.description.toLowerCase(), queryTokens)) {
-          addResult(entry, 'description', 1.5);
-        }
-      }
-    }
+    this.searchDirectIndex(index.byName, queryTokens, accumulator, options, 'name', 3);
+    this.searchDirectIndex(index.byFilename, queryTokens, accumulator, options, 'filename', 2.5);
+    this.searchGroupedIndex(index.byKeyword, queryTokens, accumulator, options, 'keyword', 2, options.includeKeywords);
+    this.searchGroupedIndex(index.byTag, queryTokens, accumulator, options, 'tag', 2, options.includeTags);
+    this.searchGroupedIndex(index.byTrigger, queryTokens, accumulator, options, 'trigger', 1.8, options.includeTriggers);
+    this.searchDescriptions(index, queryTokens, accumulator, options);
     
     // Sort by score (descending)
-    results.sort((a, b) => b.score - a.score);
+    accumulator.results.sort((a, b) => b.score - a.score);
     
     logger.debug('Portfolio search completed', {
       query: safeQuery,
-      resultCount: results.length,
+      resultCount: accumulator.results.length,
       totalIndexed: index.byName.size
     });
     
-    return results;
+    return accumulator.results;
+  }
+
+  private normalizeSearchQuery(query: string): string | null {
+    const normalizedQuery = UnicodeValidator.normalize(query);
+    if (normalizedQuery.isValid) {
+      return normalizedQuery.normalizedContent.toLowerCase().trim();
+    }
+    logger.warn('Invalid Unicode in search query', {
+      issues: normalizedQuery.detectedIssues
+    });
+    return null;
+  }
+
+  private tokenizeSearchQuery(safeQuery: string): string[] {
+    return safeQuery.split(/\s+/).filter(token => token.length > 0);
+  }
+
+  private searchDirectIndex(
+    source: Map<string, IndexEntry>,
+    queryTokens: string[],
+    accumulator: SearchAccumulator,
+    options: SearchOptions,
+    matchType: SearchResult['matchType'],
+    score: number,
+  ): void {
+    for (const [value, entry] of source) {
+      if (this.matchesQuery(value, queryTokens)) {
+        this.addSearchResult(entry, matchType, score, accumulator, options);
+      }
+    }
+  }
+
+  private searchGroupedIndex(
+    source: Map<string, IndexEntry[]>,
+    queryTokens: string[],
+    accumulator: SearchAccumulator,
+    options: SearchOptions,
+    matchType: SearchResult['matchType'],
+    score: number,
+    include: boolean | undefined,
+  ): void {
+    if (include === false) return;
+    for (const [value, entries] of source) {
+      if (this.matchesQuery(value, queryTokens)) {
+        for (const entry of entries) {
+          this.addSearchResult(entry, matchType, score, accumulator, options);
+        }
+      }
+    }
+  }
+
+  private searchDescriptions(
+    index: PortfolioIndex,
+    queryTokens: string[],
+    accumulator: SearchAccumulator,
+    options: SearchOptions,
+  ): void {
+    if (options.includeDescriptions === false) return;
+    for (const [, entry] of index.byName) {
+      if (entry.metadata.description &&
+          this.matchesQuery(entry.metadata.description.toLowerCase(), queryTokens)) {
+        this.addSearchResult(entry, 'description', 1.5, accumulator, options);
+      }
+    }
+  }
+
+  private addSearchResult(
+    entry: IndexEntry,
+    matchType: SearchResult['matchType'],
+    score: number,
+    accumulator: SearchAccumulator,
+    options: SearchOptions,
+  ): void {
+    if (accumulator.seenPaths.has(entry.filePath) || accumulator.results.length >= accumulator.maxResults) return;
+    if (options.elementType && entry.elementType !== options.elementType) return;
+
+    accumulator.seenPaths.add(entry.filePath);
+    accumulator.results.push({ entry, matchType, score });
   }
 
   /**
@@ -416,242 +441,302 @@ export class PortfolioIndexManager {
     logger.debug('Building portfolio index...');
     
     try {
-      const portfolioManager = this.portfolioManager;
+      const newIndex = this.createEmptyIndex();
+      const stats: BuildStats = { totalFiles: 0, processedFiles: 0 };
 
-      // Initialize empty index
-      const newIndex: PortfolioIndex = {
-        byName: new Map(),
-        byFilename: new Map(),
-        byType: new Map(),
-        byKeyword: new Map(),
-        byTag: new Map(),
-        byTrigger: new Map()
-      };
-      
-      // Initialize type maps
       for (const elementType of Object.values(ElementType)) {
-        newIndex.byType.set(elementType, []);
+        this.addBuildStats(stats, await this.scanElementType(elementType, newIndex));
       }
       
-      let totalFiles = 0;
-      let processedFiles = 0;
-      
-      // Scan each element type
-      for (const elementType of Object.values(ElementType)) {
-        try {
-          const elementDir = portfolioManager.getElementDir(elementType);
-
-          // Check if directory exists
-          const dirExists = await this.fileOperations.exists(elementDir);
-          if (!dirExists) {
-            logger.debug(`Element directory doesn't exist: ${elementDir}`);
-            continue;
-          }
-
-          // FIX #1188: Special handling for memories - scan .yaml files in date folders
-          if (elementType === ElementType.MEMORY) {
-            // Memories are stored in date folders (YYYY-MM-DD) as .yaml files
-            const entryNames = await this.fileOperations.listDirectory(elementDir);
-
-            // Separate directories from files
-            const directories: string[] = [];
-            const rootYamlFiles: string[] = [];
-
-            for (const entryName of entryNames) {
-              const entryPath = path.join(elementDir, entryName);
-              try {
-                const entryStat = await this.fileOperations.stat(entryPath);
-                if (entryStat.isDirectory()) {
-                  directories.push(entryName);
-                } else if (entryName.endsWith('.yaml')) {
-                  rootYamlFiles.push(entryName);
-                }
-              } catch {
-                // Skip entries we can't stat
-                continue;
-              }
-            }
-
-            for (const file of rootYamlFiles) {
-              try {
-                const filePath = path.join(elementDir, file);
-                const entry = await this.createMemoryIndexEntry(filePath, elementType);
-
-                if (entry) {
-                  this.addToIndex(newIndex, entry);
-                  processedFiles++;
-                  totalFiles++;
-                }
-              } catch (error) {
-                logger.warn(`Failed to index root memory file`, {
-                  file,
-                  path: path.join(elementDir, file),
-                  location: 'root',
-                  error: error instanceof Error ? error.message : String(error),
-                  errorType: error instanceof Error ? error.constructor.name : typeof error
-                });
-              }
-            }
-
-            // Then process date folders
-            const dateFolders = directories.filter(name => /^\d{4}-\d{2}-\d{2}$/.test(name));
-
-            for (const dateFolder of dateFolders) {
-              const folderPath = path.join(elementDir, dateFolder);
-              const folderEntryNames = await this.fileOperations.listDirectory(folderPath);
-
-              // Separate directories from files in date folder
-              const subDirs: string[] = [];
-              const yamlFiles: string[] = [];
-
-              for (const folderEntryName of folderEntryNames) {
-                const folderEntryPath = path.join(folderPath, folderEntryName);
-                try {
-                  const folderEntryStat = await this.fileOperations.stat(folderEntryPath);
-                  if (folderEntryStat.isDirectory()) {
-                    subDirs.push(folderEntryName);
-                  } else if (folderEntryName.endsWith('.yaml')) {
-                    yamlFiles.push(folderEntryName);
-                  }
-                } catch {
-                  // Skip entries we can't stat
-                  continue;
-                }
-              }
-
-              for (const file of yamlFiles) {
-                try {
-                  const filePath = path.join(folderPath, file);
-                  const entry = await this.createMemoryIndexEntry(filePath, elementType);
-
-                  if (entry) {
-                    this.addToIndex(newIndex, entry);
-                    processedFiles++;
-                    totalFiles++;
-                  }
-                } catch (error) {
-                  logger.warn(`Failed to index date folder memory file`, {
-                    file,
-                    path: path.join(folderPath, file),
-                    dateFolder,
-                    location: 'date-folder',
-                    error: error instanceof Error ? error.message : String(error),
-                    errorType: error instanceof Error ? error.constructor.name : typeof error
-                  });
-                }
-              }
-
-              // FIX #1188: Process subdirectories for sharded memories
-              // Large memories are stored as shards in named subdirectories
-              for (const subDir of subDirs) {
-                const subDirPath = path.join(folderPath, subDir);
-                const shardFiles = await this.fileOperations.listDirectory(subDirPath);
-                const shardYamlFiles = shardFiles.filter(file => file.endsWith('.yaml'));
-
-                // For sharded memories, look for metadata.yaml or the main file
-                // If not found, use the first shard as representative
-                let metadataFile = shardYamlFiles.find(f => f === 'metadata.yaml') ||
-                                   shardYamlFiles.find(f => f === `${subDir}.yaml`) ||
-                                   shardYamlFiles[0];
-
-                if (metadataFile) {
-                  try {
-                    const filePath = path.join(subDirPath, metadataFile);
-                    const entry = await this.createMemoryIndexEntry(filePath, elementType);
-
-                    if (entry) {
-                      // Mark as sharded memory in metadata
-                      entry.metadata.keywords = entry.metadata.keywords || [];
-                      if (!entry.metadata.keywords.includes('sharded')) {
-                        entry.metadata.keywords.push('sharded');
-                      }
-
-                      // Create properly typed sharded entry
-                      const shardedEntry: ShardedMemoryIndexEntry = {
-                        ...entry,
-                        shardInfo: {
-                          shardCount: shardYamlFiles.length,
-                          shardDir: path.join(dateFolder, subDir),
-                          metadataFile: metadataFile
-                        }
-                      };
-
-                      this.addToIndex(newIndex, shardedEntry);
-                      processedFiles++;
-                      totalFiles++;
-                    }
-                  } catch (error) {
-                    logger.warn(`Failed to index sharded memory`, {
-                      subDir,
-                      dateFolder,
-                      path: path.join(subDirPath, metadataFile),
-                      metadataFile,
-                      shardCount: shardYamlFiles.length,
-                      location: 'sharded-subdirectory',
-                      error: error instanceof Error ? error.message : String(error),
-                      errorType: error instanceof Error ? error.constructor.name : typeof error,
-                      shardFiles: shardYamlFiles.slice(0, 5) // Log first 5 shard files for context
-                    });
-                  }
-                }
-              }
-            }
-          } else {
-            // Standard handling for other element types (.md files in root)
-            const files = await this.fileOperations.listDirectory(elementDir);
-            const mdFiles = files.filter(file => file.endsWith('.md'));
-            totalFiles += mdFiles.length;
-
-            for (const file of mdFiles) {
-              try {
-                const filePath = path.join(elementDir, file);
-                const entry = await this.createIndexEntry(filePath, elementType);
-
-                if (entry) {
-                  this.addToIndex(newIndex, entry);
-                  processedFiles++;
-                }
-              } catch (error) {
-                logger.warn(`Failed to index file: ${file}`, {
-                  elementType,
-                  error: error instanceof Error ? error.message : String(error)
-                });
-              }
-            }
-          }
-        } catch (error) {
-          logger.error(`Failed to scan element type: ${elementType}`, {
-            error: error instanceof Error ? error.message : String(error)
-          });
-        }
-      }
-      
-      // Update instance state
-      this.indexByNamespace.set(namespace, newIndex);
-      this.lastBuiltByNamespace.set(namespace, new Date());
-      
-      const duration = Date.now() - startTime;
-      logger.info('Portfolio index built successfully', {
-        totalFiles,
-        processedFiles,
-        duration: `${duration}ms`,
-        uniqueNames: newIndex.byName.size,
-        uniqueKeywords: newIndex.byKeyword.size,
-        uniqueTags: newIndex.byTag.size
-      });
-      
-      // Log security event for audit trail
-      SecurityMonitor.logSecurityEvent({
-        type: 'PORTFOLIO_INITIALIZATION',
-        severity: 'LOW',
-        source: 'PortfolioIndexManager.performBuild',
-        details: `Portfolio index rebuilt with ${processedFiles} elements in ${duration}ms`
-      });
-      
+      this.updateIndexAtomically(namespace, newIndex, stats, startTime);
     } catch (error) {
       ErrorHandler.logError('PortfolioIndexManager.performBuild', error);
       throw ErrorHandler.wrapError(error, 'Failed to build portfolio index', ErrorCategory.SYSTEM_ERROR);
     }
+  }
+
+  private createEmptyIndex(): PortfolioIndex {
+    const newIndex: PortfolioIndex = {
+      byName: new Map(),
+      byFilename: new Map(),
+      byType: new Map(),
+      byKeyword: new Map(),
+      byTag: new Map(),
+      byTrigger: new Map()
+    };
+
+    for (const elementType of Object.values(ElementType)) {
+      newIndex.byType.set(elementType, []);
+    }
+
+    return newIndex;
+  }
+
+  private async scanElementType(elementType: ElementType, newIndex: PortfolioIndex): Promise<BuildStats> {
+    try {
+      const elementDir = this.portfolioManager.getElementDir(elementType);
+      const dirExists = await this.fileOperations.exists(elementDir);
+      if (!dirExists) {
+        logger.debug(`Element directory doesn't exist: ${elementDir}`);
+        return { totalFiles: 0, processedFiles: 0 };
+      }
+
+      return elementType === ElementType.MEMORY
+        ? this.scanMemoryDirectory(elementDir, newIndex)
+        : this.scanStandardElementDirectory(elementDir, elementType, newIndex);
+    } catch (error) {
+      logger.error(`Failed to scan element type: ${elementType}`, {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return { totalFiles: 0, processedFiles: 0 };
+    }
+  }
+
+  private async scanStandardElementDirectory(
+    elementDir: string,
+    elementType: ElementType,
+    newIndex: PortfolioIndex,
+  ): Promise<BuildStats> {
+    const files = await this.fileOperations.listDirectory(elementDir);
+    const mdFiles = files.filter(file => file.endsWith('.md'));
+    let processedFiles = 0;
+
+    for (const file of mdFiles) {
+      const indexed = await this.indexStandardFile(elementDir, file, elementType, newIndex);
+      if (indexed) processedFiles++;
+    }
+
+    return { totalFiles: mdFiles.length, processedFiles };
+  }
+
+  private async indexStandardFile(
+    elementDir: string,
+    file: string,
+    elementType: ElementType,
+    newIndex: PortfolioIndex,
+  ): Promise<boolean> {
+    try {
+      const filePath = path.join(elementDir, file);
+      const entry = await this.createIndexEntry(filePath, elementType);
+      if (!entry) return false;
+
+      this.addToIndex(newIndex, entry);
+      return true;
+    } catch (error) {
+      logger.warn(`Failed to index file: ${file}`, {
+        elementType,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return false;
+    }
+  }
+
+  private async scanMemoryDirectory(elementDir: string, newIndex: PortfolioIndex): Promise<BuildStats> {
+    const rootEntries = await this.listDirectoryEntries(elementDir);
+    const stats = await this.indexMemoryFiles(elementDir, rootEntries.yamlFiles, newIndex, {
+      message: 'Failed to index root memory file',
+      location: 'root',
+    });
+
+    const dateFolders = rootEntries.directories.filter(name => /^\d{4}-\d{2}-\d{2}$/.test(name));
+    for (const dateFolder of dateFolders) {
+      this.addBuildStats(stats, await this.indexMemoryDateFolder(elementDir, dateFolder, newIndex));
+    }
+
+    return stats;
+  }
+
+  private async indexMemoryDateFolder(
+    elementDir: string,
+    dateFolder: string,
+    newIndex: PortfolioIndex,
+  ): Promise<BuildStats> {
+    const folderPath = path.join(elementDir, dateFolder);
+    const folderEntries = await this.listDirectoryEntries(folderPath);
+    const stats = await this.indexMemoryFiles(folderPath, folderEntries.yamlFiles, newIndex, {
+      message: 'Failed to index date folder memory file',
+      location: 'date-folder',
+      dateFolder,
+    });
+
+    for (const subDir of folderEntries.directories) {
+      this.addBuildStats(stats, await this.indexShardedMemory(folderPath, dateFolder, subDir, newIndex));
+    }
+
+    return stats;
+  }
+
+  private async listDirectoryEntries(dir: string): Promise<DirectoryEntries> {
+    const entryNames = await this.fileOperations.listDirectory(dir);
+    const directories: string[] = [];
+    const yamlFiles: string[] = [];
+
+    for (const entryName of entryNames) {
+      const entryPath = path.join(dir, entryName);
+      try {
+        const entryStat = await this.fileOperations.stat(entryPath);
+        if (entryStat.isDirectory()) {
+          directories.push(entryName);
+        } else if (entryName.endsWith('.yaml')) {
+          yamlFiles.push(entryName);
+        }
+      } catch {
+        // Skip entries we can't stat.
+      }
+    }
+
+    return { directories, yamlFiles };
+  }
+
+  private async indexMemoryFiles(
+    baseDir: string,
+    files: string[],
+    newIndex: PortfolioIndex,
+    context: { message: string; location: string; dateFolder?: string },
+  ): Promise<BuildStats> {
+    const stats: BuildStats = { totalFiles: 0, processedFiles: 0 };
+
+    for (const file of files) {
+      const indexed = await this.indexMemoryFile(baseDir, file, newIndex, context);
+      if (indexed) {
+        stats.processedFiles++;
+        stats.totalFiles++;
+      }
+    }
+
+    return stats;
+  }
+
+  private async indexMemoryFile(
+    baseDir: string,
+    file: string,
+    newIndex: PortfolioIndex,
+    context: { message: string; location: string; dateFolder?: string },
+  ): Promise<boolean> {
+    try {
+      const filePath = path.join(baseDir, file);
+      const entry = await this.createMemoryIndexEntry(filePath, ElementType.MEMORY);
+      if (!entry) return false;
+
+      this.addToIndex(newIndex, entry);
+      return true;
+    } catch (error) {
+      logger.warn(context.message, {
+        file,
+        path: path.join(baseDir, file),
+        ...(context.dateFolder ? { dateFolder: context.dateFolder } : {}),
+        location: context.location,
+        error: error instanceof Error ? error.message : String(error),
+        errorType: error instanceof Error ? error.constructor.name : typeof error
+      });
+      return false;
+    }
+  }
+
+  private async indexShardedMemory(
+    folderPath: string,
+    dateFolder: string,
+    subDir: string,
+    newIndex: PortfolioIndex,
+  ): Promise<BuildStats> {
+    const subDirPath = path.join(folderPath, subDir);
+    const shardFiles = await this.fileOperations.listDirectory(subDirPath);
+    const shardYamlFiles = shardFiles.filter(file => file.endsWith('.yaml'));
+    const metadataFile = this.pickShardedMemoryMetadataFile(shardYamlFiles, subDir);
+    if (!metadataFile) return { totalFiles: 0, processedFiles: 0 };
+
+    const indexed = await this.indexShardedMemoryMetadata(
+      subDirPath,
+      dateFolder,
+      subDir,
+      metadataFile,
+      shardYamlFiles,
+      newIndex,
+    );
+    return indexed ? { totalFiles: 1, processedFiles: 1 } : { totalFiles: 0, processedFiles: 0 };
+  }
+
+  private pickShardedMemoryMetadataFile(shardYamlFiles: string[], subDir: string): string | undefined {
+    return shardYamlFiles.find(file => file === 'metadata.yaml') ||
+      shardYamlFiles.find(file => file === `${subDir}.yaml`) ||
+      shardYamlFiles[0];
+  }
+
+  private async indexShardedMemoryMetadata(
+    subDirPath: string,
+    dateFolder: string,
+    subDir: string,
+    metadataFile: string,
+    shardYamlFiles: string[],
+    newIndex: PortfolioIndex,
+  ): Promise<boolean> {
+    try {
+      const filePath = path.join(subDirPath, metadataFile);
+      const entry = await this.createMemoryIndexEntry(filePath, ElementType.MEMORY);
+      if (!entry) return false;
+
+      entry.metadata.keywords = entry.metadata.keywords || [];
+      if (!entry.metadata.keywords.includes('sharded')) {
+        entry.metadata.keywords.push('sharded');
+      }
+
+      const shardedEntry: ShardedMemoryIndexEntry = {
+        ...entry,
+        shardInfo: {
+          shardCount: shardYamlFiles.length,
+          shardDir: path.join(dateFolder, subDir),
+          metadataFile
+        }
+      };
+
+      this.addToIndex(newIndex, shardedEntry);
+      return true;
+    } catch (error) {
+      logger.warn('Failed to index sharded memory', {
+        subDir,
+        dateFolder,
+        path: path.join(subDirPath, metadataFile),
+        metadataFile,
+        shardCount: shardYamlFiles.length,
+        location: 'sharded-subdirectory',
+        error: error instanceof Error ? error.message : String(error),
+        errorType: error instanceof Error ? error.constructor.name : typeof error,
+        shardFiles: shardYamlFiles.slice(0, 5)
+      });
+      return false;
+    }
+  }
+
+  private addBuildStats(target: BuildStats, addition: BuildStats): void {
+    target.totalFiles += addition.totalFiles;
+    target.processedFiles += addition.processedFiles;
+  }
+
+  private updateIndexAtomically(
+    namespace: string,
+    newIndex: PortfolioIndex,
+    stats: BuildStats,
+    startTime: number,
+  ): void {
+    this.indexByNamespace.set(namespace, newIndex);
+    this.lastBuiltByNamespace.set(namespace, new Date());
+
+    const duration = Date.now() - startTime;
+    logger.info('Portfolio index built successfully', {
+      totalFiles: stats.totalFiles,
+      processedFiles: stats.processedFiles,
+      duration: `${duration}ms`,
+      uniqueNames: newIndex.byName.size,
+      uniqueKeywords: newIndex.byKeyword.size,
+      uniqueTags: newIndex.byTag.size
+    });
+
+    SecurityMonitor.logSecurityEvent({
+      type: 'PORTFOLIO_INITIALIZATION',
+      severity: 'LOW',
+      source: 'PortfolioIndexManager.performBuild',
+      details: `Portfolio index rebuilt with ${stats.processedFiles} elements in ${duration}ms`
+    });
   }
 
   /**

--- a/src/storage/migration/configToDatabase.ts
+++ b/src/storage/migration/configToDatabase.ts
@@ -74,6 +74,22 @@ export interface MigrationResult {
   };
 }
 
+type MigrationPlan = MigrationResult['plan'];
+
+interface MigrationPaths {
+  configRoot: string;
+  configYamlPath: string;
+  jwksKeyPath: string;
+  cookieSecretPath: string;
+  markerPath: string;
+}
+
+interface PlannedMigration {
+  plan: MigrationPlan;
+  operatorPayload: Omit<OperatorConfig, 'updatedAt'>;
+  userPayload: Omit<UserConfig, 'updatedAt'>;
+}
+
 /**
  * Read the marker file (if present) and return its contents. Returns
  * null when the marker is absent. Used by `runMigration()` to decide
@@ -105,176 +121,211 @@ export async function readMarker(configRoot?: string): Promise<{ migratedAt: num
 export async function runConfigToDatabaseMigration(
   options: MigrationOptions,
 ): Promise<MigrationResult> {
-  const configRoot = options.legacyConfigRoot ?? path.join(os.homedir(), '.dollhouse');
-  const runRoot = options.legacyRunRoot ?? path.join(configRoot, 'run');
-  const configYamlPath = path.join(configRoot, 'config.yml');
-  const jwksKeyPath = path.join(runRoot, 'oauth-signing-key.json');
-  const cookieSecretPath = path.join(runRoot, 'cookie-signing-secret.bin');
-  const markerPath = path.join(configRoot, MARKER_FILENAME);
+  const paths = resolveMigrationPaths(options);
 
   // 1. Idempotence check
-  const existingMarker = await readMarker(configRoot);
+  const existingMarker = await readMarker(paths.configRoot);
   if (existingMarker && !options.dryRun) {
-    return buildResult({
-      status: 'skipped-already-migrated',
-      configMigrated: false,
-      jwksMigrated: false,
-      cookieSecretMigrated: false,
-      markerPath,
-      plan: {
-        configYamlPath,
-        configYamlExists: false,
-        jwksKeyPath,
-        jwksKeyExists: false,
-        cookieSecretPath,
-        cookieSecretExists: false,
-        operatorSectionsToWrite: [],
-        userSectionsToWrite: [],
-        userId: options.userId,
-      },
-    });
+    return buildSkippedResult('skipped-already-migrated', paths, options.userId);
   }
 
-  // 2. Check for any legacy state at all
-  const [configYamlExists, jwksKeyExists, cookieSecretExists] = await Promise.all([
-    fileExists(configYamlPath),
-    fileExists(jwksKeyPath),
-    fileExists(cookieSecretPath),
-  ]);
-
-  if (!configYamlExists && !jwksKeyExists && !cookieSecretExists) {
-    return buildResult({
-      status: 'skipped-no-legacy-state',
-      configMigrated: false,
-      jwksMigrated: false,
-      cookieSecretMigrated: false,
-      markerPath,
-      plan: {
-        configYamlPath, configYamlExists,
-        jwksKeyPath, jwksKeyExists,
-        cookieSecretPath, cookieSecretExists,
-        operatorSectionsToWrite: [],
-        userSectionsToWrite: [],
-        userId: options.userId,
-      },
-    });
-  }
-
-  // 3. Plan: parse config.yml + classify sections
-  let parsedConfig: Record<string, unknown> = {};
-  if (configYamlExists) {
-    const raw = await fs.readFile(configYamlPath, 'utf-8');
-    const parsed = yaml.load(raw, { schema: yaml.FAILSAFE_SCHEMA });
-    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      throw new Error(`Legacy config at ${configYamlPath} is not a valid YAML object`);
-    }
-    parsedConfig = parsed as Record<string, unknown>;
-  }
-
-  const { operatorPayload, userPayload, operatorSections, userSections } = splitLegacyConfig(parsedConfig);
-
-  const plan = {
-    configYamlPath, configYamlExists,
-    jwksKeyPath, jwksKeyExists,
-    cookieSecretPath, cookieSecretExists,
-    operatorSectionsToWrite: operatorSections,
-    userSectionsToWrite: userSections,
-    userId: options.userId,
-  };
+  const planned = await planMigration(paths, options.userId);
+  const { plan } = planned;
+  if (!hasLegacyState(plan)) return buildSkippedResult('skipped-no-legacy-state', paths, options.userId, plan);
 
   if (options.dryRun) {
     return buildResult({
       status: 'preview',
-      configMigrated: configYamlExists,
-      jwksMigrated: jwksKeyExists,
-      cookieSecretMigrated: cookieSecretExists,
-      markerPath,
+      configMigrated: plan.configYamlExists,
+      jwksMigrated: plan.jwksKeyExists,
+      cookieSecretMigrated: plan.cookieSecretExists,
+      markerPath: paths.markerPath,
       plan,
     });
   }
 
   // 4. Execute writes — config first (idempotent upsert), keys second.
-  if (configYamlExists) {
-    await options.operatorStore.save(operatorPayload);
-    await options.userStore.save(options.userId, userPayload);
-    logger.info('[configToDatabase] migrated config.yml', {
-      operatorSections: operatorSections.length,
-      userSections: userSections.length,
-      userId: options.userId,
-    });
-  }
-
-  // 5. JWKS keyfile preservation — keep the existing kid + JWK so
-  // currently-issued tokens stay valid.
-  if (jwksKeyExists) {
-    const existingActive = await options.signingKeyStore.getActive('jwks');
-    if (existingActive) {
-      logger.info('[configToDatabase] active JWKS already in store; skipping keyfile import', {
-        existingKid: existingActive.kid,
-      });
-    } else {
-      const raw = await fs.readFile(jwksKeyPath, 'utf-8');
-      const parsed = JSON.parse(raw) as { kid?: string; privateKey?: unknown; publicKey?: unknown; generatedAt?: string };
-      if (typeof parsed.kid !== 'string' || !parsed.privateKey || !parsed.publicKey) {
-        throw new Error(`Legacy JWKS keyfile at ${jwksKeyPath} is malformed (missing kid / privateKey / publicKey)`);
-      }
-      await options.signingKeyStore.rotate({
-        kid: parsed.kid,
-        kind: 'jwks',
-        payload: parsed as unknown as Record<string, unknown>,
-      });
-      logger.info('[configToDatabase] migrated JWKS keyfile', { kid: parsed.kid });
-    }
-  }
-
-  // 6. Cookie secret preservation — generate an opaque kid for the DB
-  // row but preserve the existing secret bytes so existing cookies stay
-  // valid.
-  if (cookieSecretExists) {
-    const existingActive = await options.signingKeyStore.getActive('cookie');
-    if (existingActive) {
-      logger.info('[configToDatabase] active cookie key already in store; skipping keyfile import');
-    } else {
-      const buf = await fs.readFile(cookieSecretPath);
-      if (buf.length < 32) {
-        throw new Error(`Legacy cookie-signing-secret.bin at ${cookieSecretPath} is shorter than 32 bytes (${buf.length})`);
-      }
-      const { randomUUID } = await import('node:crypto');
-      await options.signingKeyStore.rotate({
-        kid: `cookie-migrated-${randomUUID()}`,
-        kind: 'cookie',
-        payload: { secret: buf.toString('base64'), length: buf.length },
-      });
-      logger.info('[configToDatabase] migrated cookie secret', { bytes: buf.length });
-    }
-  }
+  await migrateConfigYaml(options, planned);
+  await migrateJwksKeyfile(options.signingKeyStore, paths.jwksKeyPath, plan.jwksKeyExists);
+  await migrateCookieSecret(options.signingKeyStore, paths.cookieSecretPath, plan.cookieSecretExists);
 
   // 7. Write marker
-  const marker = {
-    migratedAt: Date.now(),
-    version: MARKER_VERSION,
-    fromConfig: configYamlExists,
-    fromJwks: jwksKeyExists,
-    fromCookieSecret: cookieSecretExists,
-  };
-  await fs.mkdir(path.dirname(markerPath), { recursive: true });
-  await fs.writeFile(markerPath, JSON.stringify(marker, null, 2), { mode: 0o600 });
+  await writeMigrationMarker(paths.markerPath, plan);
 
   logger.info('[configToDatabase] migration complete', {
-    markerPath,
-    configMigrated: configYamlExists,
-    jwksMigrated: jwksKeyExists,
-    cookieSecretMigrated: cookieSecretExists,
+    markerPath: paths.markerPath,
+    configMigrated: plan.configYamlExists,
+    jwksMigrated: plan.jwksKeyExists,
+    cookieSecretMigrated: plan.cookieSecretExists,
   });
 
   return buildResult({
     status: 'migrated',
-    configMigrated: configYamlExists,
-    jwksMigrated: jwksKeyExists,
-    cookieSecretMigrated: cookieSecretExists,
-    markerPath,
+    configMigrated: plan.configYamlExists,
+    jwksMigrated: plan.jwksKeyExists,
+    cookieSecretMigrated: plan.cookieSecretExists,
+    markerPath: paths.markerPath,
     plan,
   });
+}
+
+function resolveMigrationPaths(options: MigrationOptions): MigrationPaths {
+  const configRoot = options.legacyConfigRoot ?? path.join(os.homedir(), '.dollhouse');
+  const runRoot = options.legacyRunRoot ?? path.join(configRoot, 'run');
+  return {
+    configRoot,
+    configYamlPath: path.join(configRoot, 'config.yml'),
+    jwksKeyPath: path.join(runRoot, 'oauth-signing-key.json'),
+    cookieSecretPath: path.join(runRoot, 'cookie-signing-secret.bin'),
+    markerPath: path.join(configRoot, MARKER_FILENAME),
+  };
+}
+
+function buildSkippedResult(
+  status: 'skipped-already-migrated' | 'skipped-no-legacy-state',
+  paths: MigrationPaths,
+  userId: string,
+  plan?: MigrationPlan,
+): MigrationResult {
+  return buildResult({
+    status,
+    configMigrated: false,
+    jwksMigrated: false,
+    cookieSecretMigrated: false,
+    markerPath: paths.markerPath,
+    plan: plan ?? emptyPlan(paths, userId),
+  });
+}
+
+function emptyPlan(paths: MigrationPaths, userId: string): MigrationPlan {
+  return {
+    configYamlPath: paths.configYamlPath,
+    configYamlExists: false,
+    jwksKeyPath: paths.jwksKeyPath,
+    jwksKeyExists: false,
+    cookieSecretPath: paths.cookieSecretPath,
+    cookieSecretExists: false,
+    operatorSectionsToWrite: [],
+    userSectionsToWrite: [],
+    userId,
+  };
+}
+
+async function planMigration(paths: MigrationPaths, userId: string): Promise<PlannedMigration> {
+  const [configYamlExists, jwksKeyExists, cookieSecretExists] = await Promise.all([
+    fileExists(paths.configYamlPath),
+    fileExists(paths.jwksKeyPath),
+    fileExists(paths.cookieSecretPath),
+  ]);
+  const parsedConfig = configYamlExists ? await loadLegacyConfig(paths.configYamlPath) : {};
+  const { operatorPayload, userPayload, operatorSections, userSections } = splitLegacyConfig(parsedConfig);
+
+  return {
+    operatorPayload,
+    userPayload,
+    plan: {
+      configYamlPath: paths.configYamlPath,
+      configYamlExists,
+      jwksKeyPath: paths.jwksKeyPath,
+      jwksKeyExists,
+      cookieSecretPath: paths.cookieSecretPath,
+      cookieSecretExists,
+      operatorSectionsToWrite: operatorSections,
+      userSectionsToWrite: userSections,
+      userId,
+    },
+  };
+}
+
+function hasLegacyState(plan: MigrationPlan): boolean {
+  return plan.configYamlExists || plan.jwksKeyExists || plan.cookieSecretExists;
+}
+
+async function loadLegacyConfig(configYamlPath: string): Promise<Record<string, unknown>> {
+  const raw = await fs.readFile(configYamlPath, 'utf-8');
+  const parsed = yaml.load(raw, { schema: yaml.FAILSAFE_SCHEMA });
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Legacy config at ${configYamlPath} is not a valid YAML object`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+async function migrateConfigYaml(options: MigrationOptions, planned: PlannedMigration): Promise<void> {
+  if (!planned.plan.configYamlExists) return;
+
+  await options.operatorStore.save(planned.operatorPayload);
+  await options.userStore.save(options.userId, planned.userPayload);
+  logger.info('[configToDatabase] migrated config.yml', {
+    operatorSections: planned.plan.operatorSectionsToWrite.length,
+    userSections: planned.plan.userSectionsToWrite.length,
+    userId: options.userId,
+  });
+}
+
+async function migrateJwksKeyfile(
+  signingKeyStore: ISigningKeyStore,
+  jwksKeyPath: string,
+  jwksKeyExists: boolean,
+): Promise<void> {
+  if (!jwksKeyExists) return;
+
+  const existingActive = await signingKeyStore.getActive('jwks');
+  if (existingActive) {
+    logger.info('[configToDatabase] active JWKS already in store; skipping keyfile import', {
+      existingKid: existingActive.kid,
+    });
+    return;
+  }
+
+  const raw = await fs.readFile(jwksKeyPath, 'utf-8');
+  const parsed = JSON.parse(raw) as { kid?: string; privateKey?: unknown; publicKey?: unknown; generatedAt?: string };
+  if (typeof parsed.kid !== 'string' || !parsed.privateKey || !parsed.publicKey) {
+    throw new Error(`Legacy JWKS keyfile at ${jwksKeyPath} is malformed (missing kid / privateKey / publicKey)`);
+  }
+  await signingKeyStore.rotate({
+    kid: parsed.kid,
+    kind: 'jwks',
+    payload: parsed as unknown as Record<string, unknown>,
+  });
+  logger.info('[configToDatabase] migrated JWKS keyfile', { kid: parsed.kid });
+}
+
+async function migrateCookieSecret(
+  signingKeyStore: ISigningKeyStore,
+  cookieSecretPath: string,
+  cookieSecretExists: boolean,
+): Promise<void> {
+  if (!cookieSecretExists) return;
+
+  const existingActive = await signingKeyStore.getActive('cookie');
+  if (existingActive) {
+    logger.info('[configToDatabase] active cookie key already in store; skipping keyfile import');
+    return;
+  }
+
+  const buf = await fs.readFile(cookieSecretPath);
+  if (buf.length < 32) {
+    throw new Error(`Legacy cookie-signing-secret.bin at ${cookieSecretPath} is shorter than 32 bytes (${buf.length})`);
+  }
+  const { randomUUID } = await import('node:crypto');
+  await signingKeyStore.rotate({
+    kid: `cookie-migrated-${randomUUID()}`,
+    kind: 'cookie',
+    payload: { secret: buf.toString('base64'), length: buf.length },
+  });
+  logger.info('[configToDatabase] migrated cookie secret', { bytes: buf.length });
+}
+
+async function writeMigrationMarker(markerPath: string, plan: MigrationPlan): Promise<void> {
+  const marker = {
+    migratedAt: Date.now(),
+    version: MARKER_VERSION,
+    fromConfig: plan.configYamlExists,
+    fromJwks: plan.jwksKeyExists,
+    fromCookieSecret: plan.cookieSecretExists,
+  };
+  await fs.mkdir(path.dirname(markerPath), { recursive: true });
+  await fs.writeFile(markerPath, JSON.stringify(marker, null, 2), { mode: 0o600 });
 }
 
 /**


### PR DESCRIPTION
## Summary

Reduces cognitive complexity across six files by splitting large
functions into named private helpers. No behavior change; public
surfaces preserved.

## Files touched

- `src/portfolio/PortfolioIndexManager.ts` — `performBuild` (the
  highest-complexity function in the codebase) extracted into an
  orchestrator over directory-scan / per-file index / atomic-update
  helpers. `search` also refactored: five near-duplicate score loops
  collapsed into `searchDirectIndex` / `searchGroupedIndex` /
  `searchDescriptions` with a shared `addSearchResult`.
- `src/cli/admin-bootstrap.ts` — `main()` split into option parsing,
  per-method dispatch, and per-branch bootstrap helpers.
- `src/collection/CollectionIndexManager.ts` — `loadFromDisk` split
  into per-source loaders (`loadFromSharedCache`, `loadFromLegacyDisk`)
  plus a shared `validateCacheEntry`.
- `src/storage/migration/configToDatabase.ts` — `runConfigToDatabaseMigration`
  split into `resolveMigrationPaths`, `planMigration`, per-section
  migrate helpers (`migrateConfigYaml`, `migrateJwksKeyfile`,
  `migrateCookieSecret`), and `writeMigrationMarker`.
- `src/auth/GitHubAuthManager.ts` — `initiateDeviceFlow` split into
  request / response-validation / error-mapping helpers; every
  existing error message preserved verbatim.
- `src/handlers/GitHubAuthHandler.ts` — decomposed the handler into
  named private methods for response builders, OAuth helper lifecycle,
  and health-check formatting. The five public methods
  (`setupGitHubAuth`, `checkGitHubAuth`, `getOAuthHelperStatus`,
  `clearGitHubAuth`, `configureOAuth`) keep identical signatures.

## Test plan

- [x] TypeScript compile clean
- [x] ESLint with max-warnings=0
- [x] Local sonar-mirror lint clean on touched files
- [x] Unit tests pass
- [x] Integration tests pass
- [x] E2E tests pass