### PR TITLE
refactor: reduce cognitive complexity in portfolio/agent managers and split AS

### DIFF
--- a/src/auth/embedded-as/EmbeddedASAdmin.ts
+++ b/src/auth/embedded-as/EmbeddedASAdmin.ts
@@ -1,0 +1,60 @@
+import type { RequestHandler } from 'express';
+
+import type { IAuthProvider } from '../IAuthProvider.js';
+import { assertHasRole } from '../assertHasRole.js';
+import { createUnifiedAuthMiddleware } from '../authMiddleware.js';
+import type { IAuthStorageLayer } from './storage/IAuthStorageLayer.js';
+
+export class EmbeddedASAdmin {
+  constructor(
+    private readonly provider: IAuthProvider,
+    private readonly storage: IAuthStorageLayer,
+    private readonly getProtectedResourceMetadataUrl: () => string,
+  ) {}
+
+  createAdminMeHandler(): RequestHandler[] {
+    const validateBearer = createUnifiedAuthMiddleware({
+      provider: this.provider,
+      protectedResourceMetadataUrl: this.getProtectedResourceMetadataUrl(),
+    });
+    const adminGuard = assertHasRole('admin');
+    const handler: RequestHandler = (req, res, next) => {
+      void (async () => {
+        try {
+          const claims = res.locals.authClaims;
+          if (!claims) {
+            next(new Error('admin/me handler reached without authClaims'));
+            return;
+          }
+          const bootstrap = await this.storage.getBootstrapState();
+          const account = await this.storage.getAccount(claims.sub);
+
+          if (!account) {
+            res.status(410).json({
+              error: 'admin account no longer exists',
+              sub: claims.sub,
+            });
+            return;
+          }
+
+          const callerIsBootstrapAdmin = bootstrap.adminSub === claims.sub;
+          res.json({
+            sub: claims.sub,
+            roles: claims.roles ?? [],
+            email: account.email,
+            displayName: account.displayName,
+            bootstrap: {
+              adminMethod: bootstrap.adminMethod,
+              completedAt: bootstrap.completedAt,
+              ...(callerIsBootstrapAdmin ? { adminSub: bootstrap.adminSub } : {}),
+            },
+          });
+        } catch (err) {
+          next(err);
+        }
+      })();
+    };
+
+    return [validateBearer, adminGuard, handler];
+  }
+}

--- a/src/auth/embedded-as/EmbeddedASBootstrap.ts
+++ b/src/auth/embedded-as/EmbeddedASBootstrap.ts
@@ -1,0 +1,129 @@
+import type { RequestHandler } from 'express';
+
+import { logger } from '../../utils/logger.js';
+import type { IAuthMethod } from './IAuthMethod.js';
+import type { IAuthStorageLayer } from './storage/IAuthStorageLayer.js';
+
+const MULTI_USER_METHODS: ReadonlySet<string> = new Set([
+  'local-password',
+  'magic-link',
+  'github',
+]);
+
+const GATE_BYPASS_RULES: ReadonlyArray<{ path: string; mode: 'exact' | 'prefix' }> = [
+  { path: '/.well-known/', mode: 'prefix' },
+  { path: '/jwks', mode: 'exact' },
+];
+
+export class EmbeddedASBootstrap {
+  constructor(
+    private readonly methods: readonly IAuthMethod[],
+    private readonly storage: IAuthStorageLayer,
+    private readonly getReadyLatch: () => boolean,
+    private readonly setReadyLatch: (ready: boolean) => void,
+  ) {}
+
+  isMultiUserMode(): boolean {
+    return this.methods.some((m) => MULTI_USER_METHODS.has(m.id));
+  }
+
+  isHttpsPublicBaseUrl(publicBaseUrl: string): boolean {
+    try {
+      return new URL(publicBaseUrl).protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+
+  async isReadyForTraffic(): Promise<boolean> {
+    if (!this.isMultiUserMode()) return true;
+    if (this.getReadyLatch()) return true;
+    try {
+      const state = await this.storage.getBootstrapState();
+      if (state.completed === true) {
+        this.setReadyLatch(true);
+        return true;
+      }
+      return false;
+    } catch (err) {
+      logger.warn('[EmbeddedAuthorizationServer] isReadyForTraffic storage read failed; reporting not-ready', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }
+  }
+
+  bootstrapHint(): string {
+    const ids = new Set(this.methods.map((m) => m.id));
+    const lines: string[] = [];
+    if (ids.has('local-password')) {
+      lines.push(
+        "Run 'dollhouse-create-user --username <name> --email <addr>' " +
+        "to issue the first invite (this also marks bootstrap complete).",
+      );
+    }
+    if (ids.has('magic-link')) {
+      lines.push(
+        "Run 'dollhouse-admin-bootstrap --method magic-link --email <admin@example.com>' " +
+        "to claim the admin identity.",
+      );
+    }
+    if (ids.has('github')) {
+      lines.push(
+        "Run 'dollhouse-admin-bootstrap --method github --github-username <gh-username>' " +
+        "to claim the admin identity.",
+      );
+    }
+    return lines.join(' OR ');
+  }
+
+  createBootstrapGate(): RequestHandler {
+    if (!this.isMultiUserMode()) {
+      return (_req, _res, next) => next();
+    }
+
+    return async (req, res, next) => {
+      if (this.getReadyLatch()) {
+        next();
+        return;
+      }
+      if (EmbeddedASBootstrap.isGateBypass(req.path)) {
+        next();
+        return;
+      }
+      try {
+        const state = await this.storage.getBootstrapState();
+        if (state.completed) {
+          this.setReadyLatch(true);
+          next();
+          return;
+        }
+        res.status(503).json({
+          error: 'bootstrap_required',
+          error_description:
+            'This authorization server has not been bootstrapped. ' +
+            'An operator must claim the first admin identity before any ' +
+            'authentication flow is accepted.',
+          next_step: this.bootstrapHint(),
+        });
+      } catch (err) {
+        logger.error('[EmbeddedAuthorizationServer] bootstrap-gate storage read failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        res.status(503).json({
+          error: 'bootstrap_check_unavailable',
+          error_description: 'Unable to verify bootstrap state. Try again shortly.',
+        });
+      }
+    };
+  }
+
+  private static isGateBypass(path: string): boolean {
+    return GATE_BYPASS_RULES.some((rule) => {
+      if (rule.mode === 'exact') {
+        return path === rule.path;
+      }
+      return path === rule.path || path.startsWith(rule.path);
+    });
+  }
+}

--- a/src/auth/embedded-as/EmbeddedASOidcAccount.ts
+++ b/src/auth/embedded-as/EmbeddedASOidcAccount.ts
@@ -1,0 +1,52 @@
+import type { IAuthMethod } from './IAuthMethod.js';
+import type { IAuthStorageLayer } from './storage/IAuthStorageLayer.js';
+
+export class EmbeddedASOidcAccount {
+  constructor(
+    private readonly methods: readonly IAuthMethod[],
+    private readonly storage: IAuthStorageLayer,
+  ) {}
+
+  async extraTokenClaims(_ctx: unknown, token: unknown): Promise<Record<string, unknown> | undefined> {
+    const accountId = (token as { accountId?: string }).accountId;
+    if (!accountId) return undefined;
+    const account = await this.storage.getAccount(accountId);
+    if (!account) return undefined;
+    if (account.sub !== accountId) return undefined;
+    const extras: Record<string, unknown> = {};
+    if (account.lastAuthAt) {
+      extras.auth_time = Math.floor(account.lastAuthAt / 1000);
+    }
+    if (account.roles && account.roles.length > 0) {
+      extras.roles = account.roles;
+    }
+    return Object.keys(extras).length > 0 ? extras : undefined;
+  }
+
+  async findAccount(_ctx: unknown, sub: string): Promise<{
+    accountId: string;
+    claims: () => Promise<{
+      sub: string;
+      name: string | undefined;
+      email: string | undefined;
+      email_verified: boolean | undefined;
+    }>;
+  } | undefined> {
+    for (const method of this.methods) {
+      const identity = await method.findAccount(sub);
+      if (!identity) continue;
+      return {
+        accountId: identity.sub,
+        async claims() {
+          return {
+            sub: identity.sub,
+            name: identity.displayName,
+            email: identity.email,
+            email_verified: identity.emailVerified,
+          };
+        },
+      };
+    }
+    return undefined;
+  }
+}

--- a/src/auth/embedded-as/EmbeddedASTokens.ts
+++ b/src/auth/embedded-as/EmbeddedASTokens.ts
@@ -1,0 +1,149 @@
+import { importJWK, jwtVerify, SignJWT, errors as joseErrors, type JWK } from 'jose';
+
+import type {
+  AuthClaims,
+  AuthResult,
+  IssueOptions,
+} from '../IAuthProvider.js';
+import type { SigningKeyset } from './persistKeys.js';
+
+export const ALGORITHM = 'ES256';
+export const DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 3600;
+export const DEFAULT_REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 3600;
+export const DEFAULT_AUTH_CODE_TTL_SECONDS = 5 * 60;
+export const DEFAULT_INTERACTION_TTL_SECONDS = 10 * 60;
+export const DEFAULT_SESSION_TTL_SECONDS = 14 * 24 * 3600;
+export const DEFAULT_CLIENT_ID = 'dollhouse-claude-connector';
+
+export interface EmbeddedASInitializedState {
+  keyset: SigningKeyset;
+  publicSigningKey: CryptoKey;
+  privateSigningKey: CryptoKey;
+}
+
+export class EmbeddedASTokens {
+  constructor(
+    private readonly ensureInitialized: () => Promise<EmbeddedASInitializedState>,
+    private readonly getIssuer: () => string,
+    private readonly getResource: () => string,
+  ) {}
+
+  async validate(token: string): Promise<AuthResult> {
+    const { publicSigningKey, keyset } = await this.ensureInitialized();
+    try {
+      const { payload, protectedHeader } = await jwtVerify(token, publicSigningKey, {
+        issuer: this.getIssuer(),
+        audience: this.getResource(),
+        algorithms: [ALGORITHM],
+        typ: 'at+jwt',
+        crit: {},
+      });
+      return buildEmbeddedAsAuthResult(payload, protectedHeader, keyset.kid);
+    } catch (error) {
+      return { ok: false, reason: mapEmbeddedAsVerifyError(error) };
+    }
+  }
+
+  async issue(sub: string, options?: IssueOptions): Promise<string> {
+    const { keyset, privateSigningKey } = await this.ensureInitialized();
+    const ttl = options?.ttlSeconds ?? DEFAULT_ACCESS_TOKEN_TTL_SECONDS;
+    const scope = options?.scopes?.join(' ') || 'mcp';
+
+    return new SignJWT({
+      azp: DEFAULT_CLIENT_ID,
+      scope,
+      name: options?.displayName ?? sub,
+    })
+      .setProtectedHeader({ alg: ALGORITHM, kid: keyset.kid, typ: 'at+jwt' })
+      .setIssuer(this.getIssuer())
+      .setAudience(this.getResource())
+      .setSubject(sub)
+      .setIssuedAt()
+      .setExpirationTime(`${ttl}s`)
+      .sign(privateSigningKey);
+  }
+}
+
+function claimsFromPayload(payload: Record<string, unknown>): AuthClaims {
+  return {
+    sub: String(payload.sub),
+    displayName: typeof payload.name === 'string' ? payload.name : undefined,
+    email: typeof payload.email === 'string' ? payload.email : undefined,
+    tenantId: typeof payload.tenant_id === 'string' ? payload.tenant_id : null,
+    scopes: typeof payload.scope === 'string' ? payload.scope.split(/\s+/).filter(Boolean) : undefined,
+    roles: Array.isArray(payload.roles)
+      ? payload.roles.filter((r): r is string => typeof r === 'string')
+      : undefined,
+    exp: typeof payload.exp === 'number' ? payload.exp : undefined,
+  };
+}
+
+function buildEmbeddedAsAuthResult(
+  payload: Record<string, unknown>,
+  protectedHeader: { kid?: string },
+  activeKid: string,
+): AuthResult {
+  if (!protectedHeader.kid) {
+    return { ok: false, reason: 'token missing kid header' };
+  }
+  if (protectedHeader.kid !== activeKid) {
+    return { ok: false, reason: 'unknown key id' };
+  }
+  if (!payload.sub) {
+    return { ok: false, reason: 'token missing sub claim' };
+  }
+  const scopeClaim = typeof payload.scope === 'string' ? payload.scope : '';
+  const scopes = new Set(scopeClaim.split(/\s+/).filter(Boolean));
+  if (!scopes.has('mcp')) {
+    return { ok: false, reason: 'token missing mcp scope' };
+  }
+  return { ok: true, claims: claimsFromPayload(payload) };
+}
+
+function mapEmbeddedAsVerifyError(error: unknown): string {
+  if (error instanceof joseErrors.JWTExpired) {
+    return 'token expired';
+  }
+  if (error instanceof joseErrors.JWSSignatureVerificationFailed) {
+    return 'invalid signature';
+  }
+  if (error instanceof joseErrors.JOSEAlgNotAllowed) {
+    return 'algorithm not allowed';
+  }
+  if (error instanceof joseErrors.JWTClaimValidationFailed) {
+    const claim = error.claim;
+    if (claim === 'aud') return 'invalid audience';
+    if (claim === 'iss') return 'invalid issuer';
+    if (claim === 'typ') return 'wrong token type';
+    return `claim validation failed: ${claim ?? 'unknown'}`;
+  }
+  return 'token validation failed';
+}
+
+const PRIVATE_JWK_FIELDS: ReadonlySet<string> = new Set([
+  'd',
+  'p', 'q', 'dp', 'dq', 'qi',
+  'k',
+  'oth',
+]);
+
+export function stripPrivate(jwk: JWK): JWK {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(jwk as JWK & Record<string, unknown>)) {
+    if (!PRIVATE_JWK_FIELDS.has(key)) {
+      result[key] = value;
+    }
+  }
+  return result as JWK;
+}
+
+export async function importSigningKeys(keyset: SigningKeyset): Promise<{
+  publicSigningKey: CryptoKey;
+  privateSigningKey: CryptoKey;
+}> {
+  const privateJwk = keyset.jwks.keys[0];
+  return {
+    publicSigningKey: (await importJWK(stripPrivate(privateJwk), ALGORITHM)) as CryptoKey,
+    privateSigningKey: (await importJWK(privateJwk, ALGORITHM)) as CryptoKey,
+  };
+}

--- a/src/auth/embedded-as/EmbeddedAuthorizationServer.ts
+++ b/src/auth/embedded-as/EmbeddedAuthorizationServer.ts
@@ -22,13 +22,11 @@
  */
 
 import express, { type Router, type Request, type RequestHandler, type Response } from 'express';
-import { jwtVerify, importJWK, SignJWT, errors as joseErrors, type JWK } from 'jose';
 import OidcProvider from 'oidc-provider';
 import type { Configuration } from 'oidc-provider';
 import { env } from '../../config/env.js';
 import { logger } from '../../utils/logger.js';
 import type {
-  AuthClaims,
   AuthResult,
   IAuthProvider,
   IssueOptions,
@@ -67,18 +65,20 @@ import {
   type RotationRequestContext,
 } from './storage/OidcProviderAdapter.js';
 import type { IAuthStorageLayer } from './storage/IAuthStorageLayer.js';
-import { assertHasRole } from '../assertHasRole.js';
-import { createUnifiedAuthMiddleware } from '../authMiddleware.js';
-
-const ALGORITHM = 'ES256';
-const DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 3600; // 1 hour
-const DEFAULT_REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 3600; // 30 days
-const DEFAULT_AUTH_CODE_TTL_SECONDS = 5 * 60; // 5 minutes
-// Interaction TTL must stay aligned with InteractionRouter's CSRF_TTL_SECONDS;
-// the CSRF token's lifetime can't exceed the interaction's.
-const DEFAULT_INTERACTION_TTL_SECONDS = 10 * 60; // 10 minutes
-const DEFAULT_SESSION_TTL_SECONDS = 14 * 24 * 3600; // 14 days
-const DEFAULT_CLIENT_ID = 'dollhouse-claude-connector';
+import { EmbeddedASBootstrap } from './EmbeddedASBootstrap.js';
+import { EmbeddedASAdmin } from './EmbeddedASAdmin.js';
+import { EmbeddedASOidcAccount } from './EmbeddedASOidcAccount.js';
+import {
+  ALGORITHM,
+  DEFAULT_ACCESS_TOKEN_TTL_SECONDS,
+  DEFAULT_REFRESH_TOKEN_TTL_SECONDS,
+  DEFAULT_AUTH_CODE_TTL_SECONDS,
+  DEFAULT_INTERACTION_TTL_SECONDS,
+  DEFAULT_SESSION_TTL_SECONDS,
+  DEFAULT_CLIENT_ID,
+  EmbeddedASTokens,
+  importSigningKeys,
+} from './EmbeddedASTokens.js';
 
 /**
  * Cycle-8 fix (B1): predicate that decides whether oidc-provider's
@@ -224,6 +224,10 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
   private readonly cookieSecretEnvOverride: string | undefined;
   private readonly openDCR: boolean;
   private readonly signingKeyStore: ISigningKeyStore | null;
+  private readonly bootstrap: EmbeddedASBootstrap;
+  private readonly admin: EmbeddedASAdmin;
+  private readonly tokens: EmbeddedASTokens;
+  private readonly oidcAccount: EmbeddedASOidcAccount;
 
   private publicBaseUrl: string;
   private issuer: string;
@@ -258,6 +262,23 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
     this.cookieSecretEnvOverride = options.cookieSecretEnvOverride;
     this.openDCR = options.openDCR ?? env.DOLLHOUSE_AUTH_OPEN_DCR;
     this.signingKeyStore = options.signingKeyStore ?? null;
+    this.bootstrap = new EmbeddedASBootstrap(
+      this.methods,
+      this.storage,
+      () => this.bootstrapReadyLatch,
+      (ready) => { this.bootstrapReadyLatch = ready; },
+    );
+    this.admin = new EmbeddedASAdmin(
+      this,
+      this.storage,
+      () => this.getProtectedResourceMetadataUrl(),
+    );
+    this.tokens = new EmbeddedASTokens(
+      () => this.ensureInitialized(),
+      () => this.issuer,
+      () => this.resource,
+    );
+    this.oidcAccount = new EmbeddedASOidcAccount(this.methods, this.storage);
   }
 
   setPublicBaseUrl(publicBaseUrl: string): void {
@@ -277,11 +298,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
   }
 
   private isHttpsPublicBaseUrl(): boolean {
-    try {
-      return new URL(this.publicBaseUrl).protocol === 'https:';
-    } catch {
-      return false;
-    }
+    return this.bootstrap.isHttpsPublicBaseUrl(this.publicBaseUrl);
   }
 
   getAuthorizationServerMetadataUrl(): string {
@@ -302,19 +319,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
    *     header rather than silently ignoring it.
    */
   async validate(token: string): Promise<AuthResult> {
-    const { publicSigningKey, keyset } = await this.ensureInitialized();
-    try {
-      const { payload, protectedHeader } = await jwtVerify(token, publicSigningKey, {
-        issuer: this.issuer,
-        audience: this.resource,
-        algorithms: [ALGORITHM],
-        typ: 'at+jwt',
-        crit: {},
-      });
-      return buildEmbeddedAsAuthResult(payload, protectedHeader, keyset.kid);
-    } catch (error) {
-      return { ok: false, reason: mapEmbeddedAsVerifyError(error) };
-    }
+    return await this.tokens.validate(token);
   }
 
   /**
@@ -329,22 +334,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
    * production code paths must use the OAuth flow.
    */
   async issue(sub: string, options?: IssueOptions): Promise<string> {
-    const { keyset, privateSigningKey } = await this.ensureInitialized();
-    const ttl = options?.ttlSeconds ?? DEFAULT_ACCESS_TOKEN_TTL_SECONDS;
-    const scope = options?.scopes?.join(' ') || 'mcp';
-
-    return new SignJWT({
-      azp: DEFAULT_CLIENT_ID,
-      scope,
-      name: options?.displayName ?? sub,
-    })
-      .setProtectedHeader({ alg: ALGORITHM, kid: keyset.kid, typ: 'at+jwt' })
-      .setIssuer(this.issuer)
-      .setAudience(this.resource)
-      .setSubject(sub)
-      .setIssuedAt()
-      .setExpirationTime(`${ttl}s`)
-      .sign(privateSigningKey);
+    return await this.tokens.issue(sub, options);
   }
 
   /**
@@ -486,11 +476,14 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
               ipHash: hashRotationAttribute(normalizeIp(req.ip ?? ''), salt),
               uaHash: hashRotationAttribute(pickHeaderValue(req.headers['user-agent']), salt),
             };
-            withRotationRequestContext(context, () => {
-              state.provider.callback()(req, res);
-            });
+            // Await the oidc-provider callback so async rejections (e.g.
+            // adapter/DB hiccups during token issuance) reach the outer
+            // try/catch and flow to Express's error middleware via next().
+            // Without the await, the returned Promise is discarded and
+            // any async rejection becomes an unhandledRejection.
+            await withRotationRequestContext(context, () => state.provider.callback()(req, res));
           } else {
-            state.provider.callback()(req, res);
+            await state.provider.callback()(req, res);
           }
         } catch (err) {
           next(err);
@@ -499,39 +492,6 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
     });
 
     return router;
-  }
-
-  /**
-   * Multi-user methods (must-fix #22). When ANY of these is configured,
-   * the bootstrap gate is active until the admin-bootstrap CLI runs.
-   * Single-user / external-IdP modes (trivial-consent, oidc-bridge) do
-   * not need a bootstrap step and skip the gate entirely.
-   */
-  private static readonly MULTI_USER_METHODS: ReadonlySet<string> = new Set([
-    'local-password',
-    'magic-link',
-    'github',
-  ]);
-
-  /**
-   * Paths that bypass the bootstrap gate. Discovery + key-distribution
-   * endpoints MUST stay reachable even when the AS is closed so that
-   * clients can find the AS and verify any tokens already in their
-   * possession. Each entry is matched as `path === entry.path` for
-   * exact entries, or `path.startsWith(entry.path)` for prefix entries.
-   * Cycle-16 fix: `/jwks` was previously matched via `startsWith` which
-   * silently allows future `/jwks*` routes (`/jwks-rotate`, etc.) to
-   * bypass the gate — that's the wrong default for a security-relevant
-   * allowlist. Use exact match for /jwks; prefix match only for the
-   * /.well-known/ tree which is genuinely a directory.
-   */
-  private static readonly GATE_BYPASS_RULES: ReadonlyArray<{ path: string; mode: 'exact' | 'prefix' }> = [
-    { path: '/.well-known/', mode: 'prefix' },
-    { path: '/jwks', mode: 'exact' },
-  ];
-
-  private isMultiUserMode(): boolean {
-    return this.methods.some((m) => EmbeddedAuthorizationServer.MULTI_USER_METHODS.has(m.id));
   }
 
   /**
@@ -570,56 +530,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
    * storage (we want to see the moment it flips).
    */
   async isReadyForTraffic(): Promise<boolean> {
-    if (!this.isMultiUserMode()) return true;
-    if (this.bootstrapReadyLatch) return true;
-    try {
-      const state = await this.storage.getBootstrapState();
-      if (state.completed === true) {
-        this.bootstrapReadyLatch = true;
-        return true;
-      }
-      return false;
-    } catch (err) {
-      logger.warn('[EmbeddedAuthorizationServer] isReadyForTraffic storage read failed; reporting not-ready', {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      return false;
-    }
-  }
-
-  /**
-   * Render a method-specific actionable hint for the 503 body. The
-   * operator should be able to copy-paste the suggested command and
-   * have it Just Work.
-   */
-  private bootstrapHint(): string {
-    // Round 5 post-triage MEDIUM-2: hint strings name the actual
-    // registered binaries from package.json `bin` (which uses
-    // single-token hyphenated names like `dollhouse-create-user`),
-    // not a `dollhousemcp <subcommand>` form that does NOT exist.
-    // Operators copy-pasting the earlier wording got "command not
-    // found" and the bootstrap path looked broken.
-    const ids = this.methods.map((m) => m.id);
-    const lines: string[] = [];
-    if (ids.includes('local-password')) {
-      lines.push(
-        "Run 'dollhouse-create-user --username <name> --email <addr>' " +
-        "to issue the first invite (this also marks bootstrap complete).",
-      );
-    }
-    if (ids.includes('magic-link')) {
-      lines.push(
-        "Run 'dollhouse-admin-bootstrap --method magic-link --email <admin@example.com>' " +
-        "to claim the admin identity.",
-      );
-    }
-    if (ids.includes('github')) {
-      lines.push(
-        "Run 'dollhouse-admin-bootstrap --method github --github-username <gh-username>' " +
-        "to claim the admin identity.",
-      );
-    }
-    return lines.join(' OR ');
+    return await this.bootstrap.isReadyForTraffic();
   }
 
   /**
@@ -628,58 +539,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
    * (b) the cache flag below is per-middleware-instance.
    */
   private createBootstrapGate(): RequestHandler {
-    if (!this.isMultiUserMode()) {
-      // Trivial-consent / oidc-bridge: gate is unconditionally open.
-      return (_req, _res, next) => next();
-    }
-    const bypassRules = EmbeddedAuthorizationServer.GATE_BYPASS_RULES;
-    return async (req, res, next) => {
-      // Cycle-16 fix: share `bootstrapReadyLatch` with isReadyForTraffic
-      // so /readyz and the gate observe the same monotonic flag.
-      // Previously each had its own latch, so a /readyz hit and an
-      // /authorize hit each fired a separate storage read.
-      if (this.bootstrapReadyLatch) {
-        next();
-        return;
-      }
-      // Mount-relative path: `req.path` is path within this router's
-      // scope, regardless of where the router is mounted in the host app.
-      for (const rule of bypassRules) {
-        const matched = rule.mode === 'exact'
-          ? req.path === rule.path
-          : (req.path === rule.path || req.path.startsWith(rule.path));
-        if (matched) {
-          next();
-          return;
-        }
-      }
-      try {
-        const state = await this.storage.getBootstrapState();
-        if (state.completed) {
-          this.bootstrapReadyLatch = true;
-          next();
-          return;
-        }
-        res.status(503).json({
-          error: 'bootstrap_required',
-          error_description:
-            'This authorization server has not been bootstrapped. ' +
-            'An operator must claim the first admin identity before any ' +
-            'authentication flow is accepted.',
-          next_step: this.bootstrapHint(),
-        });
-      } catch (err) {
-        logger.error('[EmbeddedAuthorizationServer] bootstrap-gate storage read failed', {
-          error: err instanceof Error ? err.message : String(err),
-        });
-        // Fail closed: if the gate can't read the state, refuse traffic
-        // rather than open the AS to potential pre-bootstrap auth flow.
-        res.status(503).json({
-          error: 'bootstrap_check_unavailable',
-          error_description: 'Unable to verify bootstrap state. Try again shortly.',
-        });
-      }
-    };
+    return this.bootstrap.createBootstrapGate();
   }
 
   /**
@@ -693,76 +553,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
    * "yes, I'm authenticated as the admin".
    */
   private createAdminMeHandler(): RequestHandler[] {
-    // Compose the same middleware the rest of the codebase uses for
-    // Bearer validation. `EmbeddedAuthorizationServer` IS an
-    // `IAuthProvider` (`this`), so the unified middleware can validate
-    // tokens against it. This way the admin route's 401 body shape,
-    // WWW-Authenticate header, and SecurityMonitor audit events match
-    // every other authenticated route in the codebase. The earlier
-    // shape duplicated the validate-and-set-locals logic inline,
-    // which would silently drift if the unified middleware changed.
-    const validateBearer = createUnifiedAuthMiddleware({
-      provider: this,
-      protectedResourceMetadataUrl: this.getProtectedResourceMetadataUrl(),
-    });
-
-    const adminGuard = assertHasRole('admin');
-
-    const handler: RequestHandler = (req, res, next) => {
-      void (async () => {
-        try {
-          const claims = res.locals.authClaims;
-          if (!claims) {
-            // Defensive: validateBearer + adminGuard should both have
-            // populated/required claims by here, but if this somehow
-            // runs without claims that's a 500 not a 401.
-            next(new Error('admin/me handler reached without authClaims'));
-            return;
-          }
-          const bootstrap = await this.storage.getBootstrapState();
-          const account = await this.storage.getAccount(claims.sub);
-
-          // Round 6 review fixup: when the caller's account row no
-          // longer exists in storage (admin was deleted post-bootstrap;
-          // GDPR delete; manual operator action), refuse to echo a
-          // stub. The token still validates cryptographically, but
-          // the AS has no account-level claims to authoritatively
-          // surface. 410 Gone is the honest answer: the resource
-          // (the account behind this sub) has been deliberately
-          // removed. Operators investigating "why does my admin token
-          // fail?" get a clear signal vs. a 200 with nulls.
-          if (!account) {
-            res.status(410).json({
-              error: 'admin account no longer exists',
-              sub: claims.sub,
-            });
-            return;
-          }
-
-          // Round 5 / MED-6: only echo the bootstrap admin's sub when
-          // the caller IS the bootstrap admin. Other roles=['admin']
-          // accounts (added in the future when role assignment is
-          // wired) get the bootstrap method but not the bootstrap
-          // admin's identifier — avoids cross-admin disclosure.
-          const callerIsBootstrapAdmin = bootstrap.adminSub === claims.sub;
-          res.json({
-            sub: claims.sub,
-            roles: claims.roles ?? [],
-            email: account.email,
-            displayName: account.displayName,
-            bootstrap: {
-              adminMethod: bootstrap.adminMethod,
-              completedAt: bootstrap.completedAt,
-              ...(callerIsBootstrapAdmin ? { adminSub: bootstrap.adminSub } : {}),
-            },
-          });
-        } catch (err) {
-          next(err);
-        }
-      })();
-    };
-
-    return [validateBearer, adminGuard, handler];
+    return this.admin.createAdminMeHandler();
   }
 
   private async handleAuthorizationServerMetadata(_req: Request, res: Response): Promise<void> {
@@ -949,7 +740,6 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
       refreshRotationGraceMs: this.refreshRotationGraceMs,
       refreshRotationCheckIpUa: this.refreshRotationCheckIpUa,
     });
-    const methods = this.methods;
 
     const config: Configuration = {
       // adapter: oidc-provider's TypeScript type expects a function-shape
@@ -1066,31 +856,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
       // config was a misconfiguration — `acr` is the OIDC Authentication
       // Context Class Reference scope, not a vehicle for the auth_time
       // claim — and produced no auth_time on issued tokens.
-      extraTokenClaims: async (_ctx, token) => {
-        const accountId = (token as { accountId?: string }).accountId;
-        if (!accountId) return undefined;
-        const account = await this.storage.getAccount(accountId);
-        if (!account) return undefined;
-        // Defense in depth: refuse to emit role/auth_time claims if the
-        // row's sub doesn't match the token's accountId. A bug elsewhere
-        // that lets a token carry a foreign accountId would otherwise
-        // propagate someone else's claims onto it. Today this is
-        // unreachable (oidc-provider sets accountId from the Grant we
-        // minted) but making it a no-op rather than trusting the lookup
-        // keeps the claim honest if the surrounding code ever changes shape.
-        if (account.sub !== accountId) return undefined;
-        const extras: Record<string, unknown> = {};
-        if (account.lastAuthAt) {
-          extras.auth_time = Math.floor(account.lastAuthAt / 1000);
-        }
-        if (account.roles && account.roles.length > 0) {
-          // Roles are sourced from the durable account record set by the
-          // admin-bootstrap CLI (must-fix #22). Emitted on every token
-          // issued for this sub, so the role survives refresh-rotation.
-          extras.roles = account.roles;
-        }
-        return Object.keys(extras).length > 0 ? extras : undefined;
-      },
+      extraTokenClaims: (_ctx, token) => this.oidcAccount.extraTokenClaims(_ctx, token),
       // oidc-provider validates DCR-time AND authorize-time `scope` values
       // against THIS list (not against the published `scopes_supported` in
       // the well-known metadata — those are independent). Cycle 24: the
@@ -1139,28 +905,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
       interactions: {
         url: (_ctx, interaction) => `/interaction/${interaction.uid}`,
       },
-      async findAccount(_ctx, sub) {
-        // Each method returns null for subs it doesn't own; iterate in the
-        // configured order and take the first non-null match. This is how
-        // multi-method deployments dispatch token-issue findAccount lookups
-        // without an explicit method ID on the sub.
-        for (const m of methods) {
-          const identity = await m.findAccount(sub);
-          if (!identity) continue;
-          return {
-            accountId: identity.sub,
-            async claims() {
-              return {
-                sub: identity.sub,
-                name: identity.displayName,
-                email: identity.email,
-                email_verified: identity.emailVerified,
-              };
-            },
-          };
-        }
-        return undefined;
-      },
+      findAccount: (_ctx, sub) => this.oidcAccount.findAccount(_ctx, sub),
       // Cookie signing + transport defaults. The signing keys come from a
       // dedicated secret file (see cookieSecret.ts) — earlier code reused
       // the JWKS kid here, which made every cookie forgeable by anyone
@@ -1221,9 +966,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
     // half. The earlier shape called this `publicJwk`, which was
     // misleading — anyone reading the private-import line couldn't tell
     // it was the full private JWK. The names now match what each value is.
-    const privateJwk = keyset.jwks.keys[0];
-    const publicSigningKey = (await importJWK(stripPrivate(privateJwk), ALGORITHM)) as CryptoKey;
-    const privateSigningKey = (await importJWK(privateJwk, ALGORITHM)) as CryptoKey;
+    const { publicSigningKey, privateSigningKey } = await importSigningKeys(keyset);
 
     logger.info('[EmbeddedAuthorizationServer] initialized', {
       issuer: this.issuer,
@@ -1252,113 +995,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
 }
 
 
-function claimsFromPayload(payload: Record<string, unknown>): AuthClaims {
-  return {
-    sub: String(payload.sub),
-    displayName: typeof payload.name === 'string' ? payload.name : undefined,
-    email: typeof payload.email === 'string' ? payload.email : undefined,
-    tenantId: typeof payload.tenant_id === 'string' ? payload.tenant_id : null,
-    scopes: typeof payload.scope === 'string' ? payload.scope.split(/\s+/).filter(Boolean) : undefined,
-    roles: Array.isArray(payload.roles)
-      ? payload.roles.filter((r): r is string => typeof r === 'string')
-      : undefined,
-    exp: typeof payload.exp === 'number' ? payload.exp : undefined,
-  };
-}
-
-/**
- * Build an AuthResult from a successfully-verified embedded-AS JWT.
- * Enforces kid presence, kid match against the active keyset (so a
- * token signed with a rotated-out key can't validate), sub presence,
- * and the `mcp` scope (defence-in-depth: H6 — tokens we issue always
- * carry it, but a key-rotation bug or a future code path that
- * accidentally minted a token without scope would otherwise pass
- * everything else here). Extracted from validate() to keep its
- * cognitive complexity ≤15 (S3776).
- */
-function buildEmbeddedAsAuthResult(
-  payload: Record<string, unknown>,
-  protectedHeader: { kid?: string },
-  activeKid: string,
-): AuthResult {
-  if (!protectedHeader.kid) {
-    return { ok: false, reason: 'token missing kid header' };
-  }
-  if (protectedHeader.kid !== activeKid) {
-    return { ok: false, reason: 'unknown key id' };
-  }
-  if (!payload.sub) {
-    return { ok: false, reason: 'token missing sub claim' };
-  }
-  const scopeClaim = typeof payload.scope === 'string' ? payload.scope : '';
-  const scopes = new Set(scopeClaim.split(/\s+/).filter(Boolean));
-  if (!scopes.has('mcp')) {
-    return { ok: false, reason: 'token missing mcp scope' };
-  }
-  return { ok: true, claims: claimsFromPayload(payload) };
-}
-
-/**
- * Map a jose JWT-verification error to a stable reason string. Uses
- * jose's typed errors instead of substring-matching .message —
- * substrings like 'iss' or 'typ' collide with unrelated error text
- * ('issuer', 'unexpected', 'cryptographic', 'type'). Cycle-11 (M11-1)
- * added the JWSSignatureVerificationFailed branch for parity with the
- * other two providers; cycle-13 added JOSEAlgNotAllowed. Reason
- * strings are aligned across all three providers so operator log-grep
- * sees consistent text regardless of which provider is mounted.
- * Extracted from validate() for the cognitive-complexity refactor.
- */
-function mapEmbeddedAsVerifyError(error: unknown): string {
-  if (error instanceof joseErrors.JWTExpired) {
-    return 'token expired';
-  }
-  if (error instanceof joseErrors.JWSSignatureVerificationFailed) {
-    return 'invalid signature';
-  }
-  if (error instanceof joseErrors.JOSEAlgNotAllowed) {
-    return 'algorithm not allowed';
-  }
-  if (error instanceof joseErrors.JWTClaimValidationFailed) {
-    const claim = error.claim;
-    if (claim === 'aud') return 'invalid audience';
-    if (claim === 'iss') return 'invalid issuer';
-    if (claim === 'typ') return 'wrong token type';
-    return `claim validation failed: ${claim ?? 'unknown'}`;
-  }
-  return 'token validation failed';
-}
-
-/**
- * Cycle-16 fix: explicit denylist of private JWK fields. The earlier
- * destructure-and-discard pattern silently passed through any new
- * private field name (e.g., a future OKP `oth`) — a regression that
- * lets `d` survive into the published key would expose the signing
- * material. A denylist is self-documenting and fails closed: if a new
- * private field is added to the JWK type, it slips through and gets
- * caught by review or by an explicit test (rather than passing through
- * unstripped). Track these against RFC 7517/7518 (RSA + EC private
- * material) and RFC 8037 (OKP private material).
- */
-const PRIVATE_JWK_FIELDS: ReadonlySet<string> = new Set([
-  'd',  // RSA + EC + OKP private exponent / scalar
-  'p', 'q', 'dp', 'dq', 'qi', // RSA CRT params
-  'k',  // symmetric key material
-  'oth', // RSA "other primes" (multi-prime)
-]);
-
-function stripPrivate(jwk: JWK): JWK {
-  const result: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(jwk as JWK & Record<string, unknown>)) {
-    if (!PRIVATE_JWK_FIELDS.has(key)) {
-      result[key] = value;
-    }
-  }
-  return result as JWK;
-}
-
 function normalizePath(rawPath: string): string {
   if (!rawPath || rawPath === '/') return '/mcp';
   return rawPath.startsWith('/') ? rawPath : `/${rawPath}`;
 }
-

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -337,9 +337,7 @@ export class AgentManager extends BaseElementManager<Agent> {
       ...metadataWithoutContent
     };
     if (metadata?.goal !== undefined) {
-      normalizedMetadata.goal = this.normalizeGoalInput(
-        metadata.goal as string | Partial<AgentGoalConfig>
-      );
+      normalizedMetadata.goal = this.normalizeGoalInput(metadata.goal);
     }
     return { referenceContent, normalizedMetadata };
   }
@@ -1157,32 +1155,37 @@ export class AgentManager extends BaseElementManager<Agent> {
     metadata: AgentMetadataV2,
     executionContext: ExecutionContext
   ): Promise<ActivationResult> {
-    const result: ActivationResult = { activeElements: {}, activationWarnings: [] };
     if (!metadata.activates) {
-      return result;
+      return { activeElements: {}, activationWarnings: [] };
     }
 
+    const activeElements: ActivationResult['activeElements'] = {};
+    const activationWarnings: ActivationResult['activationWarnings'] = [];
+
     for (const [elementType, elementNames] of Object.entries(metadata.activates)) {
-      await this.activateElementGroup(agentName, elementType, elementNames, executionContext, result);
+      if (!elementNames || elementNames.length === 0) continue;
+      const group = await this.activateElementGroup(agentName, elementType, elementNames, executionContext);
+      activeElements[elementType] = group.items;
+      activationWarnings.push(...group.warnings);
     }
-    return result;
+    return { activeElements, activationWarnings };
   }
 
   private async activateElementGroup(
     agentName: string,
     elementType: string,
-    elementNames: string[] | undefined,
+    elementNames: string[],
     executionContext: ExecutionContext,
-    result: ActivationResult
-  ): Promise<void> {
-    if (!elementNames || elementNames.length === 0) {
-      return;
-    }
+  ): Promise<{ items: ActivationResult['activeElements'][string]; warnings: ActivationResult['activationWarnings'] }> {
+    const items: ActivationResult['activeElements'][string] = [];
+    const warnings: ActivationResult['activationWarnings'] = [];
 
-    result.activeElements[elementType] = [];
     for (const elementName of elementNames) {
-      await this.activateSingleElement(agentName, elementType, elementName, executionContext, result);
+      const outcome = await this.activateSingleElement(agentName, elementType, elementName, executionContext);
+      if (outcome.item) items.push(outcome.item);
+      if (outcome.warning) warnings.push(outcome.warning);
     }
+    return { items, warnings };
   }
 
   private async activateSingleElement(
@@ -1190,18 +1193,17 @@ export class AgentManager extends BaseElementManager<Agent> {
     elementType: string,
     elementName: string,
     executionContext: ExecutionContext,
-    result: ActivationResult
-  ): Promise<void> {
+  ): Promise<{ item?: ActivationResult['activeElements'][string][number]; warning?: ActivationResult['activationWarnings'][number] }> {
     try {
       const elementContent = await this.getElementContent(elementType, elementName, executionContext);
-      result.activeElements[elementType].push({ name: elementName, content: elementContent });
+      return { item: { name: elementName, content: elementContent } };
     } catch (error) {
       if (error instanceof Error && error.message.includes('Circular agent activation detected')) {
         throw error;
       }
       const errorMessage = error instanceof Error ? error.message : String(error);
-      result.activationWarnings.push({ elementType, elementName, error: errorMessage });
       logger.warn(`Agent '${agentName}': failed to activate ${elementType} '${elementName}' — ${errorMessage}`);
+      return { warning: { elementType, elementName, error: errorMessage } };
     }
   }
 
@@ -2239,7 +2241,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     agentName: string
   ): void {
     if (record[key] !== undefined && !isOneOf(record[key], allowedValues)) {
-      logger.warn(`[parseMetadata] Agent '${agentName}': ${label} '${record[key]}' is invalid, stripping`);
+      logger.warn(`[parseMetadata] Agent '${agentName}': ${label} ${JSON.stringify(record[key])} is invalid, stripping`);
       delete record[key];
     }
   }
@@ -2520,7 +2522,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     errors: string[]
   ): void {
     if (record[key] !== undefined && !isOneOf(record[key], allowedValues)) {
-      errors.push(`${label} must be one of: ${allowedValues.join(', ')} (got '${record[key]}')`);
+      errors.push(`${label} must be one of: ${allowedValues.join(', ')} (got ${JSON.stringify(record[key])})`);
     }
   }
 

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -110,6 +110,22 @@ type AgentCreateMetadata = (Partial<AgentMetadata> & Partial<AgentMetadataV2>) &
   content?: string;
 };
 
+interface PreparedCreateInput {
+  referenceContent: unknown;
+  normalizedMetadata: Partial<AgentMetadataV2>;
+}
+
+interface SanitizedCreateInput {
+  name: string;
+  description: string;
+  instructions: string;
+}
+
+interface ActivationResult {
+  activeElements: Record<string, Array<{ name: string; content: string }>>;
+  activationWarnings: Array<{ elementType: string; elementName: string; error: string }>;
+}
+
 export class AgentManager extends BaseElementManager<Agent> {
   private readonly stateCache: Map<string, AgentState> = new Map();
   private readonly stateStore: IAgentStateStore;
@@ -229,94 +245,28 @@ export class AgentManager extends BaseElementManager<Agent> {
   ): Promise<ElementCreationResult> {
     try {
       await this.initialize();
-
-      // Normalize goal input before validation - LLMs may pass string or object
-      // Strip 'content' from metadata to prevent it from overwriting the positional
-      // content param (which is the agent's instructions text) in the validation call.
-      const { content: referenceContent, ...metadataWithoutContent } = metadata ?? {};
-      const normalizedMetadata: Partial<AgentMetadataV2> = {
-        ...metadataWithoutContent
-      };
-      if (metadata?.goal !== undefined) {
-        normalizedMetadata.goal = this.normalizeGoalInput(
-          metadata.goal as string | Partial<AgentGoalConfig>
-        );
-      }
-
-      // Use specialized validator for input validation.
-      // Agents support dual-field creation: behavioral instructions and optional
-      // reference content. Validation prefers behavioral instructions when both
-      // fields are present so existing instruction-first agents keep their
-      // current semantics while content-only agents still validate correctly.
-      const validationInput: Record<string, unknown> = {
+      const preparedInput = this.prepareCreateInput(metadata);
+      const validationFailure = await this.validateAgentCreateInput(
         name,
         description,
-        ...normalizedMetadata
-      };
-      const primaryText = this.getPrimaryValidationText(content, referenceContent);
-      validationInput.content = primaryText ?? '';
-      const validationResult = await this.validator.validateCreate(validationInput);
-
-      if (!validationResult.isValid) {
-        return {
-          success: false,
-          message: `Validation failed: ${validationResult.errors.join(', ')}`
-        };
+        content,
+        preparedInput
+      );
+      if (validationFailure) {
+        return validationFailure;
       }
 
-      // Log warnings if any
-      if (validationResult.warnings && validationResult.warnings.length > 0) {
-        logger.warn(`Agent creation warnings: ${validationResult.warnings.join(', ')}`);
-      }
-
-      // Sanitize inputs for element creation
-      const sanitizedName = sanitizeInput(UnicodeValidator.normalize(name).normalizedContent, 100);
-      const sanitizedDescription = sanitizeInput(UnicodeValidator.normalize(description).normalizedContent, 500);
-      // Use ContentValidator for multi-line content to preserve formatting (newlines, tabs)
-      // while still detecting prompt injection attacks
-      const contentValidation = ContentValidator.validateAndSanitize(content, { maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH, contentContext: 'agent' });
-      const sanitizedInstructions = contentValidation.sanitizedContent || '';
-
-      if (!this.validateElementName(sanitizedName)) {
-        return {
-          success: false,
-          message: 'Invalid agent name. Use only letters, numbers, hyphens, and underscores.'
-        };
-      }
-
-      const filename = this.getFilename(sanitizedName);
-      const agent = new Agent({
-        ...normalizedMetadata,
-        name: sanitizedName,
-        description: sanitizedDescription
-      }, this.metadataService);
-
-      agent.metadata.author = normalizedMetadata?.author ?? this.getCurrentUserForAttribution();
-      agent.extensions = {
-        ...agent.extensions,
-        specializations: normalizedMetadata?.specializations ?? agent.extensions?.specializations ?? [],
-        decisionFramework: normalizedMetadata?.decisionFramework ?? agent.extensions?.decisionFramework,
-        riskTolerance: normalizedMetadata?.riskTolerance ?? agent.extensions?.riskTolerance,
-        learningEnabled: normalizedMetadata?.learningEnabled ?? agent.extensions?.learningEnabled,
-      };
-      // Promote instructions to first-class property (no longer in extensions)
-      agent.instructions = sanitizedInstructions;
-      // Also keep in extensions for backward compat during transition
-      agent.extensions.instructions = sanitizedInstructions;
-
-      // Set reference content if provided (v2.0 dual-field architecture)
-      if (typeof referenceContent === 'string' && referenceContent.trim().length > 0) {
-        const contentValidationResult = ContentValidator.validateAndSanitize(
-          referenceContent,
-          { maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH, contentContext: 'agent' }
+      const sanitizedInput = this.sanitizeAgentCreateInput(name, description, content);
+      if (!this.validateElementName(sanitizedInput.name)) {
+        return AgentManager.createFailure(
+          'Invalid agent name. Use only letters, numbers, hyphens, and underscores.'
         );
-        if (!contentValidationResult.isValid) {
-          return {
-            success: false,
-            message: `Validation failed: ${(contentValidationResult.detectedPatterns || ['Content validation failed']).join(', ')}`
-          };
-        }
-        agent.content = contentValidationResult.sanitizedContent || '';
+      }
+
+      const agent = this.buildAgentFromCreateInput(sanitizedInput, preparedInput.normalizedMetadata);
+      const referenceFailure = this.assignReferenceContent(agent, preparedInput.referenceContent);
+      if (referenceFailure) {
+        return referenceFailure;
       }
 
       // Issue #727: Validate and normalize V2 fields BEFORE assignment.
@@ -324,52 +274,25 @@ export class AgentManager extends BaseElementManager<Agent> {
       // this.validator.validateCreate) is the first. The validator catches camelCase
       // invalid values; this method also normalizes snake_case keys (which the validator
       // doesn't see) and validates them. Both layers are needed. See Issue #730.
-      const metadataV2 = normalizedMetadata as Partial<AgentMetadataV2> | undefined;
-      if (metadataV2) {
-        const v2Errors = this.validateV2FieldsForCreate(metadataV2);
-        if (v2Errors.length > 0) {
-          return {
-            success: false,
-            message: `V2 field validation failed: ${v2Errors.join('; ')}`
-          };
-        }
+      const metadataV2 = preparedInput.normalizedMetadata;
+      const v2Errors = this.validateV2FieldsForCreate(metadataV2);
+      if (v2Errors.length > 0) {
+        return AgentManager.createFailure(`V2 field validation failed: ${v2Errors.join('; ')}`);
       }
 
       // V2 FIELDS: Store V2-specific fields in agent metadata (not just extensions)
       // This enables V2 agent creation via MCP-AQL create_element operation
-      if (metadataV2?.goal) {
-        (agent.metadata as AgentMetadataV2).goal = metadataV2.goal;
-      }
-      if (metadataV2?.activates) {
-        (agent.metadata as AgentMetadataV2).activates = metadataV2.activates;
-      }
-      if (metadataV2?.tools) {
-        (agent.metadata as AgentMetadataV2).tools = metadataV2.tools;
-      }
-      if (metadataV2?.systemPrompt) {
-        (agent.metadata as AgentMetadataV2).systemPrompt = metadataV2.systemPrompt;
-      }
-      if (metadataV2?.autonomy) {
-        (agent.metadata as AgentMetadataV2).autonomy = metadataV2.autonomy;
-      }
-      // Issue #449: Persist gatekeeper policy for Gatekeeper enforcement during execution
-      if (metadataV2?.gatekeeper) {
-        (agent.metadata as AgentMetadataV2).gatekeeper = metadataV2.gatekeeper;
-      }
-      // Issue #722: Persist resilience policy (was missing from V2 field assignments)
-      if (metadataV2?.resilience) {
-        (agent.metadata as AgentMetadataV2).resilience = metadataV2.resilience;
-      }
+      this.assignV2MetadataFields(agent, metadataV2);
 
       // Issue #613: Check metadata name uniqueness (not just filename)
       const existingAgents = await this.list();
       const duplicate = existingAgents.find(a =>
-        a.metadata.name.toLowerCase() === sanitizedName.toLowerCase()
+        a.metadata.name.toLowerCase() === sanitizedInput.name.toLowerCase()
       );
       if (duplicate) {
         return {
           success: false,
-          message: `Agent '${sanitizedName}' already exists`
+          message: `Agent '${sanitizedInput.name}' already exists`
         };
       }
 
@@ -378,19 +301,19 @@ export class AgentManager extends BaseElementManager<Agent> {
       // In DB mode, the storage layer does a plain INSERT and converts the 23505 unique-
       // constraint violation into an "already exists" error. The duplicate check above via
       // list() catches the common case; exclusive handles concurrent-create races.
-      await this.save(agent, filename, { exclusive: true });
+      await this.save(agent, this.getFilename(sanitizedInput.name), { exclusive: true });
 
       SecurityMonitor.logSecurityEvent({
         type: 'ELEMENT_CREATED',
         severity: 'LOW',
         source: 'AgentManager.create',
-        details: `Agent '${sanitizedName}' created`,
+        details: `Agent '${sanitizedInput.name}' created`,
         additionalData: { agentId: agent.id }
       });
 
       return {
         success: true,
-        message: `🤖 **${sanitizedName}** by ${agent.metadata.author || 'anonymous'}`,
+        message: `🤖 **${sanitizedInput.name}** by ${agent.metadata.author || 'anonymous'}`,
         element: agent
       };
     } catch (error) {
@@ -400,6 +323,116 @@ export class AgentManager extends BaseElementManager<Agent> {
         message: error instanceof Error ? error.message : 'Failed to create agent'
       };
     }
+  }
+
+  private static createFailure(message: string): ElementCreationResult {
+    return { success: false, message };
+  }
+
+  private prepareCreateInput(metadata?: AgentCreateMetadata): PreparedCreateInput {
+    // Strip 'content' from metadata to prevent it from overwriting the positional
+    // content param, which is the agent's behavioral instructions text.
+    const { content: referenceContent, ...metadataWithoutContent } = metadata ?? {};
+    const normalizedMetadata: Partial<AgentMetadataV2> = {
+      ...metadataWithoutContent
+    };
+    if (metadata?.goal !== undefined) {
+      normalizedMetadata.goal = this.normalizeGoalInput(
+        metadata.goal as string | Partial<AgentGoalConfig>
+      );
+    }
+    return { referenceContent, normalizedMetadata };
+  }
+
+  private async validateAgentCreateInput(
+    name: string,
+    description: string,
+    content: string,
+    preparedInput: PreparedCreateInput
+  ): Promise<ElementCreationResult | null> {
+    const validationInput: Record<string, unknown> = {
+      name,
+      description,
+      ...preparedInput.normalizedMetadata,
+      content: this.getPrimaryValidationText(content, preparedInput.referenceContent) ?? '',
+    };
+    const validationResult = await this.validator.validateCreate(validationInput);
+
+    if (!validationResult.isValid) {
+      return AgentManager.createFailure(`Validation failed: ${validationResult.errors.join(', ')}`);
+    }
+    if (validationResult.warnings && validationResult.warnings.length > 0) {
+      logger.warn(`Agent creation warnings: ${validationResult.warnings.join(', ')}`);
+    }
+    return null;
+  }
+
+  private sanitizeAgentCreateInput(
+    name: string,
+    description: string,
+    content: string
+  ): SanitizedCreateInput {
+    const contentValidation = ContentValidator.validateAndSanitize(
+      content,
+      { maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH, contentContext: 'agent' }
+    );
+    return {
+      name: sanitizeInput(UnicodeValidator.normalize(name).normalizedContent, 100),
+      description: sanitizeInput(UnicodeValidator.normalize(description).normalizedContent, 500),
+      instructions: contentValidation.sanitizedContent || '',
+    };
+  }
+
+  private buildAgentFromCreateInput(
+    sanitizedInput: SanitizedCreateInput,
+    normalizedMetadata: Partial<AgentMetadataV2>
+  ): Agent {
+    const agent = new Agent({
+      ...normalizedMetadata,
+      name: sanitizedInput.name,
+      description: sanitizedInput.description
+    }, this.metadataService);
+
+    agent.metadata.author = normalizedMetadata.author ?? this.getCurrentUserForAttribution();
+    agent.extensions = {
+      ...agent.extensions,
+      specializations: normalizedMetadata.specializations ?? agent.extensions?.specializations ?? [],
+      decisionFramework: normalizedMetadata.decisionFramework ?? agent.extensions?.decisionFramework,
+      riskTolerance: normalizedMetadata.riskTolerance ?? agent.extensions?.riskTolerance,
+      learningEnabled: normalizedMetadata.learningEnabled ?? agent.extensions?.learningEnabled,
+    };
+    agent.instructions = sanitizedInput.instructions;
+    agent.extensions.instructions = sanitizedInput.instructions;
+    return agent;
+  }
+
+  private assignReferenceContent(agent: Agent, referenceContent: unknown): ElementCreationResult | null {
+    if (typeof referenceContent !== 'string' || referenceContent.trim().length === 0) {
+      return null;
+    }
+
+    const contentValidationResult = ContentValidator.validateAndSanitize(
+      referenceContent,
+      { maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH, contentContext: 'agent' }
+    );
+    if (!contentValidationResult.isValid) {
+      return AgentManager.createFailure(
+        `Validation failed: ${(contentValidationResult.detectedPatterns || ['Content validation failed']).join(', ')}`
+      );
+    }
+    agent.content = contentValidationResult.sanitizedContent || '';
+    return null;
+  }
+
+  private assignV2MetadataFields(agent: Agent, metadataV2: Partial<AgentMetadataV2>): void {
+    const target = agent.metadata as AgentMetadataV2;
+    if (metadataV2.goal) target.goal = metadataV2.goal;
+    if (metadataV2.activates) target.activates = metadataV2.activates;
+    if (metadataV2.tools) target.tools = metadataV2.tools;
+    if (metadataV2.systemPrompt) target.systemPrompt = metadataV2.systemPrompt;
+    if (metadataV2.autonomy) target.autonomy = metadataV2.autonomy;
+    if (metadataV2.gatekeeper) target.gatekeeper = metadataV2.gatekeeper;
+    if (metadataV2.resilience) target.resilience = metadataV2.resilience;
   }
 
   /**
@@ -986,239 +1019,48 @@ export class AgentManager extends BaseElementManager<Agent> {
     } = {}
   ): Promise<ExecuteAgentResult> {
     try {
-      // 1. Load agent by name
-      const agent = await this.read(name);
-      if (!agent) {
-        // FIX: Issue #275 - Throw ElementNotFoundError for consistent error handling
-        throw new ElementNotFoundError('Agent', name);
-      }
-
-      // Get metadata as v2 (may have goal config)
-      let metadata = agent.metadata as AgentMetadataV2;
-
-      // Check if this is a v2.0 agent with goal configuration
-      // If not, auto-convert V1 to V2 in place (Issue #587)
-      if (!metadata.goal || !metadata.goal.template) {
-        if (isV1Agent(metadata)) {
-          const instructions = agent.extensions?.instructions || '';
-          const conversionResult = convertV1ToV2(metadata, instructions);
-
-          if (conversionResult.converted) {
-            // Merge converted metadata onto the existing agent (in-place)
-            Object.assign(metadata, conversionResult.metadata);
-            Object.assign(agent.metadata, conversionResult.metadata);
-
-            // Log conversion warnings
-            if (conversionResult.warnings.length > 0) {
-              logger.warn(`Agent '${name}' auto-converted from V1 to V2 in place`, {
-                warnings: conversionResult.warnings,
-              });
-            }
-
-            // Save the upgraded agent back to its original file
-            const upgradedFilename = this.getFilename(sanitizeInput(name, 100));
-            await this.save(agent, upgradedFilename);
-            logger.info(`Agent '${name}' converted from V1 to V2 and saved in place`);
-          } else {
-            throw new Error(
-              `Agent '${name}' cannot be executed: missing goal.template and conversion failed.`
-            );
-          }
-        } else {
-          throw new Error(
-            `Agent '${name}' is not a v2.0 agent. Missing goal.template configuration.`
-          );
-        }
-      }
+      const agent = await this.loadExecutableAgent(name);
+      const metadata = agent.metadata as AgentMetadataV2;
 
       // 2. Clone parameters to prevent mutation of caller's object (Issue #118)
       const clonedParameters = structuredClone(parameters);
-
-      // 2b. Security validation of template parameters (Issue #103)
-      this.validateParameterSecurity(clonedParameters);
-
-      // 3. Validate parameters against goal.parameters schema
-      this.validateParameters(metadata.goal, clonedParameters, {
+      this.validateExecutionParameters(metadata.goal, clonedParameters, {
         agentName: name,
         operationName: context.operationName ?? 'execute_agent',
       });
-
-      // 4. Render goal template by replacing {parameter} placeholders
       const renderedGoal = this.renderGoalTemplate(metadata.goal.template, clonedParameters);
-
-      // 4b. Detect unmatched placeholders after rendering (Issue #126)
       const unmatchedPlaceholders = this.detectUnmatchedPlaceholders(renderedGoal);
-      if (unmatchedPlaceholders.length > 0) {
-        logger.warn('Unmatched template placeholders detected after rendering', {
-          agentName: name,
-          unmatched: unmatchedPlaceholders,
-        });
-      }
-
-      // 5. Create execution context BEFORE activating elements (Issue #109 - circular activation detection)
+      this.logUnmatchedPlaceholders(name, unmatchedPlaceholders);
       const executionContext = createExecutionContext(name);
+      await this.assertNoStaticActivationCycle(name, metadata);
 
-      // 5b. Static activation cycle detection (Issue #374)
-      if (metadata.activates?.agents?.length) {
-        const cyclePath = await this.detectActivationCycles(name, metadata.activates.agents);
-        if (cyclePath) {
-          const cycleStart = cyclePath.indexOf(cyclePath[cyclePath.length - 1]);
-          const cycle = cyclePath.slice(cycleStart);
-          throw new Error(AgentManager.formatCircularActivationError(cycle));
-        }
-      }
-
-      // 6. Activate elements (element-agnostic)
-      const activeElements: Record<string, Array<{ name: string; content: string }>> = {};
-      const activationWarnings: Array<{ elementType: string; elementName: string; error: string }> = [];
-
-      if (metadata.activates) {
-        for (const [elementType, elementNames] of Object.entries(metadata.activates)) {
-          if (!elementNames || elementNames.length === 0) {
-            continue;
-          }
-
-          activeElements[elementType] = [];
-
-          for (const elementName of elementNames) {
-            try {
-              const elementContent = await this.getElementContent(elementType, elementName, executionContext);
-              activeElements[elementType].push({
-                name: elementName,
-                content: elementContent
-              });
-            } catch (error) {
-              // HIGH-1: Re-throw circular activation errors immediately (Issue #109)
-              if (error instanceof Error && error.message.includes('Circular agent activation detected')) {
-                throw error;
-              }
-              const errorMessage = error instanceof Error ? error.message : String(error);
-              activationWarnings.push({ elementType, elementName, error: errorMessage });
-              logger.warn(`Agent '${name}': failed to activate ${elementType} '${elementName}' — ${errorMessage}`);
-              // Continue with other elements rather than failing completely
-            }
-          }
-        }
-      }
-
-      // 7. Build the result with all context (initialize with default safety tier)
-      const result: ExecuteAgentResult = {
-        agentName: name,
-        goal: renderedGoal,
-        activeElements,
-        activationWarnings: activationWarnings.length > 0 ? activationWarnings : undefined,
-        // Issue #126: Warn about unmatched template placeholders
-        templateWarnings: unmatchedPlaceholders.length > 0
-          ? unmatchedPlaceholders.map(p => `Unmatched template placeholder: {${p}}`)
-          : undefined,
-        availableTools: metadata.tools?.allowed || [],
-        successCriteria: metadata.goal.successCriteria || [],
-        systemPrompt: metadata.systemPrompt,
-        safetyTier: 'advisory', // Default, will be updated below
-      };
-
-      // 8. Create and persist the goal for LLM tracking
-      // This allows record_agent_step to find and update the goal
-
-      // Create the goal using agent.addGoal() which handles validation and sanitization
-      const newGoal = agent.addGoal({
-        description: renderedGoal,
-        priority: 'medium',
-        importance: 5,
-        urgency: 5,
-      });
-
-      // Set goal status to in_progress since execution has started
-      newGoal.status = 'in_progress';
-
-      const execSanitizedName = sanitizeInput(name, 100);
-      await this.save(agent, this.getFilename(execSanitizedName));
-
-      // Store goalId in result for LLM to use with record_agent_step
-      result.goalId = newGoal.id;
-
-      // Fix #445: Include stateVersion so subsequent calls can do version-aware operations
-      const postSaveState = agent.getState();
-      result.stateVersion = postSaveState.stateVersion || 1;
-
-      // Call validateGoalSecurity and add warnings to result
-      const securityValidation = agent.validateGoalSecurity(renderedGoal);
-      if (securityValidation.warnings && securityValidation.warnings.length > 0) {
-        result.securityWarnings = securityValidation.warnings;
-      }
-
-      // Call evaluateConstraints and add to result
-      result.constraints = agent.evaluateConstraints(newGoal);
-
-      // Call assessRisk and add to result
-      result.riskAssessment = agent.assessRisk('execute', newGoal, {});
-
-      // Call calculatePriorityScore and add to result
-      result.priorityScore = agent.calculatePriorityScore(newGoal);
-
-      // 9. Determine safety tier based on risk assessment and security warnings
-      // (Note: executionContext already created earlier for circular detection)
-      const safetyTierResult = determineSafetyTier(
-        result.riskAssessment?.score || 0,
-        result.securityWarnings || [],
+      const activationResult = await this.activateAgentElements(name, metadata, executionContext);
+      const result = this.createExecuteAgentResult(
+        name,
         renderedGoal,
-        DEFAULT_SAFETY_CONFIG,
-        executionContext
+        metadata,
+        unmatchedPlaceholders,
+        activationResult
       );
-
-      // 10. Set safety tier and related fields
-      result.safetyTier = safetyTierResult.tier;
-      result.safetyTierResult = safetyTierResult;
-      result.executionContext = executionContext;
-
-      // 11. Add tier-specific responses
-      switch (safetyTierResult.tier) {
-        case 'confirm':
-          result.confirmationRequired = createConfirmationRequest(
-            'Operation requires confirmation',
-            safetyTierResult.factors
-          );
-          break;
-
-        case 'verify':
-          result.verificationRequired = createVerificationChallenge(
-            safetyTierResult.factors.join('; '),
-            'display_code'
-          );
-          break;
-
-        case 'danger_zone':
-          result.dangerZoneBlocked = createDangerZoneOperation(
-            'agent_execution',
-            safetyTierResult.factors.join('; '),
-            DEFAULT_SAFETY_CONFIG.dangerZone.enabled
-          );
-          // Also add verification if not blocked
-          if (!result.dangerZoneBlocked.blocked) {
-            result.verificationRequired = result.dangerZoneBlocked.verificationRequired;
-          }
-          break;
-
-        case 'advisory':
-        default:
-          // No additional action needed for advisory tier
-          break;
-      }
+      const newGoal = await this.persistExecutionGoal(agent, name, renderedGoal, result);
+      this.populateExecutionAnalysis(agent, newGoal, renderedGoal, result);
+      this.applySafetyTier(renderedGoal, executionContext, result);
+      const safetyTierResult = result.safetyTierResult;
 
       SecurityMonitor.logSecurityEvent({
         type: 'AGENT_EXECUTED',
         severity: 'LOW',
         source: 'AgentManager.executeAgent',
-        details: `Agent executed: ${name} v${agent.metadata.version || 'unknown'} (safety: ${safetyTierResult.tier})`,
+        details: `Agent executed: ${name} v${agent.metadata.version || 'unknown'} (safety: ${result.safetyTier})`,
         additionalData: {
           agentId: agent.id,
           agentName: name,
           version: agent.metadata.version,
           author: agent.metadata.author,
-          safetyTier: safetyTierResult.tier,
-          riskScore: safetyTierResult.riskScore,
+          safetyTier: result.safetyTier,
+          riskScore: safetyTierResult?.riskScore,
           parameterKeys: Object.keys(parameters || {}),
-          goalCount: (metadata as any).goal?.parameters?.length || 0,
+          goalCount: metadata.goal?.parameters?.length || 0,
         }
       });
 
@@ -1226,6 +1068,251 @@ export class AgentManager extends BaseElementManager<Agent> {
     } catch (error) {
       logger.error(`Failed to execute agent '${name}':`, error);
       throw error;
+    }
+  }
+
+  private async loadExecutableAgent(name: string): Promise<Agent> {
+    const agent = await this.read(name);
+    if (!agent) {
+      throw new ElementNotFoundError('Agent', name);
+    }
+
+    const metadata = agent.metadata as AgentMetadataV2;
+    if (metadata.goal?.template) {
+      return agent;
+    }
+    await this.convertLegacyAgentForExecution(agent, name, metadata);
+    return agent;
+  }
+
+  private async convertLegacyAgentForExecution(
+    agent: Agent,
+    name: string,
+    metadata: AgentMetadataV2
+  ): Promise<void> {
+    if (!isV1Agent(metadata)) {
+      throw new Error(
+        `Agent '${name}' is not a v2.0 agent. Missing goal.template configuration.`
+      );
+    }
+
+    const conversionResult = convertV1ToV2(metadata, agent.extensions?.instructions || '');
+    if (!conversionResult.converted) {
+      throw new Error(
+        `Agent '${name}' cannot be executed: missing goal.template and conversion failed.`
+      );
+    }
+
+    Object.assign(metadata, conversionResult.metadata);
+    Object.assign(agent.metadata, conversionResult.metadata);
+    if (conversionResult.warnings.length > 0) {
+      logger.warn(`Agent '${name}' auto-converted from V1 to V2 in place`, {
+        warnings: conversionResult.warnings,
+      });
+    }
+    await this.save(agent, this.getFilename(sanitizeInput(name, 100)));
+    logger.info(`Agent '${name}' converted from V1 to V2 and saved in place`);
+  }
+
+  private validateExecutionParameters(
+    goal: AgentGoalConfig,
+    parameters: Record<string, unknown>,
+    context: {
+      agentName?: string;
+      operationName?: 'execute_agent' | 'continue_execution';
+    }
+  ): void {
+    this.validateParameterSecurity(parameters);
+    this.validateParameters(goal, parameters, context);
+  }
+
+  private logUnmatchedPlaceholders(name: string, unmatchedPlaceholders: string[]): void {
+    if (unmatchedPlaceholders.length === 0) {
+      return;
+    }
+    logger.warn('Unmatched template placeholders detected after rendering', {
+      agentName: name,
+      unmatched: unmatchedPlaceholders,
+    });
+  }
+
+  private async assertNoStaticActivationCycle(
+    name: string,
+    metadata: AgentMetadataV2
+  ): Promise<void> {
+    if (!metadata.activates?.agents?.length) {
+      return;
+    }
+    const cyclePath = await this.detectActivationCycles(name, metadata.activates.agents);
+    if (!cyclePath) {
+      return;
+    }
+    const cycleStart = cyclePath.indexOf(cyclePath[cyclePath.length - 1]);
+    const cycle = cyclePath.slice(cycleStart);
+    throw new Error(AgentManager.formatCircularActivationError(cycle));
+  }
+
+  private async activateAgentElements(
+    agentName: string,
+    metadata: AgentMetadataV2,
+    executionContext: ExecutionContext
+  ): Promise<ActivationResult> {
+    const result: ActivationResult = { activeElements: {}, activationWarnings: [] };
+    if (!metadata.activates) {
+      return result;
+    }
+
+    for (const [elementType, elementNames] of Object.entries(metadata.activates)) {
+      await this.activateElementGroup(agentName, elementType, elementNames, executionContext, result);
+    }
+    return result;
+  }
+
+  private async activateElementGroup(
+    agentName: string,
+    elementType: string,
+    elementNames: string[] | undefined,
+    executionContext: ExecutionContext,
+    result: ActivationResult
+  ): Promise<void> {
+    if (!elementNames || elementNames.length === 0) {
+      return;
+    }
+
+    result.activeElements[elementType] = [];
+    for (const elementName of elementNames) {
+      await this.activateSingleElement(agentName, elementType, elementName, executionContext, result);
+    }
+  }
+
+  private async activateSingleElement(
+    agentName: string,
+    elementType: string,
+    elementName: string,
+    executionContext: ExecutionContext,
+    result: ActivationResult
+  ): Promise<void> {
+    try {
+      const elementContent = await this.getElementContent(elementType, elementName, executionContext);
+      result.activeElements[elementType].push({ name: elementName, content: elementContent });
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('Circular agent activation detected')) {
+        throw error;
+      }
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      result.activationWarnings.push({ elementType, elementName, error: errorMessage });
+      logger.warn(`Agent '${agentName}': failed to activate ${elementType} '${elementName}' — ${errorMessage}`);
+    }
+  }
+
+  private createExecuteAgentResult(
+    name: string,
+    renderedGoal: string,
+    metadata: AgentMetadataV2,
+    unmatchedPlaceholders: string[],
+    activationResult: ActivationResult
+  ): ExecuteAgentResult {
+    return {
+      agentName: name,
+      goal: renderedGoal,
+      activeElements: activationResult.activeElements,
+      activationWarnings: activationResult.activationWarnings.length > 0
+        ? activationResult.activationWarnings
+        : undefined,
+      templateWarnings: unmatchedPlaceholders.length > 0
+        ? unmatchedPlaceholders.map(p => `Unmatched template placeholder: {${p}}`)
+        : undefined,
+      availableTools: metadata.tools?.allowed || [],
+      successCriteria: metadata.goal.successCriteria || [],
+      systemPrompt: metadata.systemPrompt,
+      safetyTier: 'advisory',
+    };
+  }
+
+  private async persistExecutionGoal(
+    agent: Agent,
+    name: string,
+    renderedGoal: string,
+    result: ExecuteAgentResult
+  ): Promise<AgentGoal> {
+    const newGoal = agent.addGoal({
+      description: renderedGoal,
+      priority: 'medium',
+      importance: 5,
+      urgency: 5,
+    });
+    newGoal.status = 'in_progress';
+    await this.save(agent, this.getFilename(sanitizeInput(name, 100)));
+
+    result.goalId = newGoal.id;
+    result.stateVersion = agent.getState().stateVersion || 1;
+    return newGoal;
+  }
+
+  private populateExecutionAnalysis(
+    agent: Agent,
+    newGoal: AgentGoal,
+    renderedGoal: string,
+    result: ExecuteAgentResult
+  ): void {
+    const securityValidation = agent.validateGoalSecurity(renderedGoal);
+    if (securityValidation.warnings && securityValidation.warnings.length > 0) {
+      result.securityWarnings = securityValidation.warnings;
+    }
+    result.constraints = agent.evaluateConstraints(newGoal);
+    result.riskAssessment = agent.assessRisk('execute', newGoal, {});
+    result.priorityScore = agent.calculatePriorityScore(newGoal);
+  }
+
+  private applySafetyTier(
+    renderedGoal: string,
+    executionContext: ExecutionContext,
+    result: ExecuteAgentResult
+  ): void {
+    const safetyTierResult = determineSafetyTier(
+      result.riskAssessment?.score || 0,
+      result.securityWarnings || [],
+      renderedGoal,
+      DEFAULT_SAFETY_CONFIG,
+      executionContext
+    );
+
+    result.safetyTier = safetyTierResult.tier;
+    result.safetyTierResult = safetyTierResult;
+    result.executionContext = executionContext;
+    this.applySafetyTierResponse(safetyTierResult, result);
+  }
+
+  private applySafetyTierResponse(
+    safetyTierResult: ReturnType<typeof determineSafetyTier>,
+    result: ExecuteAgentResult
+  ): void {
+    switch (safetyTierResult.tier) {
+      case 'confirm':
+        result.confirmationRequired = createConfirmationRequest(
+          'Operation requires confirmation',
+          safetyTierResult.factors
+        );
+        break;
+      case 'verify':
+        result.verificationRequired = createVerificationChallenge(
+          safetyTierResult.factors.join('; '),
+          'display_code'
+        );
+        break;
+      case 'danger_zone':
+        result.dangerZoneBlocked = createDangerZoneOperation(
+          'agent_execution',
+          safetyTierResult.factors.join('; '),
+          DEFAULT_SAFETY_CONFIG.dangerZone.enabled
+        );
+        if (!result.dangerZoneBlocked.blocked) {
+          result.verificationRequired = result.dangerZoneBlocked.verificationRequired;
+        }
+        break;
+      case 'advisory':
+      default:
+        break;
     }
   }
 
@@ -1265,7 +1352,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     }
 
     // Apply normalized values back (in-place, since we already cloned)
-    const normalizedData = normalized.data as Record<string, unknown>;
+    const normalizedData = normalized.data;
     for (const [key, value] of Object.entries(normalizedData)) {
       parameters[key] = value;
     }
@@ -1290,59 +1377,73 @@ export class AgentManager extends BaseElementManager<Agent> {
     } = {}
   ): void {
     const paramDefs = goalConfig.parameters || [];
+    this.assertRequiredParametersPresent(paramDefs, parameters, context);
+    for (const [key, value] of Object.entries(parameters)) {
+      this.validateProvidedParameter(key, value, paramDefs);
+    }
+    this.applyParameterDefaults(paramDefs, parameters);
+  }
+
+  private assertRequiredParametersPresent(
+    paramDefs: AgentGoalParameter[],
+    parameters: Record<string, unknown>,
+    context: {
+      agentName?: string;
+      operationName?: 'execute_agent' | 'continue_execution';
+    }
+  ): void {
     const requiredParamNames = paramDefs
       .filter(paramDef => paramDef.required)
       .map(paramDef => paramDef.name);
-
-    // Check all required parameters are present
     const missingRequired = requiredParamNames.filter(paramName => !(paramName in parameters));
-    if (missingRequired.length > 0) {
-      throw new Error(
-        this.formatMissingRequiredParametersError(
-          missingRequired,
-          requiredParamNames,
-          context
-        )
-      );
+    if (missingRequired.length === 0) {
+      return;
+    }
+    throw new Error(
+      this.formatMissingRequiredParametersError(
+        missingRequired,
+        requiredParamNames,
+        context
+      )
+    );
+  }
+
+  private validateProvidedParameter(
+    key: string,
+    value: unknown,
+    paramDefs: AgentGoalParameter[]
+  ): void {
+    const paramDef = paramDefs.find(p => p.name === key);
+    if (!paramDef) {
+      logger.warn(`Unknown parameter '${key}' provided to agent`);
+      return;
     }
 
-    // Type check provided parameters
-    for (const [key, value] of Object.entries(parameters)) {
-      const paramDef = paramDefs.find(p => p.name === key);
-      if (!paramDef) {
-        logger.warn(`Unknown parameter '${key}' provided to agent`);
-        continue;
-      }
-
-      // Type validation
-      const actualType = typeof value;
-      if (paramDef.type === 'string' && actualType !== 'string') {
-        throw new Error(
-          `Parameter '${key}' must be a string, got ${actualType}`
-        );
-      }
-      if (paramDef.type === 'number' && actualType !== 'number') {
-        throw new Error(
-          `Parameter '${key}' must be a number, got ${actualType}`
-        );
-      }
-      if (paramDef.type === 'boolean' && actualType !== 'boolean') {
-        throw new Error(
-          `Parameter '${key}' must be a boolean, got ${actualType}`
-        );
-      }
-
-      // Advisory length warning for string values (defense-in-depth, does not throw)
-      if (actualType === 'string' && (value as string).length > AGENT_LIMITS.MAX_GOAL_LENGTH) {
-        logger.warn('Parameter string value exceeds MAX_GOAL_LENGTH (advisory)', {
-          paramName: key,
-          valueLength: (value as string).length,
-          maxLength: AGENT_LIMITS.MAX_GOAL_LENGTH,
-        });
-      }
+    const actualType = typeof value;
+    if (
+      (paramDef.type === 'string' || paramDef.type === 'number' || paramDef.type === 'boolean') &&
+      paramDef.type !== actualType
+    ) {
+      throw new Error(`Parameter '${key}' must be a ${paramDef.type}, got ${actualType}`);
     }
+    this.warnForOversizedStringParameter(key, value, actualType);
+  }
 
-    // Apply defaults for optional parameters not provided
+  private warnForOversizedStringParameter(key: string, value: unknown, actualType: string): void {
+    if (actualType !== 'string' || (value as string).length <= AGENT_LIMITS.MAX_GOAL_LENGTH) {
+      return;
+    }
+    logger.warn('Parameter string value exceeds MAX_GOAL_LENGTH (advisory)', {
+      paramName: key,
+      valueLength: (value as string).length,
+      maxLength: AGENT_LIMITS.MAX_GOAL_LENGTH,
+    });
+  }
+
+  private applyParameterDefaults(
+    paramDefs: AgentGoalParameter[],
+    parameters: Record<string, unknown>
+  ): void {
     for (const paramDef of paramDefs) {
       if (!paramDef.required && !(paramDef.name in parameters) && paramDef.default !== undefined) {
         parameters[paramDef.name] = paramDef.default;
@@ -1469,102 +1570,142 @@ export class AgentManager extends BaseElementManager<Agent> {
   ): Promise<string[] | null> {
     // Cache loaded agents to avoid redundant I/O during DFS
     const agentCache = new Map<string, string[] | null>();
-
-    // Helper: load an agent's activates.agents list (cached)
-    const getActivatedAgents = async (name: string): Promise<string[]> => {
-      const cacheKey = name.toLowerCase();
-      if (agentCache.has(cacheKey)) {
-        return agentCache.get(cacheKey) || [];
-      }
-      try {
-        const agent = await this.read(name);
-        if (!agent) {
-          logger.warn(`Agent '${name}' referenced in activates.agents could not be resolved during cycle detection`);
-          agentCache.set(cacheKey, null);
-          return [];
-        }
-        const meta = agent.metadata as AgentMetadataV2;
-        const agents = meta.activates?.agents || [];
-        agentCache.set(cacheKey, agents);
-        return agents;
-      } catch {
-        logger.warn(`Agent '${name}' referenced in activates.agents could not be resolved during cycle detection`);
-        agentCache.set(cacheKey, null);
-        return [];
-      }
-    };
-
-    // Tracks nodes whose entire subtree has been explored without finding a cycle.
-    // Prevents exponential re-exploration in diamond/convergent graphs.
     const fullyExplored = new Set<string>();
     let nodesVisited = 0;
-
-    // DFS — stack entries: [currentAgent, pathSoFar, pathSetLower]
-    // pathSetLower is a Set<string> of lowercased names for O(1) cycle checks
-    const stack: Array<[string, string[], Set<string>]> = [];
-
-    const rootLower = rootName.toLowerCase();
-    for (const child of activatedAgents) {
-      // Self-loop: agent directly activates itself
-      if (child.toLowerCase() === rootLower) {
-        return [rootName, child];
-      }
-      const pathSet = new Set<string>([rootLower, child.toLowerCase()]);
-      stack.push([child, [rootName, child], pathSet]);
+    const initial = AgentManager.createActivationCycleStack(rootName, activatedAgents);
+    if (initial.selfLoop) {
+      return initial.selfLoop;
     }
 
-    while (stack.length > 0) {
-      const [current, currentPath, pathSet] = stack.pop()!;
-
+    while (initial.stack.length > 0) {
+      const entry = initial.stack.pop();
+      if (!entry) {
+        continue;
+      }
       nodesVisited++;
-      if (nodesVisited > AgentManager.MAX_NODES_VISITED) {
-        logger.warn(
-          `Activation cycle detection for '${rootName}' aborted: exceeded ${AgentManager.MAX_NODES_VISITED} nodes visited. ` +
-          `The activation graph may be too large.`
-        );
+      const decision = AgentManager.getCycleDetectionDecision(rootName, entry.path, nodesVisited);
+      if (decision === 'abort') {
         return null;
       }
-
-      if (currentPath.length > AgentManager.MAX_ACTIVATION_DEPTH + 1) {
-        logger.warn(
-          `Activation cycle detection for '${rootName}' hit depth limit of ${AgentManager.MAX_ACTIVATION_DEPTH}. ` +
-          `Skipping deeper branches.`
-        );
+      if (decision === 'skip') {
         continue;
       }
-
-      const currentLower = current.toLowerCase();
-      if (fullyExplored.has(currentLower)) {
-        continue;
-      }
-
-      // Load this agent's activations
-      const children = await getActivatedAgents(current);
-
-      let foundCycle = false;
-      for (const child of children) {
-        const childLower = child.toLowerCase();
-
-        // Check for cycle: does this child appear earlier in the path?
-        if (pathSet.has(childLower)) {
-          return [...currentPath, child];
-        }
-
-        if (!fullyExplored.has(childLower)) {
-          const newPathSet = new Set(pathSet);
-          newPathSet.add(childLower);
-          stack.push([child, [...currentPath, child], newPathSet]);
-          foundCycle = true; // has children to explore, not fully explored yet
-        }
-      }
-
-      // If no unexplored children, this node's subtree is cycle-free
-      if (!foundCycle) {
-        fullyExplored.add(currentLower);
+      const cycle = await this.expandActivationCycleEntry(entry, fullyExplored, agentCache, initial.stack);
+      if (cycle) {
+        return cycle;
       }
     }
 
     return null;
+  }
+
+  private static createActivationCycleStack(
+    rootName: string,
+    activatedAgents: string[]
+  ): {
+    stack: Array<{ current: string; path: string[]; pathSet: Set<string> }>;
+    selfLoop: string[] | null;
+  } {
+    const stack: Array<{ current: string; path: string[]; pathSet: Set<string> }> = [];
+    const rootLower = rootName.toLowerCase();
+    for (const child of activatedAgents) {
+      if (child.toLowerCase() === rootLower) {
+        return { stack, selfLoop: [rootName, child] };
+      }
+      stack.push({
+        current: child,
+        path: [rootName, child],
+        pathSet: new Set<string>([rootLower, child.toLowerCase()]),
+      });
+    }
+    return { stack, selfLoop: null };
+  }
+
+  private static getCycleDetectionDecision(
+    rootName: string,
+    currentPath: string[],
+    nodesVisited: number
+  ): 'continue' | 'skip' | 'abort' {
+    if (nodesVisited > AgentManager.MAX_NODES_VISITED) {
+      logger.warn(
+        `Activation cycle detection for '${rootName}' aborted: exceeded ${AgentManager.MAX_NODES_VISITED} nodes visited. ` +
+        `The activation graph may be too large.`
+      );
+      return 'abort';
+    }
+
+    if (currentPath.length > AgentManager.MAX_ACTIVATION_DEPTH + 1) {
+      logger.warn(
+        `Activation cycle detection for '${rootName}' hit depth limit of ${AgentManager.MAX_ACTIVATION_DEPTH}. ` +
+        `Skipping deeper branches.`
+      );
+      return 'skip';
+    }
+    return 'continue';
+  }
+
+  private async expandActivationCycleEntry(
+    entry: { current: string; path: string[]; pathSet: Set<string> },
+    fullyExplored: Set<string>,
+    agentCache: Map<string, string[] | null>,
+    stack: Array<{ current: string; path: string[]; pathSet: Set<string> }>
+  ): Promise<string[] | null> {
+    const currentLower = entry.current.toLowerCase();
+    if (fullyExplored.has(currentLower)) {
+      return null;
+    }
+
+    const children = await this.getCachedActivatedAgents(entry.current, agentCache);
+    const expansion = AgentManager.enqueueActivationChildren(entry, children, fullyExplored, stack);
+    if (!expansion.foundUnexplored) {
+      fullyExplored.add(currentLower);
+    }
+    return expansion.cyclePath;
+  }
+
+  private async getCachedActivatedAgents(
+    name: string,
+    agentCache: Map<string, string[] | null>
+  ): Promise<string[]> {
+    const cacheKey = name.toLowerCase();
+    if (agentCache.has(cacheKey)) {
+      return agentCache.get(cacheKey) || [];
+    }
+    try {
+      const agent = await this.read(name);
+      const agents = agent ? (agent.metadata as AgentMetadataV2).activates?.agents || [] : null;
+      if (!agents) {
+        logger.warn(`Agent '${name}' referenced in activates.agents could not be resolved during cycle detection`);
+      }
+      agentCache.set(cacheKey, agents);
+      return agents || [];
+    } catch {
+      logger.warn(`Agent '${name}' referenced in activates.agents could not be resolved during cycle detection`);
+      agentCache.set(cacheKey, null);
+      return [];
+    }
+  }
+
+  private static enqueueActivationChildren(
+    entry: { current: string; path: string[]; pathSet: Set<string> },
+    children: string[],
+    fullyExplored: Set<string>,
+    stack: Array<{ current: string; path: string[]; pathSet: Set<string> }>
+  ): { cyclePath: string[] | null; foundUnexplored: boolean } {
+    let foundUnexplored = false;
+    for (const child of children) {
+      const childLower = child.toLowerCase();
+      if (entry.pathSet.has(childLower)) {
+        return { cyclePath: [...entry.path, child], foundUnexplored: true };
+      }
+      if (!fullyExplored.has(childLower)) {
+        const newPathSet = new Set(entry.pathSet);
+        newPathSet.add(childLower);
+        stack.push({ current: child, path: [...entry.path, child], pathSet: newPathSet });
+        foundUnexplored = true;
+      }
+    }
+    return { cyclePath: null, foundUnexplored };
   }
 
   /**
@@ -1854,23 +1995,34 @@ export class AgentManager extends BaseElementManager<Agent> {
   }
 
   protected override async parseMetadata(data: any): Promise<AgentMetadata> {
-    const metadata = { ...(data as any) };
+    const metadata = { ...data };
+    this.normalizeAndValidateMetadataHeader(metadata);
+    this.validateMetadataTextFields(metadata);
+    this.validateMetadataSpecializations(metadata);
+    this.validateMetadataTriggersAndPolicy(metadata);
+    const agentName = metadata.name || 'unknown';
+    this.normalizeAndValidateGoal(metadata, agentName);
+    this.validateActivatesMetadata(metadata, agentName);
+    this.validateToolsMetadata(metadata, agentName);
+    this.normalizeAndValidateSystemPrompt(metadata, agentName);
+    this.promoteRootAutonomyFields(metadata, agentName);
+    this.validateAutonomyMetadata(metadata, agentName);
+    this.validateResilienceMetadata(metadata, agentName);
+    this.validateTagsMetadata(metadata, agentName);
 
-    // --- START: Backward Compatibility Fix for Legacy Agent Types ---
-    // Legacy agent definition files might use 'agent' (singular) instead of
-    // ElementType.AGENT ('agents'). This converts the singular form to the
-    // correct plural enum value to ensure backward compatibility.
+    return metadata as AgentMetadata;
+  }
+
+  private normalizeAndValidateMetadataHeader(metadata: Record<string, any>): void {
     if (metadata.type === 'agent') {
       metadata.type = ElementType.AGENT;
     }
-    // --- END: Backward Compatibility Fix ---
-
-    // Validate that the type is now ElementType.AGENT (plural)
     if (metadata.type && metadata.type !== ElementType.AGENT) {
       throw new Error(`Invalid element type: expected '${ElementType.AGENT}', got '${metadata.type}'`);
     }
+  }
 
-    // REFACTORED: Use ValidationService for name validation
+  private validateMetadataTextFields(metadata: Record<string, any>): void {
     if (metadata.name) {
       const nameResult = this.validationService.validateAndSanitizeInput(metadata.name, {
         maxLength: SECURITY_LIMITS.MAX_NAME_LENGTH,
@@ -1882,8 +2034,6 @@ export class AgentManager extends BaseElementManager<Agent> {
       metadata.name = nameResult.sanitizedValue;
     }
 
-    // REFACTORED: Use ValidationService for description validation
-    // FIX: Must specify fieldType: 'description' to allow punctuation like colons, semicolons, etc.
     if (metadata.description) {
       const descResult = this.validationService.validateAndSanitizeInput(metadata.description, {
         maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
@@ -1895,24 +2045,28 @@ export class AgentManager extends BaseElementManager<Agent> {
       }
       metadata.description = descResult.sanitizedValue;
     }
+  }
 
-    // REFACTORED: Use ValidationService for specializations array
-    if (Array.isArray(metadata.specializations)) {
-      const validatedSpecializations: string[] = [];
-      for (const value of metadata.specializations) {
-        const result = this.validationService.validateAndSanitizeInput(String(value), {
-          maxLength: SECURITY_LIMITS.MAX_TAG_LENGTH,
-          allowSpaces: true
-        });
-        if (!result.isValid) {
-          throw new Error(`Invalid specialization "${value}": ${result.errors?.join(', ')}`);
-        }
-        validatedSpecializations.push(result.sanitizedValue!);
-      }
-      metadata.specializations = validatedSpecializations;
+  private validateMetadataSpecializations(metadata: Record<string, any>): void {
+    if (!Array.isArray(metadata.specializations)) {
+      return;
     }
 
-    // KEEP: TriggerValidationService (already using service pattern)
+    const validatedSpecializations: string[] = [];
+    for (const value of metadata.specializations) {
+      const result = this.validationService.validateAndSanitizeInput(String(value), {
+        maxLength: SECURITY_LIMITS.MAX_TAG_LENGTH,
+        allowSpaces: true
+      });
+      if (!result.isValid) {
+        throw new Error(`Invalid specialization "${value}": ${result.errors?.join(', ')}`);
+      }
+      validatedSpecializations.push(result.sanitizedValue!);
+    }
+    metadata.specializations = validatedSpecializations;
+  }
+
+  private validateMetadataTriggersAndPolicy(metadata: Record<string, any>): void {
     if (metadata.triggers && Array.isArray(metadata.triggers)) {
       const validationResult = this.triggerValidationService.validateTriggers(
         metadata.triggers,
@@ -1921,215 +2075,210 @@ export class AgentManager extends BaseElementManager<Agent> {
       );
       metadata.triggers = validationResult.validTriggers;
     }
-
-    // Issue #676: Sanitize gatekeeper policy on load to prevent prompt-injection attacks
-    // Malformed policies are stripped and logged as security events (never reach enforcement)
     if (metadata.gatekeeper) {
-      metadata.gatekeeper = sanitizeGatekeeperPolicy(metadata.gatekeeper, metadata.name || 'unknown', 'agent', metadata as Record<string, unknown>);
+      metadata.gatekeeper = sanitizeGatekeeperPolicy(
+        metadata.gatekeeper,
+        metadata.name || 'unknown',
+        'agent',
+        metadata as Record<string, unknown>
+      );
     }
+  }
 
-    // Issue #722: Validate V2 agent fields on load — structural checks, strip malformed data.
-    // Fail-open: corrupted fields are removed and logged, not thrown. This prevents
-    // bad data from reaching execution time while keeping the agent loadable.
-    const agentName = metadata.name || 'unknown';
-
-    // Issue #697: Normalize `goals` (plural) → `goal` (singular)
+  private normalizeAndValidateGoal(metadata: Record<string, any>, agentName: string): void {
     if (metadata.goals !== undefined && metadata.goal === undefined) {
       metadata.goal = metadata.goals;
       delete metadata.goals;
       logger.warn(`[parseMetadata] Agent '${agentName}': migrated 'goals' (plural) to 'goal'`);
     } else if (metadata.goals !== undefined) {
-      // `goal` already set — drop the redundant plural form
       delete metadata.goals;
     }
 
-    if (metadata.goal) {
-      if (typeof metadata.goal === 'object' && typeof metadata.goal.template === 'string') {
-        // Issue #725: Normalize snake_case goal sub-fields
-        normalizeGoalKeys(metadata.goal as unknown as Record<string, unknown>);
+    if (!metadata.goal) {
+      return;
+    }
+    if (typeof metadata.goal === 'object' && typeof metadata.goal.template === 'string') {
+      normalizeGoalKeys(metadata.goal as unknown as Record<string, unknown>);
+      this.stripMalformedGoalArrays(metadata.goal, agentName);
+      return;
+    }
+    if (typeof metadata.goal !== 'string') {
+      logger.warn(`[parseMetadata] Agent '${agentName}': goal is malformed (no template), stripping`);
+      delete metadata.goal;
+    }
+  }
 
-        // Validate parameters array if present
-        if (metadata.goal.parameters && !Array.isArray(metadata.goal.parameters)) {
-          logger.warn(`[parseMetadata] Agent '${agentName}': goal.parameters is not an array, stripping`);
-          delete metadata.goal.parameters;
-        }
-        // Validate successCriteria array if present
-        if (metadata.goal.successCriteria && !Array.isArray(metadata.goal.successCriteria)) {
-          logger.warn(`[parseMetadata] Agent '${agentName}': goal.successCriteria is not an array, stripping`);
-          delete metadata.goal.successCriteria;
-        }
-      } else if (typeof metadata.goal !== 'string') {
-        // goal must be a string or an object with template — anything else is invalid
-        logger.warn(`[parseMetadata] Agent '${agentName}': goal is malformed (no template), stripping`);
-        delete metadata.goal;
+  private stripMalformedGoalArrays(goal: Record<string, any>, agentName: string): void {
+    if (goal.parameters && !Array.isArray(goal.parameters)) {
+      logger.warn(`[parseMetadata] Agent '${agentName}': goal.parameters is not an array, stripping`);
+      delete goal.parameters;
+    }
+    if (goal.successCriteria && !Array.isArray(goal.successCriteria)) {
+      logger.warn(`[parseMetadata] Agent '${agentName}': goal.successCriteria is not an array, stripping`);
+      delete goal.successCriteria;
+    }
+  }
+
+  private validateActivatesMetadata(metadata: Record<string, any>, agentName: string): void {
+    if (!metadata.activates) {
+      return;
+    }
+    if (typeof metadata.activates !== 'object' || Array.isArray(metadata.activates)) {
+      logger.warn(`[parseMetadata] Agent '${agentName}': activates is not an object, stripping`);
+      delete metadata.activates;
+      return;
+    }
+    for (const [key, value] of Object.entries(metadata.activates)) {
+      if (value !== undefined && !Array.isArray(value)) {
+        logger.warn(`[parseMetadata] Agent '${agentName}': activates.${key} is not an array, stripping`);
+        delete metadata.activates[key];
       }
     }
+  }
 
-    if (metadata.activates) {
-      if (typeof metadata.activates !== 'object' || Array.isArray(metadata.activates)) {
-        logger.warn(`[parseMetadata] Agent '${agentName}': activates is not an object, stripping`);
-        delete metadata.activates;
-      } else {
-        // Each key should map to a string array
-        for (const [key, value] of Object.entries(metadata.activates)) {
-          if (value !== undefined && !Array.isArray(value)) {
-            logger.warn(`[parseMetadata] Agent '${agentName}': activates.${key} is not an array, stripping`);
-            delete metadata.activates[key];
-          }
-        }
-      }
+  private validateToolsMetadata(metadata: Record<string, any>, agentName: string): void {
+    if (!metadata.tools) {
+      return;
     }
+    if (typeof metadata.tools !== 'object' || Array.isArray(metadata.tools)) {
+      logger.warn(`[parseMetadata] Agent '${agentName}': tools is not an object, stripping`);
+      delete metadata.tools;
+      return;
+    }
+    if (!Array.isArray(metadata.tools.allowed)) {
+      logger.warn(`[parseMetadata] Agent '${agentName}': tools.allowed is not an array, stripping tools`);
+      delete metadata.tools;
+      return;
+    }
+    if (metadata.tools.denied !== undefined && !Array.isArray(metadata.tools.denied)) {
+      logger.warn(`[parseMetadata] Agent '${agentName}': tools.denied is not an array, stripping`);
+      delete metadata.tools.denied;
+    }
+  }
 
-    if (metadata.tools) {
-      if (typeof metadata.tools !== 'object' || Array.isArray(metadata.tools)) {
-        logger.warn(`[parseMetadata] Agent '${agentName}': tools is not an object, stripping`);
-        delete metadata.tools;
-      } else if (!Array.isArray(metadata.tools.allowed)) {
-        logger.warn(`[parseMetadata] Agent '${agentName}': tools.allowed is not an array, stripping tools`);
-        delete metadata.tools;
-      } else {
-        // Gap 3: Validate tools.denied is an array if present
-        if (metadata.tools.denied !== undefined && !Array.isArray(metadata.tools.denied)) {
-          logger.warn(`[parseMetadata] Agent '${agentName}': tools.denied is not an array, stripping`);
-          delete metadata.tools.denied;
-        }
-      }
+  private normalizeAndValidateSystemPrompt(metadata: Record<string, any>, agentName: string): void {
+    if (metadata.system_prompt !== undefined && metadata.systemPrompt === undefined) {
+      metadata.systemPrompt = metadata.system_prompt;
     }
-
-    // Issue #725: Normalize system_prompt → systemPrompt (LLMs commonly use snake_case)
-    const anyMeta = metadata as Record<string, unknown>;
-    if (anyMeta.system_prompt !== undefined && metadata.systemPrompt === undefined) {
-      anyMeta.systemPrompt = anyMeta.system_prompt;
-    }
-    delete anyMeta.system_prompt;
+    delete metadata.system_prompt;
 
     if (metadata.systemPrompt !== undefined && typeof metadata.systemPrompt !== 'string') {
       logger.warn(`[parseMetadata] Agent '${agentName}': systemPrompt is not a string, stripping`);
       delete metadata.systemPrompt;
     }
+  }
 
-    // Issue #697: Promote root-level V1 autonomy fields into the `autonomy` block.
-    // V1 agents stored riskTolerance and maxAutonomousSteps at the metadata root.
-    // V2 nests them under `autonomy`. This promotion ensures downstream code only
-    // checks one location. The existing autonomy validation below validates values.
-    // Precedence: camelCase variants are listed before snake_case/short forms, so
-    // e.g. `riskTolerance` wins over `risk_tolerance` if both appear at root.
-    {
-      const rootAutonomyFields: ReadonlyArray<readonly [string, string]> = [
-        ['riskTolerance', 'riskTolerance'],
-        ['risk_tolerance', 'riskTolerance'],
-        ['maxAutonomousSteps', 'maxAutonomousSteps'],
-        ['max_autonomous_steps', 'maxAutonomousSteps'],
-        ['maxSteps', 'maxAutonomousSteps'],
-      ] as const;
-      let promoted = false;
-      for (const [rootKey, autonomyKey] of rootAutonomyFields) {
-        if (anyMeta[rootKey] !== undefined) {
-          if (!metadata.autonomy) {
-            metadata.autonomy = {};
-          }
-          const aBlock = metadata.autonomy as Record<string, unknown>;
-          if (aBlock[autonomyKey] === undefined) {
-            aBlock[autonomyKey] = anyMeta[rootKey];
-            promoted = true;
-          }
-          delete anyMeta[rootKey];
+  private promoteRootAutonomyFields(metadata: Record<string, any>, agentName: string): void {
+    const rootAutonomyFields: ReadonlyArray<readonly [string, string]> = [
+      ['riskTolerance', 'riskTolerance'],
+      ['risk_tolerance', 'riskTolerance'],
+      ['maxAutonomousSteps', 'maxAutonomousSteps'],
+      ['max_autonomous_steps', 'maxAutonomousSteps'],
+      ['maxSteps', 'maxAutonomousSteps'],
+    ] as const;
+    let promoted = false;
+    for (const [rootKey, autonomyKey] of rootAutonomyFields) {
+      if (metadata[rootKey] !== undefined) {
+        metadata.autonomy ??= {};
+        const aBlock = metadata.autonomy as Record<string, unknown>;
+        if (aBlock[autonomyKey] === undefined) {
+          aBlock[autonomyKey] = metadata[rootKey];
+          promoted = true;
         }
-      }
-      if (promoted) {
-        logger.warn(`[parseMetadata] Agent '${agentName}': promoted root-level autonomy fields into autonomy block`);
+        delete metadata[rootKey];
       }
     }
+    if (promoted) {
+      logger.warn(`[parseMetadata] Agent '${agentName}': promoted root-level autonomy fields into autonomy block`);
+    }
+  }
 
-    if (metadata.autonomy) {
-      if (typeof metadata.autonomy !== 'object' || Array.isArray(metadata.autonomy)) {
-        logger.warn(`[parseMetadata] Agent '${agentName}': autonomy is not an object, stripping`);
-        delete metadata.autonomy;
-      } else {
-        // Issue #730: Shared normalization (was duplicated in parseMetadata + validateV2FieldsForCreate)
-        const a = metadata.autonomy as Record<string, unknown>;
-        normalizeAutonomyKeys(a);
-
-        // Validate specific fields
-        // Gap 4: Validate riskTolerance enum (uses shared constants from Issue #727)
-        if (a.riskTolerance !== undefined &&
-            !isOneOf(a.riskTolerance, RISK_TOLERANCE_LEVELS)) {
-          logger.warn(`[parseMetadata] Agent '${agentName}': autonomy.riskTolerance '${a.riskTolerance}' is invalid, stripping`);
-          delete a.riskTolerance;
-        }
-        if (a.maxAutonomousSteps !== undefined &&
-            typeof a.maxAutonomousSteps !== 'number') {
-          logger.warn(`[parseMetadata] Agent '${agentName}': autonomy.maxAutonomousSteps is not a number, stripping`);
-          delete a.maxAutonomousSteps;
-        }
-        if (a.requiresApproval !== undefined &&
-            !Array.isArray(a.requiresApproval)) {
-          logger.warn(`[parseMetadata] Agent '${agentName}': autonomy.requiresApproval is not an array, stripping`);
-          delete a.requiresApproval;
-        }
-        if (a.autoApprove !== undefined &&
-            !Array.isArray(a.autoApprove)) {
-          logger.warn(`[parseMetadata] Agent '${agentName}': autonomy.autoApprove is not an array, stripping`);
-          delete a.autoApprove;
-        }
-      }
+  private validateAutonomyMetadata(metadata: Record<string, any>, agentName: string): void {
+    if (!metadata.autonomy) {
+      return;
+    }
+    if (typeof metadata.autonomy !== 'object' || Array.isArray(metadata.autonomy)) {
+      logger.warn(`[parseMetadata] Agent '${agentName}': autonomy is not an object, stripping`);
+      delete metadata.autonomy;
+      return;
     }
 
-    if (metadata.resilience) {
-      if (typeof metadata.resilience !== 'object' || Array.isArray(metadata.resilience)) {
-        logger.warn(`[parseMetadata] Agent '${agentName}': resilience is not an object, stripping`);
-        delete metadata.resilience;
-      } else {
-        // Issue #730: Shared normalization (was duplicated in parseMetadata + validateV2FieldsForCreate)
-        const r = metadata.resilience as Record<string, unknown>;
-        normalizeResilienceKeys(r);
+    const a = metadata.autonomy as Record<string, unknown>;
+    normalizeAutonomyKeys(a);
+    this.stripInvalidEnumField(a, 'riskTolerance', RISK_TOLERANCE_LEVELS, `autonomy.riskTolerance`, agentName);
+    this.stripInvalidTypedField(a, 'maxAutonomousSteps', 'number', `autonomy.maxAutonomousSteps`, agentName);
+    this.stripInvalidArrayField(a, 'requiresApproval', `autonomy.requiresApproval`, agentName);
+    this.stripInvalidArrayField(a, 'autoApprove', `autonomy.autoApprove`, agentName);
+  }
 
-        // Issue #727: Use shared enum constants for resilience validation
-        if (r.onStepLimitReached !== undefined &&
-            !isOneOf(r.onStepLimitReached, STEP_LIMIT_ACTIONS)) {
-          logger.warn(`[parseMetadata] Agent '${agentName}': resilience.onStepLimitReached '${r.onStepLimitReached}' is invalid, stripping`);
-          delete r.onStepLimitReached;
-        }
-        if (r.onExecutionFailure !== undefined &&
-            !isOneOf(r.onExecutionFailure, EXECUTION_FAILURE_ACTIONS)) {
-          logger.warn(`[parseMetadata] Agent '${agentName}': resilience.onExecutionFailure '${r.onExecutionFailure}' is invalid, stripping`);
-          delete r.onExecutionFailure;
-        }
-        if (r.maxRetries !== undefined &&
-            typeof r.maxRetries !== 'number') {
-          logger.warn(`[parseMetadata] Agent '${agentName}': resilience.maxRetries is not a number, stripping`);
-          delete r.maxRetries;
-        }
-        if (r.maxContinuations !== undefined &&
-            typeof r.maxContinuations !== 'number') {
-          logger.warn(`[parseMetadata] Agent '${agentName}': resilience.maxContinuations is not a number, stripping`);
-          delete r.maxContinuations;
-        }
-        // Gap 5: Validate retryBackoff enum and preserveState boolean (shared constants from Issue #727)
-        if (r.retryBackoff !== undefined &&
-            !isOneOf(r.retryBackoff, BACKOFF_STRATEGIES)) {
-          logger.warn(`[parseMetadata] Agent '${agentName}': resilience.retryBackoff '${r.retryBackoff}' is invalid, stripping`);
-          delete r.retryBackoff;
-        }
-        if (r.preserveState !== undefined &&
-            typeof r.preserveState !== 'boolean') {
-          logger.warn(`[parseMetadata] Agent '${agentName}': resilience.preserveState is not a boolean, stripping`);
-          delete r.preserveState;
-        }
-      }
+  private validateResilienceMetadata(metadata: Record<string, any>, agentName: string): void {
+    if (!metadata.resilience) {
+      return;
+    }
+    if (typeof metadata.resilience !== 'object' || Array.isArray(metadata.resilience)) {
+      logger.warn(`[parseMetadata] Agent '${agentName}': resilience is not an object, stripping`);
+      delete metadata.resilience;
+      return;
     }
 
-    // Tags: validate as string array (common field, all element types)
-    if (metadata.tags !== undefined) {
-      if (!Array.isArray(metadata.tags)) {
-        logger.warn(`[parseMetadata] Agent '${agentName}': tags is not an array, stripping`);
-        delete metadata.tags;
-      } else {
-        metadata.tags = metadata.tags.filter((t: unknown) => typeof t === 'string');
-      }
-    }
+    const r = metadata.resilience as Record<string, unknown>;
+    normalizeResilienceKeys(r);
+    this.stripInvalidEnumField(r, 'onStepLimitReached', STEP_LIMIT_ACTIONS, `resilience.onStepLimitReached`, agentName);
+    this.stripInvalidEnumField(r, 'onExecutionFailure', EXECUTION_FAILURE_ACTIONS, `resilience.onExecutionFailure`, agentName);
+    this.stripInvalidTypedField(r, 'maxRetries', 'number', `resilience.maxRetries`, agentName);
+    this.stripInvalidTypedField(r, 'maxContinuations', 'number', `resilience.maxContinuations`, agentName);
+    this.stripInvalidEnumField(r, 'retryBackoff', BACKOFF_STRATEGIES, `resilience.retryBackoff`, agentName);
+    this.stripInvalidTypedField(r, 'preserveState', 'boolean', `resilience.preserveState`, agentName);
+  }
 
-    return metadata as AgentMetadata;
+  private stripInvalidEnumField(
+    record: Record<string, unknown>,
+    key: string,
+    allowedValues: readonly string[],
+    label: string,
+    agentName: string
+  ): void {
+    if (record[key] !== undefined && !isOneOf(record[key], allowedValues)) {
+      logger.warn(`[parseMetadata] Agent '${agentName}': ${label} '${record[key]}' is invalid, stripping`);
+      delete record[key];
+    }
+  }
+
+  private stripInvalidTypedField(
+    record: Record<string, unknown>,
+    key: string,
+    expectedType: 'number' | 'boolean',
+    label: string,
+    agentName: string
+  ): void {
+    if (record[key] !== undefined && typeof record[key] !== expectedType) {
+      logger.warn(`[parseMetadata] Agent '${agentName}': ${label} is not a ${expectedType}, stripping`);
+      delete record[key];
+    }
+  }
+
+  private stripInvalidArrayField(
+    record: Record<string, unknown>,
+    key: string,
+    label: string,
+    agentName: string
+  ): void {
+    if (record[key] !== undefined && !Array.isArray(record[key])) {
+      logger.warn(`[parseMetadata] Agent '${agentName}': ${label} is not an array, stripping`);
+      delete record[key];
+    }
+  }
+
+  private validateTagsMetadata(metadata: Record<string, any>, agentName: string): void {
+    if (metadata.tags === undefined) {
+      return;
+    }
+    if (!Array.isArray(metadata.tags)) {
+      logger.warn(`[parseMetadata] Agent '${agentName}': tags is not an array, stripping`);
+      delete metadata.tags;
+      return;
+    }
+    metadata.tags = metadata.tags.filter((t: unknown) => typeof t === 'string');
   }
 
   protected override createElement(metadata: AgentMetadata, bodyContent: string): Agent {
@@ -2156,81 +2305,11 @@ export class AgentManager extends BaseElementManager<Agent> {
   }
 
   protected override async serializeElement(agent: Agent): Promise<string> {
-    // Start with base metadata fields (always present)
-    const metadata: Record<string, unknown> = {
-      name: agent.metadata.name,
-      type: toSingularLabel(ElementType.AGENT),
-      unique_id: agent.id,
-      version: agent.metadata.version,
-      author: agent.metadata.author,
-      created: agent.metadata.created ?? new Date().toISOString(),
-      modified: agent.metadata.modified ?? new Date().toISOString(),
-      description: agent.metadata.description,
-      format_version: 'v2',  // Fix #912: Explicit format marker
-    };
-
-    // Cast to check for v2 fields
+    const metadata = this.buildBaseSerializedMetadata(agent);
     const metadataV2 = agent.metadata as AgentMetadataV2;
-
-    // Add v2 fields if present (goal is required in v2, others optional)
-    if (metadataV2.goal) {
-      metadata.goal = metadataV2.goal;
-    }
-    if (metadataV2.activates) {
-      metadata.activates = metadataV2.activates;
-    }
-    if (metadataV2.tools) {
-      metadata.tools = metadataV2.tools;
-    }
-    if (metadataV2.systemPrompt) {
-      metadata.systemPrompt = metadataV2.systemPrompt;
-    }
-    if (metadataV2.autonomy) {
-      metadata.autonomy = metadataV2.autonomy;
-    }
-    // Issue #449: Serialize gatekeeper policy to YAML frontmatter
-    if (metadataV2.gatekeeper) {
-      metadata.gatekeeper = metadataV2.gatekeeper;
-    }
-    // Issue #526: Serialize resilience policy to YAML frontmatter
-    if (metadataV2.resilience) {
-      metadata.resilience = metadataV2.resilience;
-    }
-
-    // Issue #722: Only serialize v1 fields for agents WITHOUT a goal (legacy v1 agents).
-    // V2 agents (with goal) should not carry deprecated v1 baggage like
-    // decisionFramework, riskTolerance, learningEnabled, maxConcurrentGoals.
-    // The Agent constructor still applies these defaults at runtime for backward
-    // compat when reading old files — but we don't write them into new v2 agents.
-    const isV2Agent = !!metadataV2.goal;
-    if (!isV2Agent) {
-      if (metadataV2.decisionFramework) {
-        metadata.decisionFramework = metadataV2.decisionFramework;
-      }
-      if (metadataV2.riskTolerance) {
-        metadata.riskTolerance = metadataV2.riskTolerance;
-      }
-      if (metadataV2.learningEnabled !== undefined) {
-        metadata.learningEnabled = metadataV2.learningEnabled;
-      }
-      if (metadataV2.maxConcurrentGoals !== undefined) {
-        metadata.maxConcurrentGoals = metadataV2.maxConcurrentGoals;
-      }
-    }
-    // specializations is not a deprecated v1 field — always serialize
-    if (metadataV2.specializations) {
-      metadata.specializations = metadataV2.specializations;
-    }
-    // Issue #722: Serialize tags and triggers to YAML frontmatter
-    if (metadataV2.tags && Array.isArray(metadataV2.tags) && metadataV2.tags.length > 0) {
-      metadata.tags = metadataV2.tags;
-    }
-    if (metadataV2.triggers) {
-      metadata.triggers = metadataV2.triggers;
-    }
-    if (metadataV2.ruleEngineConfig !== undefined) {
-      metadata.ruleEngineConfig = metadataV2.ruleEngineConfig;
-    }
+    this.addSerializedV2Metadata(metadata, metadataV2);
+    this.addSerializedLegacyMetadata(metadata, metadataV2);
+    this.addSerializedCommonMetadata(metadata, metadataV2);
 
     // v2.0 format: instructions in YAML frontmatter, content as body
     const instructions = agent.instructions ||
@@ -2248,6 +2327,58 @@ export class AgentManager extends BaseElementManager<Agent> {
       cleaningStrategy: 'remove-both',  // Remove both null and undefined
       sortKeys: true
     });
+  }
+
+  private buildBaseSerializedMetadata(agent: Agent): Record<string, unknown> {
+    return {
+      name: agent.metadata.name,
+      type: toSingularLabel(ElementType.AGENT),
+      unique_id: agent.id,
+      version: agent.metadata.version,
+      author: agent.metadata.author,
+      created: agent.metadata.created ?? new Date().toISOString(),
+      modified: agent.metadata.modified ?? new Date().toISOString(),
+      description: agent.metadata.description,
+      format_version: 'v2',
+    };
+  }
+
+  private addSerializedV2Metadata(
+    metadata: Record<string, unknown>,
+    metadataV2: AgentMetadataV2
+  ): void {
+    if (metadataV2.goal) metadata.goal = metadataV2.goal;
+    if (metadataV2.activates) metadata.activates = metadataV2.activates;
+    if (metadataV2.tools) metadata.tools = metadataV2.tools;
+    if (metadataV2.systemPrompt) metadata.systemPrompt = metadataV2.systemPrompt;
+    if (metadataV2.autonomy) metadata.autonomy = metadataV2.autonomy;
+    if (metadataV2.gatekeeper) metadata.gatekeeper = metadataV2.gatekeeper;
+    if (metadataV2.resilience) metadata.resilience = metadataV2.resilience;
+  }
+
+  private addSerializedLegacyMetadata(
+    metadata: Record<string, unknown>,
+    metadataV2: AgentMetadataV2
+  ): void {
+    if (metadataV2.goal) {
+      return;
+    }
+    if (metadataV2.decisionFramework) metadata.decisionFramework = metadataV2.decisionFramework;
+    if (metadataV2.riskTolerance) metadata.riskTolerance = metadataV2.riskTolerance;
+    if (metadataV2.learningEnabled !== undefined) metadata.learningEnabled = metadataV2.learningEnabled;
+    if (metadataV2.maxConcurrentGoals !== undefined) metadata.maxConcurrentGoals = metadataV2.maxConcurrentGoals;
+  }
+
+  private addSerializedCommonMetadata(
+    metadata: Record<string, unknown>,
+    metadataV2: AgentMetadataV2
+  ): void {
+    if (metadataV2.specializations) metadata.specializations = metadataV2.specializations;
+    if (metadataV2.tags && Array.isArray(metadataV2.tags) && metadataV2.tags.length > 0) {
+      metadata.tags = metadataV2.tags;
+    }
+    if (metadataV2.triggers) metadata.triggers = metadataV2.triggers;
+    if (metadataV2.ruleEngineConfig !== undefined) metadata.ruleEngineConfig = metadataV2.ruleEngineConfig;
   }
 
   private buildDefaultInstructions(agent: Agent): string {
@@ -2296,104 +2427,124 @@ export class AgentManager extends BaseElementManager<Agent> {
    */
   private validateV2FieldsForCreate(metadata: Partial<AgentMetadataV2>): string[] {
     const errors: string[] = [];
+    this.validateCreateTools(metadata, errors);
+    this.validateCreateSystemPrompt(metadata, errors);
+    this.validateCreateAutonomy(metadata, errors);
+    this.validateCreateResilience(metadata, errors);
+    this.validateCreateActivates(metadata, errors);
+    return errors;
+  }
 
-    // --- tools ---
-    if (metadata.tools !== undefined) {
-      if (typeof metadata.tools !== 'object' || Array.isArray(metadata.tools) || metadata.tools === null) {
-        errors.push('tools must be an object with allowed/denied arrays');
-      } else {
-        if (!Array.isArray(metadata.tools.allowed)) {
-          errors.push('tools.allowed is required and must be an array of strings');
-        }
-        if (metadata.tools.denied !== undefined && !Array.isArray(metadata.tools.denied)) {
-          errors.push('tools.denied must be an array of strings');
-        }
-      }
+  private validateCreateTools(metadata: Partial<AgentMetadataV2>, errors: string[]): void {
+    if (metadata.tools === undefined) {
+      return;
     }
+    if (typeof metadata.tools !== 'object' || Array.isArray(metadata.tools) || metadata.tools === null) {
+      errors.push('tools must be an object with allowed/denied arrays');
+      return;
+    }
+    if (!Array.isArray(metadata.tools.allowed)) {
+      errors.push('tools.allowed is required and must be an array of strings');
+    }
+    if (metadata.tools.denied !== undefined && !Array.isArray(metadata.tools.denied)) {
+      errors.push('tools.denied must be an array of strings');
+    }
+  }
 
-    // --- systemPrompt ---
+  private validateCreateSystemPrompt(metadata: Partial<AgentMetadataV2>, errors: string[]): void {
     if (metadata.systemPrompt !== undefined && typeof metadata.systemPrompt !== 'string') {
       errors.push('systemPrompt must be a string');
     }
-    // snake_case variant (Issue #725: normalized at dispatcher level eventually)
-    const anyMeta = metadata as Record<string, unknown>;
+
+    const anyMeta: Record<string, unknown> = metadata;
     if (anyMeta.system_prompt !== undefined && metadata.systemPrompt === undefined) {
       if (typeof anyMeta.system_prompt === 'string') {
-        metadata.systemPrompt = anyMeta.system_prompt as string;
+        metadata.systemPrompt = anyMeta.system_prompt;
       } else {
         errors.push('system_prompt must be a string');
       }
       delete anyMeta.system_prompt;
     }
+  }
 
-    // --- autonomy ---
-    if (metadata.autonomy !== undefined) {
-      if (typeof metadata.autonomy !== 'object' || Array.isArray(metadata.autonomy) || metadata.autonomy === null) {
-        errors.push('autonomy must be an object');
-      } else {
-        // Issue #730: Shared normalization
-        const a = metadata.autonomy as Record<string, unknown>;
-        normalizeAutonomyKeys(a);
-
-        // Validate after normalization
-        if (a.riskTolerance !== undefined &&
-            !isOneOf(a.riskTolerance, RISK_TOLERANCE_LEVELS)) {
-          errors.push(`autonomy.riskTolerance must be one of: ${RISK_TOLERANCE_LEVELS.join(', ')} (got '${a.riskTolerance}')`);
-        }
-        if (a.maxAutonomousSteps !== undefined && typeof a.maxAutonomousSteps !== 'number') {
-          errors.push('autonomy.maxAutonomousSteps must be a number');
-        }
-        if (a.requiresApproval !== undefined && !Array.isArray(a.requiresApproval)) {
-          errors.push('autonomy.requiresApproval must be an array of strings');
-        }
-        if (a.autoApprove !== undefined && !Array.isArray(a.autoApprove)) {
-          errors.push('autonomy.autoApprove must be an array of strings');
-        }
-      }
+  private validateCreateAutonomy(metadata: Partial<AgentMetadataV2>, errors: string[]): void {
+    if (metadata.autonomy === undefined) {
+      return;
+    }
+    if (typeof metadata.autonomy !== 'object' || Array.isArray(metadata.autonomy) || metadata.autonomy === null) {
+      errors.push('autonomy must be an object');
+      return;
     }
 
-    // --- resilience ---
-    if (metadata.resilience !== undefined) {
-      if (typeof metadata.resilience !== 'object' || Array.isArray(metadata.resilience) || metadata.resilience === null) {
-        errors.push('resilience must be an object');
-      } else {
-        // Issue #730: Shared normalization
-        const r = metadata.resilience as Record<string, unknown>;
-        normalizeResilienceKeys(r);
+    const a = metadata.autonomy as Record<string, unknown>;
+    normalizeAutonomyKeys(a);
+    this.addEnumValidationError(a, 'riskTolerance', RISK_TOLERANCE_LEVELS, 'autonomy.riskTolerance', errors);
+    this.addTypeValidationError(a, 'maxAutonomousSteps', 'number', 'autonomy.maxAutonomousSteps', errors);
+    this.addArrayValidationError(a, 'requiresApproval', 'autonomy.requiresApproval', errors);
+    this.addArrayValidationError(a, 'autoApprove', 'autonomy.autoApprove', errors);
+  }
 
-        // Validate after normalization
-        if (r.onStepLimitReached !== undefined &&
-            !isOneOf(r.onStepLimitReached, STEP_LIMIT_ACTIONS)) {
-          errors.push(`resilience.onStepLimitReached must be one of: ${STEP_LIMIT_ACTIONS.join(', ')} (got '${r.onStepLimitReached}')`);
-        }
-        if (r.onExecutionFailure !== undefined &&
-            !isOneOf(r.onExecutionFailure, EXECUTION_FAILURE_ACTIONS)) {
-          errors.push(`resilience.onExecutionFailure must be one of: ${EXECUTION_FAILURE_ACTIONS.join(', ')} (got '${r.onExecutionFailure}')`);
-        }
-        if (r.maxRetries !== undefined && typeof r.maxRetries !== 'number') {
-          errors.push('resilience.maxRetries must be a number');
-        }
-        if (r.maxContinuations !== undefined && typeof r.maxContinuations !== 'number') {
-          errors.push('resilience.maxContinuations must be a number');
-        }
-        if (r.retryBackoff !== undefined &&
-            !isOneOf(r.retryBackoff, BACKOFF_STRATEGIES)) {
-          errors.push(`resilience.retryBackoff must be one of: ${BACKOFF_STRATEGIES.join(', ')} (got '${r.retryBackoff}')`);
-        }
-        if (r.preserveState !== undefined && typeof r.preserveState !== 'boolean') {
-          errors.push('resilience.preserveState must be a boolean');
-        }
-      }
+  private validateCreateResilience(metadata: Partial<AgentMetadataV2>, errors: string[]): void {
+    if (metadata.resilience === undefined) {
+      return;
+    }
+    if (typeof metadata.resilience !== 'object' || Array.isArray(metadata.resilience) || metadata.resilience === null) {
+      errors.push('resilience must be an object');
+      return;
     }
 
-    // --- activates ---
-    if (metadata.activates !== undefined) {
-      if (typeof metadata.activates !== 'object' || Array.isArray(metadata.activates) || metadata.activates === null) {
-        errors.push('activates must be an object with skills/personas/memories/templates/ensembles arrays');
-      }
-    }
+    const r = metadata.resilience as Record<string, unknown>;
+    normalizeResilienceKeys(r);
+    this.addEnumValidationError(r, 'onStepLimitReached', STEP_LIMIT_ACTIONS, 'resilience.onStepLimitReached', errors);
+    this.addEnumValidationError(r, 'onExecutionFailure', EXECUTION_FAILURE_ACTIONS, 'resilience.onExecutionFailure', errors);
+    this.addTypeValidationError(r, 'maxRetries', 'number', 'resilience.maxRetries', errors);
+    this.addTypeValidationError(r, 'maxContinuations', 'number', 'resilience.maxContinuations', errors);
+    this.addEnumValidationError(r, 'retryBackoff', BACKOFF_STRATEGIES, 'resilience.retryBackoff', errors);
+    this.addTypeValidationError(r, 'preserveState', 'boolean', 'resilience.preserveState', errors);
+  }
 
-    return errors;
+  private validateCreateActivates(metadata: Partial<AgentMetadataV2>, errors: string[]): void {
+    if (
+      metadata.activates !== undefined &&
+      (typeof metadata.activates !== 'object' || Array.isArray(metadata.activates) || metadata.activates === null)
+    ) {
+      errors.push('activates must be an object with skills/personas/memories/templates/ensembles arrays');
+    }
+  }
+
+  private addEnumValidationError(
+    record: Record<string, unknown>,
+    key: string,
+    allowedValues: readonly string[],
+    label: string,
+    errors: string[]
+  ): void {
+    if (record[key] !== undefined && !isOneOf(record[key], allowedValues)) {
+      errors.push(`${label} must be one of: ${allowedValues.join(', ')} (got '${record[key]}')`);
+    }
+  }
+
+  private addTypeValidationError(
+    record: Record<string, unknown>,
+    key: string,
+    expectedType: 'number' | 'boolean',
+    label: string,
+    errors: string[]
+  ): void {
+    if (record[key] !== undefined && typeof record[key] !== expectedType) {
+      errors.push(`${label} must be a ${expectedType}`);
+    }
+  }
+
+  private addArrayValidationError(
+    record: Record<string, unknown>,
+    key: string,
+    label: string,
+    errors: string[]
+  ): void {
+    if (record[key] !== undefined && !Array.isArray(record[key])) {
+      errors.push(`${label} must be an array of strings`);
+    }
   }
 
   /**
@@ -2426,8 +2577,8 @@ export class AgentManager extends BaseElementManager<Agent> {
       const validParamTypes = ['string', 'number', 'boolean'] as const;
       const validatedParams: AgentGoalParameter[] = (goal.parameters || []).map((p, index) => {
         const name = typeof p.name === 'string' ? p.name : `param_${index}`;
-        const type = validParamTypes.includes(p.type as typeof validParamTypes[number])
-          ? p.type as 'string' | 'number' | 'boolean'
+        const type = validParamTypes.includes(p.type)
+          ? p.type
           : 'string';
         const required = typeof p.required === 'boolean' ? p.required : false;
 

--- a/src/portfolio/EnhancedIndexManager.ts
+++ b/src/portfolio/EnhancedIndexManager.ts
@@ -344,7 +344,6 @@ export class EnhancedIndexManager {
    * Build or rebuild the index from portfolio
    */
   private async buildIndex(options: IndexOptions = {}): Promise<void> {
-    // Use file locking to prevent concurrent builds
     const config = this.config.getConfig();
     const indexPath = this.indexPath;
     const fileLock = this.getFileLock(indexPath);
@@ -362,93 +361,113 @@ export class EnhancedIndexManager {
     const startTime = Date.now();
 
     try {
-      // Get existing index for preservation of custom fields
       const existingIndex = options.preserveCustom && this.index ? this.index : null;
-
-      // Initialize new index structure
-      const newIndex: EnhancedIndex = {
-        metadata: {
-          version: '2.0.0',
-          created: existingIndex?.metadata.created || new Date().toISOString(),
-          last_updated: new Date().toISOString(),
-          total_elements: 0
-        },
-        action_triggers: {},
-        elements: {}
-      };
-
-      // Get portfolio index for element discovery
+      const newIndex = EnhancedIndexManager.createEmptyEnhancedIndex(existingIndex);
       const portfolioData = await this.portfolioIndexManager.getIndex();
-
-      // Process each element type
-      for (const [elementType, entries] of portfolioData.byType.entries()) {
-        if (!newIndex.elements[elementType]) {
-          newIndex.elements[elementType] = {};
-        }
-
-        for (const entry of entries) {
-          // Skip if not in update list (when specified)
-          // FIX: Add defensive check for entry.metadata
-          const entryName = entry.metadata?.name;
-          if (!entryName) {
-            logger.warn('Skipping entry with undefined metadata.name');
-            continue;
-          }
-
-          if (options.updateOnly && !options.updateOnly.includes(entryName)) {
-            // Preserve existing entry
-            if (existingIndex?.elements[elementType]?.[entryName]) {
-              newIndex.elements[elementType][entryName] =
-                existingIndex.elements[elementType][entryName];
-              continue;
-            }
-          }
-
-          const elementDef = this.elementDefinitionBuilder.build(entry, existingIndex);
-          newIndex.elements[elementType][entryName] = elementDef;
-          newIndex.metadata.total_elements++;
-
-          // Extract action triggers
-          this.extractActionTriggers(elementDef, entryName, newIndex.action_triggers);
-        }
-      }
-
-      // Calculate semantic relationships using NLP
+      this.populateEnhancedIndex(newIndex, portfolioData.byType, existingIndex, options);
       await this.calculateSemanticRelationships(newIndex);
-
-      // Discover additional relationship types
       await this.relationshipManager.discoverRelationships(newIndex);
-
-      // Preserve extensions from existing index
-      if (existingIndex?.extensions) {
-        newIndex.extensions = existingIndex.extensions;
-      }
-
-      // Save to file
-      await this.writeToFile(newIndex);
-
-      this.index = newIndex;
-      this.lastLoaded = new Date();
-
-      const duration = Date.now() - startTime;
-      logger.info('Enhanced index built', {
-        duration: `${duration}ms`,
-        elements: newIndex.metadata.total_elements,
-        triggers: Object.keys(newIndex.action_triggers).length
-      });
-
-      // Log security event
-      SecurityMonitor.logSecurityEvent({
-        type: 'PORTFOLIO_CACHE_INVALIDATION',
-        severity: 'LOW',
-        source: 'enhanced_index',
-        details: `Index rebuilt with ${newIndex.metadata.total_elements} elements in ${duration}ms`
-      });
+      await this.commitBuiltIndex(newIndex, existingIndex, startTime);
 
     } finally {
       this.isBuilding = false;
       await fileLock.release();
     }
+  }
+
+  private static createEmptyEnhancedIndex(existingIndex: EnhancedIndex | null): EnhancedIndex {
+    return {
+      metadata: {
+        version: '2.0.0',
+        created: existingIndex?.metadata.created || new Date().toISOString(),
+        last_updated: new Date().toISOString(),
+        total_elements: 0
+      },
+      action_triggers: {},
+      elements: {}
+    };
+  }
+
+  private populateEnhancedIndex(
+    newIndex: EnhancedIndex,
+    entriesByType: Map<string, any[]>,
+    existingIndex: EnhancedIndex | null,
+    options: IndexOptions
+  ): void {
+    for (const [elementType, entries] of entriesByType.entries()) {
+      newIndex.elements[elementType] ??= {};
+      for (const entry of entries) {
+        this.addEnhancedIndexEntry(newIndex, elementType, entry, existingIndex, options);
+      }
+    }
+  }
+
+  private addEnhancedIndexEntry(
+    newIndex: EnhancedIndex,
+    elementType: string,
+    entry: any,
+    existingIndex: EnhancedIndex | null,
+    options: IndexOptions
+  ): void {
+    const entryName = entry.metadata?.name;
+    if (!entryName) {
+      logger.warn('Skipping entry with undefined metadata.name');
+      return;
+    }
+    if (this.preserveExistingEnhancedEntry(newIndex, elementType, entryName, existingIndex, options)) {
+      return;
+    }
+
+    const elementDef = this.elementDefinitionBuilder.build(entry, existingIndex);
+    newIndex.elements[elementType][entryName] = elementDef;
+    newIndex.metadata.total_elements++;
+    this.extractActionTriggers(elementDef, entryName, newIndex.action_triggers);
+  }
+
+  private preserveExistingEnhancedEntry(
+    newIndex: EnhancedIndex,
+    elementType: string,
+    entryName: string,
+    existingIndex: EnhancedIndex | null,
+    options: IndexOptions
+  ): boolean {
+    if (!options.updateOnly || options.updateOnly.includes(entryName)) {
+      return false;
+    }
+    const existingEntry = existingIndex?.elements[elementType]?.[entryName];
+    if (!existingEntry) {
+      return false;
+    }
+    newIndex.elements[elementType][entryName] = existingEntry;
+    return true;
+  }
+
+  private async commitBuiltIndex(
+    newIndex: EnhancedIndex,
+    existingIndex: EnhancedIndex | null,
+    startTime: number
+  ): Promise<void> {
+    if (existingIndex?.extensions) {
+      newIndex.extensions = existingIndex.extensions;
+    }
+    await this.writeToFile(newIndex);
+    this.index = newIndex;
+    this.lastLoaded = new Date();
+    EnhancedIndexManager.logBuiltIndex(newIndex, Date.now() - startTime);
+  }
+
+  private static logBuiltIndex(newIndex: EnhancedIndex, duration: number): void {
+    logger.info('Enhanced index built', {
+      duration: `${duration}ms`,
+      elements: newIndex.metadata.total_elements,
+      triggers: Object.keys(newIndex.action_triggers).length
+    });
+    SecurityMonitor.logSecurityEvent({
+      type: 'PORTFOLIO_CACHE_INVALIDATION',
+      severity: 'LOW',
+      source: 'enhanced_index',
+      details: `Index rebuilt with ${newIndex.metadata.total_elements} elements in ${duration}ms`
+    });
   }
 
   // Configuration for verb extraction (will be overridden by ConfigManager)
@@ -591,81 +610,94 @@ export class EnhancedIndexManager {
     try {
       const configManager = this.configManager;
       const config = configManager.getConfig();
-
-      // Update limits from config
-      if (config.elements?.enhanced_index) {
-        const enhancedConfig = config.elements.enhanced_index;
-
-        // Update limits
-        if (enhancedConfig.limits) {
-          EnhancedIndexManager.VERB_EXTRACTION_CONFIG.limits = {
-            ...EnhancedIndexManager.VERB_EXTRACTION_CONFIG.limits,
-            ...enhancedConfig.limits
-          };
-        }
-
-        // Update telemetry settings
-        if (enhancedConfig.telemetry) {
-          EnhancedIndexManager.VERB_EXTRACTION_CONFIG.telemetry = {
-            ...EnhancedIndexManager.VERB_EXTRACTION_CONFIG.telemetry,
-            ...enhancedConfig.telemetry
-          };
-        }
-
-        // Add custom verb patterns if provided
-        if (enhancedConfig.verbPatterns) {
-          const patterns = enhancedConfig.verbPatterns;
-
-          // Add custom prefixes
-          if (patterns.customPrefixes && patterns.customPrefixes.length > 0) {
-            const allPrefixes = [
-              ...Object.values(EnhancedIndexManager.VERB_EXTRACTION_CONFIG.verbPrefixes).flat(),
-              ...patterns.customPrefixes
-            ];
-            EnhancedIndexManager.VERB_PREFIX_PATTERN = this.compileAndValidateRegex(
-              `^(${allPrefixes.join('|')})`,
-              'verb prefix'
-            );
-          }
-
-          // Add custom suffixes
-          if (patterns.customSuffixes && patterns.customSuffixes.length > 0) {
-            const allSuffixes = [
-              ...EnhancedIndexManager.VERB_EXTRACTION_CONFIG.verbSuffixes,
-              ...patterns.customSuffixes
-            ];
-            EnhancedIndexManager.VERB_SUFFIX_PATTERN = this.compileAndValidateRegex(
-              `(${allSuffixes.join('|')})$`,
-              'verb suffix'
-            );
-          }
-
-          // Add excluded nouns
-          if (patterns.excludedNouns && patterns.excludedNouns.length > 0) {
-            const allNouns = [
-              ...EnhancedIndexManager.VERB_EXTRACTION_CONFIG.nounSuffixes,
-              ...patterns.excludedNouns
-            ];
-            EnhancedIndexManager.NOUN_SUFFIX_PATTERN = this.compileAndValidateRegex(
-              `(${allNouns.join('|')})$`,
-              'noun suffix'
-            );
-          }
-        }
-
-        // Validate all regex patterns at startup
-        this.validateRegexPatterns();
-
-        logger.info('Loaded enhanced index configuration', {
-          limits: EnhancedIndexManager.VERB_EXTRACTION_CONFIG.limits,
-          telemetryEnabled: EnhancedIndexManager.VERB_EXTRACTION_CONFIG.telemetry.enabled
-        });
+      const enhancedConfig = config.elements?.enhanced_index;
+      if (!enhancedConfig) {
+        return;
       }
+
+      this.applyEnhancedIndexLimits(enhancedConfig);
+      this.applyEnhancedIndexTelemetry(enhancedConfig);
+      this.applyEnhancedIndexVerbPatterns(enhancedConfig);
+      this.validateRegexPatterns();
+      logger.info('Loaded enhanced index configuration', {
+        limits: EnhancedIndexManager.VERB_EXTRACTION_CONFIG.limits,
+        telemetryEnabled: EnhancedIndexManager.VERB_EXTRACTION_CONFIG.telemetry.enabled
+      });
     } catch (error) {
       logger.warn('Failed to load enhanced index configuration, using defaults', {
         error: error instanceof Error ? error.message : String(error)
       });
     }
+  }
+
+  private applyEnhancedIndexLimits(enhancedConfig: any): void {
+    if (enhancedConfig.limits) {
+      EnhancedIndexManager.VERB_EXTRACTION_CONFIG.limits = {
+        ...EnhancedIndexManager.VERB_EXTRACTION_CONFIG.limits,
+        ...enhancedConfig.limits
+      };
+    }
+  }
+
+  private applyEnhancedIndexTelemetry(enhancedConfig: any): void {
+    if (enhancedConfig.telemetry) {
+      EnhancedIndexManager.VERB_EXTRACTION_CONFIG.telemetry = {
+        ...EnhancedIndexManager.VERB_EXTRACTION_CONFIG.telemetry,
+        ...enhancedConfig.telemetry
+      };
+    }
+  }
+
+  private applyEnhancedIndexVerbPatterns(enhancedConfig: any): void {
+    const patterns = enhancedConfig.verbPatterns;
+    if (!patterns) {
+      return;
+    }
+    this.applyCustomVerbPrefixes(patterns);
+    this.applyCustomVerbSuffixes(patterns);
+    this.applyExcludedNouns(patterns);
+  }
+
+  private applyCustomVerbPrefixes(patterns: any): void {
+    if (!patterns.customPrefixes || patterns.customPrefixes.length === 0) {
+      return;
+    }
+    const allPrefixes = [
+      ...Object.values(EnhancedIndexManager.VERB_EXTRACTION_CONFIG.verbPrefixes).flat(),
+      ...patterns.customPrefixes
+    ];
+    EnhancedIndexManager.VERB_PREFIX_PATTERN = this.compileAndValidateRegex(
+      `^(${allPrefixes.join('|')})`,
+      'verb prefix'
+    );
+  }
+
+  private applyCustomVerbSuffixes(patterns: any): void {
+    if (!patterns.customSuffixes || patterns.customSuffixes.length === 0) {
+      return;
+    }
+    const allSuffixes = [
+      ...EnhancedIndexManager.VERB_EXTRACTION_CONFIG.verbSuffixes,
+      ...patterns.customSuffixes
+    ];
+    EnhancedIndexManager.VERB_SUFFIX_PATTERN = this.compileAndValidateRegex(
+      `(${allSuffixes.join('|')})$`,
+      'verb suffix'
+    );
+  }
+
+  private applyExcludedNouns(patterns: any): void {
+    if (!patterns.excludedNouns || patterns.excludedNouns.length === 0) {
+      return;
+    }
+    const allNouns = [
+      ...EnhancedIndexManager.VERB_EXTRACTION_CONFIG.nounSuffixes,
+      ...patterns.excludedNouns
+    ];
+    EnhancedIndexManager.NOUN_SUFFIX_PATTERN = this.compileAndValidateRegex(
+      `(${allNouns.join('|')})$`,
+      'noun suffix'
+    );
   }
 
   /**
@@ -1104,55 +1136,63 @@ export class EnhancedIndexManager {
     const metrics = index.metadata.trigger_metrics;
     const results: any[] = [];
 
-    // Calculate metrics for each trigger
     for (const trigger in metrics.usage_count) {
-      // Calculate daily average
-      let totalDailyUsage = 0;
-      let daysWithUsage = 0;
-      const recentUsage: number[] = [];
-
-      // Get last 7 days of usage for trend analysis
-      const today = new Date();
-      for (let i = 0; i < 7; i++) {
-        const date = new Date(today);
-        date.setDate(date.getDate() - i);
-        const dateStr = date.toISOString().split('T')[0];
-
-        if (metrics.daily_usage[dateStr] && metrics.daily_usage[dateStr][trigger]) {
-          recentUsage.push(metrics.daily_usage[dateStr][trigger]);
-        } else {
-          recentUsage.push(0);
-        }
-      }
-
-      // Calculate trend (simple comparison of first and last 3 days)
-      const firstHalf = recentUsage.slice(4, 7).reduce((a, b) => a + b, 0);
-      const secondHalf = recentUsage.slice(0, 3).reduce((a, b) => a + b, 0);
-      let trend: 'increasing' | 'stable' | 'decreasing' = 'stable';
-
-      if (secondHalf > firstHalf * 1.2) trend = 'increasing';
-      else if (secondHalf < firstHalf * 0.8) trend = 'decreasing';
-
-      // Calculate overall daily average
-      for (const date in metrics.daily_usage) {
-        if (metrics.daily_usage[date][trigger]) {
-          totalDailyUsage += metrics.daily_usage[date][trigger];
-          daysWithUsage++;
-        }
-      }
-
-      results.push({
-        trigger,
-        usage_count: metrics.usage_count[trigger],
-        last_used: metrics.last_used[trigger],
-        first_used: metrics.first_used[trigger],
-        daily_average: daysWithUsage > 0 ? totalDailyUsage / daysWithUsage : 0,
-        trend
-      });
+      results.push(EnhancedIndexManager.buildTriggerMetric(trigger, metrics));
     }
 
-    // Sort by usage count (descending)
     return results.sort((a, b) => b.usage_count - a.usage_count);
+  }
+
+  private static buildTriggerMetric(trigger: string, metrics: any): {
+    trigger: string;
+    usage_count: number;
+    last_used: string;
+    first_used: string;
+    daily_average: number;
+    trend: 'increasing' | 'stable' | 'decreasing';
+  } {
+    const recentUsage = EnhancedIndexManager.getRecentTriggerUsage(trigger, metrics.daily_usage);
+    const average = EnhancedIndexManager.calculateDailyAverage(trigger, metrics.daily_usage);
+    return {
+      trigger,
+      usage_count: metrics.usage_count[trigger],
+      last_used: metrics.last_used[trigger],
+      first_used: metrics.first_used[trigger],
+      daily_average: average,
+      trend: EnhancedIndexManager.calculateUsageTrend(recentUsage)
+    };
+  }
+
+  private static getRecentTriggerUsage(trigger: string, dailyUsage: any): number[] {
+    const recentUsage: number[] = [];
+    const today = new Date();
+    for (let i = 0; i < 7; i++) {
+      const date = new Date(today);
+      date.setDate(date.getDate() - i);
+      const dateStr = date.toISOString().split('T')[0];
+      recentUsage.push(dailyUsage[dateStr]?.[trigger] ?? 0);
+    }
+    return recentUsage;
+  }
+
+  private static calculateUsageTrend(recentUsage: number[]): 'increasing' | 'stable' | 'decreasing' {
+    const firstHalf = recentUsage.slice(4, 7).reduce((a, b) => a + b, 0);
+    const secondHalf = recentUsage.slice(0, 3).reduce((a, b) => a + b, 0);
+    if (secondHalf > firstHalf * 1.2) return 'increasing';
+    if (secondHalf < firstHalf * 0.8) return 'decreasing';
+    return 'stable';
+  }
+
+  private static calculateDailyAverage(trigger: string, dailyUsage: any): number {
+    let totalDailyUsage = 0;
+    let daysWithUsage = 0;
+    for (const date in dailyUsage) {
+      if (dailyUsage[date][trigger]) {
+        totalDailyUsage += dailyUsage[date][trigger];
+        daysWithUsage++;
+      }
+    }
+    return daysWithUsage > 0 ? totalDailyUsage / daysWithUsage : 0;
   }
 
   /**
@@ -1236,38 +1276,59 @@ export class EnhancedIndexManager {
     const results: ElementDefinition[] = [];
 
     for (const [type, elements] of Object.entries(index.elements)) {
-      // Filter by type if specified
-      if (criteria.type && type !== criteria.type) continue;
-
       for (const [, element] of Object.entries(elements)) {
-        let matches = true;
-
-        // Check verb matches
-        if (criteria.verbs && element.actions) {
-          const elementVerbs = Object.values(element.actions).map(a => a.verb);
-          matches = criteria.verbs.some(v => elementVerbs.includes(v));
-        }
-
-        // Check keyword matches
-        if (matches && criteria.keywords && element.search?.keywords) {
-          matches = criteria.keywords.some(k =>
-            element.search!.keywords!.includes(k)
-          );
-        }
-
-        // Check relationship requirement
-        if (matches && criteria.hasRelationships) {
-          matches = !!element.relationships &&
-                   Object.keys(element.relationships).length > 0;
-        }
-
-        if (matches) {
+        if (this.matchesEnhancedSearchCriteria(type, element, criteria)) {
           results.push(element);
         }
       }
     }
 
     return results;
+  }
+
+  private matchesEnhancedSearchCriteria(
+    type: string,
+    element: ElementDefinition,
+    criteria: {
+      verbs?: string[];
+      keywords?: string[];
+      type?: string;
+      hasRelationships?: boolean;
+    }
+  ): boolean {
+    return this.matchesCriteriaType(type, criteria) &&
+      EnhancedIndexManager.matchesCriteriaVerbs(element, criteria.verbs) &&
+      EnhancedIndexManager.matchesCriteriaKeywords(element, criteria.keywords) &&
+      EnhancedIndexManager.matchesCriteriaRelationships(element, criteria.hasRelationships);
+  }
+
+  private matchesCriteriaType(type: string, criteria: { type?: string }): boolean {
+    return !criteria.type || type === criteria.type;
+  }
+
+  private static matchesCriteriaVerbs(element: ElementDefinition, verbs?: string[]): boolean {
+    if (!verbs || !element.actions) {
+      return true;
+    }
+    const elementVerbs = Object.values(element.actions).map(a => a.verb);
+    return verbs.some(v => elementVerbs.includes(v));
+  }
+
+  private static matchesCriteriaKeywords(element: ElementDefinition, keywords?: string[]): boolean {
+    if (!keywords) {
+      return true;
+    }
+    return keywords.some(k => element.search?.keywords?.includes(k));
+  }
+
+  private static matchesCriteriaRelationships(
+    element: ElementDefinition,
+    hasRelationships?: boolean
+  ): boolean {
+    if (!hasRelationships) {
+      return true;
+    }
+    return !!element.relationships && Object.keys(element.relationships).length > 0;
   }
 
   private async calculateSemanticRelationships(index: EnhancedIndex): Promise<void> {

--- a/src/portfolio/EnhancedIndexManager.ts
+++ b/src/portfolio/EnhancedIndexManager.ts
@@ -79,6 +79,8 @@ export type {
   ElementPath
 };
 
+type TriggerUsageTrend = 'increasing' | 'stable' | 'decreasing';
+
 
 export class EnhancedIndexManager {
   private readonly indexByNamespace = new Map<string, EnhancedIndex>();
@@ -1125,7 +1127,7 @@ export class EnhancedIndexManager {
     last_used: string;
     first_used: string;
     daily_average: number;
-    trend: 'increasing' | 'stable' | 'decreasing';
+    trend: TriggerUsageTrend;
   }[]> {
     const index = await this.getIndex();
 

--- a/src/portfolio/GitHubPortfolioIndexer.ts
+++ b/src/portfolio/GitHubPortfolioIndexer.ts
@@ -87,54 +87,50 @@ export class GitHubPortfolioIndexer {
   public async getIndex(force = false): Promise<GitHubPortfolioIndex> {
     try {
       const userKey = this.currentUserKey();
-      // Check if we need fresh data
       if (force || this.shouldFetchFresh(userKey)) {
         return await this.fetchFresh();
       }
 
       const cachedIndex = this.cacheByUser.get(userKey);
       const lastFetch = this.lastFetchByUser.get(userKey) ?? null;
-      
-      // Return cached data if available and valid
+
       if (cachedIndex && this.isCacheValid(userKey)) {
-        logger.debug('Returning cached GitHub portfolio index', {
+        GitHubPortfolioIndexer.logCachedIndex(cachedIndex, lastFetch);
+        return cachedIndex;
+      }
+
+      return await this.fetchFreshWithFallback(cachedIndex, lastFetch);
+    } catch (error) {
+      ErrorHandler.logError('GitHubPortfolioIndexer.getIndex', error);
+      return this.cacheByUser.get(this.currentUserKey()) ?? this.createEmptyIndex();
+    }
+  }
+
+  private static logCachedIndex(cachedIndex: GitHubPortfolioIndex, lastFetch: Date | null): void {
+    logger.debug('Returning cached GitHub portfolio index', {
+      username: cachedIndex.username,
+      totalElements: cachedIndex.totalElements,
+      age: lastFetch ? Date.now() - lastFetch.getTime() : 'unknown'
+    });
+  }
+
+  private async fetchFreshWithFallback(
+    cachedIndex: GitHubPortfolioIndex | undefined,
+    lastFetch: Date | null
+  ): Promise<GitHubPortfolioIndex> {
+    try {
+      return await this.fetchFresh();
+    } catch (error) {
+      logger.warn('Failed to fetch fresh GitHub portfolio index, checking for stale cache', {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      if (cachedIndex) {
+        logger.info('Returning stale GitHub portfolio cache as fallback', {
           username: cachedIndex.username,
-          totalElements: cachedIndex.totalElements,
           age: lastFetch ? Date.now() - lastFetch.getTime() : 'unknown'
         });
         return cachedIndex;
       }
-      
-      // Try to fetch fresh, fall back to stale cache on failure
-      try {
-        return await this.fetchFresh();
-      } catch (error) {
-        logger.warn('Failed to fetch fresh GitHub portfolio index, checking for stale cache', {
-          error: error instanceof Error ? error.message : String(error)
-        });
-        
-        // Return stale cache if available
-        if (cachedIndex) {
-          logger.info('Returning stale GitHub portfolio cache as fallback', {
-            username: cachedIndex.username,
-            age: lastFetch ? Date.now() - lastFetch.getTime() : 'unknown'
-          });
-          return cachedIndex;
-        }
-        
-        // Return empty index as last resort
-        return this.createEmptyIndex();
-      }
-      
-    } catch (error) {
-      ErrorHandler.logError('GitHubPortfolioIndexer.getIndex', error);
-      
-      // Return stale cache or empty index
-      const cachedIndex = this.cacheByUser.get(this.currentUserKey());
-      if (cachedIndex) {
-        return cachedIndex;
-      }
-      
       return this.createEmptyIndex();
     }
   }
@@ -402,60 +398,63 @@ export class GitHubPortfolioIndexer {
     elementType: ElementType
   ): Promise<GitHubIndexEntry[]> {
     try {
-      // Get directory listing using PortfolioRepoManager
       const contents = await this.portfolioRepoManager.githubRequest(
         `/repos/${repoPath}/contents/${elementType}`
       );
-      
       if (!Array.isArray(contents)) {
         return [];
       }
-      
-      const entries: GitHubIndexEntry[] = [];
-      const maxConcurrent = 5; // Limit concurrent requests
-      
-      // Process files in batches to avoid rate limiting
-      for (let i = 0; i < contents.length; i += maxConcurrent) {
-        const batch = contents.slice(i, i + maxConcurrent);
-        const batchPromises = batch
-          .filter(item => item.type === 'file' && item.name.endsWith('.md'))
-          .map(item => this.createGitHubIndexEntry(elementType, item));
-        
-        const batchResults = await Promise.allSettled(batchPromises);
-        
-        for (const result of batchResults) {
-          if (result.status === 'fulfilled' && result.value) {
-            entries.push(result.value);
-          }
-        }
-        
-        // Add delay between batches to respect rate limits
-        if (i + maxConcurrent < contents.length) {
-          await new Promise(resolve => setTimeout(resolve, 100));
-        }
-      }
-      
-      return entries;
-      
+
+      return await this.createEntriesFromDirectoryContents(elementType, contents);
     } catch (error) {
-      // Directory might not exist - check for 404 errors
-      // PortfolioRepoManager will throw standard GitHub API errors
+      if (this.isGitHubNotFoundError(error)) {
+        logger.debug(`Directory ${elementType} not found in GitHub repository (this is normal if not yet created)`);
+        return [];
+      }
       if (error instanceof Error) {
-        // Check for 404 Not Found errors from GitHub API
-        if (error.message.includes('404') || 
-            error.message.includes('Not Found')) {
-          logger.debug(`Directory ${elementType} not found in GitHub repository (this is normal if not yet created)`);
-          return [];
-        }
-        
-        // Log the actual error for debugging
         logger.debug(`Error fetching ${elementType}: ${error.message}`);
       }
-      
-      // Re-throw other errors
       logger.warn(`Unexpected error fetching ${elementType}:`, error);
       throw error;
     }
+  }
+
+  private async createEntriesFromDirectoryContents(
+    elementType: ElementType,
+    contents: any[]
+  ): Promise<GitHubIndexEntry[]> {
+    const entries: GitHubIndexEntry[] = [];
+    const maxConcurrent = 5;
+    for (let i = 0; i < contents.length; i += maxConcurrent) {
+      const batchResults = await this.createIndexEntriesBatch(
+        elementType,
+        contents.slice(i, i + maxConcurrent)
+      );
+      entries.push(...batchResults);
+      if (i + maxConcurrent < contents.length) {
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+    }
+    return entries;
+  }
+
+  private async createIndexEntriesBatch(
+    elementType: ElementType,
+    batch: any[]
+  ): Promise<GitHubIndexEntry[]> {
+    const batchPromises = batch
+      .filter(item => item.type === 'file' && item.name.endsWith('.md'))
+      .map(item => this.createGitHubIndexEntry(elementType, item));
+    const batchResults = await Promise.allSettled(batchPromises);
+    return batchResults
+      .filter((result): result is PromiseFulfilledResult<GitHubIndexEntry | null> => result.status === 'fulfilled')
+      .map(result => result.value)
+      .filter((entry): entry is GitHubIndexEntry => entry !== null);
+  }
+
+  private isGitHubNotFoundError(error: unknown): boolean {
+    return error instanceof Error &&
+      (error.message.includes('404') || error.message.includes('Not Found'));
   }
 
   /**
@@ -481,31 +480,8 @@ export class GitHubPortfolioIndexer {
         lastModified: new Date(), // GitHub API doesn't provide file modification time directly
         size: fileInfo.size || 0
       };
-      
-      // Optionally fetch content to extract metadata
-      // This is expensive, so only do it for small files or when specifically needed
-      if (fileInfo.size && fileInfo.size < 10000) { // Only for files < 10KB
-        try {
-          // For download URLs, we need to fetch directly, not through API
-          const response = await fetch(fileInfo.download_url);
-          const content = await response.text();
-          const metadata = this.parseMetadataFromContent(content);
-          
-          if (metadata.name) entry.name = metadata.name;
-          if (metadata.description) entry.description = metadata.description;
-          if (metadata.version) entry.version = metadata.version;
-          if (metadata.author) entry.author = metadata.author;
-        } catch (metadataError) {
-          // Non-critical error, continue without metadata
-          logger.debug('Failed to fetch metadata for file', {
-            path: fileInfo.path,
-            error: metadataError instanceof Error ? metadataError.message : String(metadataError)
-          });
-        }
-      }
-      
+      await this.hydrateSmallFileMetadata(entry, fileInfo);
       return entry;
-      
     } catch (error) {
       logger.debug('Failed to create GitHub index entry', {
         path: fileInfo.path,
@@ -513,6 +489,33 @@ export class GitHubPortfolioIndexer {
       });
       return null;
     }
+  }
+
+  private async hydrateSmallFileMetadata(entry: GitHubIndexEntry, fileInfo: any): Promise<void> {
+    if (!fileInfo.size || fileInfo.size >= 10000) {
+      return;
+    }
+    try {
+      const response = await fetch(fileInfo.download_url);
+      const content = await response.text();
+      const metadata = this.parseMetadataFromContent(content);
+      GitHubPortfolioIndexer.applyParsedMetadata(entry, metadata);
+    } catch (metadataError) {
+      logger.debug('Failed to fetch metadata for file', {
+        path: fileInfo.path,
+        error: metadataError instanceof Error ? metadataError.message : String(metadataError)
+      });
+    }
+  }
+
+  private static applyParsedMetadata(
+    entry: GitHubIndexEntry,
+    metadata: { name?: string; description?: string; version?: string; author?: string }
+  ): void {
+    if (metadata.name) entry.name = metadata.name;
+    if (metadata.description) entry.description = metadata.description;
+    if (metadata.version) entry.version = metadata.version;
+    if (metadata.author) entry.author = metadata.author;
   }
 
   /**
@@ -531,16 +534,21 @@ export class GitHubPortfolioIndexer {
     if (frontmatterMatch) {
       const frontmatter = frontmatterMatch[1];
       
-      const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
+      // Match values with a single optional space and a value that
+      // explicitly excludes line breaks. Avoids the `\s* … .+` overlap
+      // that regexp/no-super-linear-backtracking flags as polynomial
+      // ReDoS — `?` is a bounded 0-or-1 quantifier with no character
+      // exchange against `[^\r\n]+`.
+      const nameMatch = frontmatter.match(/^name:[ \t]?([^\r\n]+)$/m);
       if (nameMatch) metadata.name = nameMatch[1].trim();
-      
-      const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
+
+      const descMatch = frontmatter.match(/^description:[ \t]?([^\r\n]+)$/m);
       if (descMatch) metadata.description = descMatch[1].trim();
-      
-      const versionMatch = frontmatter.match(/^version:\s*(.+)$/m);
+
+      const versionMatch = frontmatter.match(/^version:[ \t]?([^\r\n]+)$/m);
       if (versionMatch) metadata.version = versionMatch[1].trim();
-      
-      const authorMatch = frontmatter.match(/^author:\s*(.+)$/m);
+
+      const authorMatch = frontmatter.match(/^author:[ \t]?([^\r\n]+)$/m);
       if (authorMatch) metadata.author = authorMatch[1].trim();
     }
     

--- a/src/portfolio/GitHubPortfolioIndexer.ts
+++ b/src/portfolio/GitHubPortfolioIndexer.ts
@@ -539,16 +539,16 @@ export class GitHubPortfolioIndexer {
       // that regexp/no-super-linear-backtracking flags as polynomial
       // ReDoS — `?` is a bounded 0-or-1 quantifier with no character
       // exchange against `[^\r\n]+`.
-      const nameMatch = frontmatter.match(/^name:[ \t]?([^\r\n]+)$/m);
+      const nameMatch = /^name:[ \t]?([^\r\n]+)$/m.exec(frontmatter);
       if (nameMatch) metadata.name = nameMatch[1].trim();
 
-      const descMatch = frontmatter.match(/^description:[ \t]?([^\r\n]+)$/m);
+      const descMatch = /^description:[ \t]?([^\r\n]+)$/m.exec(frontmatter);
       if (descMatch) metadata.description = descMatch[1].trim();
 
-      const versionMatch = frontmatter.match(/^version:[ \t]?([^\r\n]+)$/m);
+      const versionMatch = /^version:[ \t]?([^\r\n]+)$/m.exec(frontmatter);
       if (versionMatch) metadata.version = versionMatch[1].trim();
 
-      const authorMatch = frontmatter.match(/^author:[ \t]?([^\r\n]+)$/m);
+      const authorMatch = /^author:[ \t]?([^\r\n]+)$/m.exec(frontmatter);
       if (authorMatch) metadata.author = authorMatch[1].trim();
     }
     

--- a/src/portfolio/PortfolioSyncManager.ts
+++ b/src/portfolio/PortfolioSyncManager.ts
@@ -337,7 +337,7 @@ export class PortfolioSyncManager {
         return securityFailure;
       }
 
-      const conflictResult = await this.resolveDownloadConflict(
+      const conflictResult = await this.resolveDownloadConflict({
         elementName,
         elementType,
         localPath,
@@ -345,8 +345,8 @@ export class PortfolioSyncManager {
         remoteContent,
         entry,
         config,
-        force
-      );
+        force,
+      });
       if (conflictResult) {
         return conflictResult;
       }
@@ -460,16 +460,17 @@ export class PortfolioSyncManager {
     };
   }
 
-  private async resolveDownloadConflict(
-    elementName: string,
-    elementType: ElementType,
-    localPath: string,
-    localContent: string | null,
-    remoteContent: string,
-    entry: GitHubIndexEntry,
-    config: DollhouseConfig,
-    force?: boolean
-  ): Promise<SyncResult | null> {
+  private async resolveDownloadConflict(args: {
+    elementName: string;
+    elementType: ElementType;
+    localPath: string;
+    localContent: string | null;
+    remoteContent: string;
+    entry: GitHubIndexEntry;
+    config: DollhouseConfig;
+    force?: boolean;
+  }): Promise<SyncResult | null> {
+    const { elementName, elementType, localPath, localContent, remoteContent, entry, config, force } = args;
     if (!localContent) {
       return null;
     }

--- a/src/portfolio/PortfolioSyncManager.ts
+++ b/src/portfolio/PortfolioSyncManager.ts
@@ -131,84 +131,12 @@ export class PortfolioSyncManager {
    */
   public async handleSyncOperation(params: SyncOperation): Promise<SyncResult> {
     try {
-      // Check if sync is enabled in config
       const config = this.configManager.getConfig();
-      if (!config.sync.enabled && params.operation !== 'list-remote') {
-        return {
-          success: false,
-          message: 'Sync is disabled. Enable it with: dollhouse_config --action update --setting sync.enabled --value true'
-        };
+      const configFailure = this.validateSyncOperationConfig(params, config);
+      if (configFailure) {
+        return configFailure;
       }
-      
-      // Check bulk permissions
-      if (params.bulk) {
-        const bulkAllowed = this.isBulkOperationAllowed(params.operation, config);
-        if (!bulkAllowed.allowed) {
-          return {
-            success: false,
-            message: bulkAllowed.message
-          };
-        }
-      }
-      
-      // Handle operations
-      switch (params.operation) {
-        case 'list-remote':
-          return await this.listRemoteElements(params.element_type);
-          
-        case 'download':
-          if (params.bulk) {
-            return await this.bulkDownload(params.element_type, params.confirm);
-          } else if (params.element_name) {
-            return await this.downloadElement(
-              params.element_name,
-              params.element_type!,
-              params.version,
-              params.force
-            );
-          } else {
-            return {
-              success: false,
-              message: 'Element name required for individual download'
-            };
-          }
-          
-        case 'upload':
-          if (params.bulk) {
-            return await this.bulkUpload(params.element_type, params.confirm);
-          } else if (params.element_name) {
-            return await this.uploadElement(
-              params.element_name,
-              params.element_type!,
-              params.confirm
-            );
-          } else {
-            return {
-              success: false,
-              message: 'Element name required for individual upload'
-            };
-          }
-          
-        case 'compare':
-          if (params.element_name && params.element_type) {
-            return await this.compareVersions(
-              params.element_name,
-              params.element_type,
-              params.show_diff
-            );
-          } else {
-            return {
-              success: false,
-              message: 'Element name and type required for comparison'
-            };
-          }
-          
-        default:
-          return {
-            success: false,
-            message: `Unknown operation: ${params.operation}`
-          };
-      }
+      return await this.dispatchSyncOperation(params);
     } catch (error) {
       logger.error('Sync operation failed', {
         operation: params.operation,
@@ -220,6 +148,74 @@ export class PortfolioSyncManager {
         message: `Sync operation failed: ${error instanceof Error ? error.message : String(error)}`
       };
     }
+  }
+
+  private validateSyncOperationConfig(
+    params: SyncOperation,
+    config: DollhouseConfig
+  ): SyncResult | null {
+    if (!config.sync.enabled && params.operation !== 'list-remote') {
+      return {
+        success: false,
+        message: 'Sync is disabled. Enable it with: dollhouse_config --action update --setting sync.enabled --value true'
+      };
+    }
+
+    if (!params.bulk) {
+      return null;
+    }
+    const bulkAllowed = this.isBulkOperationAllowed(params.operation, config);
+    return bulkAllowed.allowed ? null : { success: false, message: bulkAllowed.message };
+  }
+
+  private async dispatchSyncOperation(params: SyncOperation): Promise<SyncResult> {
+    switch (params.operation) {
+      case 'list-remote':
+        return await this.listRemoteElements(params.element_type);
+      case 'download':
+        return await this.handleDownloadOperation(params);
+      case 'upload':
+        return await this.handleUploadOperation(params);
+      case 'compare':
+        return await this.handleCompareOperation(params);
+      default:
+        return {
+          success: false,
+          message: `Unknown operation: ${params.operation}`
+        };
+    }
+  }
+
+  private async handleDownloadOperation(params: SyncOperation): Promise<SyncResult> {
+    if (params.bulk) {
+      return await this.bulkDownload(params.element_type, params.confirm);
+    }
+    if (!params.element_name) {
+      return { success: false, message: 'Element name required for individual download' };
+    }
+    return await this.downloadElement(
+      params.element_name,
+      params.element_type!,
+      params.version,
+      params.force
+    );
+  }
+
+  private async handleUploadOperation(params: SyncOperation): Promise<SyncResult> {
+    if (params.bulk) {
+      return await this.bulkUpload(params.element_type, params.confirm);
+    }
+    if (!params.element_name) {
+      return { success: false, message: 'Element name required for individual upload' };
+    }
+    return await this.uploadElement(params.element_name, params.element_type!, params.confirm);
+  }
+
+  private async handleCompareOperation(params: SyncOperation): Promise<SyncResult> {
+    if (!params.element_name || !params.element_type) {
+      return { success: false, message: 'Element name and type required for comparison' };
+    }
+    return await this.compareVersions(params.element_name, params.element_type, params.show_diff);
   }
   
   /**
@@ -315,158 +311,52 @@ export class PortfolioSyncManager {
   ): Promise<SyncResult> {
     try {
       const config = this.configManager.getConfig();
-      
-      // Validate element name
-      const validation = UnicodeValidator.normalize(elementName);
-      if (!validation.isValid) {
-        return {
-          success: false,
-          message: `Invalid element name: ${validation.detectedIssues?.[0] || 'unknown error'}`
-        };
+      const validationFailure = this.validateDownloadElementName(elementName);
+      if (validationFailure) {
+        return validationFailure;
       }
-      
-      // Get token and set it
-      const token = await this.tokenManager.getGitHubTokenAsync();
+
+      const token = await this.requireGitHubToken();
       if (!token) {
-        return {
-          success: false,
-          message: 'GitHub authentication required'
-        };
+        return { success: false, message: 'GitHub authentication required' };
       }
-      
       this.repoManager.setToken(token);
-      
-      // Get GitHub index
+
       const index = await this.indexer.getIndex();
-      
-      // Find the element - first try exact match, then fuzzy match
       const entries = index.elements.get(elementType) || [];
-      let entry = entries.find(e => e.name === elementName);
-      
-      // If exact match not found, try fuzzy matching
+      const entry = this.findRemoteElementEntry(elementName, entries);
       if (!entry) {
-        // Try case-insensitive exact match first
-        entry = entries.find(e => e.name.toLowerCase() === elementName.toLowerCase());
-        
-        // If still not found, try fuzzy matching
-        if (!entry) {
-          const fuzzyMatch = this.findFuzzyMatch(elementName, entries);
-          if (fuzzyMatch) {
-            logger.info(`Fuzzy match found: '${elementName}' matched to '${fuzzyMatch.name}'`);
-            entry = fuzzyMatch;
-          }
-        }
+        return this.buildRemoteElementNotFoundResult(elementName, elementType, entries);
       }
-      
-      if (!entry) {
-        // Generate helpful suggestions
-        const suggestions = this.getSuggestions(elementName, entries);
-        const suggestionText = suggestions.length > 0 
-          ? `\n\nDid you mean one of these?\n${suggestions.map(s => `  • ${s.name}`).join('\n')}`
-          : '';
-        
-        return {
-          success: false,
-          message: `Element '${elementName}' (${elementType}) not found in GitHub portfolio${suggestionText}`
-        };
-      }
-      
-      // Check for local conflicts
+
       const localPath = this.portfolioManager.getElementPath(elementType, `${elementName}.md`);
-      let hasLocalVersion = false;
-      let localContent: string | null = null;
-      
-      try {
-        localContent = await this.fileOperations.readFile(localPath, { source: 'PortfolioSyncManager.downloadElement' });
-        hasLocalVersion = true;
-      } catch {
-        // No local version exists
+      const localContent = await this.readLocalElementContent(localPath, 'PortfolioSyncManager.downloadElement');
+      const remoteContent = await this.fetchRemoteElementContent(entry.downloadUrl, token);
+      const securityFailure = this.validateRemoteContent(remoteContent);
+      if (securityFailure) {
+        return securityFailure;
       }
-      
-      // Download the element
-      const response = await fetch(entry.downloadUrl, {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Accept': 'application/vnd.github.v3.raw'
-        }
-      });
-      
-      if (!response.ok) {
-        throw new Error(`Failed to download: ${response.statusText}`);
-      }
-      
-      const remoteContent = await response.text();
-      
-      // Validate content security
-      const validationResult = ContentValidator.validateAndSanitize(remoteContent);
-      if (!validationResult.isValid && validationResult.severity === 'critical') {
-        return {
-          success: false,
-          message: `Security issue detected in remote content: ${validationResult.detectedPatterns?.join(', ')}`
-        };
-      }
-      
-      // Check if content is different
-      if (hasLocalVersion && localContent) {
-        const localHash = createHash('sha256').update(localContent).digest('hex');
-        const remoteHash = createHash('sha256').update(remoteContent).digest('hex');
-        
-        if (localHash === remoteHash) {
-          return {
-            success: true,
-            message: `Element '${elementName}' is already up to date`
-          };
-        }
-        
-        // Show confirmation for overwrite unless force flag is set
-        if (config.sync.individual.require_confirmation && !force) {
-          const diff = await this.generateDiff(localContent, remoteContent);
-          const conflictInfo = await this.buildConflictInfo(
-            elementName,
-            elementType,
-            localPath,
-            localContent,
-            entry
-          );
 
-          logger.warn('Sync conflict detected', {
-            element: elementName,
-            type: elementType,
-            conflict: conflictInfo
-          });
-
-          return {
-            success: false,
-            message: `Local version exists. Please confirm download will overwrite:\n\n${diff}\n\nTo proceed, use --force flag`,
-            data: { requiresConfirmation: true },
-            conflicts: [conflictInfo]
-          };
-        }
-      }
-      
-      // Phase 4.5 follow-up: when a storage-layer factory is wired AND it
-      // produces a writable layer for this element type, persist through it
-      // instead of writing to filesystem. Without this, DB-mode sync
-      // downloads land on the per-user portfolio dir (typically tmpfs in
-      // containers) and vanish on every restart. Filesystem-mode falls
-      // through to the legacy writeFile path.
-      const { persistElementViaFactory } = await import('../storage/persistElementViaFactory.js');
-      const elementDir = path.dirname(localPath);
-      const persistedViaStorageLayer = await persistElementViaFactory(
-        this.storageLayerFactory,
-        elementType,
+      const conflictResult = await this.resolveDownloadConflict(
         elementName,
+        elementType,
+        localPath,
+        localContent,
         remoteContent,
-        { elementDir, fileExtension: path.extname(localPath) || '.md', scanCooldownMs: 0 },
-        { exclusive: false },
+        entry,
+        config,
+        force
       );
-
-      if (!persistedViaStorageLayer) {
-        // Save the element to filesystem (legacy path, used when no factory
-        // or when the factory produces a non-writable filesystem layer).
-        await this.fileOperations.createDirectory(elementDir);
-        await this.fileOperations.writeFile(localPath, remoteContent, { source: 'PortfolioSyncManager.downloadElement' });
+      if (conflictResult) {
+        return conflictResult;
       }
+
+      const persistedViaStorageLayer = await this.persistDownloadedElement(
+        elementName,
+        elementType,
+        localPath,
+        remoteContent
+      );
 
       logger.info('Element downloaded from GitHub', {
         element: elementName,
@@ -487,6 +377,145 @@ export class PortfolioSyncManager {
       };
     }
   }
+
+  private validateDownloadElementName(elementName: string): SyncResult | null {
+    const validation = UnicodeValidator.normalize(elementName);
+    return validation.isValid
+      ? null
+      : {
+          success: false,
+          message: `Invalid element name: ${validation.detectedIssues?.[0] || 'unknown error'}`
+        };
+  }
+
+  private async requireGitHubToken(): Promise<string | null> {
+    return await this.tokenManager.getGitHubTokenAsync();
+  }
+
+  private findRemoteElementEntry(
+    elementName: string,
+    entries: GitHubIndexEntry[]
+  ): GitHubIndexEntry | undefined {
+    const exactMatch = entries.find(e => e.name === elementName);
+    if (exactMatch) {
+      return exactMatch;
+    }
+
+    const caseInsensitiveMatch = entries.find(e => e.name.toLowerCase() === elementName.toLowerCase());
+    if (caseInsensitiveMatch) {
+      return caseInsensitiveMatch;
+    }
+
+    const fuzzyMatch = this.findFuzzyMatch(elementName, entries);
+    if (fuzzyMatch) {
+      logger.info(`Fuzzy match found: '${elementName}' matched to '${fuzzyMatch.name}'`);
+    }
+    return fuzzyMatch ?? undefined;
+  }
+
+  private buildRemoteElementNotFoundResult(
+    elementName: string,
+    elementType: ElementType,
+    entries: GitHubIndexEntry[]
+  ): SyncResult {
+    const suggestions = this.getSuggestions(elementName, entries);
+    const suggestionText = suggestions.length > 0
+      ? `\n\nDid you mean one of these?\n${suggestions.map(s => `  • ${s.name}`).join('\n')}`
+      : '';
+    return {
+      success: false,
+      message: `Element '${elementName}' (${elementType}) not found in GitHub portfolio${suggestionText}`
+    };
+  }
+
+  private async readLocalElementContent(localPath: string, source: string): Promise<string | null> {
+    try {
+      return await this.fileOperations.readFile(localPath, { source });
+    } catch {
+      return null;
+    }
+  }
+
+  private async fetchRemoteElementContent(downloadUrl: string, token: string): Promise<string> {
+    const response = await fetch(downloadUrl, {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/vnd.github.v3.raw'
+      }
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to download: ${response.statusText}`);
+    }
+    return await response.text();
+  }
+
+  private validateRemoteContent(remoteContent: string): SyncResult | null {
+    const validationResult = ContentValidator.validateAndSanitize(remoteContent);
+    if (validationResult.isValid || validationResult.severity !== 'critical') {
+      return null;
+    }
+    return {
+      success: false,
+      message: `Security issue detected in remote content: ${validationResult.detectedPatterns?.join(', ')}`
+    };
+  }
+
+  private async resolveDownloadConflict(
+    elementName: string,
+    elementType: ElementType,
+    localPath: string,
+    localContent: string | null,
+    remoteContent: string,
+    entry: GitHubIndexEntry,
+    config: DollhouseConfig,
+    force?: boolean
+  ): Promise<SyncResult | null> {
+    if (!localContent) {
+      return null;
+    }
+    const localHash = createHash('sha256').update(localContent).digest('hex');
+    const remoteHash = createHash('sha256').update(remoteContent).digest('hex');
+    if (localHash === remoteHash) {
+      return { success: true, message: `Element '${elementName}' is already up to date` };
+    }
+    if (!config.sync.individual.require_confirmation || force) {
+      return null;
+    }
+
+    const diff = await this.generateDiff(localContent, remoteContent);
+    const conflictInfo = await this.buildConflictInfo(elementName, elementType, localPath, localContent, entry);
+    logger.warn('Sync conflict detected', { element: elementName, type: elementType, conflict: conflictInfo });
+    return {
+      success: false,
+      message: `Local version exists. Please confirm download will overwrite:\n\n${diff}\n\nTo proceed, use --force flag`,
+      data: { requiresConfirmation: true },
+      conflicts: [conflictInfo]
+    };
+  }
+
+  private async persistDownloadedElement(
+    elementName: string,
+    elementType: ElementType,
+    localPath: string,
+    remoteContent: string
+  ): Promise<boolean> {
+    const { persistElementViaFactory } = await import('../storage/persistElementViaFactory.js');
+    const elementDir = path.dirname(localPath);
+    const persistedViaStorageLayer = await persistElementViaFactory(
+      this.storageLayerFactory,
+      elementType,
+      elementName,
+      remoteContent,
+      { elementDir, fileExtension: path.extname(localPath) || '.md', scanCooldownMs: 0 },
+      { exclusive: false },
+    );
+
+    if (!persistedViaStorageLayer) {
+      await this.fileOperations.createDirectory(elementDir);
+      await this.fileOperations.writeFile(localPath, remoteContent, { source: 'PortfolioSyncManager.downloadElement' });
+    }
+    return persistedViaStorageLayer;
+  }
   
   /**
    * Upload a specific element to GitHub
@@ -498,66 +527,23 @@ export class PortfolioSyncManager {
   ): Promise<SyncResult> {
     try {
       const config = this.configManager.getConfig();
-      
-      // Check for local element
       const localPath = this.portfolioManager.getElementPath(elementType, `${elementName}.md`);
-      
-      let content: string;
-      try {
-        content = await this.fileOperations.readFile(localPath, { source: 'PortfolioSyncManager.uploadElement' });
-      } catch {
-        return {
-          success: false,
-          message: `Element '${elementName}' (${elementType}) not found locally`
-        };
+      const content = await this.readUploadContent(elementName, elementType, localPath);
+      if (typeof content !== 'string') {
+        return content;
       }
-      
-      // Check privacy metadata
+
       const parsed = SecureYamlParser.parse(content, {
         maxYamlSize: 64 * 1024,
         validateContent: false,
         validateFields: false
       });
-      
-      if (parsed.data?.privacy?.local_only === true) {
-        return {
-          success: false,
-          message: `Element '${elementName}' is marked as local-only and cannot be uploaded`
-        };
+
+      const uploadValidationFailure = this.validateUploadContent(elementName, content, parsed.data, config);
+      if (uploadValidationFailure) {
+        return uploadValidationFailure;
       }
-      
-      // Validate content security
-      const validationResult = ContentValidator.validateAndSanitize(content);
-      if (!validationResult.isValid && validationResult.severity === 'critical') {
-        return {
-          success: false,
-          message: `Security issue detected: ${validationResult.detectedPatterns?.join(', ')}`
-        };
-      }
-      
-      // Scan for sensitive content if configured
-      if (config.sync.privacy.scan_for_secrets) {
-        logger.debug('Scanning for secrets before upload');
-        // Implement actual secret scanning
-        const secretPatterns = [
-          /api[_-]?key\s*[:=]\s*['"][^'"]+['"]/gi,
-          /secret\s*[:=]\s*['"][^'"]+['"]/gi,
-          /password\s*[:=]\s*['"][^'"]+['"]/gi,
-          /token\s*[:=]\s*['"][^'"]+['"]/gi,
-          /private[_-]?key\s*[:=]\s*['"][^'"]+['"]/gi
-        ];
-        
-        for (const pattern of secretPatterns) {
-          if (pattern.test(content)) {
-            return {
-              success: false,
-              message: `Potential secret detected in content. Please review and remove sensitive information before uploading.`
-            };
-          }
-        }
-      }
-      
-      // Get confirmation if required (unless already confirmed)
+
       if (config.sync.individual.require_confirmation && !confirm) {
         return {
           success: false,
@@ -565,9 +551,8 @@ export class PortfolioSyncManager {
           data: { requiresConfirmation: true }
         };
       }
-      
-      // Get token and validate
-      const token = await this.tokenManager.getGitHubTokenAsync();
+
+      const token = await this.requireGitHubToken();
       if (!token) {
         return {
           success: false,
@@ -591,52 +576,108 @@ export class PortfolioSyncManager {
         content: content
       };
       
-      // Use PortfolioElementAdapter to properly implement IElement interface
       const adapter = new PortfolioElementAdapter(portfolioElement);
-      
-      // Use PortfolioRepoManager to upload
       this.repoManager.setToken(token);
-      
-      // DEBUG: Log upload attempt
-      logger.debug('[BULK_SYNC_DEBUG] Upload element attempt', {
-        elementName,
-        elementType,
-        hasToken: !!token,
-        tokenPrefix: token ? token.substring(0, 10) + '...' : 'none',
-        adapterHasMetadata: !!(adapter && adapter.metadata),
-        timestamp: new Date().toISOString()
-      });
-      
-      try {
-        const url = await this.repoManager.saveElement(adapter, true); // consent is true since we've already checked
-        
-        logger.info('Element uploaded to GitHub', {
-          element: elementName,
-          type: elementType,
-          url
-        });
-        
-        return {
-          success: true,
-          message: `Successfully uploaded '${elementName}' (${elementType}) to GitHub portfolio`,
-          data: { url }
-        };
-      } catch (uploadError) {
-        // Handle specific errors
-        if (uploadError instanceof Error && uploadError.message.includes('repository does not exist')) {
-          return {
-            success: false,
-            message: `GitHub portfolio repository not found. Please initialize it first using init_portfolio tool.`
-          };
-        }
-        throw uploadError;
-      }
+      return await this.saveElementToGitHub(adapter, elementName, elementType, token);
       
     } catch (error) {
       return {
         success: false,
         message: `Failed to upload element: ${error instanceof Error ? error.message : String(error)}`
       };
+    }
+  }
+
+  private async readUploadContent(
+    elementName: string,
+    elementType: ElementType,
+    localPath: string
+  ): Promise<string | SyncResult> {
+    try {
+      return await this.fileOperations.readFile(localPath, { source: 'PortfolioSyncManager.uploadElement' });
+    } catch {
+      return {
+        success: false,
+        message: `Element '${elementName}' (${elementType}) not found locally`
+      };
+    }
+  }
+
+  private validateUploadContent(
+    elementName: string,
+    content: string,
+    parsedData: any,
+    config: DollhouseConfig
+  ): SyncResult | null {
+    if (parsedData?.privacy?.local_only === true) {
+      return {
+        success: false,
+        message: `Element '${elementName}' is marked as local-only and cannot be uploaded`
+      };
+    }
+
+    const validationResult = ContentValidator.validateAndSanitize(content);
+    if (!validationResult.isValid && validationResult.severity === 'critical') {
+      return {
+        success: false,
+        message: `Security issue detected: ${validationResult.detectedPatterns?.join(', ')}`
+      };
+    }
+
+    return config.sync.privacy.scan_for_secrets
+      ? this.validateNoUploadSecrets(content)
+      : null;
+  }
+
+  private validateNoUploadSecrets(content: string): SyncResult | null {
+    logger.debug('Scanning for secrets before upload');
+    const secretPatterns = [
+      /api[_-]?key\s*[:=]\s*['"][^'"]+['"]/gi,
+      /secret\s*[:=]\s*['"][^'"]+['"]/gi,
+      /password\s*[:=]\s*['"][^'"]+['"]/gi,
+      /token\s*[:=]\s*['"][^'"]+['"]/gi,
+      /private[_-]?key\s*[:=]\s*['"][^'"]+['"]/gi
+    ];
+
+    return secretPatterns.some(pattern => pattern.test(content))
+      ? {
+          success: false,
+          message: 'Potential secret detected in content. Please review and remove sensitive information before uploading.'
+        }
+      : null;
+  }
+
+  private async saveElementToGitHub(
+    adapter: PortfolioElementAdapter,
+    elementName: string,
+    elementType: ElementType,
+    token: string
+  ): Promise<SyncResult> {
+    logger.debug('[BULK_SYNC_DEBUG] Upload element attempt', {
+      elementName,
+      elementType,
+      hasToken: !!token,
+      tokenPrefix: token.substring(0, 10) + '...',
+      adapterHasMetadata: !!adapter.metadata,
+      timestamp: new Date().toISOString()
+    });
+
+    try {
+      const url = await this.repoManager.saveElement(adapter, true);
+      logger.info('Element uploaded to GitHub', { element: elementName, type: elementType, url });
+      return {
+        success: true,
+        message: `Successfully uploaded '${elementName}' (${elementType}) to GitHub portfolio`,
+        data: { url }
+      };
+    } catch (uploadError) {
+      if (uploadError instanceof Error && uploadError.message.includes('repository does not exist')) {
+        return {
+          success: false,
+          message: 'GitHub portfolio repository not found. Please initialize it first using init_portfolio tool.'
+        };
+      }
+      throw uploadError;
     }
   }
   
@@ -649,90 +690,25 @@ export class PortfolioSyncManager {
     showDiff?: boolean
   ): Promise<SyncResult> {
     try {
-      // Get local version
       const localPath = this.portfolioManager.getElementPath(elementType, `${elementName}.md`);
-      let localContent: string | null = null;
-      let localVersion: VersionInfo | null = null;
-      
-      try {
-        localContent = await this.fileOperations.readFile(localPath, { source: 'PortfolioSyncManager.compareVersions' });
-        const parsed = SecureYamlParser.parse(localContent, {
-          maxYamlSize: 64 * 1024,
-          validateContent: false,
-          validateFields: false
-        });
-
-        localVersion = {
-          version: parsed.data?.version || '1.0.0',
-          timestamp: new Date(parsed.data?.updated || parsed.data?.created || Date.now()),
-          author: parsed.data?.author || 'unknown',
-          hash: createHash('sha256').update(localContent).digest('hex'),
-          size: Buffer.byteLength(localContent),
-          source: 'local'
-        };
-      } catch {
-        // No local version
-      }
-      
-      // Get remote version
-      const token = await this.tokenManager.getGitHubTokenAsync();
+      const local = await this.loadLocalVersion(localPath);
+      const token = await this.requireGitHubToken();
       if (!token) {
-        return {
-          success: false,
-          message: 'GitHub authentication required'
-        };
+        return { success: false, message: 'GitHub authentication required' };
       }
-      
+
       const index = await this.indexer.getIndex();
       const entries = index.elements.get(elementType) || [];
       const entry = entries.find(e => e.name === elementName);
-      
-      let remoteVersion: VersionInfo | null = null;
-      let remoteContent: string | null = null;
-      
-      if (entry) {
-        const response = await fetch(entry.downloadUrl, {
-          headers: {
-            'Authorization': `Bearer ${token}`,
-            'Accept': 'application/vnd.github.v3.raw'
-          }
-        });
-        
-        if (response.ok) {
-          remoteContent = await response.text();
-          remoteVersion = {
-            version: entry.version || '1.0.0',
-            timestamp: entry.lastModified,
-            author: entry.author || 'unknown',
-            hash: createHash('sha256').update(remoteContent).digest('hex'),
-            size: entry.size,
-            source: 'remote'
-          };
-        }
-      }
-      
-      // Build comparison result
-      const result: any = {
-        element: elementName,
-        type: elementType,
-        local: localVersion,
-        remote: remoteVersion
-      };
-      
-      if (localVersion && remoteVersion) {
-        result.status = localVersion.hash === remoteVersion.hash ? 'identical' : 'different';
-        
-        if (showDiff && localContent && remoteContent && result.status === 'different') {
-          result.diff = await this.generateDiff(localContent, remoteContent);
-        }
-      } else if (localVersion && !remoteVersion) {
-        result.status = 'local-only';
-      } else if (!localVersion && remoteVersion) {
-        result.status = 'remote-only';
-      } else {
-        result.status = 'not-found';
-      }
-      
+      const remote = entry ? await this.loadRemoteVersion(entry, token) : { version: null, content: null };
+      const result = await this.buildVersionComparisonResult(
+        elementName,
+        elementType,
+        local,
+        remote,
+        showDiff
+      );
+
       return {
         success: true,
         message: `Version comparison for '${elementName}' (${elementType})`,
@@ -746,13 +722,100 @@ export class PortfolioSyncManager {
       };
     }
   }
+
+  private async loadLocalVersion(
+    localPath: string
+  ): Promise<{ version: VersionInfo | null; content: string | null }> {
+    try {
+      const content = await this.fileOperations.readFile(localPath, { source: 'PortfolioSyncManager.compareVersions' });
+      const parsed = SecureYamlParser.parse(content, {
+        maxYamlSize: 64 * 1024,
+        validateContent: false,
+        validateFields: false
+      });
+      return {
+        content,
+        version: {
+          version: parsed.data?.version || '1.0.0',
+          timestamp: new Date(parsed.data?.updated || parsed.data?.created || Date.now()),
+          author: parsed.data?.author || 'unknown',
+          hash: createHash('sha256').update(content).digest('hex'),
+          size: Buffer.byteLength(content),
+          source: 'local'
+        }
+      };
+    } catch {
+      return { version: null, content: null };
+    }
+  }
+
+  private async loadRemoteVersion(
+    entry: GitHubIndexEntry,
+    token: string
+  ): Promise<{ version: VersionInfo | null; content: string | null }> {
+    const response = await fetch(entry.downloadUrl, {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/vnd.github.v3.raw'
+      }
+    });
+    if (!response.ok) {
+      return { version: null, content: null };
+    }
+
+    const content = await response.text();
+    return {
+      content,
+      version: {
+        version: entry.version || '1.0.0',
+        timestamp: entry.lastModified,
+        author: entry.author || 'unknown',
+        hash: createHash('sha256').update(content).digest('hex'),
+        size: entry.size,
+        source: 'remote'
+      }
+    };
+  }
+
+  private async buildVersionComparisonResult(
+    elementName: string,
+    elementType: ElementType,
+    local: { version: VersionInfo | null; content: string | null },
+    remote: { version: VersionInfo | null; content: string | null },
+    showDiff?: boolean
+  ): Promise<any> {
+    const result: any = {
+      element: elementName,
+      type: elementType,
+      local: local.version,
+      remote: remote.version
+    };
+
+    result.status = this.getVersionComparisonStatus(local.version, remote.version);
+    if (showDiff && local.content && remote.content && result.status === 'different') {
+      result.diff = await this.generateDiff(local.content, remote.content);
+    }
+    return result;
+  }
+
+  private getVersionComparisonStatus(
+    localVersion: VersionInfo | null,
+    remoteVersion: VersionInfo | null
+  ): 'identical' | 'different' | 'local-only' | 'remote-only' | 'not-found' {
+    if (localVersion && remoteVersion) {
+      return localVersion.hash === remoteVersion.hash ? 'identical' : 'different';
+    }
+    if (localVersion) return 'local-only';
+    if (remoteVersion) return 'remote-only';
+    return 'not-found';
+  }
   
   /**
    * Bulk download elements
    */
   private async bulkDownload(elementType?: ElementType, confirm?: boolean): Promise<SyncResult> {
     const config = this.configManager.getConfig();
-    
+
     if (!config.sync.bulk.download_enabled) {
       return {
         success: false,
@@ -779,57 +842,72 @@ export class PortfolioSyncManager {
         elements: []
       };
     }
-    
-    // Show preview if required (unless already confirmed)
+
     if (config.sync.bulk.require_preview && !confirm) {
-      return {
-        success: false,
-        message: `Bulk download preview:\n\n${elementsToDownload.length} elements will be downloaded:\n${elementsToDownload.map(e => `- ${e.name} (${e.type})`).join('\n')}\n\nTo proceed, use --confirm flag`,
-        data: { requiresConfirmation: true },
-        elements: elementsToDownload
-      };
+      return this.buildBulkDownloadPreview(elementsToDownload);
     }
-    
-    // Perform actual bulk download
-    const results = {
-      downloaded: [] as string[],
-      skipped: [] as string[],
-      failed: [] as { name: string; error: string }[]
-    };
-    
+
+    const results = PortfolioSyncManager.createBulkDownloadResults();
     for (const element of elementsToDownload) {
-      try {
-        const result = await this.downloadElement(element.name, element.type, undefined, true); // force=true to skip individual confirmations
-        if (result.success) {
-          results.downloaded.push(element.name);
-        } else if (result.message?.includes('already up to date')) {
-          results.skipped.push(element.name);
-        } else {
-          results.failed.push({ name: element.name, error: result.message || 'Unknown error' });
-        }
-      } catch (error) {
-        results.failed.push({ 
-          name: element.name, 
-          error: error instanceof Error ? error.message : String(error) 
-        });
-      }
+      await this.downloadBulkElement(element, results);
     }
-    
-    // Build summary message
+
+    return {
+      success: results.failed.length === 0,
+      message: PortfolioSyncManager.buildBulkDownloadSummary(results),
+      data: results
+    };
+  }
+
+  private buildBulkDownloadPreview(elementsToDownload: SyncElementInfo[]): SyncResult {
+    return {
+      success: false,
+      message: `Bulk download preview:\n\n${elementsToDownload.length} elements will be downloaded:\n${elementsToDownload.map(e => `- ${e.name} (${e.type})`).join('\n')}\n\nTo proceed, use --confirm flag`,
+      data: { requiresConfirmation: true },
+      elements: elementsToDownload
+    };
+  }
+
+  private static createBulkDownloadResults(): {
+    downloaded: string[];
+    skipped: string[];
+    failed: Array<{ name: string; error: string }>;
+  } {
+    return { downloaded: [], skipped: [], failed: [] };
+  }
+
+  private async downloadBulkElement(
+    element: SyncElementInfo,
+    results: ReturnType<typeof PortfolioSyncManager.createBulkDownloadResults>
+  ): Promise<void> {
+    try {
+      const result = await this.downloadElement(element.name, element.type, undefined, true);
+      if (result.success) {
+        results.downloaded.push(element.name);
+      } else if (result.message?.includes('already up to date')) {
+        results.skipped.push(element.name);
+      } else {
+        results.failed.push({ name: element.name, error: result.message || 'Unknown error' });
+      }
+    } catch (error) {
+      results.failed.push({
+        name: element.name,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  private static buildBulkDownloadSummary(
+    results: ReturnType<typeof PortfolioSyncManager.createBulkDownloadResults>
+  ): string {
     let message = `Bulk download complete:\n`;
     message += `- Downloaded: ${results.downloaded.length} elements\n`;
     message += `- Skipped (up to date): ${results.skipped.length} elements\n`;
     message += `- Failed: ${results.failed.length} elements`;
-    
     if (results.failed.length > 0) {
       message += `\n\nFailed downloads:\n${results.failed.map(f => `- ${f.name}: ${f.error}`).join('\n')}`;
     }
-    
-    return {
-      success: results.failed.length === 0,
-      message,
-      data: results
-    };
+    return message;
   }
   
   /**
@@ -845,36 +923,7 @@ export class PortfolioSyncManager {
       };
     }
     
-    // Get list of local elements
-    const types = elementType ? [elementType] : [
-      ElementType.PERSONA,
-      ElementType.SKILL,
-      ElementType.TEMPLATE,
-      ElementType.AGENT,
-      ElementType.MEMORY,
-      ElementType.ENSEMBLE
-    ];
-    
-    const localElements: { name: string; type: ElementType; path: string }[] = [];
-    
-    for (const type of types) {
-      const dir = this.portfolioManager.getElementDir(type);
-      try {
-        const files = await this.fileOperations.listDirectory(dir);
-        for (const file of files) {
-          if (file.endsWith('.md')) {
-            localElements.push({
-              name: file.replace('.md', ''),
-              type,
-              path: path.join(dir, file)
-            });
-          }
-        }
-      } catch {
-        // Directory may not exist yet
-        logger.debug(`Directory for ${type} does not exist yet`);
-      }
-    }
+    const localElements = await this.listLocalElementsForUpload(elementType);
     
     if (localElements.length === 0) {
       return {
@@ -884,64 +933,114 @@ export class PortfolioSyncManager {
       };
     }
     
-    // Show preview if required (unless already confirmed)
     if (config.sync.bulk.require_preview && !confirm) {
-      // Convert to SyncElementInfo format for preview
-      const previewElements: SyncElementInfo[] = localElements.map(e => ({
-        name: e.name,
-        type: e.type,
-        status: 'local-only' as const,
-        action: 'upload' as const
-      }));
-      
-      return {
-        success: false,
-        message: `Bulk upload preview:\n\n${localElements.length} elements will be uploaded:\n${localElements.map(e => `- ${e.name} (${e.type})`).join('\n')}\n\nTo proceed, use --confirm flag`,
-        data: { requiresConfirmation: true },
-        elements: previewElements
-      };
+      return this.buildBulkUploadPreview(localElements);
     }
-    
-    // Perform actual bulk upload
-    const results = {
-      uploaded: [] as string[],
-      skipped: [] as string[],
-      failed: [] as { name: string; error: string }[]
-    };
-    
+
+    const results = PortfolioSyncManager.createBulkUploadResults();
     for (const element of localElements) {
-      try {
-        const result = await this.uploadElement(element.name, element.type, true); // confirm=true to skip individual confirmations
-        if (result.success) {
-          results.uploaded.push(element.name);
-        } else if (result.message?.includes('local-only')) {
-          results.skipped.push(element.name);
-        } else {
-          results.failed.push({ name: element.name, error: result.message || 'Unknown error' });
-        }
-      } catch (error) {
-        results.failed.push({ 
-          name: element.name, 
-          error: error instanceof Error ? error.message : String(error) 
-        });
-      }
+      await this.uploadBulkElement(element, results);
     }
-    
-    // Build summary message
+
+    return {
+      success: results.failed.length === 0,
+      message: PortfolioSyncManager.buildBulkUploadSummary(results),
+      data: results
+    };
+  }
+
+  private async listLocalElementsForUpload(
+    elementType?: ElementType
+  ): Promise<Array<{ name: string; type: ElementType; path: string }>> {
+    const types = elementType ? [elementType] : [
+      ElementType.PERSONA,
+      ElementType.SKILL,
+      ElementType.TEMPLATE,
+      ElementType.AGENT,
+      ElementType.MEMORY,
+      ElementType.ENSEMBLE
+    ];
+    const localElements: Array<{ name: string; type: ElementType; path: string }> = [];
+    for (const type of types) {
+      await this.collectLocalElementsOfType(type, localElements);
+    }
+    return localElements;
+  }
+
+  private async collectLocalElementsOfType(
+    type: ElementType,
+    localElements: Array<{ name: string; type: ElementType; path: string }>
+  ): Promise<void> {
+    const dir = this.portfolioManager.getElementDir(type);
+    try {
+      const files = await this.fileOperations.listDirectory(dir);
+      for (const file of files) {
+        if (file.endsWith('.md')) {
+          localElements.push({ name: file.replace('.md', ''), type, path: path.join(dir, file) });
+        }
+      }
+    } catch {
+      logger.debug(`Directory for ${type} does not exist yet`);
+    }
+  }
+
+  private buildBulkUploadPreview(
+    localElements: Array<{ name: string; type: ElementType; path: string }>
+  ): SyncResult {
+    const previewElements: SyncElementInfo[] = localElements.map(e => ({
+      name: e.name,
+      type: e.type,
+      status: 'local-only' as const,
+      action: 'upload' as const
+    }));
+    return {
+      success: false,
+      message: `Bulk upload preview:\n\n${localElements.length} elements will be uploaded:\n${localElements.map(e => `- ${e.name} (${e.type})`).join('\n')}\n\nTo proceed, use --confirm flag`,
+      data: { requiresConfirmation: true },
+      elements: previewElements
+    };
+  }
+
+  private static createBulkUploadResults(): {
+    uploaded: string[];
+    skipped: string[];
+    failed: Array<{ name: string; error: string }>;
+  } {
+    return { uploaded: [], skipped: [], failed: [] };
+  }
+
+  private async uploadBulkElement(
+    element: { name: string; type: ElementType },
+    results: ReturnType<typeof PortfolioSyncManager.createBulkUploadResults>
+  ): Promise<void> {
+    try {
+      const result = await this.uploadElement(element.name, element.type, true);
+      if (result.success) {
+        results.uploaded.push(element.name);
+      } else if (result.message?.includes('local-only')) {
+        results.skipped.push(element.name);
+      } else {
+        results.failed.push({ name: element.name, error: result.message || 'Unknown error' });
+      }
+    } catch (error) {
+      results.failed.push({
+        name: element.name,
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  private static buildBulkUploadSummary(
+    results: ReturnType<typeof PortfolioSyncManager.createBulkUploadResults>
+  ): string {
     let message = `Bulk upload complete:\n`;
     message += `- Uploaded: ${results.uploaded.length} elements\n`;
     message += `- Skipped (local-only): ${results.skipped.length} elements\n`;
     message += `- Failed: ${results.failed.length} elements`;
-    
     if (results.failed.length > 0) {
       message += `\n\nFailed uploads:\n${results.failed.map(f => `- ${f.name}: ${f.error}`).join('\n')}`;
     }
-    
-    return {
-      success: results.failed.length === 0,
-      message,
-      data: results
-    };
+    return message;
   }
   
   /**
@@ -1074,16 +1173,23 @@ export class PortfolioSyncManager {
    * Returns a score between 0 and 1
    */
   private calculateSimilarity(a: string, b: string): number {
-    // Exact match
     if (a === b) return 1.0;
-    
-    // One contains the other
     if (a.includes(b) || b.includes(a)) return 0.8;
-    
-    // Calculate word overlap
+
     const wordsA = a.split(/[^a-z0-9]+/);
     const wordsB = b.split(/[^a-z0-9]+/);
-    
+    return this.calculateWordSimilarity(wordsA, wordsB);
+  }
+
+  private calculateWordSimilarity(wordsA: string[], wordsB: string[]): number {
+    const overlapScore = PortfolioSyncManager.calculateWordOverlapScore(wordsA, wordsB);
+    if (overlapScore > 0) {
+      return overlapScore;
+    }
+    return PortfolioSyncManager.hasPartialWordMatch(wordsA, wordsB) ? 0.5 : 0;
+  }
+
+  private static calculateWordOverlapScore(wordsA: string[], wordsB: string[]): number {
     let matches = 0;
     for (const wordA of wordsA) {
       if (wordA && wordsB.some(wordB => wordB === wordA)) {
@@ -1095,19 +1201,21 @@ export class PortfolioSyncManager {
       const overlap = (matches * 2) / (wordsA.length + wordsB.length);
       return Math.max(0.6, overlap); // At least 0.6 for any word match
     }
-    
-    // Check for partial matches
+    return 0;
+  }
+
+  private static hasPartialWordMatch(wordsA: string[], wordsB: string[]): boolean {
     for (const wordA of wordsA) {
       for (const wordB of wordsB) {
-        if (wordA.length > 3 && wordB.length > 3) {
-          if (wordA.includes(wordB) || wordB.includes(wordA)) {
-            return 0.5;
-          }
+        if (
+          wordA.length > 3 &&
+          wordB.length > 3 &&
+          (wordA.includes(wordB) || wordB.includes(wordA))
+        ) {
+          return true;
         }
       }
     }
-    
-    // No significant similarity
-    return 0;
+    return false;
   }
 }

--- a/src/portfolio/UnifiedIndexManager.ts
+++ b/src/portfolio/UnifiedIndexManager.ts
@@ -1390,7 +1390,7 @@ export class UnifiedIndexManager {
   ): number {
     let score = 0;
     if (fields.name.includes(token)) {
-      score += fields.name === token ? 10 : (fields.name.startsWith(token) ? 5 : 2);
+      score += UnifiedIndexManager.scoreNameTokenMatch(fields.name, token);
     }
     if (fields.description.includes(token)) score += 3;
     if (fields.path.includes(token)) score += 1;
@@ -1398,8 +1398,15 @@ export class UnifiedIndexManager {
     return score;
   }
 
+  private static scoreNameTokenMatch(name: string, token: string): number {
+    if (name === token) return 10;
+    if (name.startsWith(token)) return 5;
+    return 2;
+  }
+
   private static calculateExactQueryBonus(name: string, query: string): number {
-    return name.includes(query.toLowerCase()) ? (query.length > 3 ? 15 : 10) : 0;
+    if (!name.includes(query.toLowerCase())) return 0;
+    return query.length > 3 ? 15 : 10;
   }
 
   /**

--- a/src/portfolio/UnifiedIndexManager.ts
+++ b/src/portfolio/UnifiedIndexManager.ts
@@ -1056,42 +1056,55 @@ export class UnifiedIndexManager {
     try {
       const githubIndex = await this.githubIndexer.getIndex();
       const results: UnifiedSearchResult[] = [];
-      
-      const queryLower = query.toLowerCase();
-      const queryTokens = queryLower.split(/\s+/).filter(token => token.length > 0);
-      
-      if (queryTokens.length === 0 && query.trim() !== '') {
+      const queryTokens = UnifiedIndexManager.tokenizeQuery(query);
+
+      if (UnifiedIndexManager.shouldReturnNoQueryResults(query, queryTokens)) {
         return results;
       }
-      
-      // Search across all GitHub elements
+
       for (const [elementType, entries] of githubIndex.elements) {
-        // Filter by element type if specified
-        if (options.elementType && elementType !== options.elementType) {
-          continue;
-        }
-        
-        for (const entry of entries) {
-          const score = this.calculateGitHubMatchScore(entry, queryTokens, query);
-          if (score > 0 || query.trim() === '') {
-            results.push({
-              source: 'github' as const,
-              entry: this.convertGitHubEntry(entry),
-              matchType: this.determineMatchType(entry, queryTokens),
-              score: query.trim() === '' ? 1 : score, // Default score for empty query
-              version: entry.version
-            });
-          }
-        }
+        this.addGitHubSearchResults(results, elementType, entries, query, queryTokens, options);
       }
-      
+
       return results.sort((a, b) => b.score - a.score);
-      
     } catch (error) {
       logger.debug('GitHub search failed', {
         error: error instanceof Error ? error.message : String(error)
       });
       throw error; // Re-throw to trigger fallback
+    }
+  }
+
+  private static tokenizeQuery(query: string): string[] {
+    return query.toLowerCase().split(/\s+/).filter(token => token.length > 0);
+  }
+
+  private static shouldReturnNoQueryResults(query: string, queryTokens: string[]): boolean {
+    return queryTokens.length === 0 && query.trim() !== '';
+  }
+
+  private addGitHubSearchResults(
+    results: UnifiedSearchResult[],
+    elementType: ElementType,
+    entries: GitHubIndexEntry[],
+    query: string,
+    queryTokens: string[],
+    options: UnifiedSearchOptions
+  ): void {
+    if (options.elementType && elementType !== options.elementType) {
+      return;
+    }
+    for (const entry of entries) {
+      const score = this.calculateGitHubMatchScore(entry, queryTokens, query);
+      if (score > 0 || query.trim() === '') {
+        results.push({
+          source: 'github' as const,
+          entry: this.convertGitHubEntry(entry),
+          matchType: this.determineMatchType(entry, queryTokens),
+          score: query.trim() === '' ? 1 : score,
+          version: entry.version
+        });
+      }
     }
   }
   
@@ -1125,42 +1138,47 @@ export class UnifiedIndexManager {
     try {
       const collectionIndex = await this.collectionIndexCache.getIndex();
       const results: UnifiedSearchResult[] = [];
-      
-      const queryLower = query.toLowerCase();
-      const queryTokens = queryLower.split(/\s+/).filter(token => token.length > 0);
-      
-      if (queryTokens.length === 0 && query.trim() !== '') {
+      const queryTokens = UnifiedIndexManager.tokenizeQuery(query);
+
+      if (UnifiedIndexManager.shouldReturnNoQueryResults(query, queryTokens)) {
         return results;
       }
-      
-      // Search across all collection elements
+
       for (const [elementType, entries] of Object.entries(collectionIndex.index)) {
-        // Filter by element type if specified
-        if (options.elementType && elementType !== options.elementType.toString()) {
-          continue;
-        }
-        
-        for (const entry of entries) {
-          const score = this.calculateCollectionMatchScore(entry, queryTokens, query);
-          if (score > 0 || query.trim() === '') {
-            results.push({
-              source: 'collection' as const,
-              entry: this.convertCollectionEntry(entry, elementType),
-              matchType: this.determineCollectionMatchType(entry, queryTokens),
-              score: query.trim() === '' ? 1 : score, // Default score for empty query
-              version: entry.version
-            });
-          }
-        }
+        this.addCollectionSearchResults(results, elementType, entries, query, queryTokens, options);
       }
-      
+
       return results.sort((a, b) => b.score - a.score);
-      
     } catch (error) {
       logger.debug('Collection search failed', {
         error: error instanceof Error ? error.message : String(error)
       });
       throw error; // Re-throw to trigger fallback
+    }
+  }
+
+  private addCollectionSearchResults(
+    results: UnifiedSearchResult[],
+    elementType: string,
+    entries: CollectionIndexEntry[],
+    query: string,
+    queryTokens: string[],
+    options: UnifiedSearchOptions
+  ): void {
+    if (options.elementType && elementType !== options.elementType.toString()) {
+      return;
+    }
+    for (const entry of entries) {
+      const score = this.calculateCollectionMatchScore(entry, queryTokens, query);
+      if (score > 0 || query.trim() === '') {
+        results.push({
+          source: 'collection' as const,
+          entry: this.convertCollectionEntry(entry, elementType),
+          matchType: this.determineCollectionMatchType(entry, queryTokens),
+          score: query.trim() === '' ? 1 : score,
+          version: entry.version
+        });
+      }
     }
   }
   
@@ -1320,32 +1338,15 @@ export class UnifiedIndexManager {
    */
   private calculateGitHubMatchScore(entry: GitHubIndexEntry, queryTokens: string[], query: string): number {
     if (queryTokens.length === 0) return 1; // Default score for empty query
-    
-    let score = 0;
-    
-    const name = entry.name.toLowerCase();
-    const description = (entry.description || '').toLowerCase();
-    const path = (entry.path || '').toLowerCase();
-    
-    // Check name matches
-    for (const token of queryTokens) {
-      if (name.includes(token)) {
-        score += name === token ? 10 : (name.startsWith(token) ? 5 : 2);
+    return UnifiedIndexManager.calculateSearchFieldScore(
+      queryTokens,
+      query,
+      {
+        name: entry.name,
+        description: entry.description || '',
+        path: entry.path || '',
       }
-      if (description.includes(token)) {
-        score += 3;
-      }
-      if (path.includes(token)) {
-        score += 1;
-      }
-    }
-    
-    // Exact query match bonus
-    if (name.includes(query.toLowerCase())) {
-      score += query.length > 3 ? 15 : 10;
-    }
-    
-    return score;
+    );
   }
   
   /**
@@ -1353,36 +1354,52 @@ export class UnifiedIndexManager {
    */
   private calculateCollectionMatchScore(entry: CollectionIndexEntry, queryTokens: string[], query: string): number {
     if (queryTokens.length === 0) return 1; // Default score for empty query
-    
+    return UnifiedIndexManager.calculateSearchFieldScore(
+      queryTokens,
+      query,
+      {
+        name: entry.name,
+        description: entry.description || '',
+        path: entry.path || '',
+        tags: entry.tags.join(' '),
+      }
+    );
+  }
+
+  private static calculateSearchFieldScore(
+    queryTokens: string[],
+    query: string,
+    fields: { name: string; description: string; path: string; tags?: string }
+  ): number {
+    const normalized = {
+      name: fields.name.toLowerCase(),
+      description: fields.description.toLowerCase(),
+      path: fields.path.toLowerCase(),
+      tags: fields.tags?.toLowerCase() ?? '',
+    };
+    const score = queryTokens.reduce(
+      (total, token) => total + UnifiedIndexManager.calculateTokenScore(token, normalized),
+      0
+    );
+    return score + UnifiedIndexManager.calculateExactQueryBonus(normalized.name, query);
+  }
+
+  private static calculateTokenScore(
+    token: string,
+    fields: { name: string; description: string; path: string; tags: string }
+  ): number {
     let score = 0;
-    
-    const name = entry.name.toLowerCase();
-    const description = (entry.description || '').toLowerCase();
-    const path = (entry.path || '').toLowerCase();
-    const tags = entry.tags.map(tag => tag.toLowerCase()).join(' ');
-    
-    // Check matches across all fields
-    for (const token of queryTokens) {
-      if (name.includes(token)) {
-        score += name === token ? 10 : (name.startsWith(token) ? 5 : 2);
-      }
-      if (description.includes(token)) {
-        score += 3;
-      }
-      if (path.includes(token)) {
-        score += 1;
-      }
-      if (tags.includes(token)) {
-        score += 4;
-      }
+    if (fields.name.includes(token)) {
+      score += fields.name === token ? 10 : (fields.name.startsWith(token) ? 5 : 2);
     }
-    
-    // Exact query match bonus
-    if (name.includes(query.toLowerCase())) {
-      score += query.length > 3 ? 15 : 10;
-    }
-    
+    if (fields.description.includes(token)) score += 3;
+    if (fields.path.includes(token)) score += 1;
+    if (fields.tags.includes(token)) score += 4;
     return score;
+  }
+
+  private static calculateExactQueryBonus(name: string, query: string): number {
+    return name.includes(query.toLowerCase()) ? (query.length > 3 ? 15 : 10) : 0;
   }
 
   /**
@@ -1527,69 +1544,75 @@ export class UnifiedIndexManager {
    * Identifies elements that exist in multiple sources (local, GitHub, collection)
    */
   private async calculateDuplicatesCount(): Promise<number> {
-    // Track duplicates using a map of element names to sources
     const elementSources = new Map<string, Set<string>>();
 
     try {
-      // Check local index
-      const localIndex = await this.localIndexManager.getIndex();
-      if (localIndex?.byName) {
-        for (const [name] of localIndex.byName) {
-          if (name) {
-            if (!elementSources.has(name)) {
-              elementSources.set(name, new Set());
-            }
-            elementSources.get(name)!.add('local');
-          }
-        }
-      }
-
-      // Check GitHub index
-      const githubIndex = await this.githubIndexer.getIndex();
-      if (githubIndex?.elements) {
-        for (const [, entries] of githubIndex.elements) {
-          for (const entry of entries) {
-            const name = entry.name;
-            if (name) {
-              if (!elementSources.has(name)) {
-                elementSources.set(name, new Set());
-              }
-              elementSources.get(name)!.add('github');
-            }
-          }
-        }
-      }
-
-      // Check collection index
-      const collectionIndex = await this.collectionIndexCache.getIndex();
-      if (collectionIndex?.index) {
-        for (const elementType in collectionIndex.index) {
-          const entries = collectionIndex.index[elementType];
-          for (const entry of entries) {
-            const name = entry.name;
-            if (name) {
-              if (!elementSources.has(name)) {
-                elementSources.set(name, new Set());
-              }
-              elementSources.get(name)!.add('collection');
-            }
-          }
-        }
-      }
+      await this.addLocalDuplicateSources(elementSources);
+      await this.addGitHubDuplicateSources(elementSources);
+      await this.addCollectionDuplicateSources(elementSources);
     } catch (error) {
-      // Log error but don't fail
       logger.debug('Error calculating duplicates count', error);
       return 0;
     }
 
-    // Count elements that appear in more than one source
+    return UnifiedIndexManager.countMultiSourceElements(elementSources);
+  }
+
+  private async addLocalDuplicateSources(elementSources: Map<string, Set<string>>): Promise<void> {
+    const localIndex = await this.localIndexManager.getIndex();
+    if (!localIndex?.byName) {
+      return;
+    }
+    for (const [name] of localIndex.byName) {
+      UnifiedIndexManager.addElementSource(elementSources, name, 'local');
+    }
+  }
+
+  private async addGitHubDuplicateSources(elementSources: Map<string, Set<string>>): Promise<void> {
+    const githubIndex = await this.githubIndexer.getIndex();
+    if (!githubIndex?.elements) {
+      return;
+    }
+    for (const [, entries] of githubIndex.elements) {
+      for (const entry of entries) {
+        UnifiedIndexManager.addElementSource(elementSources, entry.name, 'github');
+      }
+    }
+  }
+
+  private async addCollectionDuplicateSources(elementSources: Map<string, Set<string>>): Promise<void> {
+    const collectionIndex = await this.collectionIndexCache.getIndex();
+    if (!collectionIndex?.index) {
+      return;
+    }
+    for (const elementType in collectionIndex.index) {
+      const entries = collectionIndex.index[elementType];
+      for (const entry of entries) {
+        UnifiedIndexManager.addElementSource(elementSources, entry.name, 'collection');
+      }
+    }
+  }
+
+  private static addElementSource(
+    elementSources: Map<string, Set<string>>,
+    name: string | undefined,
+    source: string
+  ): void {
+    if (!name) {
+      return;
+    }
+    const sources = elementSources.get(name) ?? new Set<string>();
+    sources.add(source);
+    elementSources.set(name, sources);
+  }
+
+  private static countMultiSourceElements(elementSources: Map<string, Set<string>>): number {
     let duplicateCount = 0;
     for (const sources of elementSources.values()) {
       if (sources.size > 1) {
         duplicateCount++;
       }
     }
-
     return duplicateCount;
   }
 


### PR DESCRIPTION
## Summary

Clears the remaining SonarCloud S3776 cognitive-complexity findings in
the portfolio/agent manager cluster (23 sites across 5 files) and splits
the 1,364-line `EmbeddedAuthorizationServer.ts` into focused per-concern
modules. No public API change; existing tests pass unchanged.

## What landed

### Cognitive-complexity sweep (23 sites cleared)

- **`src/elements/agents/AgentManager.ts`** — 7 sites including
  `parseMetadata` (was 121), `validateV2FieldsForCreate` (was 69),
  `executeAgent` (was 49), plus `create`, `validateParameters`,
  `detectActivationCycles`, and `serializeElement`. Each split into
  focused private helpers; the parent methods become orchestrators.
- **`src/portfolio/PortfolioSyncManager.ts`** — 7 sites across the sync
  flow (`handleSyncOperation`, `downloadElement`, `uploadElement`,
  `compareVersions`, `bulkDownload`, `bulkUpload`, `calculateSimilarity`).
- **`src/portfolio/EnhancedIndexManager.ts`** — 4 sites including
  `buildIndex`, `loadEnhancedIndexConfig`, `getTriggerMetrics`,
  `searchEnhanced`.
- **`src/portfolio/GitHubPortfolioIndexer.ts`** — 3 sites including
  `getIndex`, `fetchElementTypeContent`, `createGitHubIndexEntry`.
- **`src/portfolio/UnifiedIndexManager.ts`** — 2 sites including
  `calculateDuplicatesCount` (was 44).

### EmbeddedAuthorizationServer split

`src/auth/embedded-as/EmbeddedAuthorizationServer.ts` reduced from 1,364
to 998 lines by extracting into four sibling modules:

- `EmbeddedASBootstrap.ts` (129 LOC) — bootstrap gate, readiness, mode
  detection
- `EmbeddedASTokens.ts` (149 LOC) — `validate`/`issue` and JWT helpers
- `EmbeddedASAdmin.ts` (60 LOC) — admin endpoints
- `EmbeddedASOidcAccount.ts` (52 LOC) — OIDC `findAccount` / `claims`

Public class surface and method signatures preserved.

## Bug-class fixes (caught by expanded local lint)

- `EmbeddedAuthorizationServer.ts` — the `state.provider.callback()(req,
  res)` calls inside the router handler are now awaited so async
  rejections from the OIDC provider reach the surrounding `try/catch`
  and flow to Express's `next(err)`. Without the await, async errors
  during token issuance or adapter operations became unhandled
  rejections.
- `GitHubPortfolioIndexer.ts` frontmatter regexes — narrowed each
  `/^FIELD:\s*(.+)$/m` to `/^FIELD:[ \t]?([^\r\n]+)$/m` so the leading
  whitespace quantifier can't overlap with the value class. Removes the
  polynomial-backtracking shape (regexp/no-super-linear-backtracking).

## Related issues

Related to #1169 (master SonarCloud tracking), #1179 (cognitive
complexity bucket — 108 issues), and #1608 (147 flagged functions);
this PR clears 23 of the cited sites including the highest-complexity
ones in `AgentManager.ts` listed in #1608's top-offenders table.
#1629 (telemetry extraction from `EnhancedIndexManager`) is related
but not addressed — we only verified the `Math.random()` site noted
there is for telemetry sampling, not security.

## Test plan

- [x] TypeScript compile clean
- [x] ESLint with `max-warnings=0`
- [x] Local sonar-mirror lint: all 23 cognitive-complexity sites cleared
- [x] Unit tests pass with no test modifications
- [x] Integration tests pass
- [x] E2E tests pass