### PR TITLE
chore: merge develop into integration (2026-05-25)

### DIFF
--- a/docs/architecture/element-manager-consolidation.md
+++ b/docs/architecture/element-manager-consolidation.md
@@ -720,7 +720,7 @@ export abstract class BaseElementManager<T extends IElement> {
     // Sanitize inputs
     const sanitizedName = sanitizeInput(metadata.name, 100);
     const sanitizedDesc = metadata.description ?
-      sanitizeInput(metadata.description, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : '';
+      sanitizeInput(metadata.description, SECURITY_LIMITS.MAX_YAML_LENGTH) : '';
     const sanitizedContent = content ?
       sanitizeInput(content, 50000) : '';
 
@@ -1094,7 +1094,7 @@ const skillConfig: ElementTypeConfig = {
   },
   validation: {
     namePattern: /^[a-zA-Z0-9-]+$/,
-    descriptionMaxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
+    descriptionMaxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
     contentMaxLength: 50000,
     customValidation: (element) => {
       const skill = element as Skill;
@@ -1126,7 +1126,7 @@ const agentConfig: ElementTypeConfig = {
   },
   validation: {
     namePattern: /^[a-zA-Z0-9_-]+$/,
-    descriptionMaxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
+    descriptionMaxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
     contentMaxLength: 50000
   },
   fileExtension: '.md',

--- a/docs/architecture/element-manager-consolidation.md
+++ b/docs/architecture/element-manager-consolidation.md
@@ -720,7 +720,7 @@ export abstract class BaseElementManager<T extends IElement> {
     // Sanitize inputs
     const sanitizedName = sanitizeInput(metadata.name, 100);
     const sanitizedDesc = metadata.description ?
-      sanitizeInput(metadata.description, 500) : '';
+      sanitizeInput(metadata.description, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : '';
     const sanitizedContent = content ?
       sanitizeInput(content, 50000) : '';
 
@@ -1094,7 +1094,7 @@ const skillConfig: ElementTypeConfig = {
   },
   validation: {
     namePattern: /^[a-zA-Z0-9-]+$/,
-    descriptionMaxLength: 500,
+    descriptionMaxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
     contentMaxLength: 50000,
     customValidation: (element) => {
       const skill = element as Skill;
@@ -1126,7 +1126,7 @@ const agentConfig: ElementTypeConfig = {
   },
   validation: {
     namePattern: /^[a-zA-Z0-9_-]+$/,
-    descriptionMaxLength: 500,
+    descriptionMaxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
     contentMaxLength: 50000
   },
   fileExtension: '.md',

--- a/docs/architecture/element-manager-consolidation.md
+++ b/docs/architecture/element-manager-consolidation.md
@@ -720,7 +720,7 @@ export abstract class BaseElementManager<T extends IElement> {
     // Sanitize inputs
     const sanitizedName = sanitizeInput(metadata.name, 100);
     const sanitizedDesc = metadata.description ?
-      sanitizeInput(metadata.description, 500) : '';
+      sanitizeInput(metadata.description, SECURITY_LIMITS.MAX_YAML_LENGTH) : '';
     const sanitizedContent = content ?
       sanitizeInput(content, 50000) : '';
 
@@ -1094,7 +1094,7 @@ const skillConfig: ElementTypeConfig = {
   },
   validation: {
     namePattern: /^[a-zA-Z0-9-]+$/,
-    descriptionMaxLength: 500,
+    descriptionMaxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
     contentMaxLength: 50000,
     customValidation: (element) => {
       const skill = element as Skill;
@@ -1126,7 +1126,7 @@ const agentConfig: ElementTypeConfig = {
   },
   validation: {
     namePattern: /^[a-zA-Z0-9_-]+$/,
-    descriptionMaxLength: 500,
+    descriptionMaxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
     contentMaxLength: 50000
   },
   fileExtension: '.md',

--- a/docs/architecture/ensemble-system.md
+++ b/docs/architecture/ensemble-system.md
@@ -700,7 +700,7 @@ elements:
 All ensemble metadata is validated and sanitized:
 
 - **Name**: Alphanumeric, hyphens, max 100 chars
-- **Description**: Max 500 chars, HTML stripped
+- **Description**: Bounded by YAML/frontmatter safety limits, HTML stripped
 - **Element Names**: Sanitized, Unicode normalized
 - **Conditions**: Max 500 chars, injection-safe
 - **Dependencies**: Max 10 per element

--- a/docs/reference/element-types.md
+++ b/docs/reference/element-types.md
@@ -96,7 +96,7 @@ Triggers are keywords that help AI assistants discover and activate elements bas
 | Field | Max Length | Required | Description |
 |-------|------------|----------|-------------|
 | `name` | 100 | Yes | Display name for the element |
-| `description` | 500 | No | Brief explanation of purpose |
+| `description` | No description-specific cap | No | Explanation of purpose; bounded by overall YAML/file safety limits |
 | `author` | 100 | No | Creator or maintainer |
 | `version` | 20 | No | Semantic version (e.g., `1.0.0`) |
 | `category` | 50 | No | Grouping category |

--- a/docs/reference/element-types.md
+++ b/docs/reference/element-types.md
@@ -96,7 +96,7 @@ Triggers are keywords that help AI assistants discover and activate elements bas
 | Field | Max Length | Required | Description |
 |-------|------------|----------|-------------|
 | `name` | 100 | Yes | Display name for the element |
-| `description` | 500 | No | Brief explanation of purpose |
+| `description` | No arbitrary 500-character cap | No | Explanation of purpose; bounded by YAML/frontmatter and file safety limits |
 | `author` | 100 | No | Creator or maintainer |
 | `version` | 20 | No | Semantic version (e.g., `1.0.0`) |
 | `category` | 50 | No | Grouping category |

--- a/docs/reference/element-types.md
+++ b/docs/reference/element-types.md
@@ -96,7 +96,7 @@ Triggers are keywords that help AI assistants discover and activate elements bas
 | Field | Max Length | Required | Description |
 |-------|------------|----------|-------------|
 | `name` | 100 | Yes | Display name for the element |
-| `description` | No description-specific cap | No | Explanation of purpose; bounded by overall YAML/file safety limits |
+| `description` | No arbitrary 500-character cap | No | Explanation of purpose; bounded by YAML/frontmatter and file safety limits |
 | `author` | 100 | No | Creator or maintainer |
 | `version` | 20 | No | Semantic version (e.g., `1.0.0`) |
 | `category` | 50 | No | Grouping category |

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "posthog-node": "^5.24.17",
         "qrcode": "^1.5.4",
         "smol-toml": "^1.6.1",
-        "uuid": "^11.1.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -53,7 +52,6 @@
         "@types/qrcode": "^1.5.6",
         "@types/semver": "^7.7.1",
         "@types/supertest": "^7.2.0",
-        "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.46.2",
         "@typescript-eslint/parser": "^8.48.1",
         "archiver": "^7.0.1",
@@ -4041,11 +4039,6 @@
       "version": "2.0.7",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -11574,17 +11567,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "posthog-node": "^5.24.17",
         "qrcode": "^1.5.4",
         "smol-toml": "^1.6.1",
-        "uuid": "^11.1.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -53,7 +52,6 @@
         "@types/qrcode": "^1.5.6",
         "@types/semver": "^7.7.1",
         "@types/supertest": "^7.2.0",
-        "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.46.2",
         "@typescript-eslint/parser": "^8.48.1",
         "archiver": "^7.0.1",
@@ -4041,11 +4039,6 @@
       "version": "2.0.7",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -11576,17 +11569,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1204,7 +1204,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1270,7 +1272,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2036,9 +2040,9 @@
       }
     },
     "node_modules/@jest/globals/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5117,7 +5121,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6193,7 +6199,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8320,7 +8328,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8639,9 +8649,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -9293,10 +9303,13 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -9314,7 +9327,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10139,9 +10154,9 @@
       }
     },
     "node_modules/serve-handler/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10292,9 +10307,9 @@
       }
     },
     "node_modules/shelljs/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10801,7 +10816,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10887,7 +10904,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,12 +36,12 @@
         "posthog-node": "^5.24.17",
         "qrcode": "^1.5.4",
         "smol-toml": "^1.6.1",
-        "uuid": "^11.1.1",
         "zod": "^4.3.6"
       },
       "bin": {
         "dollhouse-admin-bootstrap": "dist/cli/admin-bootstrap.js",
         "dollhouse-allowlist": "dist/cli/allowlist.js",
+        "dollhouse-audit": "dist/cli/audit/dollhouse-audit.js",
         "dollhouse-console-token": "dist/cli/console-token.js",
         "dollhouse-create-user": "dist/cli/create-user.js",
         "dollhousemcp": "dist/index.js",
@@ -64,7 +64,6 @@
         "@types/qrcode": "^1.5.6",
         "@types/semver": "^7.7.1",
         "@types/supertest": "^7.2.0",
-        "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.46.2",
         "@typescript-eslint/parser": "^8.48.1",
         "archiver": "^7.0.1",
@@ -270,7 +269,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -705,21 +706,21 @@
       "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz",
-      "integrity": "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -728,9 +729,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1259,6 +1260,8 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
       "cpu": [
         "arm64"
       ],
@@ -1630,7 +1633,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1668,7 +1673,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1734,7 +1741,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1923,6 +1932,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -2500,9 +2521,9 @@
       }
     },
     "node_modules/@jest/globals/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4246,9 +4267,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4639,11 +4660,6 @@
       "version": "2.0.7",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -5052,6 +5068,8 @@
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
       "cpu": [
         "arm64"
       ],
@@ -5126,6 +5144,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5140,6 +5161,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5154,6 +5178,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5168,6 +5195,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5182,6 +5212,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5196,6 +5229,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5699,6 +5735,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.1",
       "license": "MIT",
@@ -5736,7 +5785,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5755,7 +5806,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.3",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -5773,10 +5826,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001735",
-        "electron-to-chromium": "^1.5.204",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5901,7 +5955,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001762",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {
@@ -5938,16 +5994,18 @@
       }
     },
     "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "license": "ISC",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/ci-info": {
-      "version": "4.3.0",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
       "dev": true,
       "funding": [
         {
@@ -7237,7 +7295,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.267",
+      "version": "1.5.360",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.360.tgz",
+      "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7472,7 +7532,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7923,7 +7985,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -8141,36 +8205,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "dev": true,
@@ -8178,7 +8212,10 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8481,9 +8518,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -8740,9 +8777,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
+      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -9652,7 +9689,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10071,9 +10110,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -10279,53 +10318,21 @@
     },
     "node_modules/minipass": {
       "version": "7.1.2",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
       "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">= 18"
       }
     },
     "node_modules/mlly": {
@@ -10460,7 +10467,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -10817,7 +10826,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11666,9 +11677,9 @@
       }
     },
     "node_modules/serve-handler/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11819,9 +11830,9 @@
       }
     },
     "node_modules/shelljs/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12272,21 +12283,19 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/tar-stream": {
@@ -12299,20 +12308,14 @@
         "streamx": "^2.15.0"
       }
     },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -12328,7 +12331,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12414,7 +12419,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12483,7 +12490,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13007,7 +13016,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -13102,19 +13113,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -13557,14 +13555,6 @@
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "packages/safety/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6640,7 +6640,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -7199,9 +7201,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -7412,9 +7414,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
+      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1465,6 +1465,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "dev": true,
@@ -5326,12 +5338,12 @@
       }
     },
     "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "license": "ISC",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/ci-info": {
@@ -6860,36 +6872,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -8857,53 +8839,21 @@
     },
     "node_modules/minipass": {
       "version": "7.1.2",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
       "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">= 18"
       }
     },
     "node_modules/mlly": {
@@ -10760,21 +10710,19 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/tar-stream": {
@@ -10787,20 +10735,14 @@
         "streamx": "^2.15.0"
       }
     },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -193,7 +193,6 @@
     "posthog-node": "^5.24.17",
     "qrcode": "^1.5.4",
     "smol-toml": "^1.6.1",
-    "uuid": "^11.1.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -211,7 +210,6 @@
     "@types/qrcode": "^1.5.6",
     "@types/semver": "^7.7.1",
     "@types/supertest": "^7.2.0",
-    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.46.2",
     "@typescript-eslint/parser": "^8.48.1",
     "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -240,6 +240,14 @@
     "hono": "4.12.18",
     "@hono/node-server": "1.19.13",
     "fast-uri": "3.1.2",
-    "ip-address": "10.1.1"
+    "ip-address": "10.1.1",
+    "lodash": "4.18.1",
+    "picomatch@<2.3.2": "2.3.2",
+    "picomatch@>=4.0.0 <4.0.4": "4.0.4",
+    "brace-expansion@<1.1.13": "1.1.13",
+    "brace-expansion@>=2.0.0 <2.0.3": "2.0.3",
+    "express": {
+      "path-to-regexp": "8.4.2"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -214,7 +214,6 @@
     "posthog-node": "^5.24.17",
     "qrcode": "^1.5.4",
     "smol-toml": "^1.6.1",
-    "uuid": "^11.1.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -234,7 +233,6 @@
     "@types/qrcode": "^1.5.6",
     "@types/semver": "^7.7.1",
     "@types/supertest": "^7.2.0",
-    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.46.2",
     "@typescript-eslint/parser": "^8.48.1",
     "archiver": "^7.0.1",
@@ -263,7 +261,20 @@
     "@istanbuljs/load-nyc-config": {
       "js-yaml": "3.14.2"
     },
-    "hono": "4.12.14",
-    "@hono/node-server": "1.19.13"
+    "hono": "4.12.18",
+    "@hono/node-server": "1.19.13",
+    "fast-uri": "3.1.2",
+    "ip-address": "10.1.1",
+    "lodash": "4.18.1",
+    "picomatch@<2.3.2": "2.3.2",
+    "picomatch@>=4.0.0 <4.0.4": "4.0.4",
+    "brace-expansion@<1.1.13": "1.1.13",
+    "brace-expansion@>=2.0.0 <2.0.3": "2.0.3",
+    "express": {
+      "path-to-regexp": "8.4.2"
+    },
+    "giget": {
+      "tar": "7.5.15"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -248,6 +248,9 @@
     "brace-expansion@>=2.0.0 <2.0.3": "2.0.3",
     "express": {
       "path-to-regexp": "8.4.2"
+    },
+    "giget": {
+      "tar": "7.5.15"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -239,7 +239,9 @@
     "@istanbuljs/load-nyc-config": {
       "js-yaml": "3.14.2"
     },
-    "hono": "4.12.14",
-    "@hono/node-server": "1.19.13"
+    "hono": "4.12.18",
+    "@hono/node-server": "1.19.13",
+    "fast-uri": "3.1.2",
+    "ip-address": "10.1.1"
   }
 }

--- a/src/elements/BaseElement.ts
+++ b/src/elements/BaseElement.ts
@@ -16,7 +16,7 @@ import {
   UserFeedback
 } from '../types/elements/index.js';
 import { ElementType } from '../portfolio/types.js';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
 import * as yaml from 'js-yaml';
 import { logger } from '../utils/logger.js';
 import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
@@ -106,7 +106,7 @@ export abstract class BaseElement implements IElement {
     });
 
     this.type = type;
-    this.id = metadata.name ? this.generateId(normalized.name) : uuidv4();
+    this.id = metadata.name ? this.generateId(normalized.name) : randomUUID();
     this.version = normalized.version || '1.0.0';  // Guaranteed by normalizeMetadata, but add fallback for type safety
 
     // Spread normalized common metadata

--- a/src/elements/agents/Agent.ts
+++ b/src/elements/agents/Agent.ts
@@ -66,7 +66,7 @@ export class Agent extends BaseElement implements IElement {
     const sanitizedMetadata: Partial<AgentMetadata> = {
       ...metadata,
       name: metadata.name ? sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) : undefined,
-      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
+      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
       specializations: metadata.specializations?.map(s => sanitizeInput(s, 50)),
       decisionFramework: metadata.decisionFramework || AGENT_DEFAULTS.DECISION_FRAMEWORK,
       riskTolerance: metadata.riskTolerance || AGENT_DEFAULTS.RISK_TOLERANCE,

--- a/src/elements/agents/Agent.ts
+++ b/src/elements/agents/Agent.ts
@@ -15,6 +15,7 @@ import { IElement, ElementValidationResult, ValidationError, ValidationWarning }
 import { ElementType } from '../../portfolio/types.js';
 import { randomBytes } from 'node:crypto';
 import { sanitizeInput } from '../../security/InputValidator.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
 import { logger } from '../../utils/logger.js';
@@ -65,7 +66,7 @@ export class Agent extends BaseElement implements IElement {
     const sanitizedMetadata: Partial<AgentMetadata> = {
       ...metadata,
       name: metadata.name ? sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) : undefined,
-      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, 500) : undefined,
+      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
       specializations: metadata.specializations?.map(s => sanitizeInput(s, 50)),
       decisionFramework: metadata.decisionFramework || AGENT_DEFAULTS.DECISION_FRAMEWORK,
       riskTolerance: metadata.riskTolerance || AGENT_DEFAULTS.RISK_TOLERANCE,

--- a/src/elements/agents/Agent.ts
+++ b/src/elements/agents/Agent.ts
@@ -15,6 +15,7 @@ import { IElement, ElementValidationResult, ValidationError, ValidationWarning }
 import { ElementType } from '../../portfolio/types.js';
 import { randomBytes } from 'node:crypto';
 import { sanitizeInput } from '../../security/InputValidator.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
 import { logger } from '../../utils/logger.js';
@@ -65,7 +66,7 @@ export class Agent extends BaseElement implements IElement {
     const sanitizedMetadata: Partial<AgentMetadata> = {
       ...metadata,
       name: metadata.name ? sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) : undefined,
-      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, 500) : undefined,
+      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
       specializations: metadata.specializations?.map(s => sanitizeInput(s, 50)),
       decisionFramework: metadata.decisionFramework || AGENT_DEFAULTS.DECISION_FRAMEWORK,
       riskTolerance: metadata.riskTolerance || AGENT_DEFAULTS.RISK_TOLERANCE,

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -243,7 +243,7 @@ export class AgentManager extends BaseElementManager<Agent> {
 
       // Sanitize inputs for element creation
       const sanitizedName = sanitizeInput(UnicodeValidator.normalize(name).normalizedContent, 100);
-      const sanitizedDescription = sanitizeInput(UnicodeValidator.normalize(description).normalizedContent, 500);
+      const sanitizedDescription = sanitizeInput(UnicodeValidator.normalize(description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
       // Use ContentValidator for multi-line content to preserve formatting (newlines, tabs)
       // while still detecting prompt injection attacks
       const contentValidation = ContentValidator.validateAndSanitize(content, { maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH, contentContext: 'agent' });
@@ -1874,7 +1874,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     // FIX: Must specify fieldType: 'description' to allow punctuation like colons, semicolons, etc.
     if (metadata.description) {
       const descResult = this.validationService.validateAndSanitizeInput(metadata.description, {
-        maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
         allowSpaces: true,
         fieldType: 'description'
       });
@@ -2421,7 +2421,7 @@ export class AgentManager extends BaseElementManager<Agent> {
 
         const validated: AgentGoalParameter = { name, type, required };
         if (typeof p.description === 'string' && p.description.length > 0) {
-          validated.description = sanitizeInput(p.description, 500);
+          validated.description = sanitizeInput(p.description, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
         }
         if (p.default !== undefined) {
           // Sanitize string defaults to prevent injection when used in goal rendering

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -243,7 +243,7 @@ export class AgentManager extends BaseElementManager<Agent> {
 
       // Sanitize inputs for element creation
       const sanitizedName = sanitizeInput(UnicodeValidator.normalize(name).normalizedContent, 100);
-      const sanitizedDescription = sanitizeInput(UnicodeValidator.normalize(description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
+      const sanitizedDescription = sanitizeInput(UnicodeValidator.normalize(description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH);
       // Use ContentValidator for multi-line content to preserve formatting (newlines, tabs)
       // while still detecting prompt injection attacks
       const contentValidation = ContentValidator.validateAndSanitize(content, { maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH, contentContext: 'agent' });
@@ -1874,7 +1874,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     // FIX: Must specify fieldType: 'description' to allow punctuation like colons, semicolons, etc.
     if (metadata.description) {
       const descResult = this.validationService.validateAndSanitizeInput(metadata.description, {
-        maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
         allowSpaces: true,
         fieldType: 'description'
       });
@@ -2421,7 +2421,7 @@ export class AgentManager extends BaseElementManager<Agent> {
 
         const validated: AgentGoalParameter = { name, type, required };
         if (typeof p.description === 'string' && p.description.length > 0) {
-          validated.description = sanitizeInput(p.description, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
+          validated.description = sanitizeInput(p.description, SECURITY_LIMITS.MAX_YAML_LENGTH);
         }
         if (p.default !== undefined) {
           // Sanitize string defaults to prevent injection when used in goal rendering

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -243,7 +243,7 @@ export class AgentManager extends BaseElementManager<Agent> {
 
       // Sanitize inputs for element creation
       const sanitizedName = sanitizeInput(UnicodeValidator.normalize(name).normalizedContent, 100);
-      const sanitizedDescription = sanitizeInput(UnicodeValidator.normalize(description).normalizedContent, 500);
+      const sanitizedDescription = sanitizeInput(UnicodeValidator.normalize(description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH);
       // Use ContentValidator for multi-line content to preserve formatting (newlines, tabs)
       // while still detecting prompt injection attacks
       const contentValidation = ContentValidator.validateAndSanitize(content, { maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH, contentContext: 'agent' });
@@ -1874,7 +1874,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     // FIX: Must specify fieldType: 'description' to allow punctuation like colons, semicolons, etc.
     if (metadata.description) {
       const descResult = this.validationService.validateAndSanitizeInput(metadata.description, {
-        maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
         allowSpaces: true,
         fieldType: 'description'
       });
@@ -2421,7 +2421,7 @@ export class AgentManager extends BaseElementManager<Agent> {
 
         const validated: AgentGoalParameter = { name, type, required };
         if (typeof p.description === 'string' && p.description.length > 0) {
-          validated.description = sanitizeInput(p.description, 500);
+          validated.description = sanitizeInput(p.description, SECURITY_LIMITS.MAX_YAML_LENGTH);
         }
         if (p.default !== undefined) {
           // Sanitize string defaults to prevent injection when used in goal rendering

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -376,7 +376,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     );
     return {
       name: sanitizeInput(UnicodeValidator.normalize(name).normalizedContent, 100),
-      description: sanitizeInput(UnicodeValidator.normalize(description).normalizedContent, 500),
+      description: sanitizeInput(UnicodeValidator.normalize(description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH),
       instructions: contentValidation.sanitizedContent || '',
     };
   }
@@ -2038,7 +2038,7 @@ export class AgentManager extends BaseElementManager<Agent> {
 
     if (metadata.description) {
       const descResult = this.validationService.validateAndSanitizeInput(metadata.description, {
-        maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
         allowSpaces: true,
         fieldType: 'description'
       });
@@ -2586,7 +2586,7 @@ export class AgentManager extends BaseElementManager<Agent> {
 
         const validated: AgentGoalParameter = { name, type, required };
         if (typeof p.description === 'string' && p.description.length > 0) {
-          validated.description = sanitizeInput(p.description, 500);
+          validated.description = sanitizeInput(p.description, SECURITY_LIMITS.MAX_YAML_LENGTH);
         }
         if (p.default !== undefined) {
           // Sanitize string defaults to prevent injection when used in goal rendering

--- a/src/elements/base/ElementValidation.ts
+++ b/src/elements/base/ElementValidation.ts
@@ -16,6 +16,7 @@
  */
 
 import { sanitizeInput } from '../../security/InputValidator.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { logger } from '../../utils/logger.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
@@ -25,7 +26,6 @@ import { SecurityMonitor } from '../../security/securityMonitor.js';
  */
 export const VALIDATION_CONSTANTS = {
   MAX_NAME_LENGTH: 100,
-  MAX_DESCRIPTION_LENGTH: 500,
   MAX_CATEGORY_LENGTH: 50,
   MAX_TAG_LENGTH: 50,
   MAX_AUTHOR_LENGTH: 100,
@@ -76,12 +76,12 @@ export class ElementValidation {
    * Validate and sanitize a description field
    *
    * @param description - Raw description value
-   * @param maxLength - Maximum length (default: 500)
+   * @param maxLength - Maximum length (default: global content limit)
    * @returns Sanitized description or undefined
    */
   static validateDescription(
     description: any,
-    maxLength: number = VALIDATION_CONSTANTS.MAX_DESCRIPTION_LENGTH
+    maxLength: number = SECURITY_LIMITS.MAX_CONTENT_LENGTH
   ): string | undefined {
     if (!description) {
       return undefined;

--- a/src/elements/base/ElementValidation.ts
+++ b/src/elements/base/ElementValidation.ts
@@ -16,6 +16,7 @@
  */
 
 import { sanitizeInput } from '../../security/InputValidator.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { logger } from '../../utils/logger.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
@@ -25,7 +26,6 @@ import { SecurityMonitor } from '../../security/securityMonitor.js';
  */
 export const VALIDATION_CONSTANTS = {
   MAX_NAME_LENGTH: 100,
-  MAX_DESCRIPTION_LENGTH: 500,
   MAX_CATEGORY_LENGTH: 50,
   MAX_TAG_LENGTH: 50,
   MAX_AUTHOR_LENGTH: 100,
@@ -76,12 +76,12 @@ export class ElementValidation {
    * Validate and sanitize a description field
    *
    * @param description - Raw description value
-   * @param maxLength - Maximum length (default: 500)
+   * @param maxLength - Maximum length (default: YAML/frontmatter limit)
    * @returns Sanitized description or undefined
    */
   static validateDescription(
     description: any,
-    maxLength: number = VALIDATION_CONSTANTS.MAX_DESCRIPTION_LENGTH
+    maxLength: number = SECURITY_LIMITS.MAX_YAML_LENGTH
   ): string | undefined {
     if (!description) {
       return undefined;

--- a/src/elements/base/ElementValidation.ts
+++ b/src/elements/base/ElementValidation.ts
@@ -76,12 +76,12 @@ export class ElementValidation {
    * Validate and sanitize a description field
    *
    * @param description - Raw description value
-   * @param maxLength - Maximum length (default: global content limit)
+   * @param maxLength - Maximum length (default: YAML/frontmatter limit)
    * @returns Sanitized description or undefined
    */
   static validateDescription(
     description: any,
-    maxLength: number = SECURITY_LIMITS.MAX_CONTENT_LENGTH
+    maxLength: number = SECURITY_LIMITS.MAX_YAML_LENGTH
   ): string | undefined {
     if (!description) {
       return undefined;

--- a/src/elements/ensembles/Ensemble.ts
+++ b/src/elements/ensembles/Ensemble.ts
@@ -172,7 +172,7 @@ export class Ensemble extends BaseElement implements IElement {
       ) : undefined,
       description: metadata.description !== undefined ? (
         metadata.description === '' ? '' :  // Preserve empty string for validation
-        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH)
+        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH)
       ) : undefined
     };
 

--- a/src/elements/ensembles/Ensemble.ts
+++ b/src/elements/ensembles/Ensemble.ts
@@ -31,6 +31,7 @@ import { ElementType } from '../../portfolio/types.js';
 import * as vm from 'vm';
 import { PortfolioManager } from '../../portfolio/PortfolioManager.js';
 import { sanitizeInput } from '../../security/InputValidator.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
 import { logger } from '../../utils/logger.js';
@@ -171,7 +172,7 @@ export class Ensemble extends BaseElement implements IElement {
       ) : undefined,
       description: metadata.description !== undefined ? (
         metadata.description === '' ? '' :  // Preserve empty string for validation
-        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, 500)
+        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH)
       ) : undefined
     };
 

--- a/src/elements/ensembles/Ensemble.ts
+++ b/src/elements/ensembles/Ensemble.ts
@@ -31,6 +31,7 @@ import { ElementType } from '../../portfolio/types.js';
 import * as vm from 'vm';
 import { PortfolioManager } from '../../portfolio/PortfolioManager.js';
 import { sanitizeInput } from '../../security/InputValidator.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
 import { logger } from '../../utils/logger.js';
@@ -171,7 +172,7 @@ export class Ensemble extends BaseElement implements IElement {
       ) : undefined,
       description: metadata.description !== undefined ? (
         metadata.description === '' ? '' :  // Preserve empty string for validation
-        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, 500)
+        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH)
       ) : undefined
     };
 

--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -241,7 +241,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
     if (data.description) {
       const descResult = this.validationService.validateMetadataField('description', data.description, {
         required: false,
-        maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
         pattern: VALIDATION_PATTERNS.SAFE_DESCRIPTION
       });
       if (!descResult.isValid) {
@@ -438,7 +438,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       let purpose: string | undefined;
       if (elem.purpose) {
         const purposeResult = this.validationService.validateAndSanitizeInput(String(elem.purpose), {
-          maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+          maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
           allowSpaces: true,
           fieldType: 'description'  // Allow full description punctuation (commas, em-dashes, etc.)
         });

--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -241,7 +241,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
     if (data.description) {
       const descResult = this.validationService.validateMetadataField('description', data.description, {
         required: false,
-        maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
         pattern: VALIDATION_PATTERNS.SAFE_DESCRIPTION
       });
       if (!descResult.isValid) {

--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -241,7 +241,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
     if (data.description) {
       const descResult = this.validationService.validateMetadataField('description', data.description, {
         required: false,
-        maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
         pattern: VALIDATION_PATTERNS.SAFE_DESCRIPTION
       });
       if (!descResult.isValid) {
@@ -438,7 +438,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       let purpose: string | undefined;
       if (elem.purpose) {
         const purposeResult = this.validationService.validateAndSanitizeInput(String(elem.purpose), {
-          maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+          maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
           allowSpaces: true,
           fieldType: 'description'  // Allow full description punctuation (commas, em-dashes, etc.)
         });

--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -251,7 +251,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
     if (data.description) {
       const descResult = this.validationService.validateMetadataField('description', data.description, {
         required: false,
-        maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
         pattern: VALIDATION_PATTERNS.SAFE_DESCRIPTION
       });
       if (!descResult.isValid) {
@@ -448,7 +448,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       let purpose: string | undefined;
       if (elem.purpose) {
         const purposeResult = this.validationService.validateAndSanitizeInput(String(elem.purpose), {
-          maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+          maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
           allowSpaces: true,
           fieldType: 'description'  // Allow full description punctuation (commas, em-dashes, etc.)
         });

--- a/src/elements/memories/Memory.ts
+++ b/src/elements/memories/Memory.ts
@@ -21,6 +21,7 @@ import { UnicodeValidator } from '../../security/validators/unicodeValidator.js'
 import crypto from 'crypto';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
 import { sanitizeInput } from '../../security/InputValidator.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import { MetadataService } from '../../services/MetadataService.js';
 // FIX #1315: ContentValidator no longer used in addEntry (moved to background validation)
 // Import removed to clean up unused dependencies
@@ -251,7 +252,7 @@ export class Memory extends BaseElement implements IElement {
         sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) :
         'Unnamed Memory',
       description: metadata.description ?
-        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, 500) :
+        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) :
         undefined,
       // FIX #1124: Preserve triggers for Enhanced Index
       // SECURITY: Validate BEFORE sanitization to reject invalid characters

--- a/src/elements/memories/Memory.ts
+++ b/src/elements/memories/Memory.ts
@@ -252,7 +252,7 @@ export class Memory extends BaseElement implements IElement {
         sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) :
         'Unnamed Memory',
       description: metadata.description ?
-        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) :
+        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH) :
         undefined,
       // FIX #1124: Preserve triggers for Enhanced Index
       // SECURITY: Validate BEFORE sanitization to reject invalid characters

--- a/src/elements/memories/Memory.ts
+++ b/src/elements/memories/Memory.ts
@@ -21,6 +21,7 @@ import { UnicodeValidator } from '../../security/validators/unicodeValidator.js'
 import crypto from 'crypto';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
 import { sanitizeInput } from '../../security/InputValidator.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import { MetadataService } from '../../services/MetadataService.js';
 // FIX #1315: ContentValidator no longer used in addEntry (moved to background validation)
 // Import removed to clean up unused dependencies
@@ -251,7 +252,7 @@ export class Memory extends BaseElement implements IElement {
         sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) :
         'Unnamed Memory',
       description: metadata.description ?
-        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, 500) :
+        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH) :
         undefined,
       // FIX #1124: Preserve triggers for Enhanced Index
       // SECURITY: Validate BEFORE sanitization to reject invalid characters

--- a/src/elements/memories/Memory.ts
+++ b/src/elements/memories/Memory.ts
@@ -21,6 +21,7 @@ import { UnicodeValidator } from '../../security/validators/unicodeValidator.js'
 import crypto from 'crypto';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
 import { sanitizeInput } from '../../security/InputValidator.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import { MetadataService } from '../../services/MetadataService.js';
 // FIX #1315: ContentValidator no longer used in addEntry (moved to background validation)
 // Import removed to clean up unused dependencies
@@ -256,7 +257,7 @@ export class Memory extends BaseElement implements IElement {
         sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) :
         'Unnamed Memory',
       description: metadata.description ?
-        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, 500) :
+        sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH) :
         undefined,
       // FIX #1124: Preserve triggers for Enhanced Index
       // SECURITY: Validate BEFORE sanitization to reject invalid characters

--- a/src/elements/memories/MemoryManager.ts
+++ b/src/elements/memories/MemoryManager.ts
@@ -1916,7 +1916,7 @@ export class MemoryManager extends BaseElementManager<Memory> {
     let sanitizedDescription = '';
     if (metadataSource.description) {
       const descResult = this.validationService.validateAndSanitizeInput(metadataSource.description, {
-        maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
         allowSpaces: true,
         fieldType: 'description'
       });

--- a/src/elements/memories/MemoryManager.ts
+++ b/src/elements/memories/MemoryManager.ts
@@ -1916,7 +1916,7 @@ export class MemoryManager extends BaseElementManager<Memory> {
     let sanitizedDescription = '';
     if (metadataSource.description) {
       const descResult = this.validationService.validateAndSanitizeInput(metadataSource.description, {
-        maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
         allowSpaces: true,
         fieldType: 'description'
       });

--- a/src/elements/memories/MemoryManager.ts
+++ b/src/elements/memories/MemoryManager.ts
@@ -1916,7 +1916,7 @@ export class MemoryManager extends BaseElementManager<Memory> {
     let sanitizedDescription = '';
     if (metadataSource.description) {
       const descResult = this.validationService.validateAndSanitizeInput(metadataSource.description, {
-        maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
         allowSpaces: true,
         fieldType: 'description'
       });

--- a/src/elements/memories/MemoryManager.ts
+++ b/src/elements/memories/MemoryManager.ts
@@ -2007,7 +2007,7 @@ export class MemoryManager extends BaseElementManager<Memory> {
     let sanitizedDescription = '';
     if (metadataSource.description) {
       const descResult = this.validationService.validateAndSanitizeInput(metadataSource.description, {
-        maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+        maxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
         allowSpaces: true,
         fieldType: 'description'
       });

--- a/src/elements/skills/Skill.ts
+++ b/src/elements/skills/Skill.ts
@@ -78,7 +78,7 @@ export class Skill extends BaseElement implements IElement {
     const sanitizedMetadata = {
       ...metadata,
       name: metadata.name ? sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) : undefined,
-      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, 500) : undefined
+      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined
     };
 
     super(ElementType.SKILL, sanitizedMetadata, metadataService);
@@ -112,7 +112,7 @@ export class Skill extends BaseElement implements IElement {
         const sanitized: SkillParameter = {
           ...param,
           name: sanitizeInput(UnicodeValidator.normalize(param.name).normalizedContent, 50),
-          description: sanitizeInput(UnicodeValidator.normalize(param.description).normalizedContent, 200)
+          description: sanitizeInput(UnicodeValidator.normalize(param.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH)
         };
         // Only include options if they exist (avoid undefined)
         if (param.options) {

--- a/src/elements/skills/Skill.ts
+++ b/src/elements/skills/Skill.ts
@@ -78,7 +78,7 @@ export class Skill extends BaseElement implements IElement {
     const sanitizedMetadata = {
       ...metadata,
       name: metadata.name ? sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) : undefined,
-      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, 500) : undefined
+      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined
     };
 
     super(ElementType.SKILL, sanitizedMetadata, metadataService);
@@ -112,7 +112,7 @@ export class Skill extends BaseElement implements IElement {
         const sanitized: SkillParameter = {
           ...param,
           name: sanitizeInput(UnicodeValidator.normalize(param.name).normalizedContent, 50),
-          description: sanitizeInput(UnicodeValidator.normalize(param.description).normalizedContent, 200)
+          description: sanitizeInput(UnicodeValidator.normalize(param.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH)
         };
         // Only include options if they exist (avoid undefined)
         if (param.options) {

--- a/src/elements/skills/Skill.ts
+++ b/src/elements/skills/Skill.ts
@@ -78,7 +78,7 @@ export class Skill extends BaseElement implements IElement {
     const sanitizedMetadata = {
       ...metadata,
       name: metadata.name ? sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) : undefined,
-      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined
+      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined
     };
 
     super(ElementType.SKILL, sanitizedMetadata, metadataService);
@@ -112,7 +112,7 @@ export class Skill extends BaseElement implements IElement {
         const sanitized: SkillParameter = {
           ...param,
           name: sanitizeInput(UnicodeValidator.normalize(param.name).normalizedContent, 50),
-          description: sanitizeInput(UnicodeValidator.normalize(param.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH)
+          description: sanitizeInput(UnicodeValidator.normalize(param.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH)
         };
         // Only include options if they exist (avoid undefined)
         if (param.options) {

--- a/src/elements/templates/Template.ts
+++ b/src/elements/templates/Template.ts
@@ -96,7 +96,7 @@ export class Template extends BaseElement implements IElement {
     const sanitizedMetadata = {
       ...metadata,
       name: metadata.name ? sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) : undefined,
-      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
+      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
       category: metadata.category ? sanitizeInput(UnicodeValidator.normalize(metadata.category).normalizedContent, 50) : undefined,
       output_format: metadata.output_format ? sanitizeInput(metadata.output_format, 20) : undefined
     };
@@ -144,7 +144,7 @@ export class Template extends BaseElement implements IElement {
       this.metadata.variables = this.metadata.variables.map(variable => ({
         ...variable,
         name: sanitizeInput(UnicodeValidator.normalize(variable.name).normalizedContent, 50),
-        description: variable.description ? sanitizeInput(UnicodeValidator.normalize(variable.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
+        description: variable.description ? sanitizeInput(UnicodeValidator.normalize(variable.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
         validation: variable.validation ? sanitizeInput(variable.validation, 200) : undefined
       }));
     }

--- a/src/elements/templates/Template.ts
+++ b/src/elements/templates/Template.ts
@@ -18,6 +18,7 @@ import { logger } from '../../utils/logger.js';
 import { ErrorHandler, ErrorCategory } from '../../utils/ErrorHandler.js';
 import { ValidationErrorCodes } from '../../utils/errorCodes.js';
 import { sanitizeInput } from '../../security/InputValidator.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { ContentValidator } from '../../security/contentValidator.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
@@ -95,7 +96,7 @@ export class Template extends BaseElement implements IElement {
     const sanitizedMetadata = {
       ...metadata,
       name: metadata.name ? sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) : undefined,
-      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, 500) : undefined,
+      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
       category: metadata.category ? sanitizeInput(UnicodeValidator.normalize(metadata.category).normalizedContent, 50) : undefined,
       output_format: metadata.output_format ? sanitizeInput(metadata.output_format, 20) : undefined
     };
@@ -143,7 +144,7 @@ export class Template extends BaseElement implements IElement {
       this.metadata.variables = this.metadata.variables.map(variable => ({
         ...variable,
         name: sanitizeInput(UnicodeValidator.normalize(variable.name).normalizedContent, 50),
-        description: variable.description ? sanitizeInput(UnicodeValidator.normalize(variable.description).normalizedContent, 200) : undefined,
+        description: variable.description ? sanitizeInput(UnicodeValidator.normalize(variable.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
         validation: variable.validation ? sanitizeInput(variable.validation, 200) : undefined
       }));
     }

--- a/src/elements/templates/Template.ts
+++ b/src/elements/templates/Template.ts
@@ -18,6 +18,7 @@ import { logger } from '../../utils/logger.js';
 import { ErrorHandler, ErrorCategory } from '../../utils/ErrorHandler.js';
 import { ValidationErrorCodes } from '../../utils/errorCodes.js';
 import { sanitizeInput } from '../../security/InputValidator.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { ContentValidator } from '../../security/contentValidator.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
@@ -95,7 +96,7 @@ export class Template extends BaseElement implements IElement {
     const sanitizedMetadata = {
       ...metadata,
       name: metadata.name ? sanitizeInput(UnicodeValidator.normalize(metadata.name).normalizedContent, 100) : undefined,
-      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, 500) : undefined,
+      description: metadata.description ? sanitizeInput(UnicodeValidator.normalize(metadata.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
       category: metadata.category ? sanitizeInput(UnicodeValidator.normalize(metadata.category).normalizedContent, 50) : undefined,
       output_format: metadata.output_format ? sanitizeInput(metadata.output_format, 20) : undefined
     };
@@ -143,7 +144,7 @@ export class Template extends BaseElement implements IElement {
       this.metadata.variables = this.metadata.variables.map(variable => ({
         ...variable,
         name: sanitizeInput(UnicodeValidator.normalize(variable.name).normalizedContent, 50),
-        description: variable.description ? sanitizeInput(UnicodeValidator.normalize(variable.description).normalizedContent, 200) : undefined,
+        description: variable.description ? sanitizeInput(UnicodeValidator.normalize(variable.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
         validation: variable.validation ? sanitizeInput(variable.validation, 200) : undefined
       }));
     }

--- a/src/elements/templates/TemplateManager.ts
+++ b/src/elements/templates/TemplateManager.ts
@@ -384,7 +384,7 @@ export class TemplateManager extends BaseElementManager<Template> {
     }
 
     if (data.description) {
-      metadata.description = sanitizeInput(UnicodeValidator.normalize(data.description).normalizedContent, 500);
+      metadata.description = sanitizeInput(UnicodeValidator.normalize(data.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH);
     }
 
     if (data.category) {
@@ -428,7 +428,7 @@ export class TemplateManager extends BaseElementManager<Template> {
       metadata.variables = data.variables.map((v: any) => ({
         name: sanitizeInput(v.name || '', 50),
         type: sanitizeInput(v.type || 'string', 20),
-        description: v.description ? sanitizeInput(v.description, 200) : undefined,
+        description: v.description ? sanitizeInput(v.description, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
         required: Boolean(v.required),
         default: v.default,
         validation: v.validation ? sanitizeInput(v.validation, 200) : undefined,
@@ -440,7 +440,7 @@ export class TemplateManager extends BaseElementManager<Template> {
     if (Array.isArray(data.examples)) {
       metadata.examples = data.examples.map((ex: any) => ({
         title: sanitizeInput(ex.title || '', 100),
-        description: ex.description ? sanitizeInput(ex.description, 500) : undefined,
+        description: ex.description ? sanitizeInput(ex.description, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
         variables: ex.variables || {},
         output: ex.output ? sanitizeInput(ex.output, 5000) : undefined
       }));

--- a/src/elements/templates/TemplateManager.ts
+++ b/src/elements/templates/TemplateManager.ts
@@ -384,7 +384,7 @@ export class TemplateManager extends BaseElementManager<Template> {
     }
 
     if (data.description) {
-      metadata.description = sanitizeInput(UnicodeValidator.normalize(data.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
+      metadata.description = sanitizeInput(UnicodeValidator.normalize(data.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH);
     }
 
     if (data.category) {
@@ -428,7 +428,7 @@ export class TemplateManager extends BaseElementManager<Template> {
       metadata.variables = data.variables.map((v: any) => ({
         name: sanitizeInput(v.name || '', 50),
         type: sanitizeInput(v.type || 'string', 20),
-        description: v.description ? sanitizeInput(v.description, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
+        description: v.description ? sanitizeInput(v.description, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
         required: Boolean(v.required),
         default: v.default,
         validation: v.validation ? sanitizeInput(v.validation, 200) : undefined,
@@ -440,7 +440,7 @@ export class TemplateManager extends BaseElementManager<Template> {
     if (Array.isArray(data.examples)) {
       metadata.examples = data.examples.map((ex: any) => ({
         title: sanitizeInput(ex.title || '', 100),
-        description: ex.description ? sanitizeInput(ex.description, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
+        description: ex.description ? sanitizeInput(ex.description, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
         variables: ex.variables || {},
         output: ex.output ? sanitizeInput(ex.output, 5000) : undefined
       }));

--- a/src/elements/templates/TemplateManager.ts
+++ b/src/elements/templates/TemplateManager.ts
@@ -384,7 +384,7 @@ export class TemplateManager extends BaseElementManager<Template> {
     }
 
     if (data.description) {
-      metadata.description = sanitizeInput(UnicodeValidator.normalize(data.description).normalizedContent, 500);
+      metadata.description = sanitizeInput(UnicodeValidator.normalize(data.description).normalizedContent, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
     }
 
     if (data.category) {
@@ -428,7 +428,7 @@ export class TemplateManager extends BaseElementManager<Template> {
       metadata.variables = data.variables.map((v: any) => ({
         name: sanitizeInput(v.name || '', 50),
         type: sanitizeInput(v.type || 'string', 20),
-        description: v.description ? sanitizeInput(v.description, 200) : undefined,
+        description: v.description ? sanitizeInput(v.description, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
         required: Boolean(v.required),
         default: v.default,
         validation: v.validation ? sanitizeInput(v.validation, 200) : undefined,
@@ -440,7 +440,7 @@ export class TemplateManager extends BaseElementManager<Template> {
     if (Array.isArray(data.examples)) {
       metadata.examples = data.examples.map((ex: any) => ({
         title: sanitizeInput(ex.title || '', 100),
-        description: ex.description ? sanitizeInput(ex.description, 500) : undefined,
+        description: ex.description ? sanitizeInput(ex.description, SECURITY_LIMITS.MAX_CONTENT_LENGTH) : undefined,
         variables: ex.variables || {},
         output: ex.output ? sanitizeInput(ex.output, 5000) : undefined
       }));

--- a/src/elements/templates/TemplateManager.ts
+++ b/src/elements/templates/TemplateManager.ts
@@ -387,7 +387,7 @@ export class TemplateManager extends BaseElementManager<Template> {
     }
 
     if (data.description) {
-      metadata.description = sanitizeInput(UnicodeValidator.normalize(data.description).normalizedContent, 500);
+      metadata.description = sanitizeInput(UnicodeValidator.normalize(data.description).normalizedContent, SECURITY_LIMITS.MAX_YAML_LENGTH);
     }
 
     if (data.category) {
@@ -431,7 +431,7 @@ export class TemplateManager extends BaseElementManager<Template> {
       metadata.variables = data.variables.map((v: any) => ({
         name: sanitizeInput(v.name || '', 50),
         type: sanitizeInput(v.type || 'string', 20),
-        description: v.description ? sanitizeInput(v.description, 200) : undefined,
+        description: v.description ? sanitizeInput(v.description, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
         required: Boolean(v.required),
         default: v.default,
         validation: v.validation ? sanitizeInput(v.validation, 200) : undefined,
@@ -443,7 +443,7 @@ export class TemplateManager extends BaseElementManager<Template> {
     if (Array.isArray(data.examples)) {
       metadata.examples = data.examples.map((ex: any) => ({
         title: sanitizeInput(ex.title || '', 100),
-        description: ex.description ? sanitizeInput(ex.description, 500) : undefined,
+        description: ex.description ? sanitizeInput(ex.description, SECURITY_LIMITS.MAX_YAML_LENGTH) : undefined,
         variables: ex.variables || {},
         output: ex.output ? sanitizeInput(ex.output, 5000) : undefined
       }));

--- a/src/handlers/element-crud/createElement.ts
+++ b/src/handlers/element-crud/createElement.ts
@@ -10,6 +10,7 @@ import { SECURITY_LIMITS } from '../../security/constants.js';
 import { sanitizeInput, validateContentSize, validateCategory } from '../../security/InputValidator.js';
 import {
   sanitizeMetadata,
+  findOversizedDescriptionFields,
   normalizeElementTypeInput,
   formatValidElementTypesList,
   detectUnknownMetadataProperties,
@@ -166,8 +167,18 @@ export async function createElement(context: ElementCrudContext, args: CreateEle
       };
     }
 
+    const descriptionLengthErrors = findOversizedDescriptionFields({ description, metadata });
+    if (descriptionLengthErrors.length > 0) {
+      return {
+        content: [{
+          type: "text",
+          text: `❌ Description too large:\n${descriptionLengthErrors.map(e => `  • ${e}`).join('\n')}`
+        }]
+      };
+    }
+
     const validatedName = sanitizeInput(name, SECURITY_LIMITS.MAX_FILENAME_LENGTH);
-    const validatedDescription = sanitizeInput(description, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
+    const validatedDescription = sanitizeInput(description, SECURITY_LIMITS.MAX_YAML_LENGTH);
 
     if (content) {
       try {

--- a/src/handlers/element-crud/createElement.ts
+++ b/src/handlers/element-crud/createElement.ts
@@ -167,7 +167,7 @@ export async function createElement(context: ElementCrudContext, args: CreateEle
     }
 
     const validatedName = sanitizeInput(name, SECURITY_LIMITS.MAX_FILENAME_LENGTH);
-    const validatedDescription = sanitizeInput(description, SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH);
+    const validatedDescription = sanitizeInput(description, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
 
     if (content) {
       try {

--- a/src/handlers/element-crud/createElement.ts
+++ b/src/handlers/element-crud/createElement.ts
@@ -10,6 +10,7 @@ import { SECURITY_LIMITS } from '../../security/constants.js';
 import { sanitizeInput, validateContentSize, validateCategory } from '../../security/InputValidator.js';
 import {
   sanitizeMetadata,
+  findOversizedDescriptionFields,
   normalizeElementTypeInput,
   formatValidElementTypesList,
   detectUnknownMetadataProperties,
@@ -166,8 +167,19 @@ export async function createElement(context: ElementCrudContext, args: CreateEle
       };
     }
 
+    const descriptionLengthErrors = findOversizedDescriptionFields({ description, metadata });
+    if (descriptionLengthErrors.length > 0) {
+      const formattedErrors = descriptionLengthErrors.map(error => `  • ${error}`).join('\n');
+      return {
+        content: [{
+          type: "text",
+          text: `❌ Description too large:\n${formattedErrors}`
+        }]
+      };
+    }
+
     const validatedName = sanitizeInput(name, SECURITY_LIMITS.MAX_FILENAME_LENGTH);
-    const validatedDescription = sanitizeInput(description, SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH);
+    const validatedDescription = sanitizeInput(description, SECURITY_LIMITS.MAX_YAML_LENGTH);
 
     if (content) {
       try {

--- a/src/handlers/element-crud/createElement.ts
+++ b/src/handlers/element-crud/createElement.ts
@@ -169,10 +169,11 @@ export async function createElement(context: ElementCrudContext, args: CreateEle
 
     const descriptionLengthErrors = findOversizedDescriptionFields({ description, metadata });
     if (descriptionLengthErrors.length > 0) {
+      const formattedErrors = descriptionLengthErrors.map(error => `  • ${error}`).join('\n');
       return {
         content: [{
           type: "text",
-          text: `❌ Description too large:\n${descriptionLengthErrors.map(e => `  • ${e}`).join('\n')}`
+          text: `❌ Description too large:\n${formattedErrors}`
         }]
       };
     }

--- a/src/handlers/element-crud/editElement.ts
+++ b/src/handlers/element-crud/editElement.ts
@@ -216,7 +216,7 @@ function validateFieldValue(
 
   // Determine max length based on field type, using system constants
   const maxLength = fieldType === 'name' ? SECURITY_LIMITS.MAX_NAME_LENGTH :
-                    fieldType === 'description' ? SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH :
+                    fieldType === 'description' ? SECURITY_LIMITS.MAX_CONTENT_LENGTH :
                     fieldType === 'content' ? SECURITY_LIMITS.MAX_CONTENT_LENGTH : SECURITY_LIMITS.MAX_COMMAND_ARG_LENGTH;
 
   const result = validationService.validateAndSanitizeInput(value, {

--- a/src/handlers/element-crud/editElement.ts
+++ b/src/handlers/element-crud/editElement.ts
@@ -72,6 +72,19 @@ const READ_ONLY_FIELDS = new Set([
   '_isDirty'
 ]);
 
+function getMaxLengthForFieldType(fieldType: ValidationFieldType): number {
+  switch (fieldType) {
+    case 'name':
+      return SECURITY_LIMITS.MAX_NAME_LENGTH;
+    case 'description':
+      return SECURITY_LIMITS.MAX_YAML_LENGTH;
+    case 'content':
+      return SECURITY_LIMITS.MAX_CONTENT_LENGTH;
+    case 'filename':
+      return SECURITY_LIMITS.MAX_COMMAND_ARG_LENGTH;
+  }
+}
+
 /**
  * Issue #662: Systematic field type validation at the editElement boundary.
  *
@@ -216,9 +229,7 @@ function validateFieldValue(
   }
 
   // Determine max length based on field type, using system constants
-  const maxLength = fieldType === 'name' ? SECURITY_LIMITS.MAX_NAME_LENGTH :
-                    fieldType === 'description' ? SECURITY_LIMITS.MAX_YAML_LENGTH :
-                    fieldType === 'content' ? SECURITY_LIMITS.MAX_CONTENT_LENGTH : SECURITY_LIMITS.MAX_COMMAND_ARG_LENGTH;
+  const maxLength = getMaxLengthForFieldType(fieldType);
 
   const result = validationService.validateAndSanitizeInput(value, {
     maxLength,
@@ -614,7 +625,8 @@ export async function editElement(
 
   const descriptionLengthErrors = findOversizedDescriptionFields(input);
   if (descriptionLengthErrors.length > 0) {
-    return error(`Description length validation failed:\n${descriptionLengthErrors.map(e => `  • ${e}`).join('\n')}`);
+    const formattedErrors = descriptionLengthErrors.map(descriptionError => `  • ${descriptionError}`).join('\n');
+    return error(`Description length validation failed:\n${formattedErrors}`);
   }
 
   // Validate string field values using injected validator

--- a/src/handlers/element-crud/editElement.ts
+++ b/src/handlers/element-crud/editElement.ts
@@ -27,6 +27,7 @@ import {
   formatUnknownPropertyWarnings,
   formatElementResolutionWarnings,
   collectGatekeeperAuthoringErrors,
+  findOversizedDescriptionFields,
   formatGatekeeperValidationMessage,
 } from './helpers.js';
 import type { ResolveElementTypesResult } from '../../utils/elementTypeResolver.js';
@@ -216,7 +217,7 @@ function validateFieldValue(
 
   // Determine max length based on field type, using system constants
   const maxLength = fieldType === 'name' ? SECURITY_LIMITS.MAX_NAME_LENGTH :
-                    fieldType === 'description' ? SECURITY_LIMITS.MAX_CONTENT_LENGTH :
+                    fieldType === 'description' ? SECURITY_LIMITS.MAX_YAML_LENGTH :
                     fieldType === 'content' ? SECURITY_LIMITS.MAX_CONTENT_LENGTH : SECURITY_LIMITS.MAX_COMMAND_ARG_LENGTH;
 
   const result = validationService.validateAndSanitizeInput(value, {
@@ -609,6 +610,11 @@ export async function editElement(
   const gatekeeperErrors = collectGatekeeperAuthoringErrors(input, input.metadata);
   if (gatekeeperErrors.length > 0) {
     return error(formatGatekeeperValidationMessage(gatekeeperErrors));
+  }
+
+  const descriptionLengthErrors = findOversizedDescriptionFields(input);
+  if (descriptionLengthErrors.length > 0) {
+    return error(`Description length validation failed:\n${descriptionLengthErrors.map(e => `  • ${e}`).join('\n')}`);
   }
 
   // Validate string field values using injected validator

--- a/src/handlers/element-crud/editElement.ts
+++ b/src/handlers/element-crud/editElement.ts
@@ -27,6 +27,7 @@ import {
   formatUnknownPropertyWarnings,
   formatElementResolutionWarnings,
   collectGatekeeperAuthoringErrors,
+  findOversizedDescriptionFields,
   formatGatekeeperValidationMessage,
 } from './helpers.js';
 import type { ResolveElementTypesResult } from '../../utils/elementTypeResolver.js';
@@ -70,6 +71,19 @@ const READ_ONLY_FIELDS = new Set([
   '_status',
   '_isDirty'
 ]);
+
+function getMaxLengthForFieldType(fieldType: ValidationFieldType): number {
+  switch (fieldType) {
+    case 'name':
+      return SECURITY_LIMITS.MAX_NAME_LENGTH;
+    case 'description':
+      return SECURITY_LIMITS.MAX_YAML_LENGTH;
+    case 'content':
+      return SECURITY_LIMITS.MAX_CONTENT_LENGTH;
+    case 'filename':
+      return SECURITY_LIMITS.MAX_COMMAND_ARG_LENGTH;
+  }
+}
 
 /**
  * Issue #662: Systematic field type validation at the editElement boundary.
@@ -215,9 +229,7 @@ function validateFieldValue(
   }
 
   // Determine max length based on field type, using system constants
-  const maxLength = fieldType === 'name' ? SECURITY_LIMITS.MAX_NAME_LENGTH :
-                    fieldType === 'description' ? SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH :
-                    fieldType === 'content' ? SECURITY_LIMITS.MAX_CONTENT_LENGTH : SECURITY_LIMITS.MAX_COMMAND_ARG_LENGTH;
+  const maxLength = getMaxLengthForFieldType(fieldType);
 
   const result = validationService.validateAndSanitizeInput(value, {
     maxLength,
@@ -609,6 +621,12 @@ export async function editElement(
   const gatekeeperErrors = collectGatekeeperAuthoringErrors(input, input.metadata);
   if (gatekeeperErrors.length > 0) {
     return error(formatGatekeeperValidationMessage(gatekeeperErrors));
+  }
+
+  const descriptionLengthErrors = findOversizedDescriptionFields(input);
+  if (descriptionLengthErrors.length > 0) {
+    const formattedErrors = descriptionLengthErrors.map(descriptionError => `  • ${descriptionError}`).join('\n');
+    return error(`Description length validation failed:\n${formattedErrors}`);
   }
 
   // Validate string field values using injected validator

--- a/src/handlers/element-crud/editElement.ts
+++ b/src/handlers/element-crud/editElement.ts
@@ -27,6 +27,7 @@ import {
   formatUnknownPropertyWarnings,
   formatElementResolutionWarnings,
   collectGatekeeperAuthoringErrors,
+  findOversizedDescriptionFields,
   formatGatekeeperValidationMessage,
 } from './helpers.js';
 import type { ResolveElementTypesResult } from '../../utils/elementTypeResolver.js';
@@ -70,6 +71,19 @@ const READ_ONLY_FIELDS = new Set([
   '_status',
   '_isDirty'
 ]);
+
+function getMaxLengthForFieldType(fieldType: ValidationFieldType): number {
+  switch (fieldType) {
+    case 'name':
+      return SECURITY_LIMITS.MAX_NAME_LENGTH;
+    case 'description':
+      return SECURITY_LIMITS.MAX_YAML_LENGTH;
+    case 'content':
+      return SECURITY_LIMITS.MAX_CONTENT_LENGTH;
+    case 'filename':
+      return SECURITY_LIMITS.MAX_COMMAND_ARG_LENGTH;
+  }
+}
 
 /**
  * Issue #662: Systematic field type validation at the editElement boundary.
@@ -215,9 +229,7 @@ function validateFieldValue(
   }
 
   // Determine max length based on field type, using system constants
-  const maxLength = fieldType === 'name' ? SECURITY_LIMITS.MAX_NAME_LENGTH :
-                    fieldType === 'description' ? SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH :
-                    fieldType === 'content' ? SECURITY_LIMITS.MAX_CONTENT_LENGTH : SECURITY_LIMITS.MAX_COMMAND_ARG_LENGTH;
+  const maxLength = getMaxLengthForFieldType(fieldType);
 
   const result = validationService.validateAndSanitizeInput(value, {
     maxLength,
@@ -626,6 +638,12 @@ export async function editElement(
   const gatekeeperErrors = collectGatekeeperAuthoringErrors(input, input.metadata);
   if (gatekeeperErrors.length > 0) {
     return error(formatGatekeeperValidationMessage(gatekeeperErrors));
+  }
+
+  const descriptionLengthErrors = findOversizedDescriptionFields(input);
+  if (descriptionLengthErrors.length > 0) {
+    const formattedErrors = descriptionLengthErrors.map(descriptionError => `  • ${descriptionError}`).join('\n');
+    return error(`Description length validation failed:\n${formattedErrors}`);
   }
 
   // Validate string field values using injected validator

--- a/src/handlers/element-crud/helpers.ts
+++ b/src/handlers/element-crud/helpers.ts
@@ -9,6 +9,7 @@ import { slugify } from '../../utils/filesystem.js';
 import { ElementType } from '../../portfolio/PortfolioManager.js';
 import { logger } from '../../utils/logger.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
+import { SECURITY_LIMITS } from '../../security/constants.js';
 import {
   ELEMENT_TYPE_MAP,
   ALL_ELEMENT_TYPES,
@@ -83,6 +84,47 @@ export function sanitizeMetadata(metadata: Record<string, any> | undefined): Rec
   }
 
   return sanitized;
+}
+
+/**
+ * Find description fields that would exceed the YAML/frontmatter parser limit.
+ *
+ * Element descriptions are metadata and are serialized into YAML frontmatter, so
+ * the real upper bound is the YAML safety limit rather than the content body
+ * limit. This walks nested metadata too because templates, agents, and skills
+ * all have description-like nested fields.
+ */
+export function findOversizedDescriptionFields(
+  value: unknown,
+  path = 'input',
+  maxLength = SECURITY_LIMITS.MAX_YAML_LENGTH,
+  seen = new WeakSet<object>()
+): string[] {
+  if (!value || typeof value !== 'object') {
+    return [];
+  }
+
+  if (seen.has(value)) {
+    return [];
+  }
+  seen.add(value);
+
+  const errors: string[] = [];
+  const entries = Array.isArray(value)
+    ? value.map((item, index) => [String(index), item] as const)
+    : Object.entries(value);
+
+  for (const [key, child] of entries) {
+    const childPath = Array.isArray(value) ? `${path}[${key}]` : `${path}.${key}`;
+    if (key === 'description' && typeof child === 'string' && child.length > maxLength) {
+      errors.push(`${childPath} exceeds maximum YAML/frontmatter length of ${maxLength} characters`);
+      continue;
+    }
+
+    errors.push(...findOversizedDescriptionFields(child, childPath, maxLength, seen));
+  }
+
+  return errors;
 }
 
 function asMetadataRecord(value: unknown): Record<string, unknown> | undefined {

--- a/src/security/constants.ts
+++ b/src/security/constants.ts
@@ -20,7 +20,6 @@ export const SECURITY_LIMITS = {
   // Field-level validation limits — used across element managers and validators.
   // Centralized here so a single change applies everywhere and grep finds all usages.
   MAX_NAME_LENGTH: 100,                     // Element name field
-  MAX_DESCRIPTION_LENGTH: 500,              // Element description field
   MAX_ENUM_FIELD_LENGTH: 20,                // Short enum-like fields (strategy, role, activation)
   MAX_TAG_LENGTH: 50,                       // Individual tag / category values
   MAX_COMMAND_ARG_LENGTH: 1000,             // CLI command argument validation

--- a/src/security/contentValidator.ts
+++ b/src/security/contentValidator.ts
@@ -725,9 +725,13 @@ export class ContentValidator {
     // Check all string fields in metadata
     const checkField = (fieldName: string, value: any) => {
       if (typeof value === 'string') {
-        // Check field length first
-        if (value.length > SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH) {
-          detectedPatterns.push(`${fieldName}: Field exceeds maximum length of ${SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH} characters`);
+        // Descriptions can be substantive LLM-authored text; keep them bounded by
+        // the global content limit rather than the short metadata-field limit.
+        const maxFieldLength = fieldName === 'description'
+          ? SECURITY_LIMITS.MAX_CONTENT_LENGTH
+          : SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH;
+        if (value.length > maxFieldLength) {
+          detectedPatterns.push(`${fieldName}: Field exceeds maximum length of ${maxFieldLength} characters`);
           return;
         }
         

--- a/src/security/contentValidator.ts
+++ b/src/security/contentValidator.ts
@@ -725,9 +725,13 @@ export class ContentValidator {
     // Check all string fields in metadata
     const checkField = (fieldName: string, value: any) => {
       if (typeof value === 'string') {
-        // Check field length first
-        if (value.length > SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH) {
-          detectedPatterns.push(`${fieldName}: Field exceeds maximum length of ${SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH} characters`);
+        // Descriptions can be substantive LLM-authored text; keep them bounded by
+        // the YAML/frontmatter limit rather than the short metadata-field limit.
+        const maxFieldLength = fieldName === 'description'
+          ? SECURITY_LIMITS.MAX_YAML_LENGTH
+          : SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH;
+        if (value.length > maxFieldLength) {
+          detectedPatterns.push(`${fieldName}: Field exceeds maximum length of ${maxFieldLength} characters`);
           return;
         }
         

--- a/src/security/contentValidator.ts
+++ b/src/security/contentValidator.ts
@@ -726,9 +726,9 @@ export class ContentValidator {
     const checkField = (fieldName: string, value: any) => {
       if (typeof value === 'string') {
         // Descriptions can be substantive LLM-authored text; keep them bounded by
-        // the global content limit rather than the short metadata-field limit.
+        // the YAML/frontmatter limit rather than the short metadata-field limit.
         const maxFieldLength = fieldName === 'description'
-          ? SECURITY_LIMITS.MAX_CONTENT_LENGTH
+          ? SECURITY_LIMITS.MAX_YAML_LENGTH
           : SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH;
         if (value.length > maxFieldLength) {
           detectedPatterns.push(`${fieldName}: Field exceeds maximum length of ${maxFieldLength} characters`);

--- a/src/security/contentValidator.ts
+++ b/src/security/contentValidator.ts
@@ -733,9 +733,11 @@ export class ContentValidator {
     // locally can also be installed from the collection.
     instructions: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
     content: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
-    // Default for everything else (name, description, category, author,
-    // version, tags-as-string, custom fields) — strict 1KB cap to keep
-    // each YAML frontmatter field bounded.
+    // Descriptions can be substantive LLM-authored text — bound them by
+    // the YAML/frontmatter limit rather than the short 1KB metadata cap.
+    description: SECURITY_LIMITS.MAX_YAML_LENGTH,
+    // Default for everything else (name, category, author, version,
+    // tags-as-string, custom fields) — strict 1KB cap.
   };
 
   private static fieldLengthLimit(fieldName: string): number {

--- a/src/security/secureYamlParser.ts
+++ b/src/security/secureYamlParser.ts
@@ -69,7 +69,7 @@ export class SecureYamlParser {
   // Additional validation for specific persona fields
   private static readonly FIELD_VALIDATORS: Record<string, (value: any) => boolean> = {
     name: (v) => typeof v === 'string' && v.length <= 100,
-    description: (v) => typeof v === 'string' && v.length <= 500,
+    description: (v) => typeof v === 'string',
     author: (v) => typeof v === 'string' && v.length <= 100,
     version: (v) => typeof v === 'string' && /^\d+\.\d+(\.\d+)?(-[a-zA-Z0-9.-]+)?$/.test(v),
     category: (v) => typeof v === 'string' && v.length <= 50,

--- a/src/services/validation/GenericElementValidator.ts
+++ b/src/services/validation/GenericElementValidator.ts
@@ -428,7 +428,7 @@ export class GenericElementValidator implements ElementValidator {
     }
 
     const result = this.validationService.validateAndSanitizeInput(description, {
-      maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+      maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
       allowSpaces: true,
       fieldType: 'description'
     });

--- a/src/services/validation/GenericElementValidator.ts
+++ b/src/services/validation/GenericElementValidator.ts
@@ -427,8 +427,14 @@ export class GenericElementValidator implements ElementValidator {
       return ValidatorHelpers.fail(["Description must be a string"]);
     }
 
+    if (description.length > SECURITY_LIMITS.MAX_YAML_LENGTH) {
+      return ValidatorHelpers.fail([
+        `Description exceeds maximum YAML/frontmatter length of ${SECURITY_LIMITS.MAX_YAML_LENGTH} characters`
+      ]);
+    }
+
     const result = this.validationService.validateAndSanitizeInput(description, {
-      maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+      maxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
       allowSpaces: true,
       fieldType: 'description'
     });

--- a/src/services/validation/GenericElementValidator.ts
+++ b/src/services/validation/GenericElementValidator.ts
@@ -427,8 +427,14 @@ export class GenericElementValidator implements ElementValidator {
       return ValidatorHelpers.fail(["Description must be a string"]);
     }
 
+    if (description.length > SECURITY_LIMITS.MAX_YAML_LENGTH) {
+      return ValidatorHelpers.fail([
+        `Description exceeds maximum YAML/frontmatter length of ${SECURITY_LIMITS.MAX_YAML_LENGTH} characters`
+      ]);
+    }
+
     const result = this.validationService.validateAndSanitizeInput(description, {
-      maxLength: SECURITY_LIMITS.MAX_CONTENT_LENGTH,
+      maxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
       allowSpaces: true,
       fieldType: 'description'
     });

--- a/src/telemetry/OperationalTelemetry.ts
+++ b/src/telemetry/OperationalTelemetry.ts
@@ -36,7 +36,7 @@
 
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
 import { PostHog } from 'posthog-node';
 import { logger } from '../utils/logger.js';
 import { PACKAGE_VERSION as VERSION } from '../generated/version.js';
@@ -220,7 +220,7 @@ export class OperationalTelemetry {
       }
 
       // Generate new UUID v4
-      this.installId = uuidv4();
+      this.installId = randomUUID();
 
       // Ensure directory exists
       await this.fileOperations.createDirectory(path.dirname(config.installIdPath));

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -32,9 +32,8 @@ const GITHUB_REPO = 'DollhouseMCP/mcp-server';
 const MCPB_ASSET_PATTERN = /^dollhousemcp-.*\.mcpb$/;
 import { SlidingWindowRateLimiter } from '../../utils/SlidingWindowRateLimiter.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
-import { randomInt } from 'node:crypto';
+import { randomInt, randomUUID } from 'node:crypto';
 import { PostHog } from 'posthog-node';
-import { v4 as uuidv4 } from 'uuid';
 
 function isMissingPathError(error: unknown): boolean {
   return Boolean(
@@ -454,7 +453,7 @@ async function capturePostHogLicenseEvent(licenseData: Record<string, unknown>):
     const idPath = join(homedir(), '.dollhouse', '.telemetry-id');
     installId = (await readFile(idPath, 'utf-8')).trim();
   } catch {
-    installId = uuidv4();
+    installId = randomUUID();
   }
   const eventType = (licenseData.eventType as string) ?? 'activation';
   posthog.capture({

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -31,9 +31,8 @@ const GITHUB_REPO = 'DollhouseMCP/mcp-server';
 const MCPB_ASSET_PATTERN = /^dollhousemcp-.*\.mcpb$/;
 import { SlidingWindowRateLimiter } from '../../utils/SlidingWindowRateLimiter.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
-import { randomInt } from 'node:crypto';
+import { randomInt, randomUUID } from 'node:crypto';
 import { PostHog } from 'posthog-node';
-import { v4 as uuidv4 } from 'uuid';
 
 function isMissingPathError(error: unknown): boolean {
   return Boolean(
@@ -453,7 +452,7 @@ async function capturePostHogLicenseEvent(licenseData: Record<string, unknown>):
     const idPath = join(homedir(), '.dollhouse', '.telemetry-id');
     installId = (await readFile(idPath, 'utf-8')).trim();
   } catch {
-    installId = uuidv4();
+    installId = randomUUID();
   }
   const eventType = (licenseData.eventType as string) ?? 'activation';
   posthog.capture({

--- a/tests/e2e/roundtrip-workflow.test.ts
+++ b/tests/e2e/roundtrip-workflow.test.ts
@@ -12,7 +12,7 @@
 import { describe, test, beforeAll, afterAll, beforeEach, expect, jest } from '@jest/globals';
 import path from 'path';
 import fs from 'fs/promises';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
 import { TestServer } from '../helpers/test-server.js';
 import { hasTestCredentials, getTestSkipMessage } from '../../src/config/test-env.js';
 
@@ -33,7 +33,7 @@ describe('Roundtrip Workflow E2E Tests', () => {
     ctx = {
       server: new TestServer(),
       portfolioDir: path.join(process.cwd(), 'test-portfolio'),
-      testRepoName: `test-portfolio-${uuidv4()}`,
+      testRepoName: `test-portfolio-${randomUUID()}`,
       testSkillName: 'roundtrip-test-skill',
       originalConfig: null
     };

--- a/tests/helpers/file-utils.ts
+++ b/tests/helpers/file-utils.ts
@@ -4,8 +4,8 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { randomUUID } from 'node:crypto';
 import matter from 'gray-matter';
-import { v4 as uuidv4 } from 'uuid';
 import { Persona } from '../../src/types/persona.js';
 import { createPersonaFileContent } from './test-fixtures.js';
 
@@ -102,7 +102,7 @@ export async function createTempDir(prefix: string): Promise<string> {
   }
   
   // Use UUID instead of Date.now() for better uniqueness guarantees
-  const tempDir = path.join(baseDir, `${prefix}-${uuidv4()}`);
+  const tempDir = path.join(baseDir, `${prefix}-${randomUUID()}`);
   await fs.mkdir(tempDir, { recursive: true });
   return tempDir;
 }

--- a/tests/integration/crud/config/agentConfig.ts
+++ b/tests/integration/crud/config/agentConfig.ts
@@ -121,11 +121,11 @@ export const AGENT_CONFIG: ElementTypeTestConfig = {
       required: true,
       validValues: [
         'Updated agent description',
-        'A completely different description'
+        'A completely different description',
+        'Long-form agent description. '.repeat(40)
       ],
       invalidValues: [
-        { value: '', expectedError: 'required|empty' },
-        { value: 'A'.repeat(501), expectedError: 'length|size' }
+        { value: '', expectedError: 'required|empty' }
       ]
     },
     {

--- a/tests/integration/crud/config/ensembleConfig.ts
+++ b/tests/integration/crud/config/ensembleConfig.ts
@@ -151,11 +151,11 @@ export const ENSEMBLE_CONFIG: ElementTypeTestConfig = {
       required: true,
       validValues: [
         'Updated ensemble description',
-        'A completely different description'
+        'A completely different description',
+        'Long-form ensemble description. '.repeat(40)
       ],
       invalidValues: [
-        { value: '', expectedError: 'required|empty' },
-        { value: 'A'.repeat(501), expectedError: 'length|size' }
+        { value: '', expectedError: 'required|empty' }
       ]
     },
     {

--- a/tests/integration/crud/config/memoryConfig.ts
+++ b/tests/integration/crud/config/memoryConfig.ts
@@ -117,11 +117,11 @@ export const MEMORY_CONFIG: ElementTypeTestConfig = {
       required: true,
       validValues: [
         'Updated memory description',
-        'A completely different description'
+        'A completely different description',
+        'Long-form memory description. '.repeat(40)
       ],
       invalidValues: [
-        { value: '', expectedError: 'required|empty' },
-        { value: 'A'.repeat(501), expectedError: 'length|size' }
+        { value: '', expectedError: 'required|empty' }
       ]
     },
     {

--- a/tests/integration/crud/config/personaConfig.ts
+++ b/tests/integration/crud/config/personaConfig.ts
@@ -107,11 +107,11 @@ export const PERSONA_CONFIG: ElementTypeTestConfig = {
       required: true,
       validValues: [
         'Updated description',
-        'A completely different description'
+        'A completely different description',
+        'Long-form persona description. '.repeat(40)
       ],
       invalidValues: [
-        { value: '', expectedError: 'required|empty' },
-        { value: 'A'.repeat(501), expectedError: 'length|size' }
+        { value: '', expectedError: 'required|empty' }
       ]
     },
     {

--- a/tests/integration/crud/config/skillConfig.ts
+++ b/tests/integration/crud/config/skillConfig.ts
@@ -134,11 +134,11 @@ export const SKILL_CONFIG: ElementTypeTestConfig = {
       required: true,
       validValues: [
         'Updated skill description',
-        'A completely different description'
+        'A completely different description',
+        'Long-form skill description. '.repeat(40)
       ],
       invalidValues: [
-        { value: '', expectedError: 'required|empty' },
-        { value: 'A'.repeat(501), expectedError: 'length|size' }
+        { value: '', expectedError: 'required|empty' }
       ]
     },
     {

--- a/tests/integration/crud/config/templateConfig.ts
+++ b/tests/integration/crud/config/templateConfig.ts
@@ -163,11 +163,11 @@ export const TEMPLATE_CONFIG: ElementTypeTestConfig = {
       required: true,
       validValues: [
         'Updated template description',
-        'A completely different description'
+        'A completely different description',
+        'Long-form template description. '.repeat(40)
       ],
       invalidValues: [
-        { value: '', expectedError: 'required|empty' },
-        { value: 'A'.repeat(501), expectedError: 'length|size' }
+        { value: '', expectedError: 'required|empty' }
       ]
     },
     {

--- a/tests/integration/mcp-aql/update.test.ts
+++ b/tests/integration/mcp-aql/update.test.ts
@@ -11,6 +11,7 @@ import { DollhouseMCPServer } from '../../../src/index.js';
 import { DollhouseContainer } from '../../../src/di/Container.js';
 import { MCPAQLHandler } from '../../../src/handlers/mcp-aql/MCPAQLHandler.js';
 import { createPortfolioTestEnvironment, preConfirmAllOperations, type PortfolioTestEnvironment } from '../../helpers/portfolioTestHelper.js';
+import { SecureYamlParser } from '../../../src/security/secureYamlParser.js';
 import path from 'path';
 import fs from 'fs/promises';
 
@@ -521,12 +522,12 @@ describe('MCP-AQL UPDATE Endpoint Integration', () => {
       }
     });
 
-    // TODO: Max length validation not enforced on edit (truncation happens silently)
-    it.skip('should validate field values before setting', async () => {
+    it.each([501, 4096])('should accept %i character descriptions when editing', async (descriptionLength) => {
+      const elementName = `validation-test-skill-${descriptionLength}`;
       const createResult = await mcpAqlHandler.handleCreate({
         operation: 'create_element',
         params: {
-          element_name: 'validation-test-skill',
+          element_name: elementName,
           element_type: 'skills',
           description: 'Skill for validation testing',
           content: '# Test Content\n\nThis is test content that meets minimum length requirements.',
@@ -538,31 +539,35 @@ describe('MCP-AQL UPDATE Endpoint Integration', () => {
       const verifyResult = await mcpAqlHandler.handleRead({
         operation: 'get_element',
         params: {
-          element_name: 'validation-test-skill',
+          element_name: elementName,
           element_type: 'skills',
         },
       });
       expect(verifyResult.success).toBe(true);
 
-      // Try to set a description that exceeds max length (500 chars)
-      const tooLongDescription = 'a'.repeat(501);
+      // Descriptions over 500 chars should be accepted; only global content/YAML
+      // safety limits should apply.
+      const longDescription = `Updated description ${descriptionLength}: `.padEnd(descriptionLength, 'a');
 
       const result = await mcpAqlHandler.handleUpdate({
         operation: 'edit_element',
         params: {
-          element_name: 'validation-test-skill',
+          element_name: elementName,
           element_type: 'skills',
-          input: { description: tooLongDescription },
+          input: { description: longDescription },
         },
       });
 
-      // Handler returns success:true but with error content (❌ in message)
       expect(result.success).toBe(true);
       if (result.success) {
         const data = result.data as any;
-        expect(data.content[0].text).toMatch(/❌/);
-        expect(data.content[0].text).toMatch(/invalid value/i);
+        expect(data.content[0].text).toMatch(/✅/);
       }
+
+      const skillFile = path.join(env.testDir, 'skills', `${elementName}.md`);
+      const fileContent = await fs.readFile(skillFile, 'utf-8');
+      const parsed = SecureYamlParser.parse(fileContent, { validateContent: false });
+      expect(parsed.data.description).toBe(longDescription);
     });
 
     // FIX: Issue #287 - Fixed by removing test-pattern filtering

--- a/tests/security/inputLengthValidation.test.ts
+++ b/tests/security/inputLengthValidation.test.ts
@@ -81,13 +81,40 @@ describe('Input Length Validation', () => {
     test('rejects metadata fields exceeding limit', () => {
       const metadata = {
         name: 'Test',
-        description: 'a'.repeat(SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH + 1)
+        customField: 'a'.repeat(SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH + 1)
       };
       
       const result = ContentValidator.validateMetadata(metadata);
       expect(result.isValid).toBe(false);
       expect(result.detectedPatterns).toEqual(
-        expect.arrayContaining(['description: Field exceeds maximum length of 1024 characters'])
+        expect.arrayContaining(['customField: Field exceeds maximum length of 1024 characters'])
+      );
+    });
+
+    test('allows descriptions beyond short metadata field limit', () => {
+      const metadata = {
+        name: 'Test',
+        description: 'a'.repeat(SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH + 1)
+      };
+
+      const result = ContentValidator.validateMetadata(metadata);
+
+      expect(result.isValid).toBe(true);
+    });
+
+    test('rejects descriptions exceeding YAML frontmatter limit', () => {
+      const metadata = {
+        name: 'Test',
+        description: 'a'.repeat(SECURITY_LIMITS.MAX_YAML_LENGTH + 1)
+      };
+
+      const result = ContentValidator.validateMetadata(metadata);
+
+      expect(result.isValid).toBe(false);
+      expect(result.detectedPatterns).toEqual(
+        expect.arrayContaining([
+          `description: Field exceeds maximum length of ${SECURITY_LIMITS.MAX_YAML_LENGTH} characters`
+        ])
       );
     });
   });
@@ -156,11 +183,12 @@ This is the content of the persona.`;
       expect(contentResult.isValid).toBe(true);
     });
 
-    test('large persona file is rejected early', () => {
-      // Should fail on metadata field length
+    test('large non-description metadata field is rejected early', () => {
+      // Description is allowed to be substantive; other metadata fields still use
+      // the short field-size guard.
       const result = ContentValidator.validateMetadata({
         name: 'Test',
-        description: 'a'.repeat(2000)
+        customField: 'a'.repeat(2000)
       });
       expect(result.isValid).toBe(false);
     });

--- a/tests/security/inputLengthValidation.test.ts
+++ b/tests/security/inputLengthValidation.test.ts
@@ -81,14 +81,25 @@ describe('Input Length Validation', () => {
     test('rejects metadata fields exceeding limit', () => {
       const metadata = {
         name: 'Test',
-        description: 'a'.repeat(SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH + 1)
+        customField: 'a'.repeat(SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH + 1)
       };
       
       const result = ContentValidator.validateMetadata(metadata);
       expect(result.isValid).toBe(false);
       expect(result.detectedPatterns).toEqual(
-        expect.arrayContaining(['description: Field exceeds maximum length of 1024 characters'])
+        expect.arrayContaining(['customField: Field exceeds maximum length of 1024 characters'])
       );
+    });
+
+    test('allows descriptions beyond short metadata field limit', () => {
+      const metadata = {
+        name: 'Test',
+        description: 'a'.repeat(SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH + 1)
+      };
+
+      const result = ContentValidator.validateMetadata(metadata);
+
+      expect(result.isValid).toBe(true);
     });
   });
 
@@ -156,11 +167,12 @@ This is the content of the persona.`;
       expect(contentResult.isValid).toBe(true);
     });
 
-    test('large persona file is rejected early', () => {
-      // Should fail on metadata field length
+    test('large non-description metadata field is rejected early', () => {
+      // Description is allowed to be substantive; other metadata fields still use
+      // the short field-size guard.
       const result = ContentValidator.validateMetadata({
         name: 'Test',
-        description: 'a'.repeat(2000)
+        customField: 'a'.repeat(2000)
       });
       expect(result.isValid).toBe(false);
     });

--- a/tests/security/inputLengthValidation.test.ts
+++ b/tests/security/inputLengthValidation.test.ts
@@ -101,6 +101,22 @@ describe('Input Length Validation', () => {
 
       expect(result.isValid).toBe(true);
     });
+
+    test('rejects descriptions exceeding YAML frontmatter limit', () => {
+      const metadata = {
+        name: 'Test',
+        description: 'a'.repeat(SECURITY_LIMITS.MAX_YAML_LENGTH + 1)
+      };
+
+      const result = ContentValidator.validateMetadata(metadata);
+
+      expect(result.isValid).toBe(false);
+      expect(result.detectedPatterns).toEqual(
+        expect.arrayContaining([
+          `description: Field exceeds maximum length of ${SECURITY_LIMITS.MAX_YAML_LENGTH} characters`
+        ])
+      );
+    });
   });
 
   describe('SecureYamlParser length checks', () => {

--- a/tests/security/inputLengthValidation.test.ts
+++ b/tests/security/inputLengthValidation.test.ts
@@ -81,7 +81,7 @@ describe('Input Length Validation', () => {
     test('rejects metadata fields exceeding limit', () => {
       const metadata = {
         name: 'Test',
-        description: 'a'.repeat(SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH + 1)
+        customField: 'a'.repeat(SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH + 1)
       };
       
       const result = ContentValidator.validateMetadata(metadata);
@@ -91,7 +91,34 @@ describe('Input Length Validation', () => {
       // stable prefix instead of pinning the exact string.
       expect(result.detectedPatterns).toEqual(
         expect.arrayContaining([
-          expect.stringContaining('description: Field exceeds maximum length of 1024 characters'),
+          expect.stringContaining('customField: Field exceeds maximum length of 1024 characters'),
+        ]),
+      );
+    });
+
+    test('allows descriptions beyond short metadata field limit', () => {
+      const metadata = {
+        name: 'Test',
+        description: 'a'.repeat(SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH + 1)
+      };
+
+      const result = ContentValidator.validateMetadata(metadata);
+
+      expect(result.isValid).toBe(true);
+    });
+
+    test('rejects descriptions exceeding YAML frontmatter limit', () => {
+      const metadata = {
+        name: 'Test',
+        description: 'a'.repeat(SECURITY_LIMITS.MAX_YAML_LENGTH + 1)
+      };
+
+      const result = ContentValidator.validateMetadata(metadata);
+
+      expect(result.isValid).toBe(false);
+      expect(result.detectedPatterns).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining(`description: Field exceeds maximum length of ${SECURITY_LIMITS.MAX_YAML_LENGTH} characters`),
         ]),
       );
     });
@@ -161,11 +188,12 @@ This is the content of the persona.`;
       expect(contentResult.isValid).toBe(true);
     });
 
-    test('large persona file is rejected early', () => {
-      // Should fail on metadata field length
+    test('large non-description metadata field is rejected early', () => {
+      // Description is allowed to be substantive; other metadata fields still use
+      // the short field-size guard.
       const result = ContentValidator.validateMetadata({
         name: 'Test',
-        description: 'a'.repeat(2000)
+        customField: 'a'.repeat(2000)
       });
       expect(result.isValid).toBe(false);
     });

--- a/tests/security/secureYamlParser.test.ts
+++ b/tests/security/secureYamlParser.test.ts
@@ -178,7 +178,6 @@ count: 42
     it('should validate field types', () => {
       const invalidFields = [
         { field: 'name', value: 'x'.repeat(101), error: 'Invalid value for field \'name\'' },
-        { field: 'description', value: 'x'.repeat(501), error: 'Invalid value for field \'description\'' },
         { field: 'age_rating', value: 'invalid', error: 'Invalid value for field \'age_rating\'' },
         { field: 'price', value: '$invalid', error: 'Invalid value for field \'price\'' },
         { field: 'version', value: 'not.a.version', error: 'Invalid value for field \'version\'' }
@@ -191,6 +190,19 @@ count: 42
           SecureYamlParser.parse(yaml);
         }).toThrow(error);
       });
+    });
+
+    it('should accept substantive descriptions longer than 500 characters', () => {
+      const longDescription = 'Long-form element description. '.repeat(40).trim();
+      const yaml = `---
+name: Test
+description: ${longDescription}
+---`;
+
+      const result = SecureYamlParser.parse(yaml);
+
+      expect(result.data.description).toBe(longDescription);
+      expect(result.data.description.length).toBeGreaterThan(500);
     });
 
     it('should sanitize content with security threats', () => {

--- a/tests/unit/base/ElementValidation.test.ts
+++ b/tests/unit/base/ElementValidation.test.ts
@@ -35,6 +35,13 @@ describe('ElementValidation', () => {
     expect(ElementValidation.validateDescription('  description ')).toBe('description');
   });
 
+  it('validateDescription should preserve substantive descriptions over 500 characters', () => {
+    const description = 'Long-form element description. '.repeat(40);
+
+    expect(ElementValidation.validateDescription(description)).toBe(description.trim());
+    expect(ElementValidation.validateDescription(description)!.length).toBeGreaterThan(500);
+  });
+
   it('validateTags should filter falsey values and sanitize entries', () => {
     const tags = ElementValidation.validateTags(['Tag One', '', null, 'two', undefined, 'three!']);
     expect(tags).toEqual(['Tag One', 'two', 'three']);

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -1109,6 +1109,7 @@ Content`;
 
     describe('Issue #697: V2 Field Normalization on Load', () => {
       it('should normalize goals (plural) to goal on load', async () => {
+        const longParameterDescription = 'Agent goal parameter description '.padEnd(1024, 'g');
         fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
           if (filePath.includes('.state.yaml')) {
             const error = new Error('ENOENT') as NodeJS.ErrnoException;
@@ -1122,7 +1123,7 @@ goals:
   template: "Do {{task}}"
   parameters:
     - name: task
-      description: The task to do
+      description: ${longParameterDescription}
       required: true
 ---
 Agent with plural goals field`;
@@ -1133,6 +1134,8 @@ Agent with plural goals field`;
         // goal should be set from goals
         expect((agent!.metadata as any).goal).toBeDefined();
         expect((agent!.metadata as any).goal.template).toBe('Do {{task}}');
+        expect((agent!.metadata as any).goal.parameters[0].description).toBe(longParameterDescription);
+        expect((agent!.metadata as any).goal.parameters[0].description.length).toBeGreaterThan(500);
         // goals (plural) should be removed
         expect((agent!.metadata as any).goals).toBeUndefined();
       });

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -1124,6 +1124,7 @@ Content`;
 
     describe('Issue #697: V2 Field Normalization on Load', () => {
       it('should normalize goals (plural) to goal on load', async () => {
+        const longParameterDescription = 'Agent goal parameter description '.padEnd(1024, 'g');
         fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
           if (filePath.includes('.state.yaml')) {
             const error = new Error('ENOENT') as NodeJS.ErrnoException;
@@ -1137,7 +1138,7 @@ goals:
   template: "Do {{task}}"
   parameters:
     - name: task
-      description: The task to do
+      description: ${longParameterDescription}
       required: true
 ---
 Agent with plural goals field`;
@@ -1148,6 +1149,8 @@ Agent with plural goals field`;
         // goal should be set from goals
         expect((agent!.metadata as any).goal).toBeDefined();
         expect((agent!.metadata as any).goal.template).toBe('Do {{task}}');
+        expect((agent!.metadata as any).goal.parameters[0].description).toBe(longParameterDescription);
+        expect((agent!.metadata as any).goal.parameters[0].description.length).toBeGreaterThan(500);
         // goals (plural) should be removed
         expect((agent!.metadata as any).goals).toBeUndefined();
       });

--- a/tests/unit/elements/skills/SkillManager.test.ts
+++ b/tests/unit/elements/skills/SkillManager.test.ts
@@ -129,6 +129,29 @@ This is a test skill.`;
         .rejects.toThrow();
     });
 
+    it('should preserve long parameter descriptions from skill metadata', async () => {
+      const longDescription = 'Skill parameter description '.padEnd(1024, 'a');
+      const skillContent = `---
+name: Parameter Skill
+description: A skill with detailed parameter metadata
+parameters:
+  - name: prompt
+    type: string
+    description: ${longDescription}
+---
+# Parameter Skill
+
+This skill has a parameter with a substantive description.`;
+
+      const skillPath = path.join(portfolioManager.getElementDir(ElementType.SKILL), 'parameter-skill.md');
+      await fs.writeFile(skillPath, skillContent);
+
+      const skill = await skillManager.load('parameter-skill.md');
+
+      expect(skill.metadata.parameters?.[0].description).toBe(longDescription);
+      expect(skill.metadata.parameters?.[0].description.length).toBeGreaterThan(500);
+    });
+
     it('should validate file paths', async () => {
       await expect(skillManager.load('../../../etc/passwd'))
         .rejects.toThrow('Invalid skill path');

--- a/tests/unit/elements/skills/SkillManager.test.ts
+++ b/tests/unit/elements/skills/SkillManager.test.ts
@@ -133,6 +133,29 @@ This is a test skill.`;
         .rejects.toThrow();
     });
 
+    it('should preserve long parameter descriptions from skill metadata', async () => {
+      const longDescription = 'Skill parameter description '.padEnd(1024, 'a');
+      const skillContent = `---
+name: Parameter Skill
+description: A skill with detailed parameter metadata
+parameters:
+  - name: prompt
+    type: string
+    description: ${longDescription}
+---
+# Parameter Skill
+
+This skill has a parameter with a substantive description.`;
+
+      const skillPath = path.join(portfolioManager.getElementDir(ElementType.SKILL), 'parameter-skill.md');
+      await fs.writeFile(skillPath, skillContent);
+
+      const skill = await skillManager.load('parameter-skill.md');
+
+      expect(skill.metadata.parameters?.[0].description).toBe(longDescription);
+      expect(skill.metadata.parameters?.[0].description.length).toBeGreaterThan(500);
+    });
+
     it('should validate file paths', async () => {
       await expect(skillManager.load('../../../etc/passwd'))
         .rejects.toThrow('Invalid skill path');

--- a/tests/unit/elements/templates/TemplateManager.test.ts
+++ b/tests/unit/elements/templates/TemplateManager.test.ts
@@ -177,6 +177,8 @@ Hello {{name}}!`;
 
   describe('validation methods', () => {
     it('should handle complex metadata during import', async () => {
+      const longVariableDescription = 'Template variable description: '.padEnd(1024, 'v');
+      const longExampleDescription = 'Template example description: '.padEnd(1024, 'e');
       const complexData = JSON.stringify({
         metadata: {
           name: 'Complex Template',
@@ -188,7 +190,7 @@ Hello {{name}}!`;
             {
               name: 'username',
               type: 'string',
-              description: 'User name',
+              description: longVariableDescription,
               required: true,
               validation: '^[a-zA-Z0-9_]+$'
             },
@@ -204,7 +206,7 @@ Hello {{name}}!`;
           examples: [
             {
               title: 'Basic Example',
-              description: 'Shows basic usage',
+              description: longExampleDescription,
               variables: { username: 'john_doe', count: 5 },
               output: 'Hello john_doe, you have 5 items!'
             }
@@ -217,10 +219,14 @@ Hello {{name}}!`;
       
       expect(template.metadata.variables).toHaveLength(2);
       expect(template.metadata.variables![0].name).toBe('username');
+      expect(template.metadata.variables![0].description).toBe(longVariableDescription);
+      expect(template.metadata.variables![0].description!.length).toBeGreaterThan(500);
       // The sanitization removes backslashes, so they won't be in the validation pattern
       expect(template.metadata.variables![0].validation).toBe('^[a-zA-Z0-9_]+');
       expect(template.metadata.variables![1].default).toBe(10);
       expect(template.metadata.examples).toHaveLength(1);
+      expect(template.metadata.examples![0].description).toBe(longExampleDescription);
+      expect(template.metadata.examples![0].description!.length).toBeGreaterThan(500);
       expect(template.metadata.tags).toEqual(['complex', 'advanced', 'features']);
     });
 

--- a/tests/unit/elements/templates/TemplateManager.test.ts
+++ b/tests/unit/elements/templates/TemplateManager.test.ts
@@ -181,6 +181,8 @@ Hello {{name}}!`;
 
   describe('validation methods', () => {
     it('should handle complex metadata during import', async () => {
+      const longVariableDescription = 'Template variable description: '.padEnd(1024, 'v');
+      const longExampleDescription = 'Template example description: '.padEnd(1024, 'e');
       const complexData = JSON.stringify({
         metadata: {
           name: 'Complex Template',
@@ -192,7 +194,7 @@ Hello {{name}}!`;
             {
               name: 'username',
               type: 'string',
-              description: 'User name',
+              description: longVariableDescription,
               required: true,
               validation: '^[a-zA-Z0-9_]+$'
             },
@@ -208,7 +210,7 @@ Hello {{name}}!`;
           examples: [
             {
               title: 'Basic Example',
-              description: 'Shows basic usage',
+              description: longExampleDescription,
               variables: { username: 'john_doe', count: 5 },
               output: 'Hello john_doe, you have 5 items!'
             }
@@ -221,10 +223,14 @@ Hello {{name}}!`;
       
       expect(template.metadata.variables).toHaveLength(2);
       expect(template.metadata.variables![0].name).toBe('username');
+      expect(template.metadata.variables![0].description).toBe(longVariableDescription);
+      expect(template.metadata.variables![0].description!.length).toBeGreaterThan(500);
       // The sanitization removes backslashes, so they won't be in the validation pattern
       expect(template.metadata.variables![0].validation).toBe('^[a-zA-Z0-9_]+');
       expect(template.metadata.variables![1].default).toBe(10);
       expect(template.metadata.examples).toHaveLength(1);
+      expect(template.metadata.examples![0].description).toBe(longExampleDescription);
+      expect(template.metadata.examples![0].description!.length).toBeGreaterThan(500);
       expect(template.metadata.tags).toEqual(['complex', 'advanced', 'features']);
     });
 

--- a/tests/unit/elements/version-persistence.test.ts
+++ b/tests/unit/elements/version-persistence.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
 import { SkillManager } from '../../../src/elements/skills/SkillManager.js';
 import { Skill } from '../../../src/elements/skills/Skill.js';
 import { TemplateManager } from '../../../src/elements/templates/TemplateManager.js';
@@ -33,7 +33,7 @@ describe('Version Persistence', () => {
 
   beforeEach(async () => {
     // Create unique test directory
-    testDir = path.join(os.tmpdir(), `test-version-${uuidv4()}`);
+    testDir = path.join(os.tmpdir(), `test-version-${randomUUID()}`);
     await fs.mkdir(testDir, { recursive: true });
     
     // Create subdirectories

--- a/tests/unit/elements/version-persistence.test.ts
+++ b/tests/unit/elements/version-persistence.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
 import { SkillManager } from '../../../src/elements/skills/SkillManager.js';
 import { Skill } from '../../../src/elements/skills/Skill.js';
 import { TemplateManager } from '../../../src/elements/templates/TemplateManager.js';
@@ -35,7 +35,7 @@ describe('Version Persistence', () => {
 
   beforeEach(async () => {
     // Create unique test directory
-    testDir = path.join(os.tmpdir(), `test-version-${uuidv4()}`);
+    testDir = path.join(os.tmpdir(), `test-version-${randomUUID()}`);
     await fs.mkdir(testDir, { recursive: true });
     
     // Create subdirectories

--- a/tests/unit/handlers/element-crud/createElement.helper.test.ts
+++ b/tests/unit/handlers/element-crud/createElement.helper.test.ts
@@ -149,6 +149,20 @@ describe('createElement helper', () => {
       expect(call.description).not.toContain('<script>');
     });
 
+    it('should preserve long descriptions when creating elements', async () => {
+      const longDescription = 'Long-form skill description. '.repeat(80);
+
+      await createElement(mockContext, {
+        name: 'test',
+        type: ElementType.SKILL,
+        description: longDescription,
+      });
+
+      const call = (mockContext.skillManager.create as jest.Mock).mock.calls[0][0];
+      expect(call.description).toBe(longDescription.trim());
+      expect(call.description.length).toBeGreaterThan(500);
+    });
+
     it('should sanitize metadata to remove dangerous properties', async () => {
       const metadata = {
         description: 'safe',

--- a/tests/unit/handlers/element-crud/createElement.helper.test.ts
+++ b/tests/unit/handlers/element-crud/createElement.helper.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 
 const { createElement } = await import('../../../../src/handlers/element-crud/createElement.js');
 const { ElementType } = await import('../../../../src/portfolio/PortfolioManager.js');
+const { SECURITY_LIMITS } = await import('../../../../src/security/constants.js');
 import type { ElementCrudContext } from '../../../../src/handlers/element-crud/types.js';
 
 describe('createElement helper', () => {
@@ -147,6 +148,32 @@ describe('createElement helper', () => {
 
       const call = (mockContext.skillManager.create as jest.Mock).mock.calls[0][0];
       expect(call.description).not.toContain('<script>');
+    });
+
+    it('should preserve long descriptions when creating elements', async () => {
+      const longDescription = 'Long-form skill description. '.repeat(80);
+
+      await createElement(mockContext, {
+        name: 'test',
+        type: ElementType.SKILL,
+        description: longDescription,
+      });
+
+      const call = (mockContext.skillManager.create as jest.Mock).mock.calls[0][0];
+      expect(call.description).toBe(longDescription.trim());
+      expect(call.description.length).toBeGreaterThan(500);
+    });
+
+    it('should reject descriptions that exceed the YAML frontmatter safety limit', async () => {
+      const result = await createElement(mockContext, {
+        name: 'test',
+        type: ElementType.SKILL,
+        description: 'a'.repeat(SECURITY_LIMITS.MAX_YAML_LENGTH + 1),
+      });
+
+      expect(result.content[0].text).toContain('❌ Description too large');
+      expect(result.content[0].text).toContain('input.description');
+      expect(mockContext.skillManager.create).not.toHaveBeenCalled();
     });
 
     it('should sanitize metadata to remove dangerous properties', async () => {

--- a/tests/unit/handlers/element-crud/createElement.helper.test.ts
+++ b/tests/unit/handlers/element-crud/createElement.helper.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 
 const { createElement } = await import('../../../../src/handlers/element-crud/createElement.js');
 const { ElementType } = await import('../../../../src/portfolio/PortfolioManager.js');
+const { SECURITY_LIMITS } = await import('../../../../src/security/constants.js');
 import type { ElementCrudContext } from '../../../../src/handlers/element-crud/types.js';
 
 describe('createElement helper', () => {
@@ -161,6 +162,18 @@ describe('createElement helper', () => {
       const call = (mockContext.skillManager.create as jest.Mock).mock.calls[0][0];
       expect(call.description).toBe(longDescription.trim());
       expect(call.description.length).toBeGreaterThan(500);
+    });
+
+    it('should reject descriptions that exceed the YAML frontmatter safety limit', async () => {
+      const result = await createElement(mockContext, {
+        name: 'test',
+        type: ElementType.SKILL,
+        description: 'a'.repeat(SECURITY_LIMITS.MAX_YAML_LENGTH + 1),
+      });
+
+      expect(result.content[0].text).toContain('❌ Description too large');
+      expect(result.content[0].text).toContain('input.description');
+      expect(mockContext.skillManager.create).not.toHaveBeenCalled();
     });
 
     it('should sanitize metadata to remove dangerous properties', async () => {

--- a/tests/unit/handlers/element-crud/editElement.helper.test.ts
+++ b/tests/unit/handlers/element-crud/editElement.helper.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 const { editElement } = await import('../../../../src/handlers/element-crud/editElement.js');
 const { ElementType } = await import('../../../../src/portfolio/PortfolioManager.js');
 const { ElementNotFoundError } = await import('../../../../src/utils/ErrorHandler.js');
+const { SECURITY_LIMITS } = await import('../../../../src/security/constants.js');
 import type { ElementCrudContext } from '../../../../src/handlers/element-crud/types.js';
 
 describe('editElement helper', () => {
@@ -377,6 +378,26 @@ describe('editElement helper', () => {
       const saved = (mockContext.skillManager.save as jest.Mock).mock.calls[0][0];
       expect(saved.metadata.description).toBe(longDescription);
       expect(saved.metadata.description.length).toBeGreaterThan(500);
+    });
+
+    it('should reject description edits that exceed the YAML frontmatter safety limit', async () => {
+      const element = createMockElement('test-skill');
+      mockContext.skillManager.find = jest.fn().mockResolvedValue(element);
+
+      const result = await editElement(mockContext, {
+        name: 'test-skill',
+        type: ElementType.SKILL,
+        input: {
+          metadata: {
+            description: 'a'.repeat(SECURITY_LIMITS.MAX_YAML_LENGTH + 1)
+          }
+        },
+      });
+
+      expect(result.content[0].text).toContain('❌');
+      expect(result.content[0].text).toContain('Description length validation failed');
+      expect(result.content[0].text).toContain('input.metadata.description');
+      expect(mockContext.skillManager.save).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/handlers/element-crud/editElement.helper.test.ts
+++ b/tests/unit/handlers/element-crud/editElement.helper.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 const { editElement } = await import('../../../../src/handlers/element-crud/editElement.js');
 const { ElementType } = await import('../../../../src/portfolio/PortfolioManager.js');
 const { ElementNotFoundError } = await import('../../../../src/utils/ErrorHandler.js');
+const { SECURITY_LIMITS } = await import('../../../../src/security/constants.js');
 import type { ElementCrudContext } from '../../../../src/handlers/element-crud/types.js';
 
 describe('editElement helper', () => {
@@ -337,6 +338,66 @@ describe('editElement helper', () => {
       expect(saved.metadata.description).toBe('New description');
       expect(saved.metadata.author).toBe('New Author');
       expect(saved.metadata.tags).toEqual(['tag1', 'tag2']);
+    });
+
+    it('should preserve long top-level descriptions instead of rejecting or truncating them', async () => {
+      const element = createMockElement('test-skill');
+      const longDescription = 'Long-form skill description. '.repeat(80);
+      mockContext.skillManager.find = jest.fn().mockResolvedValue(element);
+
+      const result = await editElement(mockContext, {
+        name: 'test-skill',
+        type: ElementType.SKILL,
+        input: {
+          description: longDescription
+        },
+      });
+
+      expect(result.content[0].text).toContain('✅');
+      const saved = (mockContext.skillManager.save as jest.Mock).mock.calls[0][0];
+      expect(saved.metadata.description).toBe(longDescription);
+      expect(saved.metadata.description.length).toBeGreaterThan(500);
+    });
+
+    it('should preserve long nested metadata descriptions instead of rejecting or truncating them', async () => {
+      const element = createMockElement('test-skill');
+      const longDescription = 'Nested long-form skill description. '.repeat(80);
+      mockContext.skillManager.find = jest.fn().mockResolvedValue(element);
+
+      const result = await editElement(mockContext, {
+        name: 'test-skill',
+        type: ElementType.SKILL,
+        input: {
+          metadata: {
+            description: longDescription
+          }
+        },
+      });
+
+      expect(result.content[0].text).toContain('✅');
+      const saved = (mockContext.skillManager.save as jest.Mock).mock.calls[0][0];
+      expect(saved.metadata.description).toBe(longDescription);
+      expect(saved.metadata.description.length).toBeGreaterThan(500);
+    });
+
+    it('should reject description edits that exceed the YAML frontmatter safety limit', async () => {
+      const element = createMockElement('test-skill');
+      mockContext.skillManager.find = jest.fn().mockResolvedValue(element);
+
+      const result = await editElement(mockContext, {
+        name: 'test-skill',
+        type: ElementType.SKILL,
+        input: {
+          metadata: {
+            description: 'a'.repeat(SECURITY_LIMITS.MAX_YAML_LENGTH + 1)
+          }
+        },
+      });
+
+      expect(result.content[0].text).toContain('❌');
+      expect(result.content[0].text).toContain('Description length validation failed');
+      expect(result.content[0].text).toContain('input.metadata.description');
+      expect(mockContext.skillManager.save).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/handlers/element-crud/editElement.helper.test.ts
+++ b/tests/unit/handlers/element-crud/editElement.helper.test.ts
@@ -338,6 +338,46 @@ describe('editElement helper', () => {
       expect(saved.metadata.author).toBe('New Author');
       expect(saved.metadata.tags).toEqual(['tag1', 'tag2']);
     });
+
+    it('should preserve long top-level descriptions instead of rejecting or truncating them', async () => {
+      const element = createMockElement('test-skill');
+      const longDescription = 'Long-form skill description. '.repeat(80);
+      mockContext.skillManager.find = jest.fn().mockResolvedValue(element);
+
+      const result = await editElement(mockContext, {
+        name: 'test-skill',
+        type: ElementType.SKILL,
+        input: {
+          description: longDescription
+        },
+      });
+
+      expect(result.content[0].text).toContain('✅');
+      const saved = (mockContext.skillManager.save as jest.Mock).mock.calls[0][0];
+      expect(saved.metadata.description).toBe(longDescription);
+      expect(saved.metadata.description.length).toBeGreaterThan(500);
+    });
+
+    it('should preserve long nested metadata descriptions instead of rejecting or truncating them', async () => {
+      const element = createMockElement('test-skill');
+      const longDescription = 'Nested long-form skill description. '.repeat(80);
+      mockContext.skillManager.find = jest.fn().mockResolvedValue(element);
+
+      const result = await editElement(mockContext, {
+        name: 'test-skill',
+        type: ElementType.SKILL,
+        input: {
+          metadata: {
+            description: longDescription
+          }
+        },
+      });
+
+      expect(result.content[0].text).toContain('✅');
+      const saved = (mockContext.skillManager.save as jest.Mock).mock.calls[0][0];
+      expect(saved.metadata.description).toBe(longDescription);
+      expect(saved.metadata.description.length).toBeGreaterThan(500);
+    });
   });
 
   describe('persona editing', () => {

--- a/tests/unit/security/contentValidator-perfield-limits.test.ts
+++ b/tests/unit/security/contentValidator-perfield-limits.test.ts
@@ -1,9 +1,10 @@
 /**
  * Regression: ContentValidator.validateMetadata must apply per-field
- * length limits. Identity fields (name, description, category, author,
- * version, tags) keep the strict 1KB cap; long-form fields
- * (instructions, content) get the higher MAX_CONTENT_LENGTH limit so
- * non-trivial collection personas actually install.
+ * length limits. Identity fields (name, category, author, version,
+ * tags) keep the strict 1KB cap; long-form fields (instructions,
+ * content, description) get a higher limit so non-trivial collection
+ * personas actually install. Description uses the YAML/frontmatter
+ * limit because it carries substantive LLM-authored text.
  *
  * Caught during Phase 4.5 PoC verification on 2026-05-12 — installing
  * `dollhouse-expert` from the public collection failed because the
@@ -18,7 +19,7 @@ import { SECURITY_LIMITS } from '../../../src/security/constants.js';
 
 describe('ContentValidator.validateMetadata per-field length limits', () => {
   describe('identity-shaped fields (1KB cap)', () => {
-    it.each(['name', 'description', 'category', 'author', 'version'])(
+    it.each(['name', 'category', 'author', 'version'])(
       'rejects %s when over MAX_METADATA_FIELD_LENGTH (1024 chars)',
       (fieldName) => {
         const metadata = { [fieldName]: 'a'.repeat(SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH + 10) };
@@ -29,7 +30,7 @@ describe('ContentValidator.validateMetadata per-field length limits', () => {
       },
     );
 
-    it.each(['name', 'description', 'category', 'author', 'version'])(
+    it.each(['name', 'category', 'author', 'version'])(
       'accepts %s when at MAX_METADATA_FIELD_LENGTH',
       (fieldName) => {
         const metadata = { [fieldName]: 'a'.repeat(SECURITY_LIMITS.MAX_METADATA_FIELD_LENGTH) };
@@ -79,6 +80,31 @@ describe('ContentValidator.validateMetadata per-field length limits', () => {
       expect(
         result.detectedPatterns?.find(p => p.startsWith('content:') && p.includes('exceeds maximum length')),
       ).toBeUndefined();
+    });
+
+    it('accepts description well over the short metadata limit', () => {
+      const metadata = {
+        name: 'realistic-persona',
+        // 5KB of description text — far over the 1KB metadata cap but
+        // well under MAX_YAML_LENGTH. LLM-authored descriptions need this.
+        description: 'a'.repeat(5_000),
+      };
+      const result = ContentValidator.validateMetadata(metadata);
+      expect(
+        result.detectedPatterns?.find(p => p.startsWith('description:') && p.includes('exceeds maximum length')),
+      ).toBeUndefined();
+    });
+
+    it('rejects description only when over MAX_YAML_LENGTH', () => {
+      const metadata = {
+        name: 'huge-description-persona',
+        description: 'a'.repeat(SECURITY_LIMITS.MAX_YAML_LENGTH + 10),
+      };
+      const result = ContentValidator.validateMetadata(metadata);
+      expect(result.isValid).toBe(false);
+      const lenError = result.detectedPatterns?.find(p => p.startsWith('description:') && p.includes('exceeds maximum length'));
+      expect(lenError).toBeDefined();
+      expect(lenError).toContain(String(SECURITY_LIMITS.MAX_YAML_LENGTH));
     });
   });
 

--- a/tests/unit/services/SerializationService.test.ts
+++ b/tests/unit/services/SerializationService.test.ts
@@ -807,6 +807,25 @@ description: Pure YAML
         expect(result).toContain('name: test');
         expect(result).toContain('description: Test description');
       });
+
+      it.each([500, 501, 1024, 4096, 16384, 32768])(
+        'should roundtrip a %i character description',
+        (descriptionLength) => {
+          const description = `Description ${descriptionLength}: `.padEnd(descriptionLength, 'x');
+          const metadata = {
+            name: `long-description-${descriptionLength}`,
+            description
+          };
+          const content = '# Long Description Element\n\nElement content stays separate.';
+
+          const result = service.createFrontmatter(metadata, content);
+          const parsed = service.parseFrontmatter(result);
+
+          expect(parsed.data.description).toBe(description);
+          expect(parsed.data.description).toHaveLength(descriptionLength);
+          expect(parsed.content).toBe(content);
+        }
+      );
     });
 
     describe('Method Options', () => {

--- a/tests/unit/services/SerializationService.test.ts
+++ b/tests/unit/services/SerializationService.test.ts
@@ -808,7 +808,7 @@ description: Pure YAML
         expect(result).toContain('description: Test description');
       });
 
-      it.each([500, 501, 1024, 4096, 16384, 32768])(
+      it.each([500, 501, 1024, 4096, 16384, 32768, 60000])(
         'should roundtrip a %i character description',
         (descriptionLength) => {
           const description = `Description ${descriptionLength}: `.padEnd(descriptionLength, 'x');

--- a/tests/unit/services/SerializationService.test.ts
+++ b/tests/unit/services/SerializationService.test.ts
@@ -807,6 +807,25 @@ description: Pure YAML
         expect(result).toContain('name: test');
         expect(result).toContain('description: Test description');
       });
+
+      it.each([500, 501, 1024, 4096, 16384, 32768, 60000])(
+        'should roundtrip a %i character description',
+        (descriptionLength) => {
+          const description = `Description ${descriptionLength}: `.padEnd(descriptionLength, 'x');
+          const metadata = {
+            name: `long-description-${descriptionLength}`,
+            description
+          };
+          const content = '# Long Description Element\n\nElement content stays separate.';
+
+          const result = service.createFrontmatter(metadata, content);
+          const parsed = service.parseFrontmatter(result);
+
+          expect(parsed.data.description).toBe(description);
+          expect(parsed.data.description).toHaveLength(descriptionLength);
+          expect(parsed.content).toBe(content);
+        }
+      );
     });
 
     describe('Method Options', () => {

--- a/tests/unit/services/validation/GenericElementValidator.test.ts
+++ b/tests/unit/services/validation/GenericElementValidator.test.ts
@@ -16,6 +16,7 @@ import { ValidationService } from '../../../../src/services/validation/Validatio
 import { TriggerValidationService } from '../../../../src/services/validation/TriggerValidationService.js';
 import { MetadataService } from '../../../../src/services/MetadataService.js';
 import { ElementType } from '../../../../src/portfolio/types.js';
+import { SECURITY_LIMITS } from '../../../../src/security/constants.js';
 
 // Mock the services
 jest.mock('../../../../src/services/validation/ValidationService.js');
@@ -299,6 +300,28 @@ describe('GenericElementValidator', () => {
         const result = await validator.validateCreate(data);
 
         expect(result.warnings.some(w => w.includes('Description is very long'))).toBe(true);
+      });
+
+      it('should reject descriptions beyond the YAML frontmatter safety limit', async () => {
+        const description = 'a'.repeat(SECURITY_LIMITS.MAX_YAML_LENGTH + 1);
+        const data = {
+          name: 'Test',
+          description,
+          content: 'Content'
+        };
+
+        const result = await validator.validateCreate(data);
+
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toEqual(
+          expect.arrayContaining([
+            `Description exceeds maximum YAML/frontmatter length of ${SECURITY_LIMITS.MAX_YAML_LENGTH} characters`
+          ])
+        );
+        expect(mockValidationService.validateAndSanitizeInput).not.toHaveBeenCalledWith(
+          description,
+          expect.objectContaining({ fieldType: 'description' })
+        );
       });
 
       it('should warn about very long content', async () => {

--- a/tests/unit/telemetry/OperationalTelemetry.test.ts
+++ b/tests/unit/telemetry/OperationalTelemetry.test.ts
@@ -13,11 +13,9 @@ import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals
 import * as path from 'node:path';
 import * as os from 'node:os';
 
-// Mock dependencies BEFORE imports using ESM approach
-jest.unstable_mockModule('uuid', () => ({
-  v4: jest.fn(() => 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee')
-}));
+const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+// Mock dependencies BEFORE imports using ESM approach
 jest.unstable_mockModule('../../../src/utils/logger.js', () => ({
   logger: {
     debug: jest.fn(),
@@ -209,7 +207,7 @@ describe('OperationalTelemetry', () => {
       // Should write UUID to file
       expect(mockFileOperations.writeFile).toHaveBeenCalledWith(
         expectedPath,
-        testUUID,
+        expect.stringMatching(uuidRegex),
         expect.objectContaining({ source: 'OperationalTelemetry.ensureUUID' })
       );
     });
@@ -228,8 +226,6 @@ describe('OperationalTelemetry', () => {
       expect(uuidCall).toBeDefined();
       const uuid = uuidCall![1];
 
-      // Validate UUID v4 format
-      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
       expect(uuid).toMatch(uuidRegex);
     });
   });
@@ -324,7 +320,7 @@ describe('OperationalTelemetry', () => {
         call => (call[0] as string).includes('.telemetry-id')
       );
       expect(uuidWriteCall).toBeDefined();
-      expect(uuidWriteCall![1]).toBe(testUUID);
+      expect(uuidWriteCall![1]).toMatch(uuidRegex);
     });
 
     it('should reuse cached UUID on second initialize() call', async () => {
@@ -390,10 +386,13 @@ describe('OperationalTelemetry', () => {
 
       const eventLine = logCall![1] as string;
       const event = JSON.parse(eventLine.replace(/\n$/, ''));
+      const uuidWriteCall = mockFileOperations.writeFile.mock.calls.find(
+        call => (call[0] as string).includes('.telemetry-id')
+      );
 
       expect(event).toMatchObject({
         event: 'install',
-        install_id: testUUID,
+        install_id: uuidWriteCall?.[1],
         version: testVersion,
         os: expect.any(String),
         node_version: expect.any(String),


### PR DESCRIPTION
Routine sync of `develop` into `codex/hosted-http-integration`. Brings in
two main themes from develop plus the consequent test updates.

## What develop is bringing in

**Description length cap lifted from 1KB to MAX_YAML_LENGTH (~64KB).**
Element descriptions are LLM-authored text that frequently exceeds the
old 1KB short-metadata cap; lifting them to the YAML/frontmatter limit
matches the storage path's real upper bound. Applies to all element
managers (Agent, Memory, Ensemble, Skill, Template) and the underlying
validators (`ContentValidator`, `GenericElementValidator`, plus the
YAML parser's `FIELD_VALIDATORS`).

**Dependabot security pins.** `uuid` package removed in favor of
`crypto.randomUUID`; `hono`, `fast-uri`, `ip-address`, `lodash`,
`path-to-regexp`, `picomatch`, `brace-expansion`, and `tar` pinned to
patched versions via the `overrides` block.

## Conflict resolutions

- **`contentValidator.ts`** — ported develop's per-field description
  ternary into the existing `fieldLengthLimit` map (integration's
  refactored architecture); description joins `instructions` and
  `content` as a long-form field.
- **`AgentManager.ts`** — applied `MAX_YAML_LENGTH` inside the
  refactored `sanitizeAgentCreateInput` helper rather than the
  inline `create()` body develop diffed against.
- **`inputLengthValidation.test.ts`** — combined integration's
  `expect.stringContaining(...)` pattern (handles the new `(got N)`
  error-message suffix) with develop's two new description-boundary
  tests.
- **`package.json`** — removed the unused `uuid` dependency; kept
  integration's full Postgres/auth dep set plus develop's Dependabot
  pins in the `overrides` block.
- **`package-lock.json`** — regenerated from the merged `package.json`
  via `npm install`.

## Consequent test update

`contentValidator-perfield-limits.test.ts` had a regression test
asserting "description over 1024 chars gets rejected" — that's now the
wrong behavior. Moved `description` out of the identity-shaped fields
group (which still get the 1KB cap) and into the long-form fields
group, with new boundary tests covering both the lifted limit and the
still-enforced MAX_YAML_LENGTH cap.

## Test plan

- [x] TypeScript compile clean
- [x] ESLint with max-warnings=0
- [x] Unit tests: 11,279 passing
- [x] Integration tests: 2,435 passing
- [x] E2E tests: 186 passing
- [x] Structural verification: every develop change traced to its
  function/scope-level container in the merged result; auto-merged
  files confirmed semantically correct (no orphan changes, no
  misplaced edits)

## Merge mode

Should be merged with **"Create a merge commit"** to preserve the
two-parent history (integration HEAD + develop HEAD). Squash or
rebase modes would lose the develop branch ancestry.