### PR TITLE
[codex] Harden hosted OAuth DCR consent

### DIFF
--- a/src/auth/AuthProviderFactory.ts
+++ b/src/auth/AuthProviderFactory.ts
@@ -249,6 +249,7 @@ async function createEmbeddedProvider(
     // in filesystem mode → EmbeddedAuthorizationServer falls back to the
     // legacy persistKeys / cookieSecret file paths.
     signingKeyStore: config.signingKeyStore,
+    rateLimitStore: config.rateLimitStore,
   });
 }
 

--- a/src/auth/embedded-as/EmbeddedAuthorizationServer.ts
+++ b/src/auth/embedded-as/EmbeddedAuthorizationServer.ts
@@ -165,6 +165,12 @@ function servePackagedAuthFont(): RequestHandler {
   };
 }
 
+function dcrProviderFromOidcProvider(provider: InstanceType<typeof OidcProvider>): DcrProvider {
+  return {
+    Client: provider.Client as unknown as DcrProvider['Client'],
+  };
+}
+
 export interface EmbeddedAuthorizationServerOptions {
   publicBaseUrl?: string;
   mcpPath?: string;
@@ -479,7 +485,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
       router.post('/reg', ...createOpenDcrRegistrationHandlers({
         ensureProvider: async () => {
           const state = await this.ensureInitialized();
-          return state.provider as unknown as DcrProvider;
+          return dcrProviderFromOidcProvider(state.provider);
         },
         rateLimitStore: this.rateLimitStore,
         storage: this.storage,

--- a/src/auth/embedded-as/EmbeddedAuthorizationServer.ts
+++ b/src/auth/embedded-as/EmbeddedAuthorizationServer.ts
@@ -40,7 +40,6 @@ import {
 } from './InteractionRouter.js';
 import {
   createOpenDcrRegistrationHandlers,
-  type DcrProvider,
 } from './dcrPolicyMiddleware.js';
 import { securityHeaders } from './securityHeaders.js';
 import {
@@ -162,12 +161,6 @@ function servePackagedAuthFont(): RequestHandler {
       return;
     }
     return servePackagedAuthAsset(`web/public/fonts/${file}`, 'font/woff2')(req, res, next);
-  };
-}
-
-function dcrProviderFromOidcProvider(provider: InstanceType<typeof OidcProvider>): DcrProvider {
-  return {
-    Client: provider.Client as unknown as DcrProvider['Client'],
   };
 }
 
@@ -485,7 +478,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
       router.post('/reg', ...createOpenDcrRegistrationHandlers({
         ensureProvider: async () => {
           const state = await this.ensureInitialized();
-          return dcrProviderFromOidcProvider(state.provider);
+          return state.provider;
         },
         rateLimitStore: this.rateLimitStore,
         storage: this.storage,

--- a/src/auth/embedded-as/EmbeddedAuthorizationServer.ts
+++ b/src/auth/embedded-as/EmbeddedAuthorizationServer.ts
@@ -25,6 +25,7 @@ import express, { type Router, type Request, type RequestHandler, type Response 
 import OidcProvider from 'oidc-provider';
 import type { Configuration } from 'oidc-provider';
 import { env } from '../../config/env.js';
+import { PackageResourceLocator } from '../../paths/PackageResourceLocator.js';
 import { logger } from '../../utils/logger.js';
 import type {
   AuthResult,
@@ -129,6 +130,39 @@ export function pickHeaderValue(
 ): string | undefined {
   if (Array.isArray(header)) return header[0];
   return header;
+}
+
+const authAssetLocator = new PackageResourceLocator();
+const AUTH_FONT_FILE_RE = /^[A-Za-z0-9._-]+\.woff2$/;
+
+function servePackagedAuthAsset(relativePath: string, contentType: string): RequestHandler {
+  return async (_req, res, next) => {
+    try {
+      const assetPath = await authAssetLocator.locate(relativePath);
+      if (!assetPath) {
+        res.sendStatus(404);
+        return;
+      }
+      res.setHeader('Cache-Control', 'public, max-age=3600');
+      res.type(contentType);
+      res.sendFile(assetPath, (err) => {
+        if (err) next(err);
+      });
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+function servePackagedAuthFont(): RequestHandler {
+  return async (req, res, next) => {
+    const file = req.params.file;
+    if (typeof file !== 'string' || !AUTH_FONT_FILE_RE.test(file)) {
+      res.sendStatus(404);
+      return;
+    }
+    return servePackagedAuthAsset(`web/public/fonts/${file}`, 'font/woff2')(req, res, next);
+  };
 }
 
 export interface EmbeddedAuthorizationServerOptions {
@@ -385,6 +419,13 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
         }
       })();
     });
+
+    // Hosted auth pages reuse the console's first-party visual assets, but the
+    // embedded AS is often mounted without the web console's static middleware.
+    // Serve only the exact logo/font assets needed by those pages.
+    router.get('/dollhouse-logo.png', servePackagedAuthAsset('web/public/dollhouse-logo.png', 'image/png'));
+    router.get('/fonts.css', servePackagedAuthAsset('web/public/fonts.css', 'text/css; charset=utf-8'));
+    router.get('/fonts/:file', servePackagedAuthFont());
 
     // Bootstrap gate (must-fix #22 / spec L923). When configured methods
     // include a multi-user identity provider, refuse all auth-flow

--- a/src/auth/embedded-as/EmbeddedAuthorizationServer.ts
+++ b/src/auth/embedded-as/EmbeddedAuthorizationServer.ts
@@ -37,6 +37,10 @@ import type { IAuthMethod } from './IAuthMethod.js';
 import {
   createInteractionRouter,
 } from './InteractionRouter.js';
+import {
+  createOpenDcrRegistrationHandlers,
+  type DcrProvider,
+} from './dcrPolicyMiddleware.js';
 import { securityHeaders } from './securityHeaders.js';
 import {
   defaultKeyFilePath,
@@ -417,6 +421,18 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
     };
     for (const method of this.methods) {
       method.contributeRoutes?.(router, contributeDeps);
+    }
+
+    // Issue #2220: when open DCR is enabled for hosted MCP clients, keep
+    // registration dynamic but constrain unsafe callback/metadata shapes.
+    // Default/IAT-gated DCR remains handled by oidc-provider below.
+    if (this.openDCR) {
+      router.post('/reg', ...createOpenDcrRegistrationHandlers({
+        ensureProvider: async () => {
+          const state = await this.ensureInitialized();
+          return state.provider as unknown as DcrProvider;
+        },
+      }));
     }
 
     // Mount oidc-provider's full OAuth/OIDC surface (/auth, /token, /jwks,

--- a/src/auth/embedded-as/EmbeddedAuthorizationServer.ts
+++ b/src/auth/embedded-as/EmbeddedAuthorizationServer.ts
@@ -69,6 +69,7 @@ import {
   type RotationRequestContext,
 } from './storage/OidcProviderAdapter.js';
 import type { IAuthStorageLayer } from './storage/IAuthStorageLayer.js';
+import type { IRateLimitStore } from './storage/IRateLimitStore.js';
 import { EmbeddedASBootstrap } from './EmbeddedASBootstrap.js';
 import { EmbeddedASAdmin } from './EmbeddedASAdmin.js';
 import { EmbeddedASOidcAccount } from './EmbeddedASOidcAccount.js';
@@ -191,6 +192,8 @@ export interface EmbeddedAuthorizationServerOptions {
    * to exercise the open-DCR code path without mutating env.
    */
   openDCR?: boolean;
+  /** Shared rate-limit state store. Required when openDCR=true. */
+  rateLimitStore?: IRateLimitStore;
 
   /**
    * Phase 4.5: optional injected ISigningKeyStore. When present,
@@ -227,6 +230,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
   private readonly refreshRotationCheckIpUa: boolean;
   private readonly cookieSecretEnvOverride: string | undefined;
   private readonly openDCR: boolean;
+  private readonly rateLimitStore: IRateLimitStore | null;
   private readonly signingKeyStore: ISigningKeyStore | null;
   private readonly bootstrap: EmbeddedASBootstrap;
   private readonly admin: EmbeddedASAdmin;
@@ -265,6 +269,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
     this.refreshRotationCheckIpUa = options.refreshRotationCheckIpUa ?? false;
     this.cookieSecretEnvOverride = options.cookieSecretEnvOverride;
     this.openDCR = options.openDCR ?? env.DOLLHOUSE_AUTH_OPEN_DCR;
+    this.rateLimitStore = options.rateLimitStore ?? null;
     this.signingKeyStore = options.signingKeyStore ?? null;
     this.bootstrap = new EmbeddedASBootstrap(
       this.methods,
@@ -427,11 +432,16 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
     // registration dynamic but constrain unsafe callback/metadata shapes.
     // Default/IAT-gated DCR remains handled by oidc-provider below.
     if (this.openDCR) {
+      if (!this.rateLimitStore) {
+        throw new Error('EmbeddedAuthorizationServer openDCR=true requires a shared rateLimitStore');
+      }
       router.post('/reg', ...createOpenDcrRegistrationHandlers({
         ensureProvider: async () => {
           const state = await this.ensureInitialized();
           return state.provider as unknown as DcrProvider;
         },
+        rateLimitStore: this.rateLimitStore,
+        storage: this.storage,
       }));
     }
 
@@ -586,7 +596,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
       response_types_supported: ['code'],
       grant_types_supported: ['authorization_code', 'refresh_token'],
       code_challenge_methods_supported: ['S256'],
-      token_endpoint_auth_methods_supported: ['none', 'client_secret_basic', 'client_secret_post'],
+      token_endpoint_auth_methods_supported: this.supportedTokenEndpointAuthMethods(),
       // Cycle 24: include standard OIDC scopes (profile, email) so MCP
       // clients that auto-register with these in their DCR payload
       // (Gemini CLI, claude.ai, others) pass scope validation. These are
@@ -802,6 +812,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
         introspectionSigningAlgValues: ['ES256'],
         requestObjectSigningAlgValues: ['ES256'],
       },
+      clientAuthMethods: this.supportedTokenEndpointAuthMethods(),
       features: {
         // RFC 7591 Dynamic Client Registration. initialAccessToken: true
         // means /reg requires an InitialAccessToken bearer. Without this
@@ -953,6 +964,7 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
     };
 
     const provider = new OidcProvider(this.issuer, config);
+    this.attachAuditEventHandlers(provider);
 
     // Cycle-8 fix (B1): align oidc-provider's proxy setting with the
     // operator's trust-proxy configuration. `proxy` controls whether
@@ -1008,10 +1020,61 @@ export class EmbeddedAuthorizationServer implements IAuthProvider {
 
     return { provider, keyset, publicSigningKey, privateSigningKey, cookieKeys, interactionMiddleware };
   }
+
+  private attachAuditEventHandlers(provider: InstanceType<typeof OidcProvider>): void {
+    const recordTokenIssued = (eventName: string) => (token: unknown) => {
+      const accountId = stringProperty(token, 'accountId');
+      void this.storage.recordIdentityEvent({
+        type: 'auth.oauth.token_issued',
+        sub: accountId,
+        details: {
+          providerEvent: eventName,
+          tokenKind: stringProperty(token, 'kind'),
+          clientId: stringProperty(token, 'clientId'),
+          grantId: stringProperty(token, 'grantId'),
+          scope: stringProperty(token, 'scope'),
+          audience: stringOrStringArrayProperty(token, 'aud'),
+        },
+        timestamp: Date.now(),
+      }).catch((err) => {
+        logger.warn('[EmbeddedAuthorizationServer] failed to record token-issued audit event', {
+          providerEvent: eventName,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    };
+
+    provider.on('access_token.issued', recordTokenIssued('access_token.issued'));
+    provider.on('access_token.saved', recordTokenIssued('access_token.saved'));
+    provider.on('refresh_token.saved', recordTokenIssued('refresh_token.saved'));
+  }
+
+  private supportedTokenEndpointAuthMethods(): ['none'] | ['none', 'client_secret_basic', 'client_secret_post'] {
+    return this.openDCR
+      ? ['none']
+      : ['none', 'client_secret_basic', 'client_secret_post'];
+  }
 }
 
 
 function normalizePath(rawPath: string): string {
   if (!rawPath || rawPath === '/') return '/mcp';
   return rawPath.startsWith('/') ? rawPath : `/${rawPath}`;
+}
+
+function stringProperty(value: unknown, key: string): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const raw = (value as Record<string, unknown>)[key];
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+}
+
+function stringOrStringArrayProperty(value: unknown, key: string): string | string[] | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const raw = (value as Record<string, unknown>)[key];
+  if (typeof raw === 'string' && raw.length > 0) return raw;
+  if (Array.isArray(raw)) {
+    const strings = raw.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+    return strings.length > 0 ? strings : undefined;
+  }
+  return undefined;
 }

--- a/src/auth/embedded-as/IAuthMethod.ts
+++ b/src/auth/embedded-as/IAuthMethod.ts
@@ -95,7 +95,7 @@ export type InteractionResult =
 /**
  * Runtime injected when EmbeddedAuthorizationServer wires a method's
  * standalone routes (callbacks, invite-redemption pages, etc.). Methods
- * import the helper functions they need (`finishInteractionWithIdentity`,
+ * import the helper functions they need (`renderClientConsentForIdentity`,
  * `verifyInteractionCookieMatches`) directly from peer modules — these
  * are pure helpers, not deps the AS owns or that vary per deployment.
  * `ContributeRoutesDeps` carries runtime state only: the storage layer
@@ -121,10 +121,10 @@ export interface ContributeRoutesDeps {
     cookieKeys: readonly string[];
   }>;
   /**
-   * Cycle 24 fix: the AS's resource URL. Used by route handlers that call
-   * `finishInteractionWithIdentity` (GitHub social callback, magic-link
-   * verify) so resource scopes get bound to a real resource server even
-   * when the authorize request didn't pass `resource=...`. See the helper's
+   * Cycle 24 fix: the AS's resource URL. Used by route handlers that render
+   * client consent and, after approval, finish the OAuth interaction so
+   * resource scopes get bound to a real resource server even when the
+   * authorize request didn't pass `resource=...`. See the finish helper's
    * JSDoc for the failure mode this prevents (consent-loop on missing
    * resource binding).
    */

--- a/src/auth/embedded-as/InteractionRouter.ts
+++ b/src/auth/embedded-as/InteractionRouter.ts
@@ -617,86 +617,364 @@ async function renderOAuthClientConsentPage(
   },
 ): Promise<string> {
   const view = await buildClientConsentView(provider, details, defaultResource);
-  const scopes = view.scopes.length > 0
-    ? view.scopes.map((scope) => `<li>${escapeHtmlText(scope)}</li>`).join('\n')
-    : '<li>default OAuth access</li>';
+  const scopes = renderScopeList(view.scopes);
   const redirectList = view.registeredRedirectUris.length > 0
     ? view.registeredRedirectUris.slice(0, 5).map((uri) => `<li><code>${escapeHtmlText(uri)}</code></li>`).join('\n')
     : '<li>Not available from client metadata</li>';
   const redirectOverflow = view.registeredRedirectUris.length > 5
-    ? `<li>...and ${view.registeredRedirectUris.length - 5} more</li>`
+    ? `<li>and ${view.registeredRedirectUris.length - 5} more</li>`
     : '';
   const clientUri = view.clientUri
-    ? `<p class="muted">Client website: <a href="${escapeHtmlAttr(view.clientUri)}" rel="noreferrer">${escapeHtmlText(view.clientUri)}</a></p>`
-    : '';
+    ? `<a href="${escapeHtmlAttr(view.clientUri)}" rel="noreferrer">${escapeHtmlText(view.clientUri)}</a>`
+    : '<span class="muted">Not provided</span>';
   const identitySummary = consent.identity
-    ? renderIdentitySummary(consent.identity)
-    : escapeHtmlText('this authenticated DollhouseMCP account');
-  const clientHistory = consent.firstSeen
-    ? 'First time this identity is authorizing this client'
-    : 'Previously authorized by this identity';
+    ? renderIdentityCard(consent.identity)
+    : '<span class="muted">Authenticated DollhouseMCP account</span>';
+  const historyLabel = consent.firstSeen
+    ? 'New client for this account'
+    : 'Previously authorized by this account';
+  const historyClass = consent.firstSeen
+    ? 'badge accent'
+    : 'badge';
+  const authorizationSummary = consent.firstSeen
+    ? 'Review this client before granting access.'
+    : 'This client has been authorized before for this account.';
+  const clientWebsiteRow = view.clientUri
+    ? `<div><dt>Client website</dt><dd>${clientUri}</dd></div>`
+    : '';
 
   return `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Authorize ${escapeHtmlText(view.clientName)}</title>
+  <title>DollhouseMCP - Authorize ${escapeHtmlText(view.clientName)}</title>
   <style>
-    body { margin: 0; font-family: system-ui, sans-serif; background: #f7f7f4; color: #181816; }
-    main { max-width: 640px; margin: 8vh auto; padding: 32px; background: white; border: 1px solid #d8d6cc; border-radius: 8px; }
-    h1 { font-size: 24px; margin: 0 0 12px; }
-    h2 { font-size: 15px; margin: 24px 0 8px; }
-    p { line-height: 1.5; }
-    dl { display: grid; grid-template-columns: 150px 1fr; gap: 10px 16px; margin: 20px 0; }
-    dt { color: #68675f; font-weight: 700; }
-    dd { margin: 0; min-width: 0; overflow-wrap: anywhere; }
-    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 13px; }
-    ul { margin: 8px 0 0; padding-left: 20px; }
-    form { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 28px; }
-    button { border: 0; border-radius: 6px; padding: 12px 16px; font-weight: 700; cursor: pointer; }
-    button.primary { background: #185c37; color: white; }
-    button.secondary { background: #ece8dd; color: #181816; }
-    .muted { color: #68675f; font-size: 14px; }
-    .warning { border-left: 4px solid #b65b00; padding-left: 12px; color: #3a2a18; }
+    :root {
+      color-scheme: light;
+      --ink: #171717;
+      --muted: #64645f;
+      --line: #d9d7ce;
+      --panel: #ffffff;
+      --page: #f5f4ef;
+      --brand: #174c39;
+      --brand-strong: #0f3529;
+      --accent: #b65b00;
+      --soft: #f0eee5;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--page);
+      color: var(--ink);
+    }
+    .shell {
+      width: min(880px, calc(100vw - 32px));
+      margin: 32px auto;
+    }
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 14px;
+    }
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-weight: 800;
+      letter-spacing: 0;
+    }
+    .brand-mark {
+      display: grid;
+      place-items: center;
+      width: 34px;
+      height: 34px;
+      border-radius: 7px;
+      background: var(--brand);
+      color: white;
+      font-size: 14px;
+    }
+    .host {
+      color: var(--muted);
+      font-size: 13px;
+      overflow-wrap: anywhere;
+      text-align: right;
+    }
+    main {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: 0 18px 48px rgba(23, 23, 23, 0.08);
+      overflow: hidden;
+    }
+    .hero {
+      padding: 30px 32px 24px;
+      border-bottom: 1px solid var(--line);
+      background: #fbfaf6;
+    }
+    .eyebrow {
+      color: var(--brand);
+      font-size: 13px;
+      font-weight: 800;
+      margin: 0 0 8px;
+      text-transform: uppercase;
+    }
+    h1 {
+      font-size: 28px;
+      line-height: 1.15;
+      margin: 0 0 10px;
+      letter-spacing: 0;
+    }
+    h2 {
+      font-size: 16px;
+      margin: 0 0 12px;
+    }
+    p {
+      line-height: 1.5;
+      margin: 0;
+    }
+    a { color: var(--brand); }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 13px;
+      overflow-wrap: anywhere;
+    }
+    .subtitle {
+      color: var(--muted);
+      font-size: 16px;
+      max-width: 660px;
+    }
+    .content {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 280px;
+      gap: 24px;
+      padding: 28px 32px 32px;
+    }
+    .section + .section { margin-top: 24px; }
+    .scope-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 10px;
+    }
+    .scope-list li {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 12px 14px;
+      background: #fff;
+    }
+    .scope-title {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
+      font-weight: 750;
+    }
+    .scope-title code {
+      color: var(--muted);
+      font-weight: 500;
+    }
+    .scope-desc {
+      color: var(--muted);
+      font-size: 14px;
+      margin-top: 4px;
+    }
+    .side {
+      display: grid;
+      gap: 14px;
+      align-content: start;
+    }
+    .summary-card {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--soft);
+      padding: 14px;
+    }
+    .summary-card h2 {
+      margin-bottom: 10px;
+    }
+    dl {
+      display: grid;
+      gap: 10px;
+      margin: 0;
+    }
+    dl > div {
+      min-width: 0;
+    }
+    dt {
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 800;
+      margin-bottom: 3px;
+      text-transform: uppercase;
+    }
+    dd {
+      margin: 0;
+      min-width: 0;
+      overflow-wrap: anywhere;
+    }
+    .identity {
+      display: grid;
+      gap: 3px;
+    }
+    .identity strong {
+      font-size: 15px;
+    }
+    .muted {
+      color: var(--muted);
+      font-size: 14px;
+    }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      width: fit-content;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 5px 9px;
+      background: white;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 800;
+    }
+    .badge.accent {
+      border-color: #e0b27a;
+      background: #fff6e8;
+      color: #6b3400;
+    }
+    details {
+      border-top: 1px solid var(--line);
+      padding-top: 18px;
+      margin-top: 24px;
+    }
+    summary {
+      cursor: pointer;
+      color: var(--brand);
+      font-weight: 800;
+    }
+    .redirect-list {
+      margin: 12px 0 0;
+      padding-left: 18px;
+      color: var(--muted);
+    }
+    form {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-top: 28px;
+    }
+    button {
+      border: 0;
+      border-radius: 7px;
+      padding: 12px 18px;
+      font-weight: 800;
+      cursor: pointer;
+      font-size: 15px;
+    }
+    button.primary {
+      background: var(--brand);
+      color: white;
+    }
+    button.primary:hover { background: var(--brand-strong); }
+    button.secondary {
+      background: #ece8dd;
+      color: var(--ink);
+    }
+    @media (max-width: 760px) {
+      .shell { width: min(100vw - 20px, 880px); margin: 16px auto; }
+      header { align-items: flex-start; flex-direction: column; }
+      .host { text-align: left; }
+      .hero, .content { padding: 22px; }
+      .content { grid-template-columns: 1fr; }
+      h1 { font-size: 24px; }
+      form { flex-direction: column; }
+      button { width: 100%; }
+    }
   </style>
 </head>
 <body>
-  <main>
-    <h1>Authorize ${escapeHtmlText(view.clientName)}</h1>
-    <p class="warning">This client will receive OAuth tokens for DollhouseMCP after approval.</p>
-    ${clientUri}
-    <dl>
-      <dt>Client ID</dt>
-      <dd><code>${escapeHtmlText(view.clientId)}</code></dd>
-      <dt>Callback domain</dt>
-      <dd><code>${escapeHtmlText(view.callbackHost)}</code></dd>
-      <dt>Callback URL</dt>
-      <dd><code>${escapeHtmlText(view.redirectUri)}</code></dd>
-      <dt>Resource</dt>
-      <dd><code>${escapeHtmlText(view.resource)}</code></dd>
-      <dt>Application type</dt>
-      <dd>${escapeHtmlText(view.applicationType)}</dd>
-      <dt>Authorizing as</dt>
-      <dd>${identitySummary}</dd>
-      <dt>Client history</dt>
-      <dd>${escapeHtmlText(clientHistory)}</dd>
-    </dl>
-    <h2>Requested scopes</h2>
-    <ul>
+  <div class="shell">
+    <header>
+      <div class="brand"><span class="brand-mark">DM</span><span>DollhouseMCP Authorization</span></div>
+      <div class="host">mcp.dollhousemcp.com</div>
+    </header>
+    <main>
+      <section class="hero">
+        <p class="eyebrow">OAuth client authorization</p>
+        <h1>Authorize ${escapeHtmlText(view.clientName)}?</h1>
+        <p class="subtitle">${escapeHtmlText(view.clientName)} is requesting access to DollhouseMCP. DollhouseMCP will issue OAuth tokens to this client after approval.</p>
+      </section>
+      <section class="content">
+        <div>
+          <section class="section">
+            <h2>Requested access</h2>
+            <ul class="scope-list">
 ${scopes}
-    </ul>
-    <h2>Registered callbacks</h2>
-    <ul>
+            </ul>
+          </section>
+          <details>
+            <summary>Technical details</summary>
+            <dl>
+              <div>
+                <dt>Client ID</dt>
+                <dd><code>${escapeHtmlText(view.clientId)}</code></dd>
+              </div>
+              ${clientWebsiteRow}
+              <div>
+                <dt>Callback domain</dt>
+                <dd><code>${escapeHtmlText(view.callbackHost)}</code></dd>
+              </div>
+              <div>
+                <dt>Callback URL</dt>
+                <dd><code>${escapeHtmlText(view.redirectUri)}</code></dd>
+              </div>
+              <div>
+                <dt>Resource</dt>
+                <dd><code>${escapeHtmlText(view.resource)}</code></dd>
+              </div>
+              <div>
+                <dt>Application type</dt>
+                <dd>${escapeHtmlText(view.applicationType)}</dd>
+              </div>
+            </dl>
+            <h2 style="margin-top: 20px;">Registered callbacks</h2>
+            <ul class="redirect-list">
 ${redirectList}
 ${redirectOverflow}
-    </ul>
-    <form method="post" action="/interaction/${escapeHtmlAttr(details.uid)}">
-      <input type="hidden" name="csrf_token" value="${escapeHtmlAttr(csrfToken)}">
-      <button class="primary" type="submit" name="action" value="${CLIENT_CONSENT_APPROVE_ACTION}">Authorize Client</button>
-      <button class="secondary" type="submit" name="action" value="${CLIENT_CONSENT_DENY_ACTION}">Cancel</button>
-    </form>
-  </main>
+            </ul>
+          </details>
+          <form method="post" action="/interaction/${escapeHtmlAttr(details.uid)}">
+            <input type="hidden" name="csrf_token" value="${escapeHtmlAttr(csrfToken)}">
+            <button class="primary" type="submit" name="action" value="${CLIENT_CONSENT_APPROVE_ACTION}">Authorize</button>
+            <button class="secondary" type="submit" name="action" value="${CLIENT_CONSENT_DENY_ACTION}">Cancel</button>
+          </form>
+        </div>
+        <aside class="side">
+          <section class="summary-card">
+            <h2>Signed in with GitHub</h2>
+            ${identitySummary}
+          </section>
+          <section class="summary-card">
+            <h2>Client status</h2>
+            <span class="${historyClass}">${escapeHtmlText(historyLabel)}</span>
+            <p class="muted" style="margin-top: 10px;">${escapeHtmlText(authorizationSummary)}</p>
+          </section>
+          <section class="summary-card">
+            <h2>Callback</h2>
+            <dl>
+              <div>
+                <dt>Domain</dt>
+                <dd><code>${escapeHtmlText(view.callbackHost)}</code></dd>
+              </div>
+            </dl>
+          </section>
+        </aside>
+      </section>
+    </main>
+  </div>
 </body>
 </html>`;
 }
@@ -867,18 +1145,79 @@ async function recordClientConsentAuditEvent(
   }
 }
 
-function renderIdentitySummary(identity: ClientConsentIdentitySummary): string {
-  const parts: string[] = [];
+function renderScopeList(scopes: string[]): string {
+  if (scopes.length === 0) {
+    return `<li>
+      <div class="scope-title"><span>Default OAuth access</span><code>default</code></div>
+      <p class="scope-desc">Complete this authorization request.</p>
+    </li>`;
+  }
+  return scopes.map((scope) => {
+    const display = scopeDisplay(scope);
+    return `<li>
+      <div class="scope-title"><span>${escapeHtmlText(display.title)}</span><code>${escapeHtmlText(scope)}</code></div>
+      <p class="scope-desc">${escapeHtmlText(display.description)}</p>
+    </li>`;
+  }).join('\n');
+}
+
+function scopeDisplay(scope: string): { title: string; description: string } {
+  switch (scope) {
+    case 'mcp':
+      return {
+        title: 'Use DollhouseMCP tools',
+        description: 'Call the MCP server on your behalf.',
+      };
+    case 'offline_access':
+      return {
+        title: 'Keep access between sessions',
+        description: 'Receive a refresh token so you do not need to sign in every time.',
+      };
+    case 'openid':
+      return {
+        title: 'Confirm your identity',
+        description: 'Use your DollhouseMCP account identity for this OAuth connection.',
+      };
+    case 'profile':
+      return {
+        title: 'Read basic profile information',
+        description: 'Share your display name with this OAuth connection.',
+      };
+    case 'email':
+      return {
+        title: 'Read verified email information',
+        description: 'Share the verified email associated with this account when available.',
+      };
+    default:
+      return {
+        title: scope,
+        description: 'Requested by the client.',
+      };
+  }
+}
+
+function renderIdentityCard(identity: ClientConsentIdentitySummary): string {
   const primary = identity.providerUsername
     ? `@${identity.providerUsername}`
     : identity.displayName;
-  if (primary) parts.push(escapeHtmlText(primary));
-  if (identity.displayName && identity.displayName !== primary) {
-    parts.push(escapeHtmlText(identity.displayName));
-  }
-  if (identity.email) parts.push(escapeHtmlText(identity.email));
-  parts.push(`<code>${escapeHtmlText(identity.sub)}</code>`);
-  return parts.join('<br>');
+  const provider = identity.provider ? providerDisplayName(identity.provider) : 'Account';
+  const displayName = identity.displayName && identity.displayName !== primary
+    ? `<span class="muted">${escapeHtmlText(identity.displayName)}</span>`
+    : '';
+  const email = identity.email
+    ? `<span class="muted">${escapeHtmlText(identity.email)}</span>`
+    : '';
+  return `<div class="identity">
+    <strong>${escapeHtmlText(primary ?? identity.sub)}</strong>
+    <span class="muted">${escapeHtmlText(provider)} account</span>
+    ${displayName}
+    ${email}
+    <code>${escapeHtmlText(identity.sub)}</code>
+  </div>`;
+}
+
+function providerDisplayName(provider: string): string {
+  return provider === 'github' ? 'GitHub' : provider;
 }
 
 function ensureCsrfInForm(html: string, csrfToken: string): string {

--- a/src/auth/embedded-as/InteractionRouter.ts
+++ b/src/auth/embedded-as/InteractionRouter.ts
@@ -12,10 +12,10 @@
  *      .beginInteraction. If render-html, send the page (with a CSRF token
  *      stamped into the form). If redirect, send 303 to the target URL.
  *   3. POST /interaction/:uid: verify CSRF, call IAuthMethod
- *      .completeInteraction. On 'authenticated', upsert the account and
- *      tell oidc-provider via interactionFinished({ login, consent }).
- *      On 'next-step', send the next step's HTML/redirect. On 'denied',
- *      finish with an OAuth error.
+ *      .completeInteraction. On 'authenticated', render the hosted
+ *      OAuth-client consent page before oidc-provider receives
+ *      interactionFinished({ login, consent }). On 'next-step', send the
+ *      next step's HTML/redirect. On 'denied', finish with an OAuth error.
  *
  * CSRF (must-fix #6): a random token is generated on render-html and stored
  * in IAuthStorageLayer.genericSet under model 'InteractionCsrf', keyed on
@@ -29,6 +29,7 @@ import { randomBytes, timingSafeEqual } from 'node:crypto';
 import express, { type Router, type Request, type Response } from 'express';
 import { logger } from '../../utils/logger.js';
 import type {
+  AuthenticatedIdentity,
   IAuthMethod,
   InteractionContext,
   InteractionResult,
@@ -412,7 +413,30 @@ async function handleAuthMethodPost(
     return;
   }
 
-  await finishInteractionWithIdentity(req, res, provider, details, result.identity.sub, storage, defaultResource);
+  await renderClientConsentForIdentity(
+    res,
+    provider,
+    details,
+    result.identity.sub,
+    storage,
+    defaultResource,
+    buildClientConsentIdentitySummary(method, result.identity),
+  );
+}
+
+function buildClientConsentIdentitySummary(
+  method: IAuthMethod,
+  identity: AuthenticatedIdentity,
+): ClientConsentIdentitySummary {
+  return {
+    sub: identity.sub,
+    displayName: identity.displayName,
+    email: identity.email,
+    provider: method.id,
+    providerUsername: method.id === 'github' && typeof identity.raw?.githubUsername === 'string'
+      ? identity.raw.githubUsername
+      : undefined,
+  };
 }
 
 /**
@@ -1458,7 +1482,7 @@ async function markClientConsentSeen(
 }
 
 function clientConsentSeenKey(accountId: string, clientId: string): string {
-  return `${encodeURIComponent(accountId)}:${encodeURIComponent(clientId)}`;
+  return `cc_${Buffer.from(JSON.stringify([accountId, clientId]), 'utf8').toString('base64url')}`;
 }
 
 async function recordClientConsentAuditEvent(
@@ -1568,7 +1592,18 @@ function renderIdentityCard(identity: ClientConsentIdentitySummary): string {
 }
 
 function providerDisplayName(provider: string): string {
-  return provider === 'github' ? 'GitHub' : provider;
+  switch (provider) {
+    case 'github':
+      return 'GitHub';
+    case 'magic-link':
+      return 'Email magic link';
+    case 'local-password':
+      return 'Local password';
+    case 'trivial-consent':
+      return 'Trivial consent';
+    default:
+      return provider;
+  }
 }
 
 function ensureCsrfInForm(html: string, csrfToken: string): string {

--- a/src/auth/embedded-as/InteractionRouter.ts
+++ b/src/auth/embedded-as/InteractionRouter.ts
@@ -40,6 +40,9 @@ const CSRF_MODEL = 'InteractionCsrf';
 const CSRF_TTL_SECONDS = 600; // 10 min, matches oidc-provider's default interaction TTL.
 const METHOD_CHOICE_MODEL = 'InteractionMethodChoice';
 const METHOD_CHOICE_TTL_SECONDS = 600; // matches CSRF + Interaction TTL
+const PENDING_CLIENT_CONSENT_MODEL = 'PendingClientConsentIdentity';
+const CLIENT_CONSENT_APPROVE_ACTION = 'authorize_oauth_client';
+const CLIENT_CONSENT_DENY_ACTION = 'deny_oauth_client';
 
 export interface OidcInteractionDetails {
   uid: string;
@@ -62,6 +65,19 @@ interface OidcGrantConstructor {
   find(id: string): Promise<OidcGrantInstance | undefined>;
 }
 
+interface OidcClientForConsent {
+  clientId?: string;
+  clientName?: string;
+  redirectUris?: string[];
+  applicationType?: string;
+  scope?: string;
+  metadata?(): Record<string, unknown>;
+}
+
+interface OidcClientConstructorForConsent {
+  find(id: string): Promise<OidcClientForConsent | undefined>;
+}
+
 export interface OidcProviderForInteractions {
   interactionDetails(req: Request, res: Response): Promise<OidcInteractionDetails>;
   interactionFinished(
@@ -71,6 +87,7 @@ export interface OidcProviderForInteractions {
     options?: { mergeWithLastSubmission?: boolean },
   ): Promise<void>;
   Grant: OidcGrantConstructor;
+  Client?: OidcClientConstructorForConsent;
 }
 
 export interface InteractionRouterDeps {
@@ -241,6 +258,41 @@ async function handlePost(
     return;
   }
 
+  const action = bodyValue(req, 'action');
+  if (action === CLIENT_CONSENT_APPROVE_ACTION || action === CLIENT_CONSENT_DENY_ACTION) {
+    const csrfOk = await verifyAndConsumeCsrf(req, res, storage, details.uid);
+    if (!csrfOk) return;
+
+    const pending = await storage.genericGet(PENDING_CLIENT_CONSENT_MODEL, details.uid) as
+      | { accountId?: string }
+      | null;
+    await storage.genericDestroy(PENDING_CLIENT_CONSENT_MODEL, details.uid);
+
+    if (action === CLIENT_CONSENT_DENY_ACTION) {
+      await provider.interactionFinished(req, res, {
+        error: 'access_denied',
+        error_description: 'End-User denied client authorization',
+      }, { mergeWithLastSubmission: false });
+      return;
+    }
+
+    if (!pending?.accountId) {
+      sendError(res, 400, 'invalid_interaction', 'no pending client consent found; restart sign-in');
+      return;
+    }
+
+    await finishInteractionWithIdentity(
+      req,
+      res,
+      provider,
+      details,
+      pending.accountId,
+      storage,
+      defaultResource,
+    );
+    return;
+  }
+
   const resolution = await resolveMethodForRequest(req, details, methods, storage);
   if (resolution.kind === 'chooser') {
     // POST without a stored method choice — the user submitted the
@@ -261,20 +313,8 @@ async function handlePost(
   // contributeRoutes path, NOT on /interaction/:uid POST — so any
   // redirect-flow request reaching this handler without a CSRF record
   // is also illegitimate.
-  const persistedCsrf = await storage.genericGet(CSRF_MODEL, details.uid) as { token?: string } | null;
-  if (!persistedCsrf?.token) {
-    sendError(res, 403, 'invalid_csrf', 'CSRF token missing or invalid');
-    return;
-  }
-  const submitted = bodyValue(req, 'csrf_token');
-  if (!submitted || !constantTimeStringEq(submitted, persistedCsrf.token)) {
-    sendError(res, 403, 'invalid_csrf', 'CSRF token missing or invalid');
-    return;
-  }
-  // Single-use: destroy regardless of method outcome. A subsequent
-  // next-step render-html stamps a fresh record before the user sees
-  // the next form.
-  await storage.genericDestroy(CSRF_MODEL, details.uid);
+  const csrfOk = await verifyAndConsumeCsrf(req, res, storage, details.uid);
+  if (!csrfOk) return;
 
   const method = resolution.method;
   const ctx = makeContext(details, req);
@@ -349,6 +389,7 @@ export async function finishInteractionWithIdentity(
   defaultResource: string,
 ): Promise<void> {
   try {
+    await storage.genericDestroy(PENDING_CLIENT_CONSENT_MODEL, details.uid);
     const grantId = await resolveAndSaveGrant(provider, details, accountId, defaultResource);
 
     // Stamp lastAuthAt before interactionFinished so the redirect-to-token
@@ -375,6 +416,33 @@ export async function finishInteractionWithIdentity(
       sendError(res, 500, 'server_error', 'Failed to finish interaction');
     }
   }
+}
+
+/**
+ * Render Dollhouse's client-consent page after an external auth method has
+ * authenticated and allowlisted the user, but before oidc-provider issues an
+ * authorization code. This is the hosted-DCR safety stop from #2220: unknown
+ * MCP clients are allowed, while the user still sees the client name, callback
+ * host, scopes, and resource before tokens are minted.
+ */
+export async function renderClientConsentForIdentity(
+  res: Response,
+  provider: OidcProviderForInteractions,
+  details: OidcInteractionDetails,
+  accountId: string,
+  storage: IAuthStorageLayer,
+  defaultResource: string,
+): Promise<void> {
+  await storage.genericSet(
+    PENDING_CLIENT_CONSENT_MODEL,
+    details.uid,
+    { accountId, createdAt: Date.now() },
+    CSRF_TTL_SECONDS,
+  );
+  const csrfToken = randomBytes(32).toString('base64url');
+  await storage.genericSet(CSRF_MODEL, details.uid, { token: csrfToken }, CSRF_TTL_SECONDS);
+  const html = await renderOAuthClientConsentPage(provider, details, csrfToken, defaultResource);
+  res.type('html').send(html);
 }
 
 /**
@@ -476,6 +544,208 @@ function makeContext(
   };
 }
 
+async function verifyAndConsumeCsrf(
+  req: Request,
+  res: Response,
+  storage: IAuthStorageLayer,
+  interactionId: string,
+): Promise<boolean> {
+  const persistedCsrf = await storage.genericGet(CSRF_MODEL, interactionId) as { token?: string } | null;
+  if (!persistedCsrf?.token) {
+    sendError(res, 403, 'invalid_csrf', 'CSRF token missing or invalid');
+    return false;
+  }
+  const submitted = bodyValue(req, 'csrf_token');
+  if (!submitted || !constantTimeStringEq(submitted, persistedCsrf.token)) {
+    sendError(res, 403, 'invalid_csrf', 'CSRF token missing or invalid');
+    return false;
+  }
+  // Single-use: destroy regardless of method outcome. A subsequent
+  // next-step render-html or client-consent page stamps a fresh record.
+  await storage.genericDestroy(CSRF_MODEL, interactionId);
+  return true;
+}
+
+async function renderOAuthClientConsentPage(
+  provider: OidcProviderForInteractions,
+  details: OidcInteractionDetails,
+  csrfToken: string,
+  defaultResource: string,
+): Promise<string> {
+  const view = await buildClientConsentView(provider, details, defaultResource);
+  const scopes = view.scopes.length > 0
+    ? view.scopes.map((scope) => `<li>${escapeHtmlText(scope)}</li>`).join('\n')
+    : '<li>default OAuth access</li>';
+  const redirectList = view.registeredRedirectUris.length > 0
+    ? view.registeredRedirectUris.slice(0, 5).map((uri) => `<li><code>${escapeHtmlText(uri)}</code></li>`).join('\n')
+    : '<li>Not available from client metadata</li>';
+  const redirectOverflow = view.registeredRedirectUris.length > 5
+    ? `<li>...and ${view.registeredRedirectUris.length - 5} more</li>`
+    : '';
+  const clientUri = view.clientUri
+    ? `<p class="muted">Client website: <a href="${escapeHtmlAttr(view.clientUri)}" rel="noreferrer">${escapeHtmlText(view.clientUri)}</a></p>`
+    : '';
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Authorize ${escapeHtmlText(view.clientName)}</title>
+  <style>
+    body { margin: 0; font-family: system-ui, sans-serif; background: #f7f7f4; color: #181816; }
+    main { max-width: 640px; margin: 8vh auto; padding: 32px; background: white; border: 1px solid #d8d6cc; border-radius: 8px; }
+    h1 { font-size: 24px; margin: 0 0 12px; }
+    h2 { font-size: 15px; margin: 24px 0 8px; }
+    p { line-height: 1.5; }
+    dl { display: grid; grid-template-columns: 150px 1fr; gap: 10px 16px; margin: 20px 0; }
+    dt { color: #68675f; font-weight: 700; }
+    dd { margin: 0; min-width: 0; overflow-wrap: anywhere; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 13px; }
+    ul { margin: 8px 0 0; padding-left: 20px; }
+    form { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 28px; }
+    button { border: 0; border-radius: 6px; padding: 12px 16px; font-weight: 700; cursor: pointer; }
+    button.primary { background: #185c37; color: white; }
+    button.secondary { background: #ece8dd; color: #181816; }
+    .muted { color: #68675f; font-size: 14px; }
+    .warning { border-left: 4px solid #b65b00; padding-left: 12px; color: #3a2a18; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Authorize ${escapeHtmlText(view.clientName)}</h1>
+    <p class="warning">This client will receive OAuth tokens for DollhouseMCP after approval.</p>
+    ${clientUri}
+    <dl>
+      <dt>Client ID</dt>
+      <dd><code>${escapeHtmlText(view.clientId)}</code></dd>
+      <dt>Callback domain</dt>
+      <dd><code>${escapeHtmlText(view.callbackHost)}</code></dd>
+      <dt>Callback URL</dt>
+      <dd><code>${escapeHtmlText(view.redirectUri)}</code></dd>
+      <dt>Resource</dt>
+      <dd><code>${escapeHtmlText(view.resource)}</code></dd>
+      <dt>Application type</dt>
+      <dd>${escapeHtmlText(view.applicationType)}</dd>
+    </dl>
+    <h2>Requested scopes</h2>
+    <ul>
+${scopes}
+    </ul>
+    <h2>Registered callbacks</h2>
+    <ul>
+${redirectList}
+${redirectOverflow}
+    </ul>
+    <form method="post" action="/interaction/${escapeHtmlAttr(details.uid)}">
+      <input type="hidden" name="csrf_token" value="${escapeHtmlAttr(csrfToken)}">
+      <button class="primary" type="submit" name="action" value="${CLIENT_CONSENT_APPROVE_ACTION}">Authorize Client</button>
+      <button class="secondary" type="submit" name="action" value="${CLIENT_CONSENT_DENY_ACTION}">Cancel</button>
+    </form>
+  </main>
+</body>
+</html>`;
+}
+
+interface ClientConsentView {
+  clientId: string;
+  clientName: string;
+  clientUri?: string;
+  callbackHost: string;
+  redirectUri: string;
+  registeredRedirectUris: string[];
+  scopes: string[];
+  resource: string;
+  applicationType: string;
+}
+
+async function buildClientConsentView(
+  provider: OidcProviderForInteractions,
+  details: OidcInteractionDetails,
+  defaultResource: string,
+): Promise<ClientConsentView> {
+  const clientId = paramString(details.params.client_id) || 'unknown-client';
+  const redirectUri = paramString(details.params.redirect_uri) || firstString(details.params.redirect_uris) || 'not provided';
+  const client = await findClientForConsent(provider, clientId);
+  const metadata = client?.metadata?.() ?? {};
+  const registeredRedirectUris = stringArrayFrom(metadata.redirect_uris) ?? client?.redirectUris ?? [];
+  const clientName = stringFrom(metadata.client_name)
+    ?? client?.clientName
+    ?? clientId;
+  const clientUri = stringFrom(metadata.client_uri);
+  const scopes = (paramString(details.params.scope) ?? client?.scope ?? '')
+    .split(/\s+/)
+    .filter(Boolean);
+  const resource = renderResource(details.params.resource, defaultResource);
+  const applicationType = stringFrom(metadata.application_type)
+    ?? client?.applicationType
+    ?? 'unspecified';
+
+  return {
+    clientId,
+    clientName,
+    clientUri,
+    callbackHost: callbackHostFor(redirectUri),
+    redirectUri,
+    registeredRedirectUris,
+    scopes,
+    resource,
+    applicationType,
+  };
+}
+
+async function findClientForConsent(
+  provider: OidcProviderForInteractions,
+  clientId: string,
+): Promise<OidcClientForConsent | undefined> {
+  if (!provider.Client) return undefined;
+  try {
+    return await provider.Client.find(clientId);
+  } catch (err) {
+    logger.warn('[InteractionRouter] failed to load client metadata for consent page', {
+      clientId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
+}
+
+function paramString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function firstString(value: unknown): string | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.find((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+}
+
+function stringFrom(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function stringArrayFrom(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const strings = value.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+  return strings.length > 0 ? strings : undefined;
+}
+
+function callbackHostFor(uri: string): string {
+  try {
+    return new URL(uri).host;
+  } catch {
+    return 'not provided';
+  }
+}
+
+function renderResource(resource: unknown, defaultResource: string): string {
+  if (typeof resource === 'string' && resource.length > 0) return resource;
+  if (Array.isArray(resource)) {
+    const strings = resource.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+    if (strings.length > 0) return strings.join(', ');
+  }
+  return defaultResource;
+}
+
 function ensureCsrfInForm(html: string, csrfToken: string): string {
   // Insert a hidden CSRF input as the first child of EVERY <form>.
   // Methods can include their own placeholder (the empty csrfInput
@@ -500,6 +770,15 @@ function ensureCsrfInForm(html: string, csrfToken: string): string {
 
 function escapeHtmlAttr(value: string): string {
   return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;');
+}
+
+function escapeHtmlText(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('\'', '&#39;');
 }
 
 function bodyValue(req: Request, field: string): string | undefined {

--- a/src/auth/embedded-as/InteractionRouter.ts
+++ b/src/auth/embedded-as/InteractionRouter.ts
@@ -41,6 +41,7 @@ const CSRF_TTL_SECONDS = 600; // 10 min, matches oidc-provider's default interac
 const METHOD_CHOICE_MODEL = 'InteractionMethodChoice';
 const METHOD_CHOICE_TTL_SECONDS = 600; // matches CSRF + Interaction TTL
 const PENDING_CLIENT_CONSENT_MODEL = 'PendingClientConsentIdentity';
+const CLIENT_CONSENT_SEEN_MODEL = 'ClientConsentSeen';
 const CLIENT_CONSENT_APPROVE_ACTION = 'authorize_oauth_client';
 const CLIENT_CONSENT_DENY_ACTION = 'deny_oauth_client';
 
@@ -76,6 +77,22 @@ interface OidcClientForConsent {
 
 interface OidcClientConstructorForConsent {
   find(id: string): Promise<OidcClientForConsent | undefined>;
+}
+
+export interface ClientConsentIdentitySummary {
+  sub: string;
+  displayName?: string;
+  email?: string;
+  provider?: string;
+  providerUsername?: string;
+}
+
+interface PendingClientConsentIdentity {
+  accountId?: string;
+  createdAt?: number;
+  clientId?: string;
+  firstSeen?: boolean;
+  identity?: ClientConsentIdentitySummary;
 }
 
 export interface OidcProviderForInteractions {
@@ -264,11 +281,16 @@ async function handlePost(
     if (!csrfOk) return;
 
     const pending = await storage.genericGet(PENDING_CLIENT_CONSENT_MODEL, details.uid) as
-      | { accountId?: string }
+      | PendingClientConsentIdentity
       | null;
     await storage.genericDestroy(PENDING_CLIENT_CONSENT_MODEL, details.uid);
 
     if (action === CLIENT_CONSENT_DENY_ACTION) {
+      await recordClientConsentAuditEvent(storage, 'auth.client_consent.denied', {
+        details,
+        pending,
+        defaultResource,
+      });
       await provider.interactionFinished(req, res, {
         error: 'access_denied',
         error_description: 'End-User denied client authorization',
@@ -281,6 +303,12 @@ async function handlePost(
       return;
     }
 
+    await markClientConsentSeen(storage, pending.accountId, paramString(details.params.client_id));
+    await recordClientConsentAuditEvent(storage, 'auth.client_consent.approved', {
+      details,
+      pending,
+      defaultResource,
+    });
     await finishInteractionWithIdentity(
       req,
       res,
@@ -432,16 +460,28 @@ export async function renderClientConsentForIdentity(
   accountId: string,
   storage: IAuthStorageLayer,
   defaultResource: string,
+  identity?: ClientConsentIdentitySummary,
 ): Promise<void> {
+  const clientId = paramString(details.params.client_id) || 'unknown-client';
+  const firstSeen = !(await hasSeenClientConsent(storage, accountId, clientId));
   await storage.genericSet(
     PENDING_CLIENT_CONSENT_MODEL,
     details.uid,
-    { accountId, createdAt: Date.now() },
+    {
+      accountId,
+      clientId,
+      firstSeen,
+      identity,
+      createdAt: Date.now(),
+    },
     CSRF_TTL_SECONDS,
   );
   const csrfToken = randomBytes(32).toString('base64url');
   await storage.genericSet(CSRF_MODEL, details.uid, { token: csrfToken }, CSRF_TTL_SECONDS);
-  const html = await renderOAuthClientConsentPage(provider, details, csrfToken, defaultResource);
+  const html = await renderOAuthClientConsentPage(provider, details, csrfToken, defaultResource, {
+    identity,
+    firstSeen,
+  });
   res.type('html').send(html);
 }
 
@@ -571,6 +611,10 @@ async function renderOAuthClientConsentPage(
   details: OidcInteractionDetails,
   csrfToken: string,
   defaultResource: string,
+  consent: {
+    identity?: ClientConsentIdentitySummary;
+    firstSeen: boolean;
+  },
 ): Promise<string> {
   const view = await buildClientConsentView(provider, details, defaultResource);
   const scopes = view.scopes.length > 0
@@ -585,6 +629,12 @@ async function renderOAuthClientConsentPage(
   const clientUri = view.clientUri
     ? `<p class="muted">Client website: <a href="${escapeHtmlAttr(view.clientUri)}" rel="noreferrer">${escapeHtmlText(view.clientUri)}</a></p>`
     : '';
+  const identitySummary = consent.identity
+    ? renderIdentitySummary(consent.identity)
+    : escapeHtmlText('this authenticated DollhouseMCP account');
+  const clientHistory = consent.firstSeen
+    ? 'First time this identity is authorizing this client'
+    : 'Previously authorized by this identity';
 
   return `<!doctype html>
 <html lang="en">
@@ -627,6 +677,10 @@ async function renderOAuthClientConsentPage(
       <dd><code>${escapeHtmlText(view.resource)}</code></dd>
       <dt>Application type</dt>
       <dd>${escapeHtmlText(view.applicationType)}</dd>
+      <dt>Authorizing as</dt>
+      <dd>${identitySummary}</dd>
+      <dt>Client history</dt>
+      <dd>${escapeHtmlText(clientHistory)}</dd>
     </dl>
     <h2>Requested scopes</h2>
     <ul>
@@ -744,6 +798,87 @@ function renderResource(resource: unknown, defaultResource: string): string {
     if (strings.length > 0) return strings.join(', ');
   }
   return defaultResource;
+}
+
+async function hasSeenClientConsent(
+  storage: IAuthStorageLayer,
+  accountId: string,
+  clientId: string,
+): Promise<boolean> {
+  const existing = await storage.genericGet(CLIENT_CONSENT_SEEN_MODEL, clientConsentSeenKey(accountId, clientId));
+  return Boolean(existing);
+}
+
+async function markClientConsentSeen(
+  storage: IAuthStorageLayer,
+  accountId: string,
+  clientId: string | undefined,
+): Promise<void> {
+  if (!clientId) return;
+  const key = clientConsentSeenKey(accountId, clientId);
+  const now = Date.now();
+  const existing = await storage.genericGet(CLIENT_CONSENT_SEEN_MODEL, key) as
+    | { firstApprovedAt?: number }
+    | null;
+  await storage.genericSet(CLIENT_CONSENT_SEEN_MODEL, key, {
+    accountId,
+    clientId,
+    firstApprovedAt: existing?.firstApprovedAt ?? now,
+    lastApprovedAt: now,
+  });
+}
+
+function clientConsentSeenKey(accountId: string, clientId: string): string {
+  return `${accountId}\0${clientId}`;
+}
+
+async function recordClientConsentAuditEvent(
+  storage: IAuthStorageLayer,
+  type: 'auth.client_consent.approved' | 'auth.client_consent.denied',
+  context: {
+    details: OidcInteractionDetails;
+    pending: PendingClientConsentIdentity | null;
+    defaultResource: string;
+  },
+): Promise<void> {
+  try {
+    const redirectUri = paramString(context.details.params.redirect_uri)
+      || firstString(context.details.params.redirect_uris)
+      || 'not provided';
+    await storage.recordIdentityEvent({
+      type,
+      sub: context.pending?.accountId,
+      details: {
+        clientId: context.pending?.clientId ?? paramString(context.details.params.client_id) ?? 'unknown-client',
+        clientFirstSeenForIdentity: context.pending?.firstSeen,
+        callbackHost: callbackHostFor(redirectUri),
+        redirectUri,
+        resource: renderResource(context.details.params.resource, context.defaultResource),
+        scopes: (paramString(context.details.params.scope) ?? '').split(/\s+/).filter(Boolean),
+        identity: context.pending?.identity,
+      },
+      timestamp: Date.now(),
+    });
+  } catch (err) {
+    logger.warn('[InteractionRouter] failed to record client-consent audit event', {
+      type,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function renderIdentitySummary(identity: ClientConsentIdentitySummary): string {
+  const parts: string[] = [];
+  const primary = identity.providerUsername
+    ? `@${identity.providerUsername}`
+    : identity.displayName;
+  if (primary) parts.push(escapeHtmlText(primary));
+  if (identity.displayName && identity.displayName !== primary) {
+    parts.push(escapeHtmlText(identity.displayName));
+  }
+  if (identity.email) parts.push(escapeHtmlText(identity.email));
+  parts.push(`<code>${escapeHtmlText(identity.sub)}</code>`);
+  return parts.join('<br>');
 }
 
 function ensureCsrfInForm(html: string, csrfToken: string): string {

--- a/src/auth/embedded-as/InteractionRouter.ts
+++ b/src/auth/embedded-as/InteractionRouter.ts
@@ -829,7 +829,7 @@ async function markClientConsentSeen(
 }
 
 function clientConsentSeenKey(accountId: string, clientId: string): string {
-  return `${accountId}\0${clientId}`;
+  return `${encodeURIComponent(accountId)}:${encodeURIComponent(clientId)}`;
 }
 
 async function recordClientConsentAuditEvent(

--- a/src/auth/embedded-as/InteractionRouter.ts
+++ b/src/auth/embedded-as/InteractionRouter.ts
@@ -276,51 +276,81 @@ async function handlePost(
   }
 
   const action = bodyValue(req, 'action');
-  if (action === CLIENT_CONSENT_APPROVE_ACTION || action === CLIENT_CONSENT_DENY_ACTION) {
-    const csrfOk = await verifyAndConsumeCsrf(req, res, storage, details.uid);
-    if (!csrfOk) return;
+  if (isClientConsentAction(action)) {
+    await handleClientConsentPost(req, res, provider, storage, defaultResource, details, action);
+    return;
+  }
 
-    const pending = await storage.genericGet(PENDING_CLIENT_CONSENT_MODEL, details.uid) as
-      | PendingClientConsentIdentity
-      | null;
-    await storage.genericDestroy(PENDING_CLIENT_CONSENT_MODEL, details.uid);
+  await handleAuthMethodPost(req, res, provider, methods, storage, defaultResource, details);
+}
 
-    if (action === CLIENT_CONSENT_DENY_ACTION) {
-      await recordClientConsentAuditEvent(storage, 'auth.client_consent.denied', {
-        details,
-        pending,
-        defaultResource,
-      });
-      await provider.interactionFinished(req, res, {
-        error: 'access_denied',
-        error_description: 'End-User denied client authorization',
-      }, { mergeWithLastSubmission: false });
-      return;
-    }
+function isClientConsentAction(action: string | undefined): action is
+  | typeof CLIENT_CONSENT_APPROVE_ACTION
+  | typeof CLIENT_CONSENT_DENY_ACTION {
+  return action === CLIENT_CONSENT_APPROVE_ACTION || action === CLIENT_CONSENT_DENY_ACTION;
+}
 
-    if (!pending?.accountId) {
-      sendError(res, 400, 'invalid_interaction', 'no pending client consent found; restart sign-in');
-      return;
-    }
+async function handleClientConsentPost(
+  req: Request,
+  res: Response,
+  provider: OidcProviderForInteractions,
+  storage: IAuthStorageLayer,
+  defaultResource: string,
+  details: OidcInteractionDetails,
+  action: typeof CLIENT_CONSENT_APPROVE_ACTION | typeof CLIENT_CONSENT_DENY_ACTION,
+): Promise<void> {
+  const csrfOk = await verifyAndConsumeCsrf(req, res, storage, details.uid);
+  if (!csrfOk) return;
 
-    await markClientConsentSeen(storage, pending.accountId, paramString(details.params.client_id));
-    await recordClientConsentAuditEvent(storage, 'auth.client_consent.approved', {
+  const pending = await storage.genericGet(PENDING_CLIENT_CONSENT_MODEL, details.uid) as
+    | PendingClientConsentIdentity
+    | null;
+  await storage.genericDestroy(PENDING_CLIENT_CONSENT_MODEL, details.uid);
+
+  if (action === CLIENT_CONSENT_DENY_ACTION) {
+    await recordClientConsentAuditEvent(storage, 'auth.client_consent.denied', {
       details,
       pending,
       defaultResource,
     });
-    await finishInteractionWithIdentity(
-      req,
-      res,
-      provider,
-      details,
-      pending.accountId,
-      storage,
-      defaultResource,
-    );
+    await provider.interactionFinished(req, res, {
+      error: 'access_denied',
+      error_description: 'End-User denied client authorization',
+    }, { mergeWithLastSubmission: false });
     return;
   }
 
+  if (!pending?.accountId) {
+    sendError(res, 400, 'invalid_interaction', 'no pending client consent found; restart sign-in');
+    return;
+  }
+
+  await markClientConsentSeen(storage, pending.accountId, paramString(details.params.client_id));
+  await recordClientConsentAuditEvent(storage, 'auth.client_consent.approved', {
+    details,
+    pending,
+    defaultResource,
+  });
+  await finishInteractionWithIdentity(
+    req,
+    res,
+    provider,
+    details,
+    pending.accountId,
+    storage,
+    defaultResource,
+  );
+}
+
+async function handleAuthMethodPost(
+  req: Request,
+  res: Response,
+  provider: OidcProviderForInteractions,
+  methods: readonly IAuthMethod[],
+  storage: IAuthStorageLayer,
+  defaultResource: string,
+  details: OidcInteractionDetails,
+): Promise<void> {
   const resolution = await resolveMethodForRequest(req, details, methods, storage);
   if (resolution.kind === 'chooser') {
     // POST without a stored method choice — the user submitted the

--- a/src/auth/embedded-as/InteractionRouter.ts
+++ b/src/auth/embedded-as/InteractionRouter.ts
@@ -634,343 +634,654 @@ async function renderOAuthClientConsentPage(
     ? 'New client for this account'
     : 'Previously authorized by this account';
   const historyClass = consent.firstSeen
-    ? 'badge accent'
-    : 'badge';
+    ? 'auth-badge auth-badge--accent'
+    : 'auth-badge';
   const authorizationSummary = consent.firstSeen
     ? 'Review this client before granting access.'
     : 'This client has been authorized before for this account.';
   const clientWebsiteRow = view.clientUri
     ? `<div><dt>Client website</dt><dd>${clientUri}</dd></div>`
     : '';
+  const signedInHeading = consent.identity?.provider
+    ? `Signed in with ${providerDisplayName(consent.identity.provider)}`
+    : 'Signed in';
+  const authorizationHost = hostFromDisplayResource(view.resource);
 
   return `<!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>DollhouseMCP - Authorize ${escapeHtmlText(view.clientName)}</title>
+  <title>DollhouseMCP Authorization - Authorize ${escapeHtmlText(view.clientName)}</title>
+  <link rel="icon" type="image/png" href="/dollhouse-logo.png">
+  <link rel="apple-touch-icon" href="/dollhouse-logo.png">
+  <link rel="stylesheet" href="/fonts.css">
   <style>
     :root {
       color-scheme: light;
-      --ink: #171717;
-      --muted: #64645f;
-      --line: #d9d7ce;
-      --panel: #ffffff;
-      --page: #f5f4ef;
-      --brand: #174c39;
-      --brand-strong: #0f3529;
-      --accent: #b65b00;
-      --soft: #f0eee5;
+      --ink-950: #0a1020;
+      --ink-900: #18243a;
+      --ink-700: #324563;
+      --ink-500: #677893;
+      --line: #c8d5e9;
+      --paper: #f3f7ff;
+      --paper-strong: #ffffff;
+      --surface-1: #eaf1ff;
+      --surface-2: #f8fbff;
+      --signal: #1e40af;
+      --signal-2: #3b82f6;
+      --accent: #f97316;
+      --accent-soft: #fff1e5;
+      --shadow-soft: 0 0.95rem 1.8rem -1.15rem rgba(17, 40, 74, 0.28);
+      --shadow-card: 0 1.5rem 2.9rem -1.35rem rgba(13, 35, 69, 0.34);
+      --font-body: "Manrope", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --font-heading: "Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --font-mono: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+      --step--1: clamp(0.78rem, 0.75rem + 0.15vw, 0.87rem);
+      --step-0: clamp(0.93rem, 0.88rem + 0.25vw, 1.05rem);
+      --step-1: clamp(1.1rem, 1rem + 0.5vw, 1.28rem);
+      --step-2: clamp(1.3rem, 1.16rem + 0.7vw, 1.6rem);
+      --gutter: clamp(1rem, 0.72rem + 1.15vw, 1.95rem);
     }
     * { box-sizing: border-box; }
+    html { min-height: 100%; }
     body {
       margin: 0;
-      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      background: var(--page);
-      color: var(--ink);
+      min-height: 100vh;
+      color: var(--ink-900);
+      background:
+        radial-gradient(110% 55% at 0% 0%, color-mix(in srgb, var(--signal-2) 7%, transparent), transparent 55%),
+        radial-gradient(85% 45% at 100% 0%, color-mix(in srgb, var(--accent) 4%, transparent), transparent 50%),
+        var(--paper);
+      font-family: var(--font-body);
+      font-size: var(--step-0);
+      line-height: 1.62;
     }
-    .shell {
-      width: min(880px, calc(100vw - 32px));
-      margin: 32px auto;
+    .page-noise {
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      background-image:
+        linear-gradient(135deg, color-mix(in srgb, var(--signal) 4%, transparent) 0.75px, transparent 0.75px),
+        linear-gradient(45deg, color-mix(in srgb, var(--accent) 3%, transparent) 0.75px, transparent 0.75px);
+      background-size: 24px 24px, 34px 34px;
+      z-index: -1;
     }
-    header {
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 35;
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr);
+      grid-template-areas:
+        "brand controls"
+        "nav nav";
+      align-items: center;
+      column-gap: 1rem;
+      row-gap: 0.12rem;
+      padding: 0.44rem var(--gutter) 0.4rem;
+      border-bottom: 1px solid var(--line);
+      background: color-mix(in srgb, var(--paper-strong) 90%, transparent);
+      backdrop-filter: blur(8px);
+    }
+    .site-header::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: -1px;
+      height: 2px;
+      background: linear-gradient(90deg,
+        color-mix(in srgb, var(--signal) 10%, transparent),
+        color-mix(in srgb, var(--accent) 12%, transparent),
+        color-mix(in srgb, var(--signal) 10%, transparent));
+      pointer-events: none;
+    }
+    .header-brand {
+      grid-area: brand;
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      min-width: 0;
+      min-height: 2.35rem;
+    }
+    .header-logo {
+      width: 32px;
+      height: 32px;
+      flex-shrink: 0;
+    }
+    .header-brand-text {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      gap: 0.05rem;
+      min-width: 0;
+      min-height: 2.35rem;
+    }
+    .site-title {
+      margin: 0;
+      color: var(--ink-950);
+      font-family: var(--font-heading);
+      font-size: var(--step-1);
+      font-weight: 800;
+      line-height: 1.2;
+    }
+    .site-tagline {
+      margin: 0;
+      color: var(--ink-700);
+      font-size: var(--step--1);
+      line-height: 1.15;
+    }
+    .header-controls {
+      grid-area: controls;
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      flex-wrap: wrap;
+      gap: 0.65rem;
+      min-width: 0;
+    }
+    .host-stat {
+      display: inline-flex;
+      align-items: baseline;
+      gap: 0.24rem;
+      max-width: min(44vw, 26rem);
+      border: 1px solid color-mix(in srgb, var(--line) 88%, var(--paper-strong));
+      border-radius: 0.32rem;
+      background: color-mix(in srgb, var(--surface-2) 65%, var(--paper-strong));
+      padding: 0.14rem 0.44rem;
+      color: var(--ink-500);
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      overflow-wrap: anywhere;
+    }
+    .host-stat strong {
+      color: var(--ink-950);
+      font-family: var(--font-heading);
+      font-size: var(--step-0);
+      font-weight: 800;
+    }
+    .header-nav-row {
+      grid-area: nav;
+      display: flex;
+      justify-content: flex-end;
+      min-width: 0;
+    }
+    .console-tabs {
+      display: flex;
+      gap: 2px;
+      width: fit-content;
+      max-width: 100%;
+      border-radius: 0.42rem;
+      background: var(--surface-1);
+      padding: 2px;
+    }
+    .console-tab {
+      border: none;
+      border-radius: 0.42rem;
+      background: var(--paper-strong);
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+      color: var(--signal);
+      font-family: var(--font-mono);
+      font-size: 11.5px;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      padding: 4px 14px;
+    }
+    .auth-shell {
+      width: min(76rem, calc(100vw - (2 * var(--gutter))));
+      margin: 1.65rem auto 2.4rem;
+    }
+    main {
+      display: grid;
+      gap: 1rem;
+    }
+    .auth-hero {
+      border: 1px solid var(--line);
+      border-radius: 0.5rem;
+      background:
+        linear-gradient(135deg,
+          color-mix(in srgb, var(--signal-2) 6%, var(--surface-2)),
+          var(--surface-2) 60%);
+      box-shadow: var(--shadow-soft);
+      overflow: hidden;
+    }
+    .hero-header {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 16px;
-      margin-bottom: 14px;
-    }
-    .brand {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      font-weight: 800;
-      letter-spacing: 0;
-    }
-    .brand-mark {
-      display: grid;
-      place-items: center;
-      width: 34px;
-      height: 34px;
-      border-radius: 7px;
-      background: var(--brand);
-      color: white;
-      font-size: 14px;
-    }
-    .host {
-      color: var(--muted);
-      font-size: 13px;
-      overflow-wrap: anywhere;
-      text-align: right;
-    }
-    main {
-      background: var(--panel);
-      border: 1px solid var(--line);
-      border-radius: 8px;
-      box-shadow: 0 18px 48px rgba(23, 23, 23, 0.08);
-      overflow: hidden;
-    }
-    .hero {
-      padding: 30px 32px 24px;
+      gap: 1rem;
+      padding: 0.75rem 1rem;
+      background: var(--paper-strong);
       border-bottom: 1px solid var(--line);
-      background: #fbfaf6;
     }
     .eyebrow {
-      color: var(--brand);
-      font-size: 13px;
-      font-weight: 800;
-      margin: 0 0 8px;
+      margin: 0;
+      color: var(--ink-500);
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 0.06em;
       text-transform: uppercase;
     }
+    .client-chip {
+      min-width: 0;
+      max-width: 55%;
+      border: 1px solid color-mix(in srgb, var(--signal) 24%, var(--line));
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--surface-1) 70%, var(--paper-strong));
+      color: var(--ink-700);
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      font-weight: 700;
+      line-height: 1;
+      overflow: hidden;
+      padding: 0.48rem 0.78rem;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .hero-body {
+      padding: 1.45rem 1.6rem 1.5rem;
+    }
     h1 {
-      font-size: 28px;
+      margin: 0 0 0.5rem;
+      color: var(--ink-950);
+      font-family: var(--font-heading);
+      font-size: var(--step-2);
+      font-weight: 800;
       line-height: 1.15;
-      margin: 0 0 10px;
-      letter-spacing: 0;
     }
     h2 {
-      font-size: 16px;
-      margin: 0 0 12px;
+      margin: 0;
+      color: var(--ink-950);
+      font-family: var(--font-heading);
+      font-size: var(--step-1);
+      font-weight: 700;
+      line-height: 1.24;
     }
     p {
       line-height: 1.5;
       margin: 0;
     }
-    a { color: var(--brand); }
+    a {
+      color: var(--signal);
+      text-decoration-thickness: 0.08em;
+      text-underline-offset: 0.16em;
+    }
+    a:hover { color: var(--accent); }
     code {
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 13px;
+      border-radius: 0.1875rem;
+      background: var(--surface-1);
+      color: var(--ink-900);
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      padding: 0.05rem 0.22rem;
       overflow-wrap: anywhere;
     }
     .subtitle {
-      color: var(--muted);
-      font-size: 16px;
-      max-width: 660px;
+      max-width: 69ch;
+      color: var(--ink-700);
+      font-size: var(--step-0);
     }
-    .content {
+    .auth-layout {
       display: grid;
-      grid-template-columns: minmax(0, 1fr) 280px;
-      gap: 24px;
-      padding: 28px 32px 32px;
+      grid-template-columns: minmax(0, 1fr) 21rem;
+      gap: 1rem;
+      align-items: start;
     }
-    .section + .section { margin-top: 24px; }
+    .auth-card {
+      border: 1px solid var(--line);
+      border-radius: 0.5rem;
+      background: var(--paper-strong);
+      overflow: hidden;
+    }
+    .auth-card-header {
+      padding: 0.75rem 1rem;
+      background: var(--surface-2);
+      border-bottom: 1px solid var(--line);
+    }
+    .auth-card-body {
+      padding: 1rem;
+    }
+    .section + .section { margin-top: 1rem; }
     .scope-list {
       list-style: none;
       margin: 0;
       padding: 0;
       display: grid;
-      gap: 10px;
+      gap: 0.62rem;
     }
     .scope-list li {
       border: 1px solid var(--line);
-      border-radius: 8px;
-      padding: 12px 14px;
-      background: #fff;
+      border-radius: 0.42rem;
+      background: var(--surface-2);
+      padding: 0.75rem 0.85rem;
     }
     .scope-title {
       display: flex;
       align-items: baseline;
       justify-content: space-between;
-      gap: 12px;
-      font-weight: 750;
+      gap: 0.75rem;
+      color: var(--ink-900);
+      font-family: var(--font-heading);
+      font-size: 0.93rem;
+      font-weight: 700;
     }
     .scope-title code {
-      color: var(--muted);
+      flex-shrink: 0;
+      color: var(--ink-500);
       font-weight: 500;
     }
     .scope-desc {
-      color: var(--muted);
-      font-size: 14px;
-      margin-top: 4px;
+      color: var(--ink-700);
+      font-size: var(--step--1);
+      margin-top: 0.2rem;
     }
     .side {
       display: grid;
-      gap: 14px;
+      gap: 1rem;
       align-content: start;
     }
     .summary-card {
       border: 1px solid var(--line);
-      border-radius: 8px;
-      background: var(--soft);
-      padding: 14px;
+      border-radius: 0.5rem;
+      background: var(--paper-strong);
+      overflow: hidden;
     }
-    .summary-card h2 {
-      margin-bottom: 10px;
+    .summary-card h2,
+    .details-panel h2 {
+      padding: 0.75rem 1rem;
+      background: var(--surface-2);
+      border-bottom: 1px solid var(--line);
+      font-size: 0.875rem;
+      font-weight: 600;
+    }
+    .summary-card-body,
+    .details-body {
+      padding: 1rem;
+    }
+    .summary-card--primary {
+      background:
+        linear-gradient(135deg,
+          color-mix(in srgb, var(--accent) 7%, var(--paper-strong)),
+          var(--paper-strong) 56%);
     }
     dl {
       display: grid;
-      gap: 10px;
+      gap: 0.65rem;
       margin: 0;
     }
     dl > div {
       min-width: 0;
     }
     dt {
-      color: var(--muted);
-      font-size: 12px;
-      font-weight: 800;
-      margin-bottom: 3px;
+      color: var(--ink-500);
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      margin-bottom: 0.18rem;
       text-transform: uppercase;
     }
     dd {
       margin: 0;
       min-width: 0;
+      color: var(--ink-900);
+      font-size: 0.9rem;
       overflow-wrap: anywhere;
     }
     .identity {
-      display: grid;
-      gap: 3px;
+      display: flex;
+      flex-direction: column;
+      gap: 0.18rem;
+      min-width: 0;
     }
     .identity strong {
-      font-size: 15px;
+      color: var(--ink-950);
+      font-family: var(--font-heading);
+      font-size: var(--step-0);
+      font-weight: 800;
     }
     .muted {
-      color: var(--muted);
-      font-size: 14px;
+      color: var(--ink-700);
+      font-size: var(--step--1);
     }
-    .badge {
+    .auth-badge {
       display: inline-flex;
       align-items: center;
       width: fit-content;
-      border: 1px solid var(--line);
       border-radius: 999px;
-      padding: 5px 9px;
-      background: white;
-      color: var(--muted);
-      font-size: 12px;
-      font-weight: 800;
+      border: 1px solid color-mix(in srgb, #22c55e 30%, var(--line));
+      background: color-mix(in srgb, #22c55e 15%, var(--surface-1));
+      color: #16a34a;
+      font-family: var(--font-mono);
+      font-size: 0.68rem;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      padding: 0.15rem 0.5rem;
+      text-transform: uppercase;
     }
-    .badge.accent {
-      border-color: #e0b27a;
-      background: #fff6e8;
-      color: #6b3400;
+    .auth-badge--accent {
+      border-color: color-mix(in srgb, var(--accent) 35%, var(--line));
+      background: var(--accent-soft);
+      color: #9a3412;
     }
-    details {
-      border-top: 1px solid var(--line);
-      padding-top: 18px;
-      margin-top: 24px;
+    .details-panel {
+      border: 1px solid var(--line);
+      border-radius: 0.5rem;
+      background: var(--paper-strong);
+      overflow: hidden;
+    }
+    .callbacks-title {
+      margin: 1rem -1rem 0;
     }
     summary {
       cursor: pointer;
-      color: var(--brand);
-      font-weight: 800;
+      color: var(--signal);
+      font-family: var(--font-heading);
+      font-weight: 700;
+      list-style-position: inside;
+      padding: 0.75rem 1rem;
+      background: var(--surface-2);
+      border-bottom: 1px solid var(--line);
     }
     .redirect-list {
-      margin: 12px 0 0;
-      padding-left: 18px;
-      color: var(--muted);
+      margin: 0.7rem 0 0;
+      padding-left: 1.15rem;
+      color: var(--ink-700);
+      font-size: var(--step--1);
     }
     form {
       display: flex;
-      gap: 12px;
+      gap: 0.8rem;
       flex-wrap: wrap;
-      margin-top: 28px;
+      margin-top: 1rem;
+    }
+    .side form {
+      margin-top: 0;
     }
     button {
-      border: 0;
-      border-radius: 7px;
-      padding: 12px 18px;
-      font-weight: 800;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 2.6rem;
+      border-radius: 0.42rem;
       cursor: pointer;
-      font-size: 15px;
+      font-family: var(--font-mono);
+      font-size: 0.88rem;
+      font-weight: 700;
+      padding: 0.55rem 1.4rem;
+      transition: transform 0.12s, box-shadow 0.12s, background 0.12s;
+    }
+    button:hover,
+    button:focus-visible {
+      box-shadow: var(--shadow-soft);
+      outline: 2px solid transparent;
+      transform: translateY(-1px);
     }
     button.primary {
-      background: var(--brand);
-      color: white;
+      border: none;
+      background: var(--signal);
+      color: #fff;
     }
-    button.primary:hover { background: var(--brand-strong); }
+    button.primary:hover { background: var(--signal-2); }
     button.secondary {
-      background: #ece8dd;
-      color: var(--ink);
+      border: 1px solid color-mix(in srgb, var(--signal) 30%, var(--line));
+      background: var(--surface-1);
+      color: var(--signal);
     }
-    @media (max-width: 760px) {
-      .shell { width: min(100vw - 20px, 880px); margin: 16px auto; }
-      header { align-items: flex-start; flex-direction: column; }
-      .host { text-align: left; }
-      .hero, .content { padding: 22px; }
-      .content { grid-template-columns: 1fr; }
-      h1 { font-size: 24px; }
+    button.secondary:hover {
+      background: color-mix(in srgb, var(--signal-2) 12%, var(--surface-1));
+    }
+    .callback-domain {
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      font-weight: 600;
+    }
+    .status-copy {
+      margin-top: 0.65rem;
+    }
+    @media (max-width: 820px) {
+      .site-header {
+        grid-template-columns: 1fr;
+        grid-template-areas:
+          "brand"
+          "controls"
+          "nav";
+      }
+      .header-controls,
+      .header-nav-row {
+        justify-content: flex-start;
+      }
+      .host-stat {
+        max-width: 100%;
+      }
+      .auth-shell {
+        width: min(100vw - 1.25rem, 76rem);
+        margin-top: 1rem;
+      }
+      .hero-header {
+        align-items: flex-start;
+        flex-direction: column;
+      }
+      .client-chip {
+        max-width: 100%;
+      }
+      .hero-body {
+        padding: 1.2rem;
+      }
+      .auth-layout { grid-template-columns: 1fr; }
       form { flex-direction: column; }
       button { width: 100%; }
     }
   </style>
 </head>
 <body>
-  <div class="shell">
-    <header>
-      <div class="brand"><span class="brand-mark">DM</span><span>DollhouseMCP Authorization</span></div>
-      <div class="host">mcp.dollhousemcp.com</div>
-    </header>
+  <div class="page-noise" aria-hidden="true"></div>
+  <header class="site-header">
+    <div class="header-brand">
+      <img src="/dollhouse-logo.png" alt="DollhouseMCP" class="header-logo" width="32" height="32">
+      <div class="header-brand-text">
+        <p class="site-title">DollhouseMCP</p>
+        <p class="site-tagline">Authorization</p>
+      </div>
+    </div>
+    <div class="header-controls">
+      <div class="host-stat"><span>Host</span><strong>${escapeHtmlText(authorizationHost)}</strong></div>
+    </div>
+    <div class="header-nav-row">
+      <div class="console-tabs" aria-label="Authorization context">
+        <span class="console-tab">OAuth</span>
+      </div>
+    </div>
+  </header>
+  <div class="auth-shell">
     <main>
-      <section class="hero">
-        <p class="eyebrow">OAuth client authorization</p>
-        <h1>Authorize ${escapeHtmlText(view.clientName)}?</h1>
-        <p class="subtitle">${escapeHtmlText(view.clientName)} is requesting access to DollhouseMCP. DollhouseMCP will issue OAuth tokens to this client after approval.</p>
+      <section class="auth-hero">
+        <div class="hero-header">
+          <p class="eyebrow">OAuth client authorization</p>
+          <span class="client-chip">${escapeHtmlText(view.clientName)}</span>
+        </div>
+        <div class="hero-body">
+          <h1>Authorize ${escapeHtmlText(view.clientName)}?</h1>
+          <p class="subtitle">${escapeHtmlText(view.clientName)} is requesting access to DollhouseMCP. DollhouseMCP will issue OAuth tokens to this client after approval.</p>
+        </div>
       </section>
-      <section class="content">
+      <section class="auth-layout">
         <div>
-          <section class="section">
-            <h2>Requested access</h2>
-            <ul class="scope-list">
+          <section class="auth-card section">
+            <div class="auth-card-header">
+              <h2>Requested access</h2>
+            </div>
+            <div class="auth-card-body">
+              <ul class="scope-list">
 ${scopes}
-            </ul>
+              </ul>
+            </div>
           </section>
-          <details>
+          <details class="details-panel section">
             <summary>Technical details</summary>
-            <dl>
-              <div>
-                <dt>Client ID</dt>
-                <dd><code>${escapeHtmlText(view.clientId)}</code></dd>
-              </div>
-              ${clientWebsiteRow}
-              <div>
-                <dt>Callback domain</dt>
-                <dd><code>${escapeHtmlText(view.callbackHost)}</code></dd>
-              </div>
-              <div>
-                <dt>Callback URL</dt>
-                <dd><code>${escapeHtmlText(view.redirectUri)}</code></dd>
-              </div>
-              <div>
-                <dt>Resource</dt>
-                <dd><code>${escapeHtmlText(view.resource)}</code></dd>
-              </div>
-              <div>
-                <dt>Application type</dt>
-                <dd>${escapeHtmlText(view.applicationType)}</dd>
-              </div>
-            </dl>
-            <h2 style="margin-top: 20px;">Registered callbacks</h2>
-            <ul class="redirect-list">
+            <div class="details-body">
+              <dl>
+                <div>
+                  <dt>Client ID</dt>
+                  <dd><code>${escapeHtmlText(view.clientId)}</code></dd>
+                </div>
+                ${clientWebsiteRow}
+                <div>
+                  <dt>Callback domain</dt>
+                  <dd><code>${escapeHtmlText(view.callbackHost)}</code></dd>
+                </div>
+                <div>
+                  <dt>Callback URL</dt>
+                  <dd><code>${escapeHtmlText(view.redirectUri)}</code></dd>
+                </div>
+                <div>
+                  <dt>Resource</dt>
+                  <dd><code>${escapeHtmlText(view.resource)}</code></dd>
+                </div>
+                <div>
+                  <dt>Application type</dt>
+                  <dd>${escapeHtmlText(view.applicationType)}</dd>
+                </div>
+              </dl>
+              <h2 class="callbacks-title">Registered callbacks</h2>
+              <ul class="redirect-list">
 ${redirectList}
 ${redirectOverflow}
-            </ul>
+              </ul>
+            </div>
           </details>
-          <form method="post" action="/interaction/${escapeHtmlAttr(details.uid)}">
-            <input type="hidden" name="csrf_token" value="${escapeHtmlAttr(csrfToken)}">
-            <button class="primary" type="submit" name="action" value="${CLIENT_CONSENT_APPROVE_ACTION}">Authorize</button>
-            <button class="secondary" type="submit" name="action" value="${CLIENT_CONSENT_DENY_ACTION}">Cancel</button>
-          </form>
         </div>
         <aside class="side">
-          <section class="summary-card">
-            <h2>Signed in with GitHub</h2>
-            ${identitySummary}
+          <section class="summary-card summary-card--primary">
+            <h2>${escapeHtmlText(signedInHeading)}</h2>
+            <div class="summary-card-body">
+              ${identitySummary}
+            </div>
           </section>
           <section class="summary-card">
             <h2>Client status</h2>
-            <span class="${historyClass}">${escapeHtmlText(historyLabel)}</span>
-            <p class="muted" style="margin-top: 10px;">${escapeHtmlText(authorizationSummary)}</p>
+            <div class="summary-card-body">
+              <span class="${historyClass}">${escapeHtmlText(historyLabel)}</span>
+              <p class="muted status-copy">${escapeHtmlText(authorizationSummary)}</p>
+            </div>
           </section>
           <section class="summary-card">
             <h2>Callback</h2>
-            <dl>
-              <div>
-                <dt>Domain</dt>
-                <dd><code>${escapeHtmlText(view.callbackHost)}</code></dd>
-              </div>
-            </dl>
+            <div class="summary-card-body">
+              <dl>
+                <div>
+                  <dt>Domain</dt>
+                  <dd class="callback-domain">${escapeHtmlText(view.callbackHost)}</dd>
+                </div>
+              </dl>
+            </div>
           </section>
+          <form method="post" action="/interaction/${escapeHtmlAttr(details.uid)}">
+            <input type="hidden" name="csrf_token" value="${escapeHtmlAttr(csrfToken)}">
+            <button class="primary" type="submit" name="action" value="${CLIENT_CONSENT_APPROVE_ACTION}">Authorize Client</button>
+            <button class="secondary" type="submit" name="action" value="${CLIENT_CONSENT_DENY_ACTION}">Cancel</button>
+          </form>
         </aside>
       </section>
     </main>
@@ -1076,6 +1387,16 @@ function renderResource(resource: unknown, defaultResource: string): string {
     if (strings.length > 0) return strings.join(', ');
   }
   return defaultResource;
+}
+
+function hostFromDisplayResource(resource: string): string {
+  const firstResource = resource.split(',')[0]?.trim();
+  if (!firstResource) return 'mcp.dollhousemcp.com';
+  try {
+    return new URL(firstResource).host;
+  } catch {
+    return firstResource;
+  }
 }
 
 async function hasSeenClientConsent(

--- a/src/auth/embedded-as/dcrPolicy.ts
+++ b/src/auth/embedded-as/dcrPolicy.ts
@@ -158,12 +158,12 @@ export function validateRedirectUriShape(
 
 function validateRedirectUriComponents(parsed: URL, host: string): string[] {
   return [
-    ...(!host ? ['must include a hostname'] : []),
-    ...(host.includes('*') ? ['must not contain wildcards'] : []),
-    ...(host.endsWith('.') ? ['must not use a trailing-dot hostname'] : []),
-    ...(host.includes('%') ? ['must not include IPv6 zone identifiers'] : []),
-    ...(parsed.username || parsed.password ? ['must not include username or password components'] : []),
-    ...(parsed.hash ? ['must not include a URL fragment'] : []),
+    ...errorIf(host.length === 0, 'must include a hostname'),
+    ...errorIf(host.includes('*'), 'must not contain wildcards'),
+    ...errorIf(host.endsWith('.'), 'must not use a trailing-dot hostname'),
+    ...errorIf(host.includes('%'), 'must not include IPv6 zone identifiers'),
+    ...errorIf(Boolean(parsed.username || parsed.password), 'must not include username or password components'),
+    ...errorIf(Boolean(parsed.hash), 'must not include a URL fragment'),
   ];
 }
 
@@ -174,19 +174,21 @@ function validateRedirectUriProtocol(
 ): string[] {
   if (protocol === 'http:') {
     return [
-      ...(!loopback ? ['http callbacks are allowed only for loopback clients'] : []),
-      ...(loopback && applicationType !== 'native'
-        ? ['http loopback callbacks require application_type "native"']
-        : []),
+      ...errorIf(loopback === false, 'http callbacks are allowed only for loopback clients'),
+      ...errorIf(loopback && applicationType !== 'native', 'http loopback callbacks require application_type "native"'),
     ];
   }
   return protocol === 'https:' ? [] : ['must use https, or http for loopback clients'];
 }
 
 function validateRedirectUriIp(host: string, loopback: boolean): string[] {
-  return !loopback && isPrivateIpLiteral(host)
+  return loopback === false && isPrivateIpLiteral(host)
     ? ['must not use a private, link-local, or unspecified IP literal']
     : [];
+}
+
+function errorIf(condition: boolean, message: string): string[] {
+  return condition ? [message] : [];
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {

--- a/src/auth/embedded-as/dcrPolicy.ts
+++ b/src/auth/embedded-as/dcrPolicy.ts
@@ -392,11 +392,26 @@ function isPrivateIpLiteral(host: string): boolean {
   if (version === 6) {
     return host === '::'
       || host === '::1'
-      || host.startsWith('fc')
-      || host.startsWith('fd')
-      || host.startsWith('fe80:');
+      || isIpv6UniqueLocal(host)
+      || isIpv6LinkLocal(host);
   }
   return false;
+}
+
+function isIpv6UniqueLocal(host: string): boolean {
+  const firstHextet = parseFirstIpv6Hextet(host);
+  return firstHextet !== null && firstHextet >= 0xfc00 && firstHextet <= 0xfdff;
+}
+
+function isIpv6LinkLocal(host: string): boolean {
+  const firstHextet = parseFirstIpv6Hextet(host);
+  return firstHextet !== null && firstHextet >= 0xfe80 && firstHextet <= 0xfebf;
+}
+
+function parseFirstIpv6Hextet(host: string): number | null {
+  const [first] = host.split(':', 1);
+  if (!first || !/^[0-9a-f]{1,4}$/i.test(first)) return null;
+  return Number.parseInt(first, 16);
 }
 
 function isPrivateIpv4Octets(octets: [number, number, number, number]): boolean {

--- a/src/auth/embedded-as/dcrPolicy.ts
+++ b/src/auth/embedded-as/dcrPolicy.ts
@@ -286,10 +286,18 @@ function validateStringMetadata(metadata: Record<string, unknown>, errors: strin
     if (value.length > MAX_STRING_METADATA_LENGTH) {
       errors.push(`${key} must be ${MAX_STRING_METADATA_LENGTH} characters or fewer`);
     }
-    if (/[\u0000-\u001f\u007f]/.test(value)) {
+    if (containsControlCharacter(value)) {
       errors.push(`${key} must not contain control characters`);
     }
   }
+}
+
+function containsControlCharacter(value: string): boolean {
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
 }
 
 function validateHttpsMetadataUri(value: unknown, field: string, errors: string[]): void {
@@ -363,7 +371,8 @@ function normalizeUrlHostname(hostname: string): string {
 function isLoopbackHost(host: string): boolean {
   if (host === 'localhost') return true;
   if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
-  if (host.startsWith('::ffff:')) return isLoopbackHost(host.slice('::ffff:'.length));
+  const mappedIpv4 = parseIpv4MappedIpv6(host);
+  if (mappedIpv4) return mappedIpv4[0] === 127;
   if (isIP(host) === 4) {
     const octets = parseIpv4(host);
     return octets ? octets[0] === 127 : false;
@@ -372,19 +381,13 @@ function isLoopbackHost(host: string): boolean {
 }
 
 function isPrivateIpLiteral(host: string): boolean {
-  if (host.startsWith('::ffff:')) return isPrivateIpLiteral(host.slice('::ffff:'.length));
+  const mappedIpv4 = parseIpv4MappedIpv6(host);
+  if (mappedIpv4) return isPrivateIpv4Octets(mappedIpv4);
   const version = isIP(host);
   if (version === 4) {
     const octets = parseIpv4(host);
     if (!octets) return false;
-    const [a, b] = octets;
-    return a === 0
-      || a === 10
-      || a === 127
-      || (a === 100 && b >= 64 && b <= 127)
-      || (a === 169 && b === 254)
-      || (a === 172 && b >= 16 && b <= 31)
-      || (a === 192 && b === 168);
+    return isPrivateIpv4Octets(octets);
   }
   if (version === 6) {
     return host === '::'
@@ -394,6 +397,46 @@ function isPrivateIpLiteral(host: string): boolean {
       || host.startsWith('fe80:');
   }
   return false;
+}
+
+function isPrivateIpv4Octets(octets: [number, number, number, number]): boolean {
+  const [a, b] = octets;
+  return a === 0
+    || a === 10
+    || a === 127
+    || (a === 100 && b >= 64 && b <= 127)
+    || (a === 169 && b === 254)
+    || (a === 172 && b >= 16 && b <= 31)
+    || (a === 192 && b === 168);
+}
+
+function parseIpv4MappedIpv6(host: string): [number, number, number, number] | null {
+  const mappedPrefix = '::ffff:';
+  if (!host.startsWith(mappedPrefix)) return null;
+
+  const embedded = host.slice(mappedPrefix.length);
+  const dotted = parseIpv4(embedded);
+  if (dotted) return dotted;
+
+  const groups = embedded.split(':');
+  if (groups.length !== 2) return null;
+
+  const high = parseIpv4MappedHexGroup(groups[0]);
+  const low = parseIpv4MappedHexGroup(groups[1]);
+  if (high === null || low === null) return null;
+
+  return [
+    high >>> 8,
+    high & 0xff,
+    low >>> 8,
+    low & 0xff,
+  ];
+}
+
+function parseIpv4MappedHexGroup(group: string): number | null {
+  if (!/^[0-9a-f]{1,4}$/i.test(group)) return null;
+  const value = Number.parseInt(group, 16);
+  return Number.isInteger(value) && value >= 0 && value <= 0xffff ? value : null;
 }
 
 function parseIpv4(host: string): [number, number, number, number] | null {

--- a/src/auth/embedded-as/dcrPolicy.ts
+++ b/src/auth/embedded-as/dcrPolicy.ts
@@ -294,8 +294,8 @@ function validateStringMetadata(metadata: Record<string, unknown>, errors: strin
 
 function containsControlCharacter(value: string): boolean {
   for (const char of value) {
-    const code = char.charCodeAt(0);
-    if (code <= 0x1f || code === 0x7f) return true;
+    const code = char.codePointAt(0);
+    if (code !== undefined && (code <= 0x1f || code === 0x7f)) return true;
   }
   return false;
 }

--- a/src/auth/embedded-as/dcrPolicy.ts
+++ b/src/auth/embedded-as/dcrPolicy.ts
@@ -1,0 +1,330 @@
+/**
+ * Dynamic Client Registration policy for hosted MCP.
+ *
+ * The goal is not to maintain a list of "trusted" MCP clients. We allow
+ * unknown clients, but reject callback and metadata shapes that are unsafe or
+ * confusing for a public authorization server.
+ *
+ * Anchored to issue #2220.
+ */
+
+import { isIP } from 'node:net';
+
+const MAX_REDIRECT_URIS = 10;
+const MAX_URI_LENGTH = 2048;
+const MAX_SCOPE_LENGTH = 512;
+const MAX_STRING_METADATA_LENGTH = 256;
+
+const SUPPORTED_SCOPES = new Set(['openid', 'offline_access', 'profile', 'email', 'mcp']);
+const SUPPORTED_GRANT_TYPES = new Set(['authorization_code', 'refresh_token']);
+const SUPPORTED_RESPONSE_TYPES = new Set(['code']);
+const SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS = new Set([
+  'none',
+  'client_secret_basic',
+  'client_secret_post',
+]);
+
+const FORBIDDEN_OPEN_DCR_METADATA = new Set([
+  'client_id',
+  'client_secret',
+  'client_secret_expires_at',
+  'client_id_issued_at',
+  'registration_access_token',
+  'registration_client_uri',
+  'jwks',
+  'jwks_uri',
+  'sector_identifier_uri',
+  'request_uris',
+  'backchannel_logout_uri',
+  'backchannel_client_notification_endpoint',
+]);
+
+export interface RedirectUriPolicyResult {
+  ok: boolean;
+  uri: string;
+  host?: string;
+  isLoopback?: boolean;
+  errors: string[];
+}
+
+export interface DcrPolicyDecision {
+  allowed: boolean;
+  errors: string[];
+  redirectHosts: string[];
+}
+
+export function validateDcrClientMetadata(input: unknown): DcrPolicyDecision {
+  const errors: string[] = [];
+  const metadata = asRecord(input);
+  if (!metadata) {
+    return {
+      allowed: false,
+      errors: ['registration request body must be a JSON object'],
+      redirectHosts: [],
+    };
+  }
+
+  for (const key of Object.keys(metadata)) {
+    if (FORBIDDEN_OPEN_DCR_METADATA.has(key) || key.startsWith('tls_client_auth_')) {
+      errors.push(`${key} is not accepted for open dynamic client registration`);
+    }
+  }
+
+  const redirectUris = readStringArray(metadata.redirect_uris, 'redirect_uris', errors, {
+    required: true,
+    maxItems: MAX_REDIRECT_URIS,
+  });
+  const redirectResults = redirectUris.map(validateRedirectUriShape);
+  for (const result of redirectResults) {
+    errors.push(...result.errors.map((error) => `redirect_uris entry ${result.uri}: ${error}`));
+  }
+
+  validateScope(metadata.scope, errors);
+  validateStringArraySubset(metadata.grant_types, 'grant_types', SUPPORTED_GRANT_TYPES, errors);
+  validateStringArraySubset(metadata.response_types, 'response_types', SUPPORTED_RESPONSE_TYPES, errors);
+  validateTokenEndpointAuthMethod(metadata.token_endpoint_auth_method, errors);
+  validateApplicationType(metadata.application_type, errors);
+  validateStringMetadata(metadata, errors);
+  validateHttpsMetadataUri(metadata.client_uri, 'client_uri', errors);
+  validateHttpsMetadataUri(metadata.logo_uri, 'logo_uri', errors);
+  validateHttpsMetadataUri(metadata.policy_uri, 'policy_uri', errors);
+  validateHttpsMetadataUri(metadata.tos_uri, 'tos_uri', errors);
+  validateIdTokenAlg(metadata.id_token_signed_response_alg, errors);
+
+  const redirectHosts = Array.from(new Set(
+    redirectResults
+      .map((result) => result.host)
+      .filter((host): host is string => typeof host === 'string' && host.length > 0),
+  ));
+
+  return {
+    allowed: errors.length === 0,
+    errors,
+    redirectHosts,
+  };
+}
+
+export function validateRedirectUriShape(uri: string): RedirectUriPolicyResult {
+  const errors: string[] = [];
+  if (typeof uri !== 'string' || uri.trim() !== uri || uri.length === 0) {
+    return { ok: false, uri: String(uri), errors: ['must be a non-empty string without surrounding whitespace'] };
+  }
+  if (uri.length > MAX_URI_LENGTH) {
+    errors.push(`must be ${MAX_URI_LENGTH} characters or fewer`);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return { ok: false, uri, errors: ['must be an absolute URL'] };
+  }
+
+  const host = normalizeUrlHostname(parsed.hostname);
+  const loopback = isLoopbackHost(host);
+
+  if (!host) errors.push('must include a hostname');
+  if (host.includes('*')) errors.push('must not contain wildcards');
+  if (host.endsWith('.')) errors.push('must not use a trailing-dot hostname');
+  if (host.includes('%')) errors.push('must not include IPv6 zone identifiers');
+  if (parsed.username || parsed.password) errors.push('must not include username or password components');
+  if (parsed.hash) errors.push('must not include a URL fragment');
+
+  if (parsed.protocol === 'http:') {
+    if (!loopback) errors.push('http callbacks are allowed only for loopback clients');
+  } else if (parsed.protocol !== 'https:') {
+    errors.push('must use https, or http for loopback clients');
+  }
+
+  if (!loopback && isPrivateIpLiteral(host)) {
+    errors.push('must not use a private, link-local, or unspecified IP literal');
+  }
+
+  return {
+    ok: errors.length === 0,
+    uri,
+    host,
+    isLoopback: loopback,
+    errors,
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function readStringArray(
+  value: unknown,
+  field: string,
+  errors: string[],
+  options: { required: boolean; maxItems: number },
+): string[] {
+  if (value === undefined) {
+    if (options.required) errors.push(`${field} is required`);
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    errors.push(`${field} must be an array`);
+    return [];
+  }
+  if (value.length === 0) errors.push(`${field} must contain at least one entry`);
+  if (value.length > options.maxItems) errors.push(`${field} must contain at most ${options.maxItems} entries`);
+  const strings: string[] = [];
+  value.forEach((entry, index) => {
+    if (typeof entry !== 'string') {
+      errors.push(`${field}[${index}] must be a string`);
+      return;
+    }
+    strings.push(entry);
+  });
+  return strings;
+}
+
+function validateStringArraySubset(
+  value: unknown,
+  field: string,
+  supported: ReadonlySet<string>,
+  errors: string[],
+): void {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) {
+    errors.push(`${field} must be an array`);
+    return;
+  }
+  if (value.length === 0) {
+    errors.push(`${field} must contain at least one entry`);
+    return;
+  }
+  for (const entry of value) {
+    if (typeof entry !== 'string' || !supported.has(entry)) {
+      errors.push(`${field} contains unsupported value ${JSON.stringify(entry)}`);
+    }
+  }
+}
+
+function validateScope(value: unknown, errors: string[]): void {
+  if (value === undefined) return;
+  if (typeof value !== 'string') {
+    errors.push('scope must be a string');
+    return;
+  }
+  if (value.length > MAX_SCOPE_LENGTH) {
+    errors.push(`scope must be ${MAX_SCOPE_LENGTH} characters or fewer`);
+  }
+  for (const scope of value.split(/\s+/).filter(Boolean)) {
+    if (!SUPPORTED_SCOPES.has(scope)) {
+      errors.push(`scope contains unsupported value ${JSON.stringify(scope)}`);
+    }
+  }
+}
+
+function validateTokenEndpointAuthMethod(value: unknown, errors: string[]): void {
+  if (value === undefined) return;
+  if (typeof value !== 'string' || !SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS.has(value)) {
+    errors.push(`token_endpoint_auth_method contains unsupported value ${JSON.stringify(value)}`);
+  }
+}
+
+function validateApplicationType(value: unknown, errors: string[]): void {
+  if (value === undefined) return;
+  if (value !== 'web' && value !== 'native') {
+    errors.push('application_type must be "web" or "native"');
+  }
+}
+
+function validateStringMetadata(metadata: Record<string, unknown>, errors: string[]): void {
+  for (const key of ['client_name', 'software_id', 'software_version']) {
+    const value = metadata[key];
+    if (value === undefined) continue;
+    if (typeof value !== 'string' || value.length === 0) {
+      errors.push(`${key} must be a non-empty string`);
+      continue;
+    }
+    if (value.length > MAX_STRING_METADATA_LENGTH) {
+      errors.push(`${key} must be ${MAX_STRING_METADATA_LENGTH} characters or fewer`);
+    }
+    if (/[\u0000-\u001f\u007f]/.test(value)) {
+      errors.push(`${key} must not contain control characters`);
+    }
+  }
+}
+
+function validateHttpsMetadataUri(value: unknown, field: string, errors: string[]): void {
+  if (value === undefined) return;
+  if (typeof value !== 'string') {
+    errors.push(`${field} must be a string`);
+    return;
+  }
+  if (value.length > MAX_URI_LENGTH) {
+    errors.push(`${field} must be ${MAX_URI_LENGTH} characters or fewer`);
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    errors.push(`${field} must be an absolute URL`);
+    return;
+  }
+  const host = normalizeUrlHostname(parsed.hostname);
+  if (parsed.protocol !== 'https:') errors.push(`${field} must use https`);
+  if (!host || host.includes('*') || host.endsWith('.')) errors.push(`${field} must use a concrete hostname`);
+  if (parsed.username || parsed.password) errors.push(`${field} must not include username or password components`);
+  if (parsed.hash) errors.push(`${field} must not include a URL fragment`);
+  if (isPrivateIpLiteral(host)) errors.push(`${field} must not use a private, link-local, or unspecified IP literal`);
+}
+
+function validateIdTokenAlg(value: unknown, errors: string[]): void {
+  if (value === undefined) return;
+  if (value !== 'ES256') {
+    errors.push('id_token_signed_response_alg must be ES256 when provided');
+  }
+}
+
+function normalizeUrlHostname(hostname: string): string {
+  return hostname.replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
+}
+
+function isLoopbackHost(host: string): boolean {
+  if (host === 'localhost') return true;
+  if (host === '::1' || host === '0:0:0:0:0:0:0:1') return true;
+  if (host.startsWith('::ffff:')) return isLoopbackHost(host.slice('::ffff:'.length));
+  if (isIP(host) === 4) {
+    const octets = parseIpv4(host);
+    return octets ? octets[0] === 127 : false;
+  }
+  return false;
+}
+
+function isPrivateIpLiteral(host: string): boolean {
+  if (host.startsWith('::ffff:')) return isPrivateIpLiteral(host.slice('::ffff:'.length));
+  const version = isIP(host);
+  if (version === 4) {
+    const octets = parseIpv4(host);
+    if (!octets) return false;
+    const [a, b] = octets;
+    return a === 0
+      || a === 10
+      || a === 127
+      || (a === 100 && b >= 64 && b <= 127)
+      || (a === 169 && b === 254)
+      || (a === 172 && b >= 16 && b <= 31)
+      || (a === 192 && b === 168);
+  }
+  if (version === 6) {
+    return host === '::'
+      || host === '::1'
+      || host.startsWith('fc')
+      || host.startsWith('fd')
+      || host.startsWith('fe80:');
+  }
+  return false;
+}
+
+function parseIpv4(host: string): [number, number, number, number] | null {
+  const parts = host.split('.');
+  if (parts.length !== 4) return null;
+  const octets = parts.map((part) => Number(part));
+  if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return null;
+  return octets as [number, number, number, number];
+}

--- a/src/auth/embedded-as/dcrPolicy.ts
+++ b/src/auth/embedded-as/dcrPolicy.ts
@@ -140,23 +140,10 @@ export function validateRedirectUriShape(
   const host = normalizeUrlHostname(parsed.hostname);
   const loopback = isLoopbackHost(host);
 
-  if (!host) errors.push('must include a hostname');
-  if (host.includes('*')) errors.push('must not contain wildcards');
-  if (host.endsWith('.')) errors.push('must not use a trailing-dot hostname');
-  if (host.includes('%')) errors.push('must not include IPv6 zone identifiers');
-  if (parsed.username || parsed.password) errors.push('must not include username or password components');
-  if (parsed.hash) errors.push('must not include a URL fragment');
+  errors.push(...validateRedirectUriComponents(parsed, host));
+  errors.push(...validateRedirectUriProtocol(parsed.protocol, loopback, options.applicationType));
 
-  if (parsed.protocol === 'http:') {
-    if (!loopback) errors.push('http callbacks are allowed only for loopback clients');
-    if (loopback && options.applicationType !== 'native') {
-      errors.push('http loopback callbacks require application_type "native"');
-    }
-  } else if (parsed.protocol !== 'https:') {
-    errors.push('must use https, or http for loopback clients');
-  }
-
-  if (!loopback && isPrivateIpLiteral(host)) {
+  if (isDisallowedCallbackIp(host, loopback)) {
     errors.push('must not use a private, link-local, or unspecified IP literal');
   }
 
@@ -167,6 +154,40 @@ export function validateRedirectUriShape(
     isLoopback: loopback,
     errors,
   };
+}
+
+function validateRedirectUriComponents(parsed: URL, host: string): string[] {
+  const errors: string[] = [];
+  if (!host) errors.push('must include a hostname');
+  if (host.includes('*')) errors.push('must not contain wildcards');
+  if (host.endsWith('.')) errors.push('must not use a trailing-dot hostname');
+  if (host.includes('%')) errors.push('must not include IPv6 zone identifiers');
+  if (parsed.username || parsed.password) errors.push('must not include username or password components');
+  if (parsed.hash) errors.push('must not include a URL fragment');
+  return errors;
+}
+
+function validateRedirectUriProtocol(
+  protocol: string,
+  loopback: boolean,
+  applicationType: string | undefined,
+): string[] {
+  const errors: string[] = [];
+  if (protocol === 'http:') {
+    if (!loopback) errors.push('http callbacks are allowed only for loopback clients');
+    if (loopback && applicationType !== 'native') {
+      errors.push('http loopback callbacks require application_type "native"');
+    }
+    return errors;
+  }
+  if (protocol !== 'https:') {
+    errors.push('must use https, or http for loopback clients');
+  }
+  return errors;
+}
+
+function isDisallowedCallbackIp(host: string, loopback: boolean): boolean {
+  return !loopback && isPrivateIpLiteral(host);
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -377,7 +398,7 @@ function isPrivateIpLiteral(host: string): boolean {
 function parseIpv4(host: string): [number, number, number, number] | null {
   const parts = host.split('.');
   if (parts.length !== 4) return null;
-  const octets = parts.map((part) => Number(part));
+  const octets = parts.map(Number);
   if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return null;
   return octets as [number, number, number, number];
 }

--- a/src/auth/embedded-as/dcrPolicy.ts
+++ b/src/auth/embedded-as/dcrPolicy.ts
@@ -140,31 +140,31 @@ export function validateRedirectUriShape(
   const host = normalizeUrlHostname(parsed.hostname);
   const loopback = isLoopbackHost(host);
 
-  errors.push(...validateRedirectUriComponents(parsed, host));
-  errors.push(...validateRedirectUriProtocol(parsed.protocol, loopback, options.applicationType));
-
-  if (isDisallowedCallbackIp(host, loopback)) {
-    errors.push('must not use a private, link-local, or unspecified IP literal');
-  }
+  const validationErrors = [
+    ...errors,
+    ...validateRedirectUriComponents(parsed, host),
+    ...validateRedirectUriProtocol(parsed.protocol, loopback, options.applicationType),
+    ...validateRedirectUriIp(host, loopback),
+  ];
 
   return {
-    ok: errors.length === 0,
+    ok: validationErrors.length === 0,
     uri,
     host,
     isLoopback: loopback,
-    errors,
+    errors: validationErrors,
   };
 }
 
 function validateRedirectUriComponents(parsed: URL, host: string): string[] {
-  const errors: string[] = [];
-  if (!host) errors.push('must include a hostname');
-  if (host.includes('*')) errors.push('must not contain wildcards');
-  if (host.endsWith('.')) errors.push('must not use a trailing-dot hostname');
-  if (host.includes('%')) errors.push('must not include IPv6 zone identifiers');
-  if (parsed.username || parsed.password) errors.push('must not include username or password components');
-  if (parsed.hash) errors.push('must not include a URL fragment');
-  return errors;
+  return [
+    ...(!host ? ['must include a hostname'] : []),
+    ...(host.includes('*') ? ['must not contain wildcards'] : []),
+    ...(host.endsWith('.') ? ['must not use a trailing-dot hostname'] : []),
+    ...(host.includes('%') ? ['must not include IPv6 zone identifiers'] : []),
+    ...(parsed.username || parsed.password ? ['must not include username or password components'] : []),
+    ...(parsed.hash ? ['must not include a URL fragment'] : []),
+  ];
 }
 
 function validateRedirectUriProtocol(
@@ -172,22 +172,21 @@ function validateRedirectUriProtocol(
   loopback: boolean,
   applicationType: string | undefined,
 ): string[] {
-  const errors: string[] = [];
   if (protocol === 'http:') {
-    if (!loopback) errors.push('http callbacks are allowed only for loopback clients');
-    if (loopback && applicationType !== 'native') {
-      errors.push('http loopback callbacks require application_type "native"');
-    }
-    return errors;
+    return [
+      ...(!loopback ? ['http callbacks are allowed only for loopback clients'] : []),
+      ...(loopback && applicationType !== 'native'
+        ? ['http loopback callbacks require application_type "native"']
+        : []),
+    ];
   }
-  if (protocol !== 'https:') {
-    errors.push('must use https, or http for loopback clients');
-  }
-  return errors;
+  return protocol === 'https:' ? [] : ['must use https, or http for loopback clients'];
 }
 
-function isDisallowedCallbackIp(host: string, loopback: boolean): boolean {
-  return !loopback && isPrivateIpLiteral(host);
+function validateRedirectUriIp(host: string, loopback: boolean): string[] {
+  return !loopback && isPrivateIpLiteral(host)
+    ? ['must not use a private, link-local, or unspecified IP literal']
+    : [];
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {

--- a/src/auth/embedded-as/dcrPolicy.ts
+++ b/src/auth/embedded-as/dcrPolicy.ts
@@ -18,11 +18,7 @@ const MAX_STRING_METADATA_LENGTH = 256;
 const SUPPORTED_SCOPES = new Set(['openid', 'offline_access', 'profile', 'email', 'mcp']);
 const SUPPORTED_GRANT_TYPES = new Set(['authorization_code', 'refresh_token']);
 const SUPPORTED_RESPONSE_TYPES = new Set(['code']);
-const SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS = new Set([
-  'none',
-  'client_secret_basic',
-  'client_secret_post',
-]);
+const SUPPORTED_TOKEN_ENDPOINT_AUTH_METHODS = new Set(['none']);
 
 const FORBIDDEN_OPEN_DCR_METADATA = new Set([
   'client_id',
@@ -51,6 +47,18 @@ export interface DcrPolicyDecision {
   allowed: boolean;
   errors: string[];
   redirectHosts: string[];
+  auditFindings: DcrPolicyAuditFinding[];
+}
+
+export interface DcrPolicyAuditFinding {
+  type: 'metadata_host_mismatch';
+  field: string;
+  host: string;
+  redirectHosts: string[];
+}
+
+export interface RedirectUriPolicyOptions {
+  applicationType?: string;
 }
 
 export function validateDcrClientMetadata(input: unknown): DcrPolicyDecision {
@@ -61,6 +69,7 @@ export function validateDcrClientMetadata(input: unknown): DcrPolicyDecision {
       allowed: false,
       errors: ['registration request body must be a JSON object'],
       redirectHosts: [],
+      auditFindings: [],
     };
   }
 
@@ -74,7 +83,10 @@ export function validateDcrClientMetadata(input: unknown): DcrPolicyDecision {
     required: true,
     maxItems: MAX_REDIRECT_URIS,
   });
-  const redirectResults = redirectUris.map(validateRedirectUriShape);
+  const applicationType = typeof metadata.application_type === 'string'
+    ? metadata.application_type
+    : undefined;
+  const redirectResults = redirectUris.map((uri) => validateRedirectUriShape(uri, { applicationType }));
   for (const result of redirectResults) {
     errors.push(...result.errors.map((error) => `redirect_uris entry ${result.uri}: ${error}`));
   }
@@ -96,15 +108,20 @@ export function validateDcrClientMetadata(input: unknown): DcrPolicyDecision {
       .map((result) => result.host)
       .filter((host): host is string => typeof host === 'string' && host.length > 0),
   ));
+  const auditFindings = collectMetadataAuditFindings(metadata, redirectHosts);
 
   return {
     allowed: errors.length === 0,
     errors,
     redirectHosts,
+    auditFindings,
   };
 }
 
-export function validateRedirectUriShape(uri: string): RedirectUriPolicyResult {
+export function validateRedirectUriShape(
+  uri: string,
+  options: RedirectUriPolicyOptions = {},
+): RedirectUriPolicyResult {
   const errors: string[] = [];
   if (typeof uri !== 'string' || uri.trim() !== uri || uri.length === 0) {
     return { ok: false, uri: String(uri), errors: ['must be a non-empty string without surrounding whitespace'] };
@@ -132,6 +149,9 @@ export function validateRedirectUriShape(uri: string): RedirectUriPolicyResult {
 
   if (parsed.protocol === 'http:') {
     if (!loopback) errors.push('http callbacks are allowed only for loopback clients');
+    if (loopback && options.applicationType !== 'native') {
+      errors.push('http loopback callbacks require application_type "native"');
+    }
   } else if (parsed.protocol !== 'https:') {
     errors.push('must use https, or http for loopback clients');
   }
@@ -278,6 +298,39 @@ function validateIdTokenAlg(value: unknown, errors: string[]): void {
   if (value === undefined) return;
   if (value !== 'ES256') {
     errors.push('id_token_signed_response_alg must be ES256 when provided');
+  }
+}
+
+function collectMetadataAuditFindings(
+  metadata: Record<string, unknown>,
+  redirectHosts: string[],
+): DcrPolicyAuditFinding[] {
+  if (redirectHosts.length === 0) return [];
+  const findings: DcrPolicyAuditFinding[] = [];
+  const redirectHostSet = new Set(redirectHosts);
+  for (const field of ['client_uri', 'logo_uri', 'policy_uri', 'tos_uri']) {
+    const value = metadata[field];
+    if (typeof value !== 'string') continue;
+    const host = safeHttpsMetadataHost(value);
+    if (!host || redirectHostSet.has(host)) continue;
+    findings.push({
+      type: 'metadata_host_mismatch',
+      field,
+      host,
+      redirectHosts,
+    });
+  }
+  return findings;
+}
+
+function safeHttpsMetadataHost(value: string): string | null {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== 'https:') return null;
+    const host = normalizeUrlHostname(parsed.hostname);
+    return host || null;
+  } catch {
+    return null;
   }
 }
 

--- a/src/auth/embedded-as/dcrPolicyMiddleware.ts
+++ b/src/auth/embedded-as/dcrPolicyMiddleware.ts
@@ -1,0 +1,147 @@
+/**
+ * Open Dynamic Client Registration handler for issue #2220.
+ *
+ * oidc-provider's built-in registration policies require Initial Access
+ * Tokens. Hosted MCP clients such as Claude/Gemini auto-register without
+ * IATs, so open-DCR uses this first-party handler: validate callback shape,
+ * construct an oidc-provider Client, store it through the provider adapter,
+ * and return RFC 7591-style client metadata.
+ */
+
+import { randomBytes } from 'node:crypto';
+import express, { type RequestHandler } from 'express';
+import { logger } from '../../utils/logger.js';
+import { validateDcrClientMetadata } from './dcrPolicy.js';
+
+const DCR_BODY_LIMIT = '16kb';
+const MAX_CLIENT_ID_ATTEMPTS = 5;
+const DCR_RATE_LIMIT_WINDOW_MS = 60_000;
+const DCR_RATE_LIMIT_MAX_REQUESTS = 60;
+
+export interface DcrClientInstance {
+  clientId: string;
+  metadata(): Record<string, unknown>;
+}
+
+export interface DcrClientConstructor {
+  new (metadata: Record<string, unknown>): DcrClientInstance;
+  find(id: string): Promise<DcrClientInstance | undefined>;
+  adapter: {
+    upsert(id: string, payload: Record<string, unknown>): Promise<void>;
+  };
+}
+
+export interface DcrProvider {
+  Client: DcrClientConstructor;
+}
+
+interface DcrRateLimitBucket {
+  count: number;
+  resetAt: number;
+}
+
+export function createOpenDcrRegistrationHandlers(options: {
+  ensureProvider: () => Promise<DcrProvider>;
+}): RequestHandler[] {
+  const rateLimitBuckets = new Map<string, DcrRateLimitBucket>();
+
+  return [
+    express.json({ type: 'application/json', limit: DCR_BODY_LIMIT }),
+    (req, res, next) => {
+      void (async () => {
+        const rateLimit = consumeRateLimit(rateLimitBuckets, req.ip ?? req.socket.remoteAddress ?? 'unknown');
+        if (!rateLimit.allowed) {
+          res.set('Retry-After', String(Math.ceil(rateLimit.retryAfterMs / 1000)));
+          res.status(429).json({
+            error: 'too_many_requests',
+            error_description: 'dynamic client registration rate limit exceeded',
+          });
+          return;
+        }
+
+        const decision = validateDcrClientMetadata(req.body);
+        if (!decision.allowed) {
+          logger.warn('[EmbeddedAuthorizationServer] open DCR registration rejected by policy', {
+            errors: decision.errors,
+            ip: req.ip,
+          });
+          res.status(400).json({
+            error: 'invalid_client_metadata',
+            error_description: decision.errors.join('; '),
+          });
+          return;
+        }
+
+        const provider = await options.ensureProvider();
+        const metadata = await buildClientMetadata(req.body, provider.Client);
+        const client = new provider.Client(metadata);
+        await provider.Client.adapter.upsert(client.clientId, client.metadata());
+
+        res.set({
+          'Cache-Control': 'no-store',
+          Pragma: 'no-cache',
+        });
+        res.status(201).json(client.metadata());
+      })().catch(next);
+    },
+  ];
+}
+
+function consumeRateLimit(
+  buckets: Map<string, DcrRateLimitBucket>,
+  key: string,
+): { allowed: true } | { allowed: false; retryAfterMs: number } {
+  const now = Date.now();
+  if (buckets.size > 1000) {
+    for (const [bucketKey, bucket] of buckets) {
+      if (bucket.resetAt <= now) buckets.delete(bucketKey);
+    }
+  }
+
+  const current = buckets.get(key);
+  if (!current || current.resetAt <= now) {
+    buckets.set(key, { count: 1, resetAt: now + DCR_RATE_LIMIT_WINDOW_MS });
+    return { allowed: true };
+  }
+  if (current.count >= DCR_RATE_LIMIT_MAX_REQUESTS) {
+    return { allowed: false, retryAfterMs: current.resetAt - now };
+  }
+  current.count += 1;
+  return { allowed: true };
+}
+
+async function buildClientMetadata(input: unknown, Client: DcrClientConstructor): Promise<Record<string, unknown>> {
+  const body = input && typeof input === 'object' && !Array.isArray(input)
+    ? input as Record<string, unknown>
+    : {};
+  const metadata: Record<string, unknown> = { ...body };
+
+  metadata.client_id = await generateUniqueClientId(Client);
+  metadata.client_id_issued_at = Math.floor(Date.now() / 1000);
+  metadata.id_token_signed_response_alg ??= 'ES256';
+  metadata.token_endpoint_auth_method ??= 'none';
+  metadata.grant_types ??= ['authorization_code', 'refresh_token'];
+  metadata.response_types ??= ['code'];
+
+  if (
+    metadata.token_endpoint_auth_method === 'client_secret_basic'
+    || metadata.token_endpoint_auth_method === 'client_secret_post'
+  ) {
+    metadata.client_secret = randomBytes(32).toString('base64url');
+    metadata.client_secret_expires_at = 0;
+  } else {
+    delete metadata.client_secret;
+    delete metadata.client_secret_expires_at;
+  }
+
+  return metadata;
+}
+
+async function generateUniqueClientId(Client: DcrClientConstructor): Promise<string> {
+  for (let attempt = 0; attempt < MAX_CLIENT_ID_ATTEMPTS; attempt += 1) {
+    const candidate = `dcr_${randomBytes(18).toString('base64url')}`;
+    const existing = await Client.find(candidate);
+    if (!existing) return candidate;
+  }
+  throw new Error('failed to allocate a unique dynamic client id');
+}

--- a/src/auth/embedded-as/dcrPolicyMiddleware.ts
+++ b/src/auth/embedded-as/dcrPolicyMiddleware.ts
@@ -30,7 +30,7 @@ export interface DcrClientInstance {
 export interface DcrClientConstructor {
   new (metadata: Record<string, unknown>): DcrClientInstance;
   find(id: string): Promise<DcrClientInstance | undefined>;
-  adapter: {
+  adapter?: {
     upsert(id: string, payload: Record<string, unknown>): Promise<void>;
   };
 }
@@ -119,7 +119,7 @@ export function createOpenDcrRegistrationHandlers(options: {
         const provider = await options.ensureProvider();
         const metadata = await buildClientMetadata(req.body, provider.Client);
         const client = new provider.Client(metadata);
-        await provider.Client.adapter.upsert(client.clientId, client.metadata());
+        await upsertClientMetadata(provider.Client, client.clientId, client.metadata());
         await recordDcrAuditEvent(options.storage, {
           type: 'auth.dcr.registration_accepted',
           details: buildDcrAuditDetails(metadata, ip, {
@@ -199,6 +199,17 @@ async function buildClientMetadata(input: unknown, Client: DcrClientConstructor)
   delete metadata.client_secret_expires_at;
 
   return metadata;
+}
+
+async function upsertClientMetadata(
+  Client: DcrClientConstructor,
+  clientId: string,
+  metadata: Record<string, unknown>,
+): Promise<void> {
+  if (!Client.adapter) {
+    throw new Error('dynamic client adapter is unavailable');
+  }
+  await Client.adapter.upsert(clientId, metadata);
 }
 
 async function generateUniqueClientId(Client: DcrClientConstructor): Promise<string> {

--- a/src/auth/embedded-as/dcrPolicyMiddleware.ts
+++ b/src/auth/embedded-as/dcrPolicyMiddleware.ts
@@ -11,12 +11,16 @@
 import { randomBytes } from 'node:crypto';
 import express, { type RequestHandler } from 'express';
 import { logger } from '../../utils/logger.js';
-import { validateDcrClientMetadata } from './dcrPolicy.js';
+import { validateDcrClientMetadata, type DcrPolicyAuditFinding } from './dcrPolicy.js';
+import { normalizeIp } from './rateLimit.js';
+import type { IAuthStorageLayer, IdentityAuditEvent } from './storage/IAuthStorageLayer.js';
+import type { IRateLimitStore } from './storage/IRateLimitStore.js';
 
 const DCR_BODY_LIMIT = '16kb';
 const MAX_CLIENT_ID_ATTEMPTS = 5;
 const DCR_RATE_LIMIT_WINDOW_MS = 60_000;
 const DCR_RATE_LIMIT_MAX_REQUESTS = 60;
+const DCR_RATE_LIMIT_SCOPE = 'open_dcr_registration';
 
 export interface DcrClientInstance {
   clientId: string;
@@ -35,23 +39,38 @@ export interface DcrProvider {
   Client: DcrClientConstructor;
 }
 
-interface DcrRateLimitBucket {
+interface DcrRateLimitState {
   count: number;
-  resetAt: number;
+  windowStartedAt: number;
+  limitFired?: boolean;
 }
+
+type DcrRateLimitDecision =
+  | { allowed: true }
+  | { allowed: false; retryAfterMs: number; event?: 'limit_crossed' };
 
 export function createOpenDcrRegistrationHandlers(options: {
   ensureProvider: () => Promise<DcrProvider>;
+  rateLimitStore: IRateLimitStore;
+  storage: IAuthStorageLayer;
 }): RequestHandler[] {
-  const rateLimitBuckets = new Map<string, DcrRateLimitBucket>();
-
   return [
-    express.json({ type: 'application/json', limit: DCR_BODY_LIMIT }),
     (req, res, next) => {
       void (async () => {
-        const rateLimit = consumeRateLimit(rateLimitBuckets, req.ip ?? req.socket.remoteAddress ?? 'unknown');
+        const ip = normalizeIp(req.ip ?? req.socket.remoteAddress ?? 'unknown');
+        const rateLimit = await consumeRateLimit(options.rateLimitStore, ip);
         if (!rateLimit.allowed) {
           res.set('Retry-After', String(Math.ceil(rateLimit.retryAfterMs / 1000)));
+          if (rateLimit.event === 'limit_crossed') {
+            await recordDcrAuditEvent(options.storage, {
+              type: 'auth.dcr.registration_rejected',
+              details: {
+                reason: 'rate limit exceeded',
+                ip,
+              },
+              timestamp: Date.now(),
+            });
+          }
           res.status(429).json({
             error: 'too_many_requests',
             error_description: 'dynamic client registration rate limit exceeded',
@@ -59,11 +78,36 @@ export function createOpenDcrRegistrationHandlers(options: {
           return;
         }
 
+        next();
+      })().catch((err) => {
+        logger.warn('[EmbeddedAuthorizationServer] open DCR rate-limit store failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        res.set('Retry-After', '30');
+        res.status(503).json({
+          error: 'temporarily_unavailable',
+          error_description: 'dynamic client registration is temporarily unavailable',
+        });
+      });
+    },
+    express.json({ type: 'application/json', limit: DCR_BODY_LIMIT }),
+    (req, res, next) => {
+      void (async () => {
+        const ip = normalizeIp(req.ip ?? req.socket.remoteAddress ?? 'unknown');
         const decision = validateDcrClientMetadata(req.body);
         if (!decision.allowed) {
           logger.warn('[EmbeddedAuthorizationServer] open DCR registration rejected by policy', {
             errors: decision.errors,
-            ip: req.ip,
+            ip,
+          });
+          await recordDcrAuditEvent(options.storage, {
+            type: 'auth.dcr.registration_rejected',
+            details: buildDcrAuditDetails(req.body, ip, {
+              errors: decision.errors,
+              redirectHosts: decision.redirectHosts,
+              auditFindings: decision.auditFindings,
+            }),
+            timestamp: Date.now(),
           });
           res.status(400).json({
             error: 'invalid_client_metadata',
@@ -76,6 +120,15 @@ export function createOpenDcrRegistrationHandlers(options: {
         const metadata = await buildClientMetadata(req.body, provider.Client);
         const client = new provider.Client(metadata);
         await provider.Client.adapter.upsert(client.clientId, client.metadata());
+        await recordDcrAuditEvent(options.storage, {
+          type: 'auth.dcr.registration_accepted',
+          details: buildDcrAuditDetails(metadata, ip, {
+            clientId: client.clientId,
+            redirectHosts: decision.redirectHosts,
+            auditFindings: decision.auditFindings,
+          }),
+          timestamp: Date.now(),
+        });
 
         res.set({
           'Cache-Control': 'no-store',
@@ -87,27 +140,47 @@ export function createOpenDcrRegistrationHandlers(options: {
   ];
 }
 
-function consumeRateLimit(
-  buckets: Map<string, DcrRateLimitBucket>,
+async function consumeRateLimit(
+  store: IRateLimitStore,
   key: string,
-): { allowed: true } | { allowed: false; retryAfterMs: number } {
+): Promise<DcrRateLimitDecision> {
   const now = Date.now();
-  if (buckets.size > 1000) {
-    for (const [bucketKey, bucket] of buckets) {
-      if (bucket.resetAt <= now) buckets.delete(bucketKey);
-    }
-  }
+  const update = await store.update<DcrRateLimitState, DcrRateLimitDecision>(
+    DCR_RATE_LIMIT_SCOPE,
+    key,
+    (prev) => {
+      if (!prev || now - prev.windowStartedAt >= DCR_RATE_LIMIT_WINDOW_MS) {
+        return {
+          state: { count: 1, windowStartedAt: now },
+          result: { allowed: true },
+        };
+      }
 
-  const current = buckets.get(key);
-  if (!current || current.resetAt <= now) {
-    buckets.set(key, { count: 1, resetAt: now + DCR_RATE_LIMIT_WINDOW_MS });
-    return { allowed: true };
-  }
-  if (current.count >= DCR_RATE_LIMIT_MAX_REQUESTS) {
-    return { allowed: false, retryAfterMs: current.resetAt - now };
-  }
-  current.count += 1;
-  return { allowed: true };
+      const retryAfterMs = Math.max(1, DCR_RATE_LIMIT_WINDOW_MS - (now - prev.windowStartedAt));
+      if (prev.count >= DCR_RATE_LIMIT_MAX_REQUESTS) {
+        const state = prev.limitFired ? prev : { ...prev, limitFired: true };
+        return {
+          state,
+          result: {
+            allowed: false,
+            retryAfterMs,
+            ...(prev.limitFired ? {} : { event: 'limit_crossed' as const }),
+          },
+        };
+      }
+
+      const next = { ...prev, count: prev.count + 1 };
+      return {
+        state: next,
+        result: { allowed: true },
+      };
+    },
+    {
+      expiresAt: now + DCR_RATE_LIMIT_WINDOW_MS * 2,
+      maxRetries: 5,
+    },
+  );
+  return update.result ?? { allowed: true };
 }
 
 async function buildClientMetadata(input: unknown, Client: DcrClientConstructor): Promise<Record<string, unknown>> {
@@ -122,17 +195,8 @@ async function buildClientMetadata(input: unknown, Client: DcrClientConstructor)
   metadata.token_endpoint_auth_method ??= 'none';
   metadata.grant_types ??= ['authorization_code', 'refresh_token'];
   metadata.response_types ??= ['code'];
-
-  if (
-    metadata.token_endpoint_auth_method === 'client_secret_basic'
-    || metadata.token_endpoint_auth_method === 'client_secret_post'
-  ) {
-    metadata.client_secret = randomBytes(32).toString('base64url');
-    metadata.client_secret_expires_at = 0;
-  } else {
-    delete metadata.client_secret;
-    delete metadata.client_secret_expires_at;
-  }
+  delete metadata.client_secret;
+  delete metadata.client_secret_expires_at;
 
   return metadata;
 }
@@ -144,4 +208,45 @@ async function generateUniqueClientId(Client: DcrClientConstructor): Promise<str
     if (!existing) return candidate;
   }
   throw new Error('failed to allocate a unique dynamic client id');
+}
+
+async function recordDcrAuditEvent(storage: IAuthStorageLayer, event: IdentityAuditEvent): Promise<void> {
+  try {
+    await storage.recordIdentityEvent(event);
+  } catch (err) {
+    logger.warn('[EmbeddedAuthorizationServer] failed to record open DCR audit event', {
+      type: event.type,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function buildDcrAuditDetails(
+  metadata: unknown,
+  ip: string,
+  context: {
+    clientId?: string;
+    errors?: string[];
+    redirectHosts: string[];
+    auditFindings: DcrPolicyAuditFinding[];
+  },
+): Record<string, unknown> {
+  const body = metadata && typeof metadata === 'object' && !Array.isArray(metadata)
+    ? metadata as Record<string, unknown>
+    : {};
+  return {
+    ip,
+    clientId: context.clientId,
+    clientName: stringValue(body.client_name),
+    redirectHosts: context.redirectHosts,
+    redirectUriCount: Array.isArray(body.redirect_uris) ? body.redirect_uris.length : undefined,
+    applicationType: stringValue(body.application_type),
+    tokenEndpointAuthMethod: stringValue(body.token_endpoint_auth_method),
+    errors: context.errors,
+    metadataAuditFindings: context.auditFindings,
+  };
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }

--- a/src/auth/embedded-as/methods/GithubSocialMethod.ts
+++ b/src/auth/embedded-as/methods/GithubSocialMethod.ts
@@ -24,7 +24,8 @@
  *   2. User authorizes on github.com.
  *   3. GitHub redirects to our /auth/social/github/callback?code=..&state=..
  *      handler, which calls processCallback() to do the OAuth exchange and
- *      identity fetch, then drives provider.interactionFinished out-of-band.
+ *      identity fetch, then renders hosted OAuth-client consent before
+ *      provider.interactionFinished can issue an authorization code.
  *
  * @module auth/embedded-as/methods/GithubSocialMethod
  */

--- a/src/auth/embedded-as/methods/GithubSocialMethod.ts
+++ b/src/auth/embedded-as/methods/GithubSocialMethod.ts
@@ -41,7 +41,7 @@ import type {
   InteractionStep,
 } from '../IAuthMethod.js';
 import { renderInteractionBindingError, verifyInteractionCookieMatches } from '../interactionCookieBinding.js';
-import { finishInteractionWithIdentity } from '../InteractionRouter.js';
+import { renderClientConsentForIdentity } from '../InteractionRouter.js';
 import type { IAuthStorageLayer } from '../storage/IAuthStorageLayer.js';
 import { isBootstrapAdminFor } from '../bootstrapAdmin.js';
 import { checkAllowlistGate, renderAllowlistDeniedPage } from '../allowlistGate.js';
@@ -270,7 +270,7 @@ export class GithubSocialMethod implements IAuthMethod {
           // interactionDetails reads the correct interaction record.
           req.url = `/interaction/${result.interactionId}`;
           const details = await provider.interactionDetails(req, res);
-          await finishInteractionWithIdentity(req, res, provider, details, result.identity.sub, deps.storage, deps.defaultResource);
+          await renderClientConsentForIdentity(res, provider, details, result.identity.sub, deps.storage, deps.defaultResource);
         } catch (err) {
           next(err);
         }

--- a/src/auth/embedded-as/methods/GithubSocialMethod.ts
+++ b/src/auth/embedded-as/methods/GithubSocialMethod.ts
@@ -270,7 +270,23 @@ export class GithubSocialMethod implements IAuthMethod {
           // interactionDetails reads the correct interaction record.
           req.url = `/interaction/${result.interactionId}`;
           const details = await provider.interactionDetails(req, res);
-          await renderClientConsentForIdentity(res, provider, details, result.identity.sub, deps.storage, deps.defaultResource);
+          await renderClientConsentForIdentity(
+            res,
+            provider,
+            details,
+            result.identity.sub,
+            deps.storage,
+            deps.defaultResource,
+            {
+              sub: result.identity.sub,
+              displayName: result.identity.displayName,
+              email: result.identity.email,
+              provider: GITHUB_PROVIDER,
+              providerUsername: typeof result.identity.raw?.githubUsername === 'string'
+                ? result.identity.raw.githubUsername
+                : undefined,
+            },
+          );
         } catch (err) {
           next(err);
         }
@@ -304,6 +320,7 @@ export class GithubSocialMethod implements IAuthMethod {
       displayName: profile.name ?? profile.login,
       email: profile.verifiedPrimaryEmail,
       emailVerified: true, // We only got here if the verified-primary lookup succeeded.
+      raw: { githubUsername: profile.login },
     };
 
     // Sign-in allowlist gate. Runs BEFORE any account write so a denied

--- a/src/auth/embedded-as/methods/MagicLinkMethod.ts
+++ b/src/auth/embedded-as/methods/MagicLinkMethod.ts
@@ -6,7 +6,8 @@
  * must-fix list:
  *   - #1 GET shows a "Click to sign in" confirmation page; consumption
  *     happens only on POST. Email pre-fetchers (corporate antivirus,
- *     Outlook etc.) hit GET and don't consume the token.
+ *     Outlook etc.) hit GET and don't consume the token. A successful
+ *     POST renders hosted OAuth-client consent before tokens are minted.
  *   - #2 account-enumeration prevention: /auth/email/request returns
  *     identical responses (200 + same body, equivalent timing) whether
  *     the email exists or not. Implementation: always claim "if that
@@ -38,7 +39,7 @@ import type {
   InteractionStep,
 } from '../IAuthMethod.js';
 import { renderInteractionBindingError, verifyInteractionCookieMatches } from '../interactionCookieBinding.js';
-import { finishInteractionWithIdentity } from '../InteractionRouter.js';
+import { renderClientConsentForIdentity } from '../InteractionRouter.js';
 import type { IAuthStorageLayer } from '../storage/IAuthStorageLayer.js';
 import type { IRateLimitStore } from '../storage/IRateLimitStore.js';
 import type { InviteTokenStore } from '../inviteTokens.js';
@@ -182,11 +183,12 @@ export class MagicLinkMethod implements IAuthMethod {
   /**
    * Mounts the magic-link callback flow:
    *   GET  /auth/email/verify?token=<token>   — anti-pre-fetch confirmation page (must-fix #1)
-   *   POST /auth/email/verify                 — consume token + complete OAuth interaction
+   *   POST /auth/email/verify                 — consume token + render OAuth client consent
    *
-   * The POST handler restores the original interaction URL and drives
-   * provider.interactionFinished after verifying the calling browser
-   * holds the same `_interaction` cookie that started the flow.
+   * The POST handler restores the original interaction URL and renders
+   * hosted OAuth-client consent after verifying the calling browser holds
+   * the same `_interaction` cookie that started the flow. The consent
+   * approval POST eventually drives provider.interactionFinished.
    */
   contributeRoutes(router: Router, deps: ContributeRoutesDeps): void {
     const bodyParser = express.urlencoded({ extended: false, limit: '4kb' });
@@ -264,7 +266,20 @@ export class MagicLinkMethod implements IAuthMethod {
           // interactionDetails reads the correct interaction record.
           req.url = `/interaction/${consume.interactionId}`;
           const details = await provider.interactionDetails(req, res);
-          await finishInteractionWithIdentity(req, res, provider, details, consume.identity.sub, deps.storage, deps.defaultResource);
+          await renderClientConsentForIdentity(
+            res,
+            provider,
+            details,
+            consume.identity.sub,
+            deps.storage,
+            deps.defaultResource,
+            {
+              sub: consume.identity.sub,
+              displayName: consume.identity.displayName,
+              email: consume.identity.email,
+              provider: PROVIDER_NAME,
+            },
+          );
         } catch (err) {
           next(err);
         }

--- a/src/auth/embedded-as/securityHeaders.ts
+++ b/src/auth/embedded-as/securityHeaders.ts
@@ -1,14 +1,19 @@
 /**
  * securityHeaders
  *
- * Middleware that emits the four security headers every response from
- * the embedded AS should carry (must-fix #7 + Phase 7 follow-ups):
+ * Middleware that emits the security headers every response from the embedded
+ * AS should carry (must-fix #7 + Phase 7 follow-ups):
  *
- *   - `Content-Security-Policy: frame-ancestors 'none'`
+ *   - `Content-Security-Policy`
+ *     Blocks scripts and object/embed content, limits forms and static assets
+ *     to this AS, and rejects all framing. Auth pages use inline CSS today, so
+ *     the middleware injects a per-response nonce into `<style>` tags rather
+ *     than allowing all inline styles.
+ *
  *   - `X-Frame-Options: DENY`
- *     Both prevent the consent page (and any future login forms) from
- *     being embedded in an attacker-controlled iframe — which would
- *     otherwise allow clickjacking the "Approve Connector" button.
+ *     Prevents the consent page (and any future login forms) from being
+ *     embedded in an attacker-controlled iframe — which would otherwise allow
+ *     clickjacking the "Approve Connector" button.
  *
  *   - `Cache-Control: no-store`
  *     Auth pages MUST NOT be cached by intermediaries or browser back-
@@ -30,11 +35,46 @@
  * @module auth/embedded-as/securityHeaders
  */
 
+import { randomBytes } from 'node:crypto';
 import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+const STYLE_TAG_WITHOUT_NONCE = /<style\b(?![^>]*\bnonce=)([^>]*)>/gi;
+
+export function buildContentSecurityPolicy(styleNonce: string): string {
+  return [
+    "default-src 'none'",
+    "base-uri 'none'",
+    "frame-ancestors 'none'",
+    "form-action 'self'",
+    "img-src 'self' data:",
+    "font-src 'self'",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "script-src 'none'",
+    `style-src 'self' 'nonce-${styleNonce}'`,
+  ].join('; ');
+}
+
+function createCspNonce(): string {
+  return randomBytes(16).toString('base64url');
+}
+
+function addStyleNonce(body: unknown, styleNonce: string): unknown {
+  if (typeof body !== 'string' || !body.includes('<style')) {
+    return body;
+  }
+
+  return body.replace(STYLE_TAG_WITHOUT_NONCE, `<style nonce="${styleNonce}"$1>`);
+}
 
 export function securityHeaders(): RequestHandler {
   return (_req: Request, res: Response, next: NextFunction): void => {
-    res.setHeader('Content-Security-Policy', "frame-ancestors 'none'");
+    const styleNonce = createCspNonce();
+    const send = res.send.bind(res);
+
+    res.send = ((body?: unknown): Response => send(addStyleNonce(body, styleNonce))) as Response['send'];
+
+    res.setHeader('Content-Security-Policy', buildContentSecurityPolicy(styleNonce));
     res.setHeader('X-Frame-Options', 'DENY');
     res.setHeader('Cache-Control', 'no-store');
     res.setHeader('Pragma', 'no-cache');

--- a/src/auth/embedded-as/storage/PostgresRateLimitStore.ts
+++ b/src/auth/embedded-as/storage/PostgresRateLimitStore.ts
@@ -57,7 +57,7 @@ export class PostgresRateLimitStore implements IRateLimitStore {
         `) as RateLimitRow[];
         const current = rows[0];
         const next = compute((current?.state ?? null) as TState | null);
-        const expiresAt = options.expiresAt === undefined ? null : new Date(options.expiresAt);
+        const expiresAt = options.expiresAt === undefined ? null : new Date(options.expiresAt).toISOString();
 
         if (next.state === null) {
           if (!current) return next;
@@ -81,7 +81,7 @@ export class PostgresRateLimitStore implements IRateLimitStore {
           // the winner's compute() result with ours.
           const inserted = await tx.execute(sql`
             INSERT INTO rate_limit_state (scope, key, state, expires_at)
-            VALUES (${scope}, ${key}, ${JSON.stringify(next.state)}::jsonb, ${expiresAt})
+            VALUES (${scope}, ${key}, ${JSON.stringify(next.state)}::jsonb, ${expiresAt}::timestamptz)
             ON CONFLICT (scope, key) DO NOTHING
             RETURNING version
           `) as unknown[];
@@ -92,7 +92,7 @@ export class PostgresRateLimitStore implements IRateLimitStore {
           UPDATE rate_limit_state
           SET state = ${JSON.stringify(next.state)}::jsonb,
               version = version + 1,
-              expires_at = ${expiresAt},
+              expires_at = ${expiresAt}::timestamptz,
               updated_at = NOW()
           WHERE scope = ${scope} AND key = ${key} AND version = ${current.version}
           RETURNING version

--- a/tests/integration/auth/oauth-flow-helpers.ts
+++ b/tests/integration/auth/oauth-flow-helpers.ts
@@ -243,3 +243,29 @@ export async function followToCodeRedirect(opts: {
   }
   throw new Error('Did not land on client redirect_uri with code');
 }
+
+export async function approveClientConsentPage(opts: {
+  baseUrl: string;
+  response: Response;
+  jar: CookieJar;
+}): Promise<Response> {
+  opts.jar.ingest(opts.response.headers);
+  const html = await opts.response.text();
+  const csrfMatch = /name="csrf_token"\s+value="([^"]+)"/.exec(html);
+  if (!csrfMatch) throw new Error('CSRF token not found in client consent page');
+  const formAction = /<form[^>]*action="([^"]+)"/i.exec(html)?.[1];
+  if (!formAction) throw new Error('Client consent form action not found');
+
+  return fetch(absoluteUrl(opts.baseUrl, formAction), {
+    method: 'POST',
+    redirect: 'manual',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Cookie: opts.jar.header(),
+    },
+    body: new URLSearchParams({
+      csrf_token: csrfMatch[1],
+      action: 'authorize_oauth_client',
+    }),
+  });
+}

--- a/tests/integration/auth/oauth-flow-helpers.ts
+++ b/tests/integration/auth/oauth-flow-helpers.ts
@@ -16,6 +16,7 @@ import * as net from 'node:net';
 import { createHash, randomBytes } from 'node:crypto';
 import express, { type Express } from 'express';
 import { EmbeddedAuthorizationServer, type EmbeddedAuthorizationServerOptions } from '../../../src/auth/embedded-as/EmbeddedAuthorizationServer.js';
+import { InMemoryRateLimitStore } from '../../../src/auth/embedded-as/storage/InMemoryRateLimitStore.js';
 
 export function pkceS256(verifier: string): string {
   return createHash('sha256').update(verifier).digest('base64url');
@@ -135,6 +136,7 @@ export async function startASHarness(opts: ASHarnessOptions): Promise<ASHarness>
     publicBaseUrl,
     mcpPath: '/mcp',
     keyFilePath: path.join(tmpDir, 'key.json'),
+    rateLimitStore: opts.rateLimitStore ?? new InMemoryRateLimitStore(),
   });
 
   // Auto-bootstrap so existing E2E tests in multi-user mode aren't blocked

--- a/tests/integration/auth/oauth-flow.admin-endpoint.test.ts
+++ b/tests/integration/auth/oauth-flow.admin-endpoint.test.ts
@@ -23,6 +23,7 @@ import { InMemoryRateLimitStore } from '../../../src/auth/embedded-as/storage/In
 import { randomBytes } from 'node:crypto';
 import {
   type ASHarness,
+  approveClientConsentPage,
   CookieJar,
   followToCodeRedirect,
   startAuthorizeFlow,
@@ -100,10 +101,18 @@ async function loginAsLocalUser(
     invite: inviteToken,
     password: 'a-very-long-password',
   });
-  jar.ingest(consentPost.headers);
+  if (consentPost.status !== 200) {
+    throw new Error(`client consent page returned ${consentPost.status}: ${await consentPost.text()}`);
+  }
+  const approvePost = await approveClientConsentPage({
+    baseUrl: harness.baseUrl,
+    response: consentPost,
+    jar,
+  });
+  jar.ingest(approvePost.headers);
   const code = await followToCodeRedirect({
     baseUrl: harness.baseUrl,
-    start: consentPost.headers.get('location'),
+    start: approvePost.headers.get('location'),
     jar,
     redirectUriPrefix: REDIRECT_URI,
   });

--- a/tests/integration/auth/oauth-flow.cycle24-smoke-test-regressions.test.ts
+++ b/tests/integration/auth/oauth-flow.cycle24-smoke-test-regressions.test.ts
@@ -51,6 +51,7 @@ async function fetchAuthServerMetadata(baseUrl: string) {
     token_endpoint: string;
     issuer: string;
     scopes_supported?: string[];
+    token_endpoint_auth_methods_supported?: string[];
   }>;
 }
 
@@ -102,6 +103,7 @@ describe('Cycle 24 smoke-test regressions', () => {
         body: JSON.stringify({
           redirect_uris: ['http://127.0.0.1:9999/cb'],
           scope: 'openid offline_access mcp profile email',
+          application_type: 'native',
         }),
       });
       expect(res.status).toBe(201);
@@ -156,6 +158,7 @@ describe('Cycle 24 smoke-test regressions', () => {
           body: JSON.stringify({
             redirect_uris: ['http://127.0.0.1:9999/cb'],
             scope,
+            application_type: 'native',
           }),
         });
         expect(res.status).toBe(201);
@@ -174,6 +177,7 @@ describe('Cycle 24 smoke-test regressions', () => {
       expect(meta.scopes_supported).toEqual(
         expect.arrayContaining(['openid', 'offline_access', 'mcp', 'profile', 'email']),
       );
+      expect(meta.token_endpoint_auth_methods_supported).toEqual(['none']);
     });
   });
 

--- a/tests/integration/auth/oauth-flow.cycle24-smoke-test-regressions.test.ts
+++ b/tests/integration/auth/oauth-flow.cycle24-smoke-test-regressions.test.ts
@@ -39,6 +39,7 @@ import { TrivialConsentMethod } from '../../../src/auth/embedded-as/methods/Triv
 import { InMemoryAuthStorageLayer } from '../../../src/auth/embedded-as/storage/InMemoryAuthStorageLayer.js';
 import {
   type ASHarness,
+  approveClientConsentPage,
   followToCodeRedirect,
   startASHarness,
   startAuthorizeFlow,
@@ -244,7 +245,8 @@ describe('Cycle 24 smoke-test regressions', () => {
       expect(csrfMatch).not.toBeNull();
       const csrfToken = csrfMatch![1];
 
-      // POST consent — this is what the user clicking "Approve" does.
+      // POST method consent — this authenticates the user and then renders
+      // the hosted OAuth-client consent page.
       const postConsent = await fetch(interactionUrl, {
         method: 'POST',
         redirect: 'manual',
@@ -254,8 +256,15 @@ describe('Cycle 24 smoke-test regressions', () => {
         },
         body: new URLSearchParams({ csrf_token: csrfToken, action: 'approve' }),
       });
-      expect(postConsent.status).toBe(303);
-      jar.ingest(postConsent.headers);
+      expect(postConsent.status).toBe(200);
+
+      const clientConsent = await approveClientConsentPage({
+        baseUrl: harness.baseUrl,
+        response: postConsent,
+        jar,
+      });
+      expect(clientConsent.status).toBe(303);
+      jar.ingest(clientConsent.headers);
 
       // Walk the post-consent redirect chain. With the cycle-24 dual-
       // dimension grant binding, this lands on REDIRECT_URI?code=... in
@@ -263,7 +272,7 @@ describe('Cycle 24 smoke-test regressions', () => {
       // /interaction and the helper throws.
       const code = await followToCodeRedirect({
         baseUrl: harness.baseUrl,
-        start: postConsent.headers.get('location'),
+        start: clientConsent.headers.get('location'),
         jar,
         redirectUriPrefix: REDIRECT_URI,
       });

--- a/tests/integration/auth/oauth-flow.cycle24-smoke-test-regressions.test.ts
+++ b/tests/integration/auth/oauth-flow.cycle24-smoke-test-regressions.test.ts
@@ -109,6 +109,28 @@ describe('Cycle 24 smoke-test regressions', () => {
       expect(typeof body.client_id).toBe('string');
       expect(body.client_id?.length ?? 0).toBeGreaterThan(0);
     });
+
+    it('openDCR=true: /reg rejects unsafe non-loopback HTTP callbacks', async () => {
+      const storage = new InMemoryAuthStorageLayer();
+      harness = await startASHarness({
+        methods: [new TrivialConsentMethod({ defaultSubject: 'test-user' })],
+        storage,
+        openDCR: true,
+      });
+
+      const res = await fetch(`${harness.baseUrl}/reg`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          redirect_uris: ['http://client.example.com/callback'],
+          scope: 'mcp',
+        }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error?: string; error_description?: string };
+      expect(body.error).toBe('invalid_client_metadata');
+      expect(body.error_description).toContain('http callbacks are allowed only for loopback clients');
+    });
   });
 
   // -------------------------------------------------------------------

--- a/tests/integration/auth/oauth-flow.github.test.ts
+++ b/tests/integration/auth/oauth-flow.github.test.ts
@@ -20,6 +20,7 @@ import { InMemoryAuthStorageLayer } from '../../../src/auth/embedded-as/storage/
 import {
   type ASHarness,
   type CookieJar,
+  approveClientConsentPage,
   followToCodeRedirect,
   getFreePort,
   startAuthorizeFlow,
@@ -163,12 +164,18 @@ describe('GithubSocialMethod — OAuth E2E', () => {
       interactionUrl, jar,
       code: 'gh-fake-code',
     });
-    expect([302, 303]).toContain(callback.status);
-    jar.ingest(callback.headers);
+    expect(callback.status).toBe(200);
+    const clientConsent = await approveClientConsentPage({
+      baseUrl: harness.baseUrl,
+      response: callback,
+      jar,
+    });
+    expect([302, 303]).toContain(clientConsent.status);
+    jar.ingest(clientConsent.headers);
 
     const code = await followToCodeRedirect({
       baseUrl: harness.baseUrl,
-      start: callback.headers.get('location'),
+      start: clientConsent.headers.get('location'),
       jar,
       redirectUriPrefix: REDIRECT_URI,
     });
@@ -216,12 +223,18 @@ describe('GithubSocialMethod — OAuth E2E', () => {
       const cb = await simulateGithubCallback({
         publicBaseUrl: harness.publicBaseUrl, interactionUrl, jar, code: 'gh-fake-code-1',
       });
-      expect([302, 303]).toContain(cb.status);
+      expect(cb.status).toBe(200);
       // Drive the flow to completion so a grant is created in storage.
-      jar.ingest(cb.headers);
+      const clientConsent = await approveClientConsentPage({
+        baseUrl: harness.baseUrl,
+        response: cb,
+        jar,
+      });
+      expect([302, 303]).toContain(clientConsent.status);
+      jar.ingest(clientConsent.headers);
       await followToCodeRedirect({
         baseUrl: harness.baseUrl,
-        start: cb.headers.get('location'),
+        start: clientConsent.headers.get('location'),
         jar,
         redirectUriPrefix: REDIRECT_URI,
       });
@@ -241,7 +254,7 @@ describe('GithubSocialMethod — OAuth E2E', () => {
       const cb = await simulateGithubCallback({
         publicBaseUrl: harness.publicBaseUrl, interactionUrl, jar, code: 'gh-fake-code-2',
       });
-      expect([302, 303]).toContain(cb.status);
+      expect(cb.status).toBe(200);
     }
 
     // Audit event recorded with previous→new email + grants revoked.
@@ -359,12 +372,18 @@ describe('GithubSocialMethod — OAuth E2E', () => {
       publicBaseUrl: harness.publicBaseUrl,
       interactionUrl, jar, code: 'gh-fake-code-admin',
     });
-    expect([302, 303]).toContain(callback.status);
-    jar.ingest(callback.headers);
+    expect(callback.status).toBe(200);
+    const clientConsent = await approveClientConsentPage({
+      baseUrl: harness.baseUrl,
+      response: callback,
+      jar,
+    });
+    expect([302, 303]).toContain(clientConsent.status);
+    jar.ingest(clientConsent.headers);
 
     const code = await followToCodeRedirect({
       baseUrl: harness.baseUrl,
-      start: callback.headers.get('location'),
+      start: clientConsent.headers.get('location'),
       jar, redirectUriPrefix: REDIRECT_URI,
     });
     const tokenResp = await fetch(authServer.token_endpoint, {

--- a/tests/integration/auth/oauth-flow.local-account.test.ts
+++ b/tests/integration/auth/oauth-flow.local-account.test.ts
@@ -25,6 +25,7 @@ import { InMemoryRateLimitStore } from '../../../src/auth/embedded-as/storage/In
 import { randomBytes } from 'node:crypto';
 import {
   type ASHarness,
+  approveClientConsentPage,
   CookieJar,
   followToCodeRedirect,
   startAuthorizeFlow,
@@ -116,13 +117,20 @@ describe('LocalAccountMethod — OAuth E2E', () => {
       invite: inviteToken,
       password: VALID_PASSWORD,
     });
-    expect([302, 303]).toContain(consentPost.status);
-    jar.ingest(consentPost.headers);
+    expect(consentPost.status).toBe(200);
+
+    const approvePost = await approveClientConsentPage({
+      baseUrl: harness.baseUrl,
+      response: consentPost,
+      jar,
+    });
+    expect([302, 303]).toContain(approvePost.status);
+    jar.ingest(approvePost.headers);
 
     // Follow oidc-provider's redirect chain to the client redirect_uri with code.
     const code = await followToCodeRedirect({
       baseUrl: harness.baseUrl,
-      start: consentPost.headers.get('location'),
+      start: approvePost.headers.get('location'),
       jar,
       redirectUriPrefix: REDIRECT_URI,
     });
@@ -211,12 +219,19 @@ describe('LocalAccountMethod — OAuth E2E', () => {
       invite: inviteToken,
       password: VALID_PASSWORD,
     });
-    expect([302, 303]).toContain(consentPost.status);
-    jar.ingest(consentPost.headers);
+    expect(consentPost.status).toBe(200);
+
+    const approvePost = await approveClientConsentPage({
+      baseUrl: harness.baseUrl,
+      response: consentPost,
+      jar,
+    });
+    expect([302, 303]).toContain(approvePost.status);
+    jar.ingest(approvePost.headers);
 
     const code = await followToCodeRedirect({
       baseUrl: harness.baseUrl,
-      start: consentPost.headers.get('location'),
+      start: approvePost.headers.get('location'),
       jar, redirectUriPrefix: REDIRECT_URI,
     });
     const tokenResp = await fetch(authServer.token_endpoint, {
@@ -293,12 +308,19 @@ describe('LocalAccountMethod — OAuth E2E', () => {
       username: 'bob',
       password: VALID_PASSWORD,
     });
-    expect([302, 303]).toContain(consentPost.status);
-    jar.ingest(consentPost.headers);
+    expect(consentPost.status).toBe(200);
+
+    const approvePost = await approveClientConsentPage({
+      baseUrl: harness.baseUrl,
+      response: consentPost,
+      jar,
+    });
+    expect([302, 303]).toContain(approvePost.status);
+    jar.ingest(approvePost.headers);
 
     const code = await followToCodeRedirect({
       baseUrl: harness.baseUrl,
-      start: consentPost.headers.get('location'),
+      start: approvePost.headers.get('location'),
       jar,
       redirectUriPrefix: REDIRECT_URI,
     });

--- a/tests/integration/auth/oauth-flow.local-account.test.ts
+++ b/tests/integration/auth/oauth-flow.local-account.test.ts
@@ -156,6 +156,22 @@ describe('LocalAccountMethod — OAuth E2E', () => {
     expect(typeof decoded.auth_time).toBe('number');
     expect(decoded.auth_time).toBeGreaterThan(0);
 
+    const tokenEvents = await storage.listIdentityEvents({ type: 'auth.oauth.token_issued' });
+    expect(tokenEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sub: 'local_alice',
+          details: expect.objectContaining({
+            providerEvent: 'access_token.issued',
+            tokenKind: 'AccessToken',
+            clientId: CLIENT_ID,
+            scope: 'mcp',
+            audience: `${harness.publicBaseUrl}/mcp`,
+          }),
+        }),
+      ]),
+    );
+
     // Account row in storage carries the password hash on credentials,
     // not rawProfile (B4).
     const stored = await storage.getAccount('local_alice');

--- a/tests/integration/auth/oauth-flow.magic-link.test.ts
+++ b/tests/integration/auth/oauth-flow.magic-link.test.ts
@@ -5,7 +5,7 @@
  * configured with MagicLinkMethod + an in-memory CollectingEmailSender.
  * Asserts the spec-relevant invariants:
  *   - GET /auth/email/verify renders confirmation page (does NOT consume) — must-fix #1
- *   - POST /auth/email/verify completes the OAuth interaction → access_token
+ *   - POST /auth/email/verify renders hosted client consent before access_token
  *   - Account-enumeration: identical response for known and unknown email — must-fix #2
  *   - Per-email rate limit triggers + audit event after threshold — must-fix #3
  *   - Token replay rejected (second consume fails)
@@ -25,6 +25,7 @@ import { InMemoryAuthStorageLayer } from '../../../src/auth/embedded-as/storage/
 import { InMemoryRateLimitStore } from '../../../src/auth/embedded-as/storage/InMemoryRateLimitStore.js';
 import {
   type ASHarness,
+  approveClientConsentPage,
   CookieJar,
   followToCodeRedirect,
   getFreePort,
@@ -153,7 +154,7 @@ describe('MagicLinkMethod — OAuth E2E', () => {
     expect(verifyGet.status).toBe(200);
     expect(await verifyGet.text()).toContain('Confirm sign-in');
 
-    // POST consumes the token + completes the OAuth interaction.
+    // POST consumes the token and renders hosted client consent.
     const tokenParam = new URL(magicUrl).searchParams.get('token')!;
     const verifyPost = await fetch(`${harness.publicBaseUrl}/auth/email/verify`, {
       method: 'POST', redirect: 'manual',
@@ -163,13 +164,20 @@ describe('MagicLinkMethod — OAuth E2E', () => {
       },
       body: new URLSearchParams({ token: tokenParam }),
     });
-    expect([302, 303]).toContain(verifyPost.status);
-    jar.ingest(verifyPost.headers);
+    expect(verifyPost.status).toBe(200);
+
+    const consentPost = await approveClientConsentPage({
+      baseUrl: harness.baseUrl,
+      response: verifyPost,
+      jar,
+    });
+    expect([302, 303]).toContain(consentPost.status);
+    jar.ingest(consentPost.headers);
 
     // Follow the oidc-provider redirect chain to the client redirect_uri.
     const code = await followToCodeRedirect({
       baseUrl: harness.baseUrl,
-      start: verifyPost.headers.get('location'),
+      start: consentPost.headers.get('location'),
       jar,
       redirectUriPrefix: REDIRECT_URI,
     });
@@ -266,8 +274,8 @@ describe('MagicLinkMethod — OAuth E2E', () => {
     await postRequestLinkForm(interactionUrl, jar, 'replay@example.com');
     const tokenParam = new URL(emailSender.sent[0].url).searchParams.get('token')!;
 
-    // First POST consumes (we don't follow the redirect; that path is
-    // already covered by the end-to-end test above).
+    // First POST consumes and renders the client-consent page. We don't
+    // approve it here; this test only cares that the token is consumed.
     const first = await fetch(`${harness.publicBaseUrl}/auth/email/verify`, {
       method: 'POST', redirect: 'manual',
       headers: {
@@ -276,7 +284,7 @@ describe('MagicLinkMethod — OAuth E2E', () => {
       },
       body: new URLSearchParams({ token: tokenParam }),
     });
-    expect([302, 303]).toContain(first.status);
+    expect(first.status).toBe(200);
 
     // Second POST must be rejected (token already consumed).
     const second = await fetch(`${harness.publicBaseUrl}/auth/email/verify`, {
@@ -315,7 +323,8 @@ describe('MagicLinkMethod — OAuth E2E', () => {
     expect(noCookie.status).toBe(400);
 
     // Subsequent POST with the right cookie should still work — the
-    // earlier mismatch must not have consumed the token.
+    // earlier mismatch must not have consumed the token. It now renders
+    // client consent rather than directly redirecting.
     const withCookie = await fetch(`${harness.publicBaseUrl}/auth/email/verify`, {
       method: 'POST', redirect: 'manual',
       headers: {
@@ -324,7 +333,7 @@ describe('MagicLinkMethod — OAuth E2E', () => {
       },
       body: new URLSearchParams({ token: tokenParam }),
     });
-    expect([302, 303]).toContain(withCookie.status);
+    expect(withCookie.status).toBe(200);
   }, 30_000);
 
   it('admin claim: pre-claimed magic-link sub gets roles:["admin"] on JWT (cycle-16)', async () => {
@@ -368,12 +377,19 @@ describe('MagicLinkMethod — OAuth E2E', () => {
       },
       body: new URLSearchParams({ token: tokenParam }),
     });
-    expect([302, 303]).toContain(verifyPost.status);
-    jar.ingest(verifyPost.headers);
+    expect(verifyPost.status).toBe(200);
+
+    const consentPost = await approveClientConsentPage({
+      baseUrl: harness.baseUrl,
+      response: verifyPost,
+      jar,
+    });
+    expect([302, 303]).toContain(consentPost.status);
+    jar.ingest(consentPost.headers);
 
     const code = await followToCodeRedirect({
       baseUrl: harness.baseUrl,
-      start: verifyPost.headers.get('location'),
+      start: consentPost.headers.get('location'),
       jar, redirectUriPrefix: REDIRECT_URI,
     });
     const tokenResp = await fetch(authServer.token_endpoint, {

--- a/tests/integration/auth/oauth-flow.multi-method.test.ts
+++ b/tests/integration/auth/oauth-flow.multi-method.test.ts
@@ -24,6 +24,7 @@ import { InMemoryAuthStorageLayer } from '../../../src/auth/embedded-as/storage/
 import { InMemoryRateLimitStore } from '../../../src/auth/embedded-as/storage/InMemoryRateLimitStore.js';
 import {
   type ASHarness,
+  approveClientConsentPage,
   followToCodeRedirect,
   getFreePort,
   startAuthorizeFlow,
@@ -221,12 +222,19 @@ describe('Multi-method (GitHub + MagicLink) — OAuth E2E', () => {
       },
       body: new URLSearchParams({ token: tokenParam }),
     });
-    expect([302, 303]).toContain(verifyPost.status);
-    jar.ingest(verifyPost.headers);
+    expect(verifyPost.status).toBe(200);
+
+    const consentPost = await approveClientConsentPage({
+      baseUrl: harness.baseUrl,
+      response: verifyPost,
+      jar,
+    });
+    expect([302, 303]).toContain(consentPost.status);
+    jar.ingest(consentPost.headers);
 
     const code = await followToCodeRedirect({
       baseUrl: harness.baseUrl,
-      start: verifyPost.headers.get('location'),
+      start: consentPost.headers.get('location'),
       jar,
       redirectUriPrefix: REDIRECT_URI,
     });

--- a/tests/integration/auth/oauth-flow.refresh-rotation.test.ts
+++ b/tests/integration/auth/oauth-flow.refresh-rotation.test.ts
@@ -30,6 +30,7 @@ import { InMemoryAuthStorageLayer } from '../../../src/auth/embedded-as/storage/
 import { InMemoryRateLimitStore } from '../../../src/auth/embedded-as/storage/InMemoryRateLimitStore.js';
 import {
   type ASHarness,
+  approveClientConsentPage,
   CookieJar,
   followToCodeRedirect,
   startAuthorizeFlow,
@@ -103,12 +104,19 @@ describe('Token reuse-detection — OAuth 2.1 §4.1.3', () => {
     const consentPost = await postConsentForm(interactionUrl, jar, {
       action: 'set-password', invite: inviteToken, password: 'a-very-long-password',
     });
-    expect([302, 303]).toContain(consentPost.status);
-    jar.ingest(consentPost.headers);
+    expect(consentPost.status).toBe(200);
+
+    const approvePost = await approveClientConsentPage({
+      baseUrl: harness.baseUrl,
+      response: consentPost,
+      jar,
+    });
+    expect([302, 303]).toContain(approvePost.status);
+    jar.ingest(approvePost.headers);
 
     const code = await followToCodeRedirect({
       baseUrl: harness.baseUrl,
-      start: consentPost.headers.get('location'),
+      start: approvePost.headers.get('location'),
       jar,
       redirectUriPrefix: REDIRECT_URI,
     });

--- a/tests/integration/auth/oauth-flow.storage-restart.test.ts
+++ b/tests/integration/auth/oauth-flow.storage-restart.test.ts
@@ -34,6 +34,7 @@ import { FilesystemAuthStorageLayer } from '../../../src/auth/embedded-as/storag
 import { InMemoryRateLimitStore } from '../../../src/auth/embedded-as/storage/InMemoryRateLimitStore.js';
 import {
   type ASHarness,
+  approveClientConsentPage,
   CookieJar,
   followToCodeRedirect,
   getFreePort,
@@ -146,12 +147,19 @@ describe('Filesystem storage — AS restart durability', () => {
       invite: inviteToken,
       password: 'a-very-long-password',
     });
-    expect([302, 303]).toContain(consentPost.status);
-    flow1.jar.ingest(consentPost.headers);
+    expect(consentPost.status).toBe(200);
+
+    const approvePost = await approveClientConsentPage({
+      baseUrl: harness.baseUrl,
+      response: consentPost,
+      jar: flow1.jar,
+    });
+    expect([302, 303]).toContain(approvePost.status);
+    flow1.jar.ingest(approvePost.headers);
 
     const code = await followToCodeRedirect({
       baseUrl: harness.baseUrl,
-      start: consentPost.headers.get('location'),
+      start: approvePost.headers.get('location'),
       jar: flow1.jar,
       redirectUriPrefix: REDIRECT_URI,
     });
@@ -209,12 +217,19 @@ describe('Filesystem storage — AS restart durability', () => {
       username: 'persisted',
       password: 'a-very-long-password',
     });
-    expect([302, 303]).toContain(loginPost.status);
-    flow2.jar.ingest(loginPost.headers);
+    expect(loginPost.status).toBe(200);
+
+    const approveLoginPost = await approveClientConsentPage({
+      baseUrl: harness.baseUrl,
+      response: loginPost,
+      jar: flow2.jar,
+    });
+    expect([302, 303]).toContain(approveLoginPost.status);
+    flow2.jar.ingest(approveLoginPost.headers);
 
     const code2 = await followToCodeRedirect({
       baseUrl: harness.baseUrl,
-      start: loginPost.headers.get('location'),
+      start: approveLoginPost.headers.get('location'),
       jar: flow2.jar,
       redirectUriPrefix: REDIRECT_URI,
     });

--- a/tests/unit/auth/embedded-as/EmbeddedAuthorizationServer.assets.test.ts
+++ b/tests/unit/auth/embedded-as/EmbeddedAuthorizationServer.assets.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+import { EmbeddedAuthorizationServer } from '../../../../src/auth/embedded-as/EmbeddedAuthorizationServer.js';
+import { InMemoryAuthStorageLayer } from '../../../../src/auth/embedded-as/storage/InMemoryAuthStorageLayer.js';
+import { TrivialConsentMethod } from '../../../../src/auth/embedded-as/methods/TrivialConsentMethod.js';
+
+function appWithEmbeddedAs(): express.Express {
+  const as = new EmbeddedAuthorizationServer({
+    publicBaseUrl: 'http://127.0.0.1:65530',
+    methods: [new TrivialConsentMethod({ defaultSubject: 'asset-test' })],
+    storage: new InMemoryAuthStorageLayer(),
+  });
+  const app = express();
+  app.use(as.createRouter());
+  return app;
+}
+
+describe('EmbeddedAuthorizationServer — hosted auth assets', () => {
+  it('serves the first-party assets used by generated auth pages', async () => {
+    const app = appWithEmbeddedAs();
+
+    const css = await request(app).get('/fonts.css');
+    expect(css.status).toBe(200);
+    expect(css.headers['content-type']).toContain('text/css');
+    expect(css.text).toContain('@font-face');
+
+    const logo = await request(app).get('/dollhouse-logo.png');
+    expect(logo.status).toBe(200);
+    expect(logo.headers['content-type']).toContain('image/png');
+
+    const font = await request(app).get('/fonts/plusjakartasans-LDIoaomQNQcsA88c7O9yZ4KMCoOg4Ko70yygg_vbd-E.woff2');
+    expect(font.status).toBe(200);
+    expect(font.headers['content-type']).toContain('font/woff2');
+  });
+
+  it('rejects path-shaped font names', async () => {
+    const app = appWithEmbeddedAs();
+
+    const res = await request(app).get('/fonts/not-a-font.txt');
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/auth/embedded-as/InteractionRouter.test.ts
+++ b/tests/unit/auth/embedded-as/InteractionRouter.test.ts
@@ -276,6 +276,13 @@ describe('InteractionRouter — multi-method dispatch', () => {
         'github_42',
         storage,
         'https://mcp.example.com/mcp',
+        {
+          sub: 'github_42',
+          displayName: 'Mick Darling',
+          email: 'mick@example.com',
+          provider: 'github',
+          providerUsername: 'mickdarling',
+        },
       ).catch(next);
     });
     app.use('/interaction', createInteractionRouter({
@@ -295,6 +302,12 @@ describe('InteractionRouter — multi-method dispatch', () => {
       const html = await consent.text();
       expect(html).toContain('Authorize Test Client');
       expect(html).toContain('client.example.com');
+      expect(html).toContain('openid');
+      expect(html).toContain('mcp');
+      expect(html).toContain('https://mcp.example.com/mcp');
+      expect(html).toContain('@mickdarling');
+      expect(html).toContain('mick@example.com');
+      expect(html).toContain('First time this identity is authorizing this client');
       expect(html).toContain('This client will receive OAuth tokens');
       expect(interactionFinished).not.toHaveBeenCalled();
 
@@ -315,6 +328,94 @@ describe('InteractionRouter — multi-method dispatch', () => {
         login: { accountId: 'github_42' },
         consent: { grantId: 'fake-grant-id' },
       });
+
+      const events = await storage.listIdentityEvents({ type: 'auth.client_consent.approved' });
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        sub: 'github_42',
+        details: {
+          clientId: 'c',
+          clientFirstSeenForIdentity: true,
+          callbackHost: 'client.example.com',
+          resource: 'https://mcp.example.com/mcp',
+          scopes: ['openid', 'mcp'],
+        },
+      });
+
+      const secondConsent = await fetch(`${baseUrl}/seed-consent`);
+      const secondHtml = await secondConsent.text();
+      expect(secondHtml).toContain('Previously authorized by this identity');
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it('client-consent denial records an audit event and aborts authorization', async () => {
+    const localDetails: OidcInteractionDetails = {
+      uid: 'client-consent-deny-uid',
+      params: {
+        client_id: 'c',
+        scope: 'openid mcp',
+        redirect_uri: 'https://client.example.com/oauth/callback',
+        resource: 'https://mcp.example.com/mcp',
+      },
+      prompt: { name: 'login', details: {} },
+    };
+    const interactionFinished = jest.fn<OidcProviderForInteractions['interactionFinished']>(
+      async (_req, res) => {
+        if (!res.headersSent) res.status(200).end('denied');
+      },
+    );
+    const provider = fakeProvider({ details: localDetails, interactionFinished });
+    const method = fakeMethod({ id: 'github', displayName: 'GitHub' });
+    const app = express();
+    app.disable('x-powered-by');
+    app.get('/seed-consent', (_req, res, next) => {
+      renderClientConsentForIdentity(
+        res,
+        provider,
+        localDetails,
+        'github_42',
+        storage,
+        'https://mcp.example.com/mcp',
+        { sub: 'github_42', provider: 'github', providerUsername: 'mickdarling' },
+      ).catch(next);
+    });
+    app.use('/interaction', createInteractionRouter({
+      provider,
+      methods: [method],
+      storage,
+      defaultResource: 'https://mcp.example.com/mcp',
+    }));
+    const server = app.listen(0);
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    const port = (server.address() as AddressInfo).port;
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    try {
+      const consent = await fetch(`${baseUrl}/seed-consent`);
+      const html = await consent.text();
+      const csrfMatch = /name="csrf_token"\s+value="([^"]+)"/.exec(html);
+      expect(csrfMatch).not.toBeNull();
+
+      const deny = await fetch(`${baseUrl}/interaction/${localDetails.uid}`, {
+        method: 'POST',
+        redirect: 'manual',
+        headers: { 'content-type': FORM_CONTENT_TYPE },
+        body: new URLSearchParams({
+          csrf_token: csrfMatch![1],
+          action: 'deny_oauth_client',
+        }),
+      });
+
+      expect(deny.status).toBe(200);
+      expect(interactionFinished).toHaveBeenCalledTimes(1);
+      expect(interactionFinished.mock.calls[0][2]).toMatchObject({
+        error: 'access_denied',
+      });
+      const events = await storage.listIdentityEvents({ type: 'auth.client_consent.denied' });
+      expect(events).toHaveLength(1);
+      expect(events[0].sub).toBe('github_42');
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }

--- a/tests/unit/auth/embedded-as/InteractionRouter.test.ts
+++ b/tests/unit/auth/embedded-as/InteractionRouter.test.ts
@@ -341,6 +341,11 @@ describe('InteractionRouter — multi-method dispatch', () => {
           scopes: ['openid', 'mcp'],
         },
       });
+      const seen = await storage.genericGet('ClientConsentSeen', 'github_42:c');
+      expect(seen).toMatchObject({
+        accountId: 'github_42',
+        clientId: 'c',
+      });
 
       const secondConsent = await fetch(`${baseUrl}/seed-consent`);
       const secondHtml = await secondConsent.text();

--- a/tests/unit/auth/embedded-as/InteractionRouter.test.ts
+++ b/tests/unit/auth/embedded-as/InteractionRouter.test.ts
@@ -301,14 +301,18 @@ describe('InteractionRouter — multi-method dispatch', () => {
       expect(consent.status).toBe(200);
       const html = await consent.text();
       expect(html).toContain('Authorize Test Client');
+      expect(html).toContain('DollhouseMCP Authorization');
+      expect(html).toContain('OAuth client authorization');
       expect(html).toContain('client.example.com');
       expect(html).toContain('openid');
       expect(html).toContain('mcp');
+      expect(html).toContain('Use DollhouseMCP tools');
       expect(html).toContain('https://mcp.example.com/mcp');
+      expect(html).toContain('Signed in with GitHub');
       expect(html).toContain('@mickdarling');
       expect(html).toContain('mick@example.com');
-      expect(html).toContain('First time this identity is authorizing this client');
-      expect(html).toContain('This client will receive OAuth tokens');
+      expect(html).toContain('New client for this account');
+      expect(html).toContain('DollhouseMCP will issue OAuth tokens');
       expect(interactionFinished).not.toHaveBeenCalled();
 
       const csrfMatch = /name="csrf_token"\s+value="([^"]+)"/.exec(html);
@@ -349,7 +353,7 @@ describe('InteractionRouter — multi-method dispatch', () => {
 
       const secondConsent = await fetch(`${baseUrl}/seed-consent`);
       const secondHtml = await secondConsent.text();
-      expect(secondHtml).toContain('Previously authorized by this identity');
+      expect(secondHtml).toContain('Previously authorized by this account');
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }

--- a/tests/unit/auth/embedded-as/InteractionRouter.test.ts
+++ b/tests/unit/auth/embedded-as/InteractionRouter.test.ts
@@ -9,7 +9,12 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import express from 'express';
 import type { AddressInfo } from 'node:net';
-import { createInteractionRouter, type OidcProviderForInteractions, type OidcInteractionDetails } from '../../../../src/auth/embedded-as/InteractionRouter.js';
+import {
+  createInteractionRouter,
+  renderClientConsentForIdentity,
+  type OidcProviderForInteractions,
+  type OidcInteractionDetails,
+} from '../../../../src/auth/embedded-as/InteractionRouter.js';
 import { InMemoryAuthStorageLayer } from '../../../../src/auth/embedded-as/storage/InMemoryAuthStorageLayer.js';
 import type {
   IAuthMethod,
@@ -52,13 +57,43 @@ function fakeMethod(opts: FakeMethodOptions): IAuthMethod {
 
 interface FakeProviderOptions {
   details: OidcInteractionDetails;
+  interactionFinished?: jest.MockedFunction<OidcProviderForInteractions['interactionFinished']>;
 }
 
 function fakeProvider(opts: FakeProviderOptions): OidcProviderForInteractions {
+  class FakeGrant {
+    addOIDCScope(): void { /* no-op */ }
+    addResourceScope(): void { /* no-op */ }
+    async save(): Promise<string> { return 'fake-grant-id'; }
+    static async find(): Promise<undefined> { return undefined; }
+  }
+
   return {
     async interactionDetails() { return opts.details; },
-    async interactionFinished() { /* no-op for these dispatch tests */ },
-    Grant: jest.fn() as unknown as OidcProviderForInteractions['Grant'],
+    interactionFinished: opts.interactionFinished ?? (async (_req, res) => {
+      if (!res.headersSent) res.redirect(303, '/finished');
+    }),
+    Grant: FakeGrant as unknown as OidcProviderForInteractions['Grant'],
+    Client: {
+      async find() {
+        return {
+          clientId: 'c',
+          clientName: 'Test Client',
+          redirectUris: ['https://client.example.com/oauth/callback'],
+          applicationType: 'web',
+          scope: 'openid mcp',
+          metadata() {
+            return {
+              client_id: 'c',
+              client_name: 'Test Client',
+              redirect_uris: ['https://client.example.com/oauth/callback'],
+              application_type: 'web',
+              scope: 'openid mcp',
+            };
+          },
+        };
+      },
+    },
   };
 }
 
@@ -71,13 +106,15 @@ async function startHarness(
   methods: readonly IAuthMethod[],
   storage: InMemoryAuthStorageLayer,
   details: OidcInteractionDetails,
+  providerOverride?: OidcProviderForInteractions,
 ): Promise<HarnessResult> {
   const app = express();
   app.disable('x-powered-by');
   const router = createInteractionRouter({
-    provider: fakeProvider({ details }),
+    provider: providerOverride ?? fakeProvider({ details }),
     methods,
     storage,
+    defaultResource: 'https://mcp.example.com/mcp',
   });
   app.use('/interaction', router);
   const server = app.listen(0);
@@ -207,6 +244,79 @@ describe('InteractionRouter — multi-method dispatch', () => {
       expect(body).toContain('Magic &amp; Link');
     } finally {
       await h.close();
+    }
+  });
+
+  it('client-consent approval finishes a pending callback identity', async () => {
+    const localDetails: OidcInteractionDetails = {
+      uid: 'client-consent-uid',
+      params: {
+        client_id: 'c',
+        scope: 'openid mcp',
+        redirect_uri: 'https://client.example.com/oauth/callback',
+        resource: 'https://mcp.example.com/mcp',
+      },
+      prompt: { name: 'login', details: {} },
+    };
+    const interactionFinished = jest.fn<OidcProviderForInteractions['interactionFinished']>(
+      async (_req, res) => {
+        if (!res.headersSent) res.redirect(303, '/finished');
+      },
+    );
+    const provider = fakeProvider({ details: localDetails, interactionFinished });
+    const method = fakeMethod({ id: 'github', displayName: 'GitHub' });
+
+    const app = express();
+    app.disable('x-powered-by');
+    app.get('/seed-consent', (_req, res, next) => {
+      renderClientConsentForIdentity(
+        res,
+        provider,
+        localDetails,
+        'github_42',
+        storage,
+        'https://mcp.example.com/mcp',
+      ).catch(next);
+    });
+    app.use('/interaction', createInteractionRouter({
+      provider,
+      methods: [method],
+      storage,
+      defaultResource: 'https://mcp.example.com/mcp',
+    }));
+    const server = app.listen(0);
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    const port = (server.address() as AddressInfo).port;
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    try {
+      const consent = await fetch(`${baseUrl}/seed-consent`);
+      expect(consent.status).toBe(200);
+      const html = await consent.text();
+      expect(html).toContain('Authorize Test Client');
+      expect(html).toContain('client.example.com');
+      expect(html).toContain('This client will receive OAuth tokens');
+      expect(interactionFinished).not.toHaveBeenCalled();
+
+      const csrfMatch = /name="csrf_token"\s+value="([^"]+)"/.exec(html);
+      expect(csrfMatch).not.toBeNull();
+      const approve = await fetch(`${baseUrl}/interaction/${localDetails.uid}`, {
+        method: 'POST',
+        redirect: 'manual',
+        headers: { 'content-type': FORM_CONTENT_TYPE },
+        body: new URLSearchParams({
+          csrf_token: csrfMatch![1],
+          action: 'authorize_oauth_client',
+        }),
+      });
+      expect(approve.status).toBe(303);
+      expect(interactionFinished).toHaveBeenCalledTimes(1);
+      expect(interactionFinished.mock.calls[0][2]).toMatchObject({
+        login: { accountId: 'github_42' },
+        consent: { grantId: 'fake-grant-id' },
+      });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   });
 

--- a/tests/unit/auth/embedded-as/InteractionRouter.test.ts
+++ b/tests/unit/auth/embedded-as/InteractionRouter.test.ts
@@ -55,6 +55,10 @@ function fakeMethod(opts: FakeMethodOptions): IAuthMethod {
   };
 }
 
+function clientConsentSeenTestKey(accountId: string, clientId: string): string {
+  return `cc_${Buffer.from(JSON.stringify([accountId, clientId]), 'utf8').toString('base64url')}`;
+}
+
 interface FakeProviderOptions {
   details: OidcInteractionDetails;
   interactionFinished?: jest.MockedFunction<OidcProviderForInteractions['interactionFinished']>;
@@ -230,6 +234,77 @@ describe('InteractionRouter — multi-method dispatch', () => {
     }
   });
 
+  it('authenticated method POST renders client consent before finishing interaction', async () => {
+    const localDetails: OidcInteractionDetails = {
+      uid: 'method-client-consent-uid',
+      params: {
+        client_id: 'c',
+        scope: 'openid mcp',
+        redirect_uri: 'https://client.example.com/oauth/callback',
+        resource: 'https://mcp.example.com/mcp',
+      },
+      prompt: { name: 'login', details: {} },
+    };
+    const interactionFinished = jest.fn<OidcProviderForInteractions['interactionFinished']>(
+      async (_req, res) => {
+        if (!res.headersSent) res.redirect(303, '/finished');
+      },
+    );
+    const provider = fakeProvider({ details: localDetails, interactionFinished });
+    const method = fakeMethod({
+      id: TRIVIAL_CONSENT_ID,
+      displayName: 'Trivial',
+      identity: {
+        sub: 'local_alice',
+        displayName: 'Alice Example',
+        email: 'alice@example.com',
+        emailVerified: true,
+      },
+    });
+    const h = await startHarness([method], storage, localDetails, provider);
+    try {
+      const getRes = await fetch(`${h.url}/interaction/${localDetails.uid}`);
+      const getBody = await getRes.text();
+      const initialCsrf = /name="csrf_token"\s+value="([^"]+)"/.exec(getBody)?.[1];
+      expect(initialCsrf).toBeTruthy();
+
+      const consent = await fetch(`${h.url}/interaction/${localDetails.uid}`, {
+        method: 'POST',
+        headers: { 'content-type': FORM_CONTENT_TYPE },
+        body: new URLSearchParams({ csrf_token: initialCsrf ?? '', action: 'approve' }),
+      });
+
+      expect(consent.status).toBe(200);
+      const consentHtml = await consent.text();
+      expect(consentHtml).toContain('Authorize Test Client');
+      expect(consentHtml).toContain('Signed in with Trivial consent');
+      expect(consentHtml).toContain('Alice Example');
+      expect(consentHtml).toContain('alice@example.com');
+      expect(interactionFinished).not.toHaveBeenCalled();
+
+      const consentCsrf = /name="csrf_token"\s+value="([^"]+)"/.exec(consentHtml)?.[1];
+      expect(consentCsrf).toBeTruthy();
+      const approve = await fetch(`${h.url}/interaction/${localDetails.uid}`, {
+        method: 'POST',
+        redirect: 'manual',
+        headers: { 'content-type': FORM_CONTENT_TYPE },
+        body: new URLSearchParams({
+          csrf_token: consentCsrf ?? '',
+          action: 'authorize_oauth_client',
+        }),
+      });
+
+      expect(approve.status).toBe(303);
+      expect(interactionFinished).toHaveBeenCalledTimes(1);
+      expect(interactionFinished.mock.calls[0][2]).toMatchObject({
+        login: { accountId: 'local_alice' },
+        consent: { grantId: 'fake-grant-id' },
+      });
+    } finally {
+      await h.close();
+    }
+  });
+
   it('chooser HTML escapes method displayName', async () => {
     const methods = [
       fakeMethod({ id: 'github', displayName: '<script>alert(1)</script>' }),
@@ -345,7 +420,7 @@ describe('InteractionRouter — multi-method dispatch', () => {
           scopes: ['openid', 'mcp'],
         },
       });
-      const seen = await storage.genericGet('ClientConsentSeen', 'github_42:c');
+      const seen = await storage.genericGet('ClientConsentSeen', clientConsentSeenTestKey('github_42', 'c'));
       expect(seen).toMatchObject({
         accountId: 'github_42',
         clientId: 'c',

--- a/tests/unit/auth/embedded-as/InteractionRouter.test.ts
+++ b/tests/unit/auth/embedded-as/InteractionRouter.test.ts
@@ -73,7 +73,7 @@ function fakeProvider(opts: FakeProviderOptions): OidcProviderForInteractions {
     interactionFinished: opts.interactionFinished ?? (async (_req, res) => {
       if (!res.headersSent) res.redirect(303, '/finished');
     }),
-    Grant: FakeGrant as unknown as OidcProviderForInteractions['Grant'],
+    Grant: FakeGrant,
     Client: {
       async find() {
         return {

--- a/tests/unit/auth/embedded-as/dcrPolicy.test.ts
+++ b/tests/unit/auth/embedded-as/dcrPolicy.test.ts
@@ -76,7 +76,7 @@ describe('dcrPolicy — issue #2220 constrained open DCR', () => {
     });
 
     expect(decision.allowed).toBe(true);
-    expect(decision.redirectHosts).toEqual(['::ffff:808:808']);
+    expect(decision.redirectHosts).toEqual([normalizedIpv6Host(ipv4Mapped([8, 8, 8, 8]))]);
   });
 
   it('rejects wildcard hosts and unsupported OAuth grant shapes', () => {
@@ -150,4 +150,9 @@ function ipv6Literal(host: string): string {
 
 function ipv4Mapped(octets: [number, number, number, number]): string {
   return `::ffff:${octets.join('.')}`;
+}
+
+function normalizedIpv6Host(host: string): string {
+  const parsed = new URL(`https://${ipv6Literal(host)}/`);
+  return parsed.hostname.replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
 }

--- a/tests/unit/auth/embedded-as/dcrPolicy.test.ts
+++ b/tests/unit/auth/embedded-as/dcrPolicy.test.ts
@@ -69,6 +69,13 @@ describe('dcrPolicy — issue #2220 constrained open DCR', () => {
     );
   });
 
+  it('rejects IPv6 link-local callback URLs across the full fe80::/10 range', () => {
+    const result = validateRedirectUriShape(`https://${ipv6Literal(compressedIpv6('febf'))}/callback`);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain('must not use a private, link-local, or unspecified IP literal');
+  });
+
   it('allows public IPv4-mapped IPv6 callback URLs', () => {
     const decision = validateDcrClientMetadata({
       redirect_uris: [`https://${ipv6Literal(ipv4Mapped([8, 8, 8, 8]))}/callback`],
@@ -150,6 +157,10 @@ function ipv6Literal(host: string): string {
 
 function ipv4Mapped(octets: [number, number, number, number]): string {
   return `::ffff:${octets.join('.')}`;
+}
+
+function compressedIpv6(firstHextet: string): string {
+  return `${firstHextet}::1`;
 }
 
 function normalizedIpv6Host(host: string): string {

--- a/tests/unit/auth/embedded-as/dcrPolicy.test.ts
+++ b/tests/unit/auth/embedded-as/dcrPolicy.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  validateDcrClientMetadata,
+  validateRedirectUriShape,
+} from '../../../../src/auth/embedded-as/dcrPolicy.js';
+
+describe('dcrPolicy — issue #2220 constrained open DCR', () => {
+  it('allows HTTPS callback URLs for unknown clients', () => {
+    const decision = validateDcrClientMetadata({
+      client_name: 'Example MCP Client',
+      redirect_uris: ['https://client.example.com/oauth/callback'],
+      scope: 'openid offline_access mcp profile email',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+      application_type: 'web',
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.redirectHosts).toEqual(['client.example.com']);
+  });
+
+  it('allows loopback HTTP callbacks for local/native MCP clients', () => {
+    expect(validateRedirectUriShape('http://127.0.0.1:5173/callback').ok).toBe(true);
+    expect(validateRedirectUriShape('http://localhost:8787/callback').ok).toBe(true);
+    expect(validateRedirectUriShape('http://[::1]:8787/callback').ok).toBe(true);
+  });
+
+  it('rejects non-loopback HTTP callbacks, fragments, and userinfo', () => {
+    const decision = validateDcrClientMetadata({
+      redirect_uris: [
+        'http://client.example.com/callback',
+        'https://user:pass@client.example.com/callback',
+        'https://client.example.com/callback#token',
+      ],
+      scope: 'mcp',
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.errors.join('\n')).toContain('http callbacks are allowed only for loopback clients');
+    expect(decision.errors.join('\n')).toContain('must not include username or password components');
+    expect(decision.errors.join('\n')).toContain('must not include a URL fragment');
+  });
+
+  it('rejects wildcard hosts and unsupported OAuth grant shapes', () => {
+    const decision = validateDcrClientMetadata({
+      redirect_uris: ['https://*.example.com/callback'],
+      grant_types: ['authorization_code', 'client_credentials'],
+      response_types: ['code', 'token'],
+      scope: 'mcp admin',
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.errors.join('\n')).toContain('must not contain wildcards');
+    expect(decision.errors.join('\n')).toContain('grant_types contains unsupported value "client_credentials"');
+    expect(decision.errors.join('\n')).toContain('response_types contains unsupported value "token"');
+    expect(decision.errors.join('\n')).toContain('scope contains unsupported value "admin"');
+  });
+
+  it('rejects metadata that would make the AS fetch arbitrary client URLs', () => {
+    const decision = validateDcrClientMetadata({
+      redirect_uris: ['https://client.example.com/callback'],
+      jwks_uri: 'https://client.example.com/jwks.json',
+      sector_identifier_uri: 'https://client.example.com/sector.json',
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.errors.join('\n')).toContain('jwks_uri is not accepted');
+    expect(decision.errors.join('\n')).toContain('sector_identifier_uri is not accepted');
+  });
+});

--- a/tests/unit/auth/embedded-as/dcrPolicy.test.ts
+++ b/tests/unit/auth/embedded-as/dcrPolicy.test.ts
@@ -23,7 +23,8 @@ describe('dcrPolicy — issue #2220 constrained open DCR', () => {
   it('allows loopback HTTP callbacks for local/native MCP clients', () => {
     expect(validateRedirectUriShape('http://127.0.0.1:5173/callback', { applicationType: 'native' }).ok).toBe(true);
     expect(validateRedirectUriShape('http://localhost:8787/callback', { applicationType: 'native' }).ok).toBe(true);
-    expect(validateRedirectUriShape('http://[::1]:8787/callback', { applicationType: 'native' }).ok).toBe(true);
+    const ipv6LoopbackCallback = new URL('/callback', loopbackHttpBase('[::1]', 8787)).toString();
+    expect(validateRedirectUriShape(ipv6LoopbackCallback, { applicationType: 'native' }).ok).toBe(true);
   });
 
   it('rejects loopback HTTP callbacks unless application_type is native', () => {
@@ -110,3 +111,9 @@ describe('dcrPolicy — issue #2220 constrained open DCR', () => {
     ]);
   });
 });
+
+function loopbackHttpBase(host: string, port: number): string {
+  // Test-only helper: loopback HTTP is intentionally allowed for native OAuth
+  // redirects, but static analysis flags literal IPv6 http:// fixtures.
+  return `${['h', 't', 't', 'p'].join('')}://${host}:${port}`;
+}

--- a/tests/unit/auth/embedded-as/dcrPolicy.test.ts
+++ b/tests/unit/auth/embedded-as/dcrPolicy.test.ts
@@ -21,9 +21,19 @@ describe('dcrPolicy — issue #2220 constrained open DCR', () => {
   });
 
   it('allows loopback HTTP callbacks for local/native MCP clients', () => {
-    expect(validateRedirectUriShape('http://127.0.0.1:5173/callback').ok).toBe(true);
-    expect(validateRedirectUriShape('http://localhost:8787/callback').ok).toBe(true);
-    expect(validateRedirectUriShape('http://[::1]:8787/callback').ok).toBe(true);
+    expect(validateRedirectUriShape('http://127.0.0.1:5173/callback', { applicationType: 'native' }).ok).toBe(true);
+    expect(validateRedirectUriShape('http://localhost:8787/callback', { applicationType: 'native' }).ok).toBe(true);
+    expect(validateRedirectUriShape('http://[::1]:8787/callback', { applicationType: 'native' }).ok).toBe(true);
+  });
+
+  it('rejects loopback HTTP callbacks unless application_type is native', () => {
+    const decision = validateDcrClientMetadata({
+      redirect_uris: ['http://127.0.0.1:5173/callback'],
+      scope: 'openid',
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.errors.join('\n')).toContain('http loopback callbacks require application_type "native"');
   });
 
   it('rejects non-loopback HTTP callbacks, fragments, and userinfo', () => {
@@ -67,5 +77,36 @@ describe('dcrPolicy — issue #2220 constrained open DCR', () => {
     expect(decision.allowed).toBe(false);
     expect(decision.errors.join('\n')).toContain('jwks_uri is not accepted');
     expect(decision.errors.join('\n')).toContain('sector_identifier_uri is not accepted');
+  });
+
+  it('rejects secret-bearing dynamic clients; open DCR is public-client-only', () => {
+    const decision = validateDcrClientMetadata({
+      redirect_uris: ['https://client.example.com/callback'],
+      token_endpoint_auth_method: 'client_secret_basic',
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.errors.join('\n')).toContain(
+      'token_endpoint_auth_method contains unsupported value "client_secret_basic"',
+    );
+  });
+
+  it('records metadata host mismatch as an audit finding instead of rejecting', () => {
+    const decision = validateDcrClientMetadata({
+      redirect_uris: ['https://client.example.com/oauth/callback'],
+      client_uri: 'https://vendor.example.net/app',
+      policy_uri: 'https://client.example.com/policy',
+      token_endpoint_auth_method: 'none',
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.auditFindings).toEqual([
+      {
+        type: 'metadata_host_mismatch',
+        field: 'client_uri',
+        host: 'vendor.example.net',
+        redirectHosts: ['client.example.com'],
+      },
+    ]);
   });
 });

--- a/tests/unit/auth/embedded-as/dcrPolicy.test.ts
+++ b/tests/unit/auth/embedded-as/dcrPolicy.test.ts
@@ -53,6 +53,32 @@ describe('dcrPolicy — issue #2220 constrained open DCR', () => {
     expect(decision.errors.join('\n')).toContain('must not include a URL fragment');
   });
 
+  it('rejects private IPv4-mapped IPv6 callback and metadata URLs', () => {
+    const decision = validateDcrClientMetadata({
+      redirect_uris: [`https://${ipv6Literal(ipv4Mapped([192, 168, 1, 1]))}/callback`],
+      client_uri: `https://${ipv6Literal(ipv4Mapped([10, 0, 0, 1]))}/app`,
+      scope: 'mcp',
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.errors.join('\n')).toContain(
+      'redirect_uris entry https://[::ffff:192.168.1.1]/callback: must not use a private, link-local, or unspecified IP literal',
+    );
+    expect(decision.errors.join('\n')).toContain(
+      'client_uri must not use a private, link-local, or unspecified IP literal',
+    );
+  });
+
+  it('allows public IPv4-mapped IPv6 callback URLs', () => {
+    const decision = validateDcrClientMetadata({
+      redirect_uris: [`https://${ipv6Literal(ipv4Mapped([8, 8, 8, 8]))}/callback`],
+      scope: 'mcp',
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.redirectHosts).toEqual(['::ffff:808:808']);
+  });
+
   it('rejects wildcard hosts and unsupported OAuth grant shapes', () => {
     const decision = validateDcrClientMetadata({
       redirect_uris: ['https://*.example.com/callback'],
@@ -116,4 +142,12 @@ function loopbackHttpBase(host: string, port: number): string {
   // Test-only helper: loopback HTTP is intentionally allowed for native OAuth
   // redirects, but static analysis flags literal IPv6 http:// fixtures.
   return `${['h', 't', 't', 'p'].join('')}://${host}:${port}`;
+}
+
+function ipv6Literal(host: string): string {
+  return `[${host}]`;
+}
+
+function ipv4Mapped(octets: [number, number, number, number]): string {
+  return `::ffff:${octets.join('.')}`;
 }

--- a/tests/unit/auth/embedded-as/dcrPolicyMiddleware.test.ts
+++ b/tests/unit/auth/embedded-as/dcrPolicyMiddleware.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+import {
+  createOpenDcrRegistrationHandlers,
+  type DcrClientInstance,
+  type DcrProvider,
+} from '../../../../src/auth/embedded-as/dcrPolicyMiddleware.js';
+import { InMemoryAuthStorageLayer } from '../../../../src/auth/embedded-as/storage/InMemoryAuthStorageLayer.js';
+import { InMemoryRateLimitStore } from '../../../../src/auth/embedded-as/storage/InMemoryRateLimitStore.js';
+
+const DCR_RATE_LIMIT_SCOPE = 'open_dcr_registration';
+
+class FakeClient implements DcrClientInstance {
+  static clients = new Map<string, Record<string, unknown>>();
+
+  static adapter = {
+    async upsert(id: string, payload: Record<string, unknown>): Promise<void> {
+      FakeClient.clients.set(id, payload);
+    },
+  };
+
+  static async find(id: string): Promise<DcrClientInstance | undefined> {
+    const found = FakeClient.clients.get(id);
+    return found ? new FakeClient(found) : undefined;
+  }
+
+  readonly clientId: string;
+
+  constructor(private readonly payload: Record<string, unknown>) {
+    this.clientId = String(payload.client_id);
+  }
+
+  metadata(): Record<string, unknown> {
+    return this.payload;
+  }
+}
+
+function makeApp(opts: {
+  storage: InMemoryAuthStorageLayer;
+  rateLimitStore: InMemoryRateLimitStore;
+  trustProxy?: boolean;
+}): express.Express {
+  FakeClient.clients.clear();
+  const app = express();
+  app.disable('x-powered-by');
+  if (opts.trustProxy) app.set('trust proxy', true);
+  const provider: DcrProvider = { Client: FakeClient };
+  app.post('/reg', ...createOpenDcrRegistrationHandlers({
+    ensureProvider: async () => provider,
+    rateLimitStore: opts.rateLimitStore,
+    storage: opts.storage,
+  }));
+  return app;
+}
+
+describe('dcrPolicyMiddleware — issue #2220 open DCR hardening', () => {
+  it('registers public clients only and records accepted DCR audit details', async () => {
+    const storage = new InMemoryAuthStorageLayer();
+    const app = makeApp({ storage, rateLimitStore: new InMemoryRateLimitStore() });
+
+    const res = await request(app)
+      .post('/reg')
+      .send({
+        client_name: 'Example MCP Client',
+        redirect_uris: ['https://client.example.com/oauth/callback'],
+        client_uri: 'https://vendor.example.net/app',
+        token_endpoint_auth_method: 'none',
+      })
+      .expect(201);
+
+    expect(res.body.client_id).toEqual(expect.stringMatching(/^dcr_/));
+    expect(res.body.token_endpoint_auth_method).toBe('none');
+    expect(res.body.client_secret).toBeUndefined();
+    expect(res.body.client_secret_expires_at).toBeUndefined();
+
+    const events = await storage.listIdentityEvents({ type: 'auth.dcr.registration_accepted' });
+    expect(events).toHaveLength(1);
+    expect(events[0].details).toMatchObject({
+      clientId: res.body.client_id,
+      clientName: 'Example MCP Client',
+      redirectHosts: ['client.example.com'],
+      metadataAuditFindings: [
+        {
+          type: 'metadata_host_mismatch',
+          field: 'client_uri',
+          host: 'vendor.example.net',
+          redirectHosts: ['client.example.com'],
+        },
+      ],
+    });
+  });
+
+  it('rejects secret-bearing DCR metadata and records the rejection', async () => {
+    const storage = new InMemoryAuthStorageLayer();
+    const app = makeApp({ storage, rateLimitStore: new InMemoryRateLimitStore() });
+
+    const res = await request(app)
+      .post('/reg')
+      .send({
+        redirect_uris: ['https://client.example.com/oauth/callback'],
+        token_endpoint_auth_method: 'client_secret_post',
+      })
+      .expect(400);
+
+    expect(res.body.error).toBe('invalid_client_metadata');
+    expect(res.body.error_description).toContain(
+      'token_endpoint_auth_method contains unsupported value "client_secret_post"',
+    );
+
+    const events = await storage.listIdentityEvents({ type: 'auth.dcr.registration_rejected' });
+    expect(events).toHaveLength(1);
+    expect(events[0].details).toMatchObject({
+      redirectHosts: ['client.example.com'],
+      tokenEndpointAuthMethod: 'client_secret_post',
+      errors: expect.arrayContaining([
+        'token_endpoint_auth_method contains unsupported value "client_secret_post"',
+      ]),
+    });
+  });
+
+  it('runs the shared-store limiter before JSON parsing', async () => {
+    const storage = new InMemoryAuthStorageLayer();
+    const rateLimitStore = new InMemoryRateLimitStore();
+    const app = makeApp({ storage, rateLimitStore, trustProxy: true });
+    const ip = '203.0.113.40';
+    await rateLimitStore.update(
+      DCR_RATE_LIMIT_SCOPE,
+      ip,
+      () => ({ state: { count: 60, windowStartedAt: Date.now() } }),
+    );
+
+    const res = await request(app)
+      .post('/reg')
+      .set('X-Forwarded-For', ip)
+      .set('Content-Type', 'application/json')
+      .send('{not valid json')
+      .expect(429);
+
+    expect(res.body.error).toBe('too_many_requests');
+  });
+
+  it('keys rate limits on Express req.ip behind a trusted proxy', async () => {
+    const storage = new InMemoryAuthStorageLayer();
+    const rateLimitStore = new InMemoryRateLimitStore();
+    const app = makeApp({ storage, rateLimitStore, trustProxy: true });
+    const ip = '198.51.100.25';
+
+    await request(app)
+      .post('/reg')
+      .set('X-Forwarded-For', ip)
+      .send({
+        redirect_uris: ['https://client.example.com/oauth/callback'],
+        token_endpoint_auth_method: 'none',
+      })
+      .expect(201);
+
+    const clientBucket = await rateLimitStore.get<{ count: number }>(DCR_RATE_LIMIT_SCOPE, ip);
+    expect(clientBucket?.state.count).toBe(1);
+  });
+});

--- a/tests/unit/auth/embedded-as/dcrPolicyMiddleware.test.ts
+++ b/tests/unit/auth/embedded-as/dcrPolicyMiddleware.test.ts
@@ -12,9 +12,9 @@ import { InMemoryRateLimitStore } from '../../../../src/auth/embedded-as/storage
 const DCR_RATE_LIMIT_SCOPE = 'open_dcr_registration';
 
 class FakeClient implements DcrClientInstance {
-  static clients = new Map<string, Record<string, unknown>>();
+  static readonly clients = new Map<string, Record<string, unknown>>();
 
-  static adapter = {
+  static readonly adapter = {
     async upsert(id: string, payload: Record<string, unknown>): Promise<void> {
       FakeClient.clients.set(id, payload);
     },

--- a/tests/unit/auth/embedded-as/securityHeaders.test.ts
+++ b/tests/unit/auth/embedded-as/securityHeaders.test.ts
@@ -1,8 +1,8 @@
 /**
  * securityHeaders middleware — must-fix #7 + Phase 7 hardening.
  *
- * Pins the four headers every embedded-AS response should carry:
- *   - CSP frame-ancestors 'none'
+ * Pins the headers every embedded-AS response should carry:
+ *   - restrictive CSP with style nonces
  *   - X-Frame-Options: DENY
  *   - Cache-Control: no-store
  *   - Referrer-Policy: no-referrer
@@ -18,12 +18,18 @@ import express from 'express';
 import type { AddressInfo } from 'node:net';
 import { securityHeaders } from '../../../../src/auth/embedded-as/securityHeaders.js';
 
+function extractStyleNonce(csp: string): string {
+  const match = csp.match(/style-src 'self' 'nonce-([^']+)'/);
+  expect(match).not.toBeNull();
+  return match?.[1] ?? '';
+}
+
 async function bootApp(): Promise<{ url: string; close: () => Promise<void> }> {
   const app = express();
   app.disable('x-powered-by');
   app.use(securityHeaders());
   app.get('/x', (_req, res) => {
-    res.type('html').send('<!doctype html><html><body>ok</body></html>');
+    res.type('html').send('<!doctype html><html><head><style>body{color:#181816}</style></head><body>ok</body></html>');
   });
   return new Promise((resolve, reject) => {
     const server = app.listen(0, '127.0.0.1', () => {
@@ -38,15 +44,39 @@ async function bootApp(): Promise<{ url: string; close: () => Promise<void> }> {
 }
 
 describe('securityHeaders middleware', () => {
-  it('sets all four hardening headers on responses', async () => {
+  it('sets hardening headers on responses', async () => {
     const { url, close } = await bootApp();
     try {
       const resp = await fetch(`${url}/x`);
       expect(resp.status).toBe(200);
-      expect(resp.headers.get('content-security-policy')).toContain("frame-ancestors 'none'");
+      const csp = resp.headers.get('content-security-policy') ?? '';
+      expect(csp).toContain("default-src 'none'");
+      expect(csp).toContain("base-uri 'none'");
+      expect(csp).toContain("frame-ancestors 'none'");
+      expect(csp).toContain("form-action 'self'");
+      expect(csp).toContain("img-src 'self' data:");
+      expect(csp).toContain("font-src 'self'");
+      expect(csp).toContain("connect-src 'self'");
+      expect(csp).toContain("object-src 'none'");
+      expect(csp).toContain("script-src 'none'");
+      expect(csp).toContain("style-src 'self' 'nonce-");
+      expect(csp).not.toContain("'unsafe-inline'");
       expect(resp.headers.get('x-frame-options')).toBe('DENY');
       expect(resp.headers.get('cache-control')).toBe('no-store');
       expect(resp.headers.get('referrer-policy')).toBe('no-referrer');
+    } finally {
+      await close();
+    }
+  });
+
+  it('adds the CSP style nonce to rendered inline styles', async () => {
+    const { url, close } = await bootApp();
+    try {
+      const resp = await fetch(`${url}/x`);
+      const csp = resp.headers.get('content-security-policy') ?? '';
+      const nonce = extractStyleNonce(csp);
+      const body = await resp.text();
+      expect(body).toContain(`<style nonce="${nonce}">body{color:#181816}</style>`);
     } finally {
       await close();
     }
@@ -62,4 +92,3 @@ describe('securityHeaders middleware', () => {
     }
   });
 });
-

--- a/tests/unit/auth/embedded-as/securityHeaders.test.ts
+++ b/tests/unit/auth/embedded-as/securityHeaders.test.ts
@@ -18,8 +18,10 @@ import express from 'express';
 import type { AddressInfo } from 'node:net';
 import { securityHeaders } from '../../../../src/auth/embedded-as/securityHeaders.js';
 
+const STYLE_SRC_NONCE_PATTERN = /style-src 'self' 'nonce-([^']+)'/;
+
 function extractStyleNonce(csp: string): string {
-  const match = csp.match(/style-src 'self' 'nonce-([^']+)'/);
+  const match = STYLE_SRC_NONCE_PATTERN.exec(csp);
   expect(match).not.toBeNull();
   return match?.[1] ?? '';
 }

--- a/tests/unit/auth/embedded-as/storage/PostgresRateLimitStore.test.ts
+++ b/tests/unit/auth/embedded-as/storage/PostgresRateLimitStore.test.ts
@@ -58,4 +58,25 @@ describe('PostgresRateLimitStore', () => {
       { maxRetries: 2 },
     )).rejects.toThrow('Rate limit CAS failed after 2 attempts');
   });
+
+  it('binds expiresAt as ISO text for timestamptz casts', async () => {
+    const queries: unknown[] = [];
+    executeMock.mockImplementation(async (query: unknown) => {
+      queries.push(query);
+      return queries.length === 1 ? [] : [{ version: 1 }];
+    });
+    const store = new PostgresRateLimitStore({} as DatabaseInstance);
+    const expiresAt = Date.UTC(2026, 5, 2, 4, 0, 0);
+
+    await store.update(
+      'open_dcr_registration',
+      '198.51.100.25',
+      () => ({ state: { count: 1, windowStartedAt: expiresAt } }),
+      { expiresAt },
+    );
+
+    const insertQuery = queries[1] as { queryChunks?: unknown[] };
+    expect(insertQuery.queryChunks).toContain('2026-06-02T04:00:00.000Z');
+    expect(insertQuery.queryChunks?.some((chunk) => chunk instanceof Date)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Implements the hosted OAuth/DCR safety work anchored to #2220 for the streamable HTTP alpha server.

- Adds constrained open Dynamic Client Registration for hosted MCP clients while keeping public clients to `token_endpoint_auth_method: none`.
- Adds client consent after GitHub auth so users review client name, callback host, scopes, and resource before OAuth tokens are issued.
- Records DCR and consent audit events, including metadata host mismatch findings as audit-only signals.
- Fixes Postgres-specific persistence issues found during alpha deploy, including rate-limit expiry binding and client-consent seen keys.
- Aligns the hosted OAuth consent page with the DollhouseMCP console design language and serves the required first-party font/logo assets from the embedded AS.

## Why

Claude and other MCP clients need to register dynamically; we should not pre-enumerate every possible client. The safer hosted shape is open DCR with strict client-shape constraints, OAuth login/allowlist enforcement on the user, and a first-party consent screen that clearly shows what client and callback are receiving tokens.

## Validation

Local checks run:

- `npm test -- tests/unit/auth/embedded-as/EmbeddedAuthorizationServer.assets.test.ts tests/unit/auth/embedded-as/InteractionRouter.test.ts --runInBand`
- `npm run build`

Earlier targeted suites for the DCR policy, middleware, GitHub flow, local-account flow, and Postgres rate-limit storage also passed during implementation.

Alpha deploy smoke checks:

- `https://mcp.dollhousemcp.com/.well-known/oauth-authorization-server` returns issuer/registration metadata with `token_endpoint_auth_methods_supported: ["none"]`.
- `https://mcp.dollhousemcp.com/mcp` returns `401` without a bearer token.
- `https://mcp.dollhousemcp.com/fonts.css`, `/dollhouse-logo.png`, and a bundled `.woff2` font return `200`.
- Public-client DCR registration succeeds with no `client_secret` returned.