### PR TITLE
Allow consent redirect CSP target

### DIFF
--- a/src/auth/embedded-as/InteractionRouter.ts
+++ b/src/auth/embedded-as/InteractionRouter.ts
@@ -1422,10 +1422,19 @@ function allowOAuthRedirectFormAction(res: Response, details: OidcInteractionDet
   if (!redirectUri) return;
 
   try {
+    // Safe only for the hosted client-consent page: oidc-provider has already
+    // matched this redirect_uri to the registered OAuth client, and this CSP
+    // source allows only the browser's final form-submit redirect back to that
+    // client origin. All other embedded auth pages keep form-action at 'self'.
     allowCspFormActionOrigin(res, new URL(redirectUri).origin);
-  } catch {
+  } catch (err) {
     // oidc-provider validates redirect_uri before creating the interaction.
     // Keep the CSP opt-in fail-closed if provider details are unexpected.
+    logger.debug('[InteractionRouter] skipped OAuth redirect CSP form-action origin', {
+      interactionIdHash: fingerprintTransientId(details.uid),
+      redirectUriHash: fingerprintTransientId(redirectUri),
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 

--- a/src/auth/embedded-as/InteractionRouter.ts
+++ b/src/auth/embedded-as/InteractionRouter.ts
@@ -36,6 +36,7 @@ import type {
   InteractionStep,
 } from './IAuthMethod.js';
 import type { IAuthStorageLayer } from './storage/IAuthStorageLayer.js';
+import { allowCspFormActionOrigin } from './securityHeaders.js';
 
 const CSRF_MODEL = 'InteractionCsrf';
 const CSRF_TTL_SECONDS = 600; // 10 min, matches oidc-provider's default interaction TTL.
@@ -536,6 +537,7 @@ export async function renderClientConsentForIdentity(
   );
   const csrfToken = randomBytes(32).toString('base64url');
   await storage.genericSet(CSRF_MODEL, details.uid, { token: csrfToken }, CSRF_TTL_SECONDS);
+  allowOAuthRedirectFormAction(res, details);
   const html = await renderOAuthClientConsentPage(provider, details, csrfToken, defaultResource, {
     identity,
     firstSeen,
@@ -1413,6 +1415,18 @@ async function findClientForConsent(
 
 function paramString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function allowOAuthRedirectFormAction(res: Response, details: OidcInteractionDetails): void {
+  const redirectUri = paramString(details.params.redirect_uri);
+  if (!redirectUri) return;
+
+  try {
+    allowCspFormActionOrigin(res, new URL(redirectUri).origin);
+  } catch {
+    // oidc-provider validates redirect_uri before creating the interaction.
+    // Keep the CSP opt-in fail-closed if provider details are unexpected.
+  }
 }
 
 function firstString(value: unknown): string | undefined {

--- a/src/auth/embedded-as/securityHeaders.ts
+++ b/src/auth/embedded-as/securityHeaders.ts
@@ -39,13 +39,22 @@ import { randomBytes } from 'node:crypto';
 import type { Request, Response, NextFunction, RequestHandler } from 'express';
 
 const STYLE_TAG_WITHOUT_NONCE = /<style\b(?![^>]*\bnonce=)([^>]*)>/gi;
+const FORM_ACTION_EXTRA_ORIGINS_LOCAL = 'dollhouseCspFormActionExtraOrigins';
 
-export function buildContentSecurityPolicy(styleNonce: string): string {
+interface SecurityHeaderLocals {
+  [FORM_ACTION_EXTRA_ORIGINS_LOCAL]?: string[];
+}
+
+export function buildContentSecurityPolicy(
+  styleNonce: string,
+  extraFormActionOrigins: readonly string[] = [],
+): string {
+  const formActionSources = buildFormActionSources(extraFormActionOrigins);
   return [
     "default-src 'none'",
     "base-uri 'none'",
     "frame-ancestors 'none'",
-    "form-action 'self'",
+    `form-action ${formActionSources.join(' ')}`,
     "img-src 'self' data:",
     "font-src 'self'",
     "connect-src 'self'",
@@ -55,8 +64,47 @@ export function buildContentSecurityPolicy(styleNonce: string): string {
   ].join('; ');
 }
 
+export function allowCspFormActionOrigin(res: Response, origin: string): void {
+  const normalized = normalizeHttpOrigin(origin);
+  if (!normalized) return;
+
+  const locals = res.locals as SecurityHeaderLocals;
+  const existing = locals[FORM_ACTION_EXTRA_ORIGINS_LOCAL] ?? [];
+  if (existing.includes(normalized)) return;
+  locals[FORM_ACTION_EXTRA_ORIGINS_LOCAL] = [...existing, normalized];
+}
+
 function createCspNonce(): string {
   return randomBytes(16).toString('base64url');
+}
+
+function buildFormActionSources(extraFormActionOrigins: readonly string[]): string[] {
+  const sources = ["'self'"];
+  const seen = new Set(sources);
+  for (const origin of extraFormActionOrigins) {
+    const normalized = normalizeHttpOrigin(origin);
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    sources.push(normalized);
+  }
+  return sources;
+}
+
+function normalizeHttpOrigin(origin: string): string | null {
+  try {
+    const parsed = new URL(origin);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      return null;
+    }
+    return parsed.origin;
+  } catch {
+    return null;
+  }
+}
+
+function getExtraFormActionOrigins(res: Response): readonly string[] {
+  const locals = res.locals as SecurityHeaderLocals;
+  return locals[FORM_ACTION_EXTRA_ORIGINS_LOCAL] ?? [];
 }
 
 function addStyleNonce(body: unknown, styleNonce: string): unknown {
@@ -71,10 +119,19 @@ export function securityHeaders(): RequestHandler {
   return (_req: Request, res: Response, next: NextFunction): void => {
     const styleNonce = createCspNonce();
     const send = res.send.bind(res);
+    const setContentSecurityPolicy = (): void => {
+      res.setHeader(
+        'Content-Security-Policy',
+        buildContentSecurityPolicy(styleNonce, getExtraFormActionOrigins(res)),
+      );
+    };
 
-    res.send = ((body?: unknown): Response => send(addStyleNonce(body, styleNonce))) as Response['send'];
+    res.send = ((body?: unknown): Response => {
+      setContentSecurityPolicy();
+      return send(addStyleNonce(body, styleNonce));
+    }) as Response['send'];
 
-    res.setHeader('Content-Security-Policy', buildContentSecurityPolicy(styleNonce));
+    setContentSecurityPolicy();
     res.setHeader('X-Frame-Options', 'DENY');
     res.setHeader('Cache-Control', 'no-store');
     res.setHeader('Pragma', 'no-cache');

--- a/tests/unit/auth/embedded-as/InteractionRouter.test.ts
+++ b/tests/unit/auth/embedded-as/InteractionRouter.test.ts
@@ -23,6 +23,7 @@ import type {
   InteractionStep,
 } from '../../../../src/auth/embedded-as/IAuthMethod.js';
 import type { AuthMethodId } from '../../../../src/auth/embedded-as/AuthMethodFactory.js';
+import { securityHeaders } from '../../../../src/auth/embedded-as/securityHeaders.js';
 
 const TRIVIAL_CONSENT_ID = 'trivial-consent';
 const MAGIC_LINK_ID = 'magic-link';
@@ -343,6 +344,7 @@ describe('InteractionRouter — multi-method dispatch', () => {
 
     const app = express();
     app.disable('x-powered-by');
+    app.use(securityHeaders());
     app.get('/seed-consent', (_req, res, next) => {
       renderClientConsentForIdentity(
         res,
@@ -374,6 +376,7 @@ describe('InteractionRouter — multi-method dispatch', () => {
     try {
       const consent = await fetch(`${baseUrl}/seed-consent`);
       expect(consent.status).toBe(200);
+      expect(consent.headers.get('content-security-policy')).toContain("form-action 'self' https://client.example.com");
       const html = await consent.text();
       expect(html).toContain('Authorize Test Client');
       expect(html).toContain('DollhouseMCP Authorization');

--- a/tests/unit/auth/embedded-as/securityHeaders.test.ts
+++ b/tests/unit/auth/embedded-as/securityHeaders.test.ts
@@ -16,7 +16,10 @@
 import { describe, it, expect } from '@jest/globals';
 import express from 'express';
 import type { AddressInfo } from 'node:net';
-import { securityHeaders } from '../../../../src/auth/embedded-as/securityHeaders.js';
+import {
+  allowCspFormActionOrigin,
+  securityHeaders,
+} from '../../../../src/auth/embedded-as/securityHeaders.js';
 
 const STYLE_SRC_NONCE_PATTERN = /style-src 'self' 'nonce-([^']+)'/;
 
@@ -32,6 +35,14 @@ async function bootApp(): Promise<{ url: string; close: () => Promise<void> }> {
   app.use(securityHeaders());
   app.get('/x', (_req, res) => {
     res.type('html').send('<!doctype html><html><head><style>body{color:#181816}</style></head><body>ok</body></html>');
+  });
+  app.get('/oauth-consent', (_req, res) => {
+    allowCspFormActionOrigin(res, 'https://claude.ai');
+    res.type('html').send('<!doctype html><html><head><style>body{color:#181816}</style></head><body>ok</body></html>');
+  });
+  app.get('/invalid-form-action', (_req, res) => {
+    allowCspFormActionOrigin(res, 'javascript:alert(1)');
+    res.type('html').send('<!doctype html><html><body>ok</body></html>');
   });
   return new Promise((resolve, reject) => {
     const server = app.listen(0, '127.0.0.1', () => {
@@ -89,6 +100,29 @@ describe('securityHeaders middleware', () => {
     try {
       const resp = await fetch(`${url}/x`);
       expect(resp.headers.get('pragma')).toBe('no-cache');
+    } finally {
+      await close();
+    }
+  });
+
+  it('can allow the active OAuth callback origin for consent form redirects', async () => {
+    const { url, close } = await bootApp();
+    try {
+      const resp = await fetch(`${url}/oauth-consent`);
+      const csp = resp.headers.get('content-security-policy') ?? '';
+      expect(csp).toContain("form-action 'self' https://claude.ai");
+    } finally {
+      await close();
+    }
+  });
+
+  it('ignores non-HTTP form-action origins', async () => {
+    const { url, close } = await bootApp();
+    try {
+      const resp = await fetch(`${url}/invalid-form-action`);
+      const csp = resp.headers.get('content-security-policy') ?? '';
+      expect(csp).toContain("form-action 'self'");
+      expect(csp).not.toContain('javascript:');
     } finally {
       await close();
     }


### PR DESCRIPTION
## Summary
- allow hosted OAuth consent pages to opt in the current redirect URI origin for CSP form-action
- keep the default embedded auth CSP locked to self
- cover the header helper and consent page behavior with focused unit tests

## Why
Claude consent approval reached the server and produced an authorization code, but the browser stayed on the Dollhouse consent page instead of following the final redirect back to Claude. The likely blocker was the consent page CSP using `form-action 'self'`, which can block the post-submit redirect chain to the OAuth callback origin.\n\n## Validation\n- `npm test -- tests/unit/auth/embedded-as/securityHeaders.test.ts --runInBand`\n- `npm test -- tests/unit/auth/embedded-as/InteractionRouter.test.ts --runInBand`\n- `npm run build -- --pretty false`\n- deployed commit `e68081909bd62bd3c9dbc0511e2cc3b88ffb81ca` to alpha and verified `/healthz` + `/readyz`