### PR TITLE
[codex] Harden hosted remote backup retries

### DIFF
--- a/docs/guides/hosted-deployment-automation.md
+++ b/docs/guides/hosted-deployment-automation.md
@@ -125,6 +125,8 @@ The remote wrapper additionally creates operator backups before it invokes the h
 - a Postgres dump under `backups/pre-remote-<action>-<timestamp>.sql`
 - `.env` and `.env.production` copies under `backups/`
 
+Database readiness and `pg_dump` receive bounded retries before `update`, `migrate`, and `rollback` continue. Retry delays use exponential backoff from the configured base delay. If a dump attempt writes partial output and then fails, the wrapper moves that partial output to `backups/pre-remote-<action>-<timestamp>.sql.failed-attempt-<n>` with `0600` permissions before retrying or failing.
+
 Set `DOLLHOUSE_REMOTE_SKIP_BACKUP=true` or pass `--skip-backup` only when a separate backup already exists.
 
 ## Configuration
@@ -160,6 +162,8 @@ Remote wrapper variables:
 | `DOLLHOUSE_REMOTE_SSH_PORT` | Optional SSH port | default SSH port |
 | `DOLLHOUSE_REMOTE_KNOWN_HOSTS_FILE` | Optional known-hosts file used with strict host-key checking | OpenSSH default known-hosts files |
 | `DOLLHOUSE_REMOTE_ACCEPT_HOST_KEY` | Permit `enroll-host` to append the scanned host key after operator verification | `false` |
+| `DOLLHOUSE_REMOTE_BACKUP_RETRIES` | Attempts for remote Postgres readiness and database dump backup | `3` |
+| `DOLLHOUSE_REMOTE_BACKUP_RETRY_DELAY` | Base seconds for exponential backoff between remote backup attempts | `2` |
 | `DOLLHOUSE_REMOTE_SKIP_BACKUP` | Skip remote DB/env backups before running the helper | `false` |
 | `DOLLHOUSE_REMOTE_SKIP_LOCAL_VERIFY` | Skip local public endpoint checks after the remote helper completes | `false` |
 | `DOLLHOUSE_REMOTE_KEEP_WORKDIR` | Keep the temporary remote clone for debugging | `false` |

--- a/scripts/hosted-remote-deploy.sh
+++ b/scripts/hosted-remote-deploy.sh
@@ -27,6 +27,8 @@ SKIP_BACKUP="${DOLLHOUSE_REMOTE_SKIP_BACKUP:-false}"
 SKIP_LOCAL_VERIFY="${DOLLHOUSE_REMOTE_SKIP_LOCAL_VERIFY:-false}"
 KEEP_WORKDIR="${DOLLHOUSE_REMOTE_KEEP_WORKDIR:-false}"
 DRY_RUN="${DOLLHOUSE_REMOTE_DRY_RUN:-false}"
+BACKUP_RETRIES="${DOLLHOUSE_REMOTE_BACKUP_RETRIES:-3}"
+BACKUP_RETRY_DELAY="${DOLLHOUSE_REMOTE_BACKUP_RETRY_DELAY:-2}"
 
 usage() {
   cat <<'EOF'
@@ -53,6 +55,8 @@ Options:
   --git-url URL             Repository URL cloned remotely. Env: DOLLHOUSE_HOSTED_GIT_URL
   --ref REF                 Branch/ref cloned remotely. Env: DOLLHOUSE_HOSTED_GIT_REF
   --skip-backup             Skip DB/env backup before remote action
+  --backup-retries N        Backup attempts before failing. Env: DOLLHOUSE_REMOTE_BACKUP_RETRIES
+  --backup-retry-delay N    Base seconds for exponential backup retry backoff
   --skip-local-verify       Skip local public endpoint checks after remote action
   --keep-workdir            Keep remote temporary clone for debugging
   --dry-run                 Print the plan without opening SSH
@@ -119,6 +123,28 @@ validate_port_value() {
 
   if [[ -n "${value}" && ( ! "${value}" =~ ^[0-9]+$ || "${value}" -lt 1 || "${value}" -gt 65535 ) ]]; then
     die "${key} must be an integer from 1 to 65535, got: ${value}"
+  fi
+
+  return 0
+}
+
+validate_positive_integer() {
+  local key="$1"
+  local value="$2"
+
+  if [[ ! "${value}" =~ ^[0-9]+$ || "${value}" -lt 1 ]]; then
+    die "${key} must be an integer greater than or equal to 1, got: ${value}"
+  fi
+
+  return 0
+}
+
+validate_nonnegative_integer() {
+  local key="$1"
+  local value="$2"
+
+  if [[ ! "${value}" =~ ^[0-9]+$ ]]; then
+    die "${key} must be an integer greater than or equal to 0, got: ${value}"
   fi
 
   return 0
@@ -228,6 +254,16 @@ parse_args() {
         ;;
       --skip-backup)
         SKIP_BACKUP="true"
+        ;;
+      --backup-retries)
+        BACKUP_RETRIES="${1:-}"
+        [[ -n "${BACKUP_RETRIES}" ]] || die "--backup-retries requires a count"
+        shift
+        ;;
+      --backup-retry-delay)
+        BACKUP_RETRY_DELAY="${1:-}"
+        [[ -n "${BACKUP_RETRY_DELAY}" ]] || die "--backup-retry-delay requires a second count"
+        shift
         ;;
       --skip-local-verify)
         SKIP_LOCAL_VERIFY="true"
@@ -367,6 +403,8 @@ validate_config() {
   validate_bool DOLLHOUSE_REMOTE_DRY_RUN "${DRY_RUN}"
   validate_bool DOLLHOUSE_REMOTE_ACCEPT_HOST_KEY "${REMOTE_ACCEPT_HOST_KEY}"
   validate_port_value DOLLHOUSE_REMOTE_SSH_PORT "${REMOTE_SSH_PORT}"
+  validate_positive_integer DOLLHOUSE_REMOTE_BACKUP_RETRIES "${BACKUP_RETRIES}"
+  validate_nonnegative_integer DOLLHOUSE_REMOTE_BACKUP_RETRY_DELAY "${BACKUP_RETRY_DELAY}"
   [[ -n "${REMOTE_SSH_TARGET}" ]] || die "set --target or DOLLHOUSE_REMOTE_SSH_TARGET"
   [[ "${REMOTE_SSH_TARGET}" != *[[:space:]]* ]] || die "SSH target must not contain whitespace"
   resolve_ssh_host
@@ -422,6 +460,7 @@ run_dry_plan() {
     log "dry-run: would skip remote DB/env backups"
   else
     log "dry-run: would create remote DB/env backups when an existing deployment is present"
+    log "dry-run: backup retries=${BACKUP_RETRIES} base_retry_delay=${BACKUP_RETRY_DELAY}s exponential_backoff=true"
   fi
   log "dry-run: would clone $(redact_url "${GIT_URL}") at ${GIT_REF} on the remote host"
   log "dry-run: would run scripts/hosted-deploy.sh ${ACTION} on the remote host"
@@ -508,7 +547,9 @@ run_remote_action() {
     "${GIT_REF}" \
     "${LOG_LEVEL}" \
     "${SKIP_BACKUP}" \
-    "${KEEP_WORKDIR}" <<'REMOTE_BOOTSTRAP'
+    "${KEEP_WORKDIR}" \
+    "${BACKUP_RETRIES}" \
+    "${BACKUP_RETRY_DELAY}" <<'REMOTE_BOOTSTRAP'
 set -euo pipefail
 
 # Run the payload from a file so stdin-consuming remote commands cannot consume
@@ -538,6 +579,8 @@ git_ref="$6"
 log_level="$7"
 skip_backup="$8"
 keep_workdir="$9"
+backup_retries="${10}"
+backup_retry_delay="${11}"
 workdir=""
 
 remote_log() {
@@ -595,8 +638,41 @@ trap remote_cleanup EXIT
 
 remote_compose() {
   (cd "${deploy_dir}" && docker compose --env-file "${deploy_dir}/.env.production" -f "${deploy_dir}/compose.yml" "$@")
+}
+
+backup_delay_for_attempt() {
+  local attempt="$1"
+  local delay="${backup_retry_delay}"
+  local index
+
+  for ((index = 1; index < attempt; index++)); do
+    delay=$((delay * 2))
+  done
+
+  printf '%s\n' "${delay}"
+  return 0
+}
+
+sleep_between_backup_attempts() {
+  local attempt="$1"
+  local delay
+
+  delay="$(backup_delay_for_attempt "${attempt}")"
+  if [[ "${delay}" -gt 0 ]]; then
+    sleep "${delay}"
+  fi
 
   return 0
+}
+
+backup_requires_database() {
+  case "${action}" in
+    update|migrate|rollback)
+      return 0
+      ;;
+  esac
+
+  return 1
 }
 
 backup_env_files() {
@@ -606,13 +682,100 @@ backup_env_files() {
   for file in .env .env.production; do
     if [[ -f "${deploy_dir}/${file}" ]]; then
       backup_name="${deploy_dir}/backups/${file#.}.pre-remote-${action}-${stamp}"
-      cp "${deploy_dir}/${file}" "${backup_name}"
-      chmod 0600 "${backup_name}"
+      cp "${deploy_dir}/${file}" "${backup_name}" || \
+        remote_die "failed to copy ${file} backup to ${backup_name}"
+      chmod 0600 "${backup_name}" || \
+        remote_die "failed to secure ${file} backup permissions for ${backup_name}"
       remote_log "backed up ${file} to ${backup_name}"
     fi
   done
 
   return 0
+}
+
+wait_for_database_backup_ready() {
+  local attempt retry_delay
+
+  for ((attempt = 1; attempt <= backup_retries; attempt++)); do
+    if remote_compose exec -T postgres pg_isready -U dollhouse -d dollhousemcp >/dev/null 2>&1; then
+      if [[ "${attempt}" -gt 1 ]]; then
+        remote_log "postgres ready for backup on attempt ${attempt}/${backup_retries}"
+      fi
+      return 0
+    fi
+
+    if [[ "${attempt}" -lt "${backup_retries}" ]]; then
+      retry_delay="$(backup_delay_for_attempt "${attempt}")"
+      remote_warn "postgres not ready for backup attempt ${attempt}/${backup_retries}; retrying in ${retry_delay}s"
+      sleep_between_backup_attempts "${attempt}"
+    fi
+  done
+
+  if backup_requires_database; then
+    remote_die "postgres is not ready for pre-${action} backup after ${backup_retries} attempt(s); set DOLLHOUSE_REMOTE_SKIP_BACKUP=true only if you have a separate backup"
+  fi
+
+  remote_warn "postgres is not ready after ${backup_retries} attempt(s); skipping database backup"
+  return 1
+}
+
+quarantine_partial_backup() {
+  local tmp_file="$1"
+  local backup_file="$2"
+  local attempt="$3"
+  local failed_file
+
+  if [[ ! -f "${tmp_file}" ]]; then
+    return 0
+  fi
+
+  if [[ ! -s "${tmp_file}" ]]; then
+    rm -f "${tmp_file}"
+    return 0
+  fi
+
+  failed_file="${backup_file}.failed-attempt-${attempt}"
+  mv "${tmp_file}" "${failed_file}" || \
+    remote_die "failed to quarantine partial database backup ${tmp_file}"
+  chmod 0600 "${failed_file}" || \
+    remote_die "failed to secure quarantined partial database backup ${failed_file}"
+  remote_warn "partial database backup from attempt ${attempt} moved to ${failed_file}"
+
+  return 0
+}
+
+dump_database_with_retries() {
+  local backup_file="$1"
+  local attempt retry_delay tmp_file
+
+  for ((attempt = 1; attempt <= backup_retries; attempt++)); do
+    tmp_file="${backup_file}.tmp"
+    rm -f "${tmp_file}"
+    remote_log "creating database backup ${backup_file} (attempt ${attempt}/${backup_retries})"
+
+    if remote_compose exec -T postgres pg_dump -U dollhouse dollhousemcp > "${tmp_file}"; then
+      if [[ ! -s "${tmp_file}" ]]; then
+        remote_warn "database backup attempt ${attempt}/${backup_retries} produced an empty dump"
+        rm -f "${tmp_file}"
+      else
+        mv "${tmp_file}" "${backup_file}" || \
+          remote_die "failed to finalize database backup ${backup_file}"
+        chmod 0600 "${backup_file}" || \
+          remote_die "failed to secure database backup permissions for ${backup_file}"
+        return 0
+      fi
+    else
+      quarantine_partial_backup "${tmp_file}" "${backup_file}" "${attempt}"
+    fi
+
+    if [[ "${attempt}" -lt "${backup_retries}" ]]; then
+      retry_delay="$(backup_delay_for_attempt "${attempt}")"
+      remote_warn "database backup attempt ${attempt}/${backup_retries} failed; retrying in ${retry_delay}s"
+      sleep_between_backup_attempts "${attempt}"
+    fi
+  done
+
+  remote_die "failed to create database backup ${backup_file} after ${backup_retries} attempt(s); partial attempts were quarantined as ${backup_file}.failed-attempt-*"
 }
 
 backup_database() {
@@ -624,23 +787,10 @@ backup_database() {
     return 0
   fi
 
-  if ! remote_compose exec -T postgres pg_isready -U dollhouse -d dollhousemcp >/dev/null 2>&1; then
-    case "${action}" in
-      update|migrate|rollback)
-        remote_die "postgres is not ready for pre-${action} backup; set DOLLHOUSE_REMOTE_SKIP_BACKUP=true only if you have a separate backup"
-        ;;
-      *)
-        remote_warn "postgres is not ready; skipping database backup"
-        return 0
-        ;;
-    esac
-  fi
+  wait_for_database_backup_ready || return 0
 
   backup_file="${deploy_dir}/backups/pre-remote-${action}-${stamp}.sql"
-  remote_log "creating database backup ${backup_file}"
-  remote_compose exec -T postgres pg_dump -U dollhouse dollhousemcp > "${backup_file}" || \
-    remote_die "failed to create database backup ${backup_file}"
-  chmod 0600 "${backup_file}"
+  dump_database_with_retries "${backup_file}"
 
   return 0
 }
@@ -658,8 +808,10 @@ backup_existing_deploy() {
   fi
 
   stamp="$(date -u +%Y%m%dT%H%M%SZ)"
-  mkdir -p "${deploy_dir}/backups"
-  chmod 0750 "${deploy_dir}/backups"
+  mkdir -p "${deploy_dir}/backups" || \
+    remote_die "failed to create backup directory ${deploy_dir}/backups"
+  chmod 0750 "${deploy_dir}/backups" || \
+    remote_die "failed to secure backup directory permissions for ${deploy_dir}/backups"
   backup_env_files "${stamp}"
   backup_database "${stamp}"
 

--- a/tests/scripts/hosted-remote-deploy.test.sh
+++ b/tests/scripts/hosted-remote-deploy.test.sh
@@ -12,6 +12,8 @@ REMOTE_LOG="${TMP_ROOT}/remote.log"
 SSH_LOG="${TMP_ROOT}/ssh.log"
 CURL_LOG="${TMP_ROOT}/curl.log"
 KNOWN_HOSTS_FILE="${TMP_ROOT}/known_hosts"
+FAKE_STATE_DIR="${TMP_ROOT}/state"
+EXPECTED_HOSTED_ACTION="hosted action=update ref=codex/test-ref"
 
 cleanup() {
   if [[ -n "${TMP_ROOT:-}" && -d "${TMP_ROOT}" && "${TMP_ROOT}" == "${TMPDIR:-/tmp}"* ]]; then
@@ -32,7 +34,11 @@ fail() {
 assert_contains() {
   local file="$1"
   local expected="$2"
-  grep -Fq "${expected}" "${file}" || fail "expected ${file} to contain: ${expected}"
+  if ! grep -Fq "${expected}" "${file}"; then
+    printf '[hosted-remote-deploy-test] %s contents:\n' "${file}" >&2
+    sed 's/^/[hosted-remote-deploy-test]   /' "${file}" >&2 || true
+    fail "expected ${file} to contain: ${expected}"
+  fi
 }
 
 assert_not_contains() {
@@ -41,6 +47,14 @@ assert_not_contains() {
   if grep -Fq "${unexpected}" "${file}"; then
     fail "expected ${file} not to contain: ${unexpected}"
   fi
+}
+
+reset_fake_state() {
+  rm -R "${FAKE_STATE_DIR}" 2>/dev/null || true
+  mkdir -p "${FAKE_STATE_DIR}"
+  : > "${REMOTE_LOG}"
+
+  return 0
 }
 
 write_fake_commands() {
@@ -147,6 +161,13 @@ case "${1:-}" in
 esac
 EOF
 
+  cat > "${FAKE_BIN}/sleep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'sleep %s\n' "$*" >> "${DOLLHOUSE_FAKE_REMOTE_LOG:?}"
+EOF
+
   cat > "${FAKE_BIN}/git" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -204,11 +225,35 @@ if [[ "${1:-}" == "compose" && "${2:-}" == "version" ]]; then
   exit 0
 fi
 
+increment_counter() {
+  local name="$1"
+  local file count
+
+  mkdir -p "${DOLLHOUSE_FAKE_STATE_DIR:?}"
+  file="${DOLLHOUSE_FAKE_STATE_DIR}/${name}"
+  count="0"
+  if [[ -f "${file}" ]]; then
+    count="$(cat "${file}")"
+  fi
+  count=$((count + 1))
+  printf '%s\n' "${count}" > "${file}"
+  printf '%s\n' "${count}"
+}
+
 if [[ "$*" == *"pg_isready"* ]]; then
+  attempt="$(increment_counter pg_isready)"
+  if [[ "${attempt}" -le "${DOLLHOUSE_FAKE_PG_ISREADY_FAILS:-0}" ]]; then
+    exit 1
+  fi
   exit 0
 fi
 if [[ "$*" == *"pg_dump"* ]]; then
+  attempt="$(increment_counter pg_dump)"
   cat >/dev/null || true
+  if [[ "${attempt}" -le "${DOLLHOUSE_FAKE_PG_DUMP_FAILS:-0}" ]]; then
+    printf 'partial sql backup attempt %s\n' "${attempt}"
+    exit 42
+  fi
   printf 'fake sql backup\n'
   exit 0
 fi
@@ -237,7 +282,7 @@ done
 exit 0
 EOF
 
-  chmod +x "${FAKE_BIN}/ssh" "${FAKE_BIN}/ssh-keyscan" "${FAKE_BIN}/ssh-keygen" "${FAKE_BIN}/git" "${FAKE_BIN}/docker" "${FAKE_BIN}/curl"
+  chmod +x "${FAKE_BIN}/ssh" "${FAKE_BIN}/ssh-keyscan" "${FAKE_BIN}/ssh-keygen" "${FAKE_BIN}/sleep" "${FAKE_BIN}/git" "${FAKE_BIN}/docker" "${FAKE_BIN}/curl"
 }
 
 prepare_existing_deploy() {
@@ -259,8 +304,13 @@ run_remote() {
   DOLLHOUSE_FAKE_CURL_MCP_STATUS="${DOLLHOUSE_FAKE_CURL_MCP_STATUS:-401}" \
   DOLLHOUSE_FAKE_GIT_FAIL_REF="${DOLLHOUSE_FAKE_GIT_FAIL_REF:-}" \
   DOLLHOUSE_FAKE_KEYSCAN_EMPTY="${DOLLHOUSE_FAKE_KEYSCAN_EMPTY:-false}" \
+  DOLLHOUSE_FAKE_STATE_DIR="${FAKE_STATE_DIR}" \
+  DOLLHOUSE_FAKE_PG_ISREADY_FAILS="${DOLLHOUSE_FAKE_PG_ISREADY_FAILS:-0}" \
+  DOLLHOUSE_FAKE_PG_DUMP_FAILS="${DOLLHOUSE_FAKE_PG_DUMP_FAILS:-0}" \
   DOLLHOUSE_REMOTE_SSH_TARGET=root@example.test \
   DOLLHOUSE_REMOTE_KNOWN_HOSTS_FILE="${DOLLHOUSE_TEST_KNOWN_HOSTS_FILE:-${KNOWN_HOSTS_FILE}}" \
+  DOLLHOUSE_REMOTE_BACKUP_RETRIES="${DOLLHOUSE_TEST_BACKUP_RETRIES:-3}" \
+  DOLLHOUSE_REMOTE_BACKUP_RETRY_DELAY="${DOLLHOUSE_TEST_BACKUP_RETRY_DELAY:-0}" \
   DOLLHOUSE_HOSTED_DEPLOY_DIR="${DEPLOY_DIR}" \
   DOLLHOUSE_HOSTED_HOSTNAME=mcp.example.com \
   DOLLHOUSE_HOSTED_GIT_URL="${DOLLHOUSE_TEST_GIT_URL:-https://github.com/DollhouseMCP/mcp-server.git}" \
@@ -317,6 +367,7 @@ assert_contains "${PORT_ENROLL_OUTPUT}" "wrote [example.test]:2222 to ${PORT_KNO
 assert_contains "${PORT_KNOWN_HOSTS}" "[example.test]:2222 ssh-ed25519 AAAATESTKEY"
 
 log "checking remote update wrapper"
+reset_fake_state
 OUTPUT="${TMP_ROOT}/update.out"
 run_remote update > "${OUTPUT}"
 assert_contains "${SSH_LOG}" "target=root@example.test"
@@ -324,7 +375,7 @@ assert_contains "${SSH_LOG}" "StrictHostKeyChecking=yes"
 assert_contains "${SSH_LOG}" "UserKnownHostsFile=${KNOWN_HOSTS_FILE}"
 assert_not_contains "${SSH_LOG}" "StrictHostKeyChecking=accept-new"
 assert_contains "${REMOTE_LOG}" "git clone --depth 1 --branch codex/test-ref"
-assert_contains "${REMOTE_LOG}" "hosted action=update ref=codex/test-ref"
+assert_contains "${REMOTE_LOG}" "${EXPECTED_HOSTED_ACTION}"
 assert_contains "${REMOTE_LOG}" "pg_dump"
 assert_contains "${OUTPUT}" "backed up .env.production"
 assert_contains "${OUTPUT}" "creating database backup"
@@ -337,6 +388,92 @@ assert_contains "${DEPLOY_DIR}/DEPLOYED_REVISION" "codex/test-ref"
 latest_db_backup="$(find "${DEPLOY_DIR}/backups" -name 'pre-remote-update-*.sql' -print | head -n 1)"
 [[ -n "${latest_db_backup}" ]] || fail "expected database backup"
 assert_contains "${latest_db_backup}" "fake sql backup"
+
+log "checking postgres readiness retry"
+reset_fake_state
+READINESS_RETRY_OUTPUT="${TMP_ROOT}/readiness-retry.out"
+DOLLHOUSE_FAKE_PG_ISREADY_FAILS=1
+DOLLHOUSE_TEST_BACKUP_RETRIES=2
+run_remote update > "${READINESS_RETRY_OUTPUT}" 2>&1
+unset DOLLHOUSE_FAKE_PG_ISREADY_FAILS DOLLHOUSE_TEST_BACKUP_RETRIES
+assert_contains "${READINESS_RETRY_OUTPUT}" "postgres not ready for backup attempt 1/2"
+assert_contains "${READINESS_RETRY_OUTPUT}" "postgres ready for backup on attempt 2/2"
+assert_contains "${REMOTE_LOG}" "${EXPECTED_HOSTED_ACTION}"
+
+log "checking postgres readiness exponential backoff"
+reset_fake_state
+READINESS_BACKOFF_OUTPUT="${TMP_ROOT}/readiness-backoff.out"
+DOLLHOUSE_FAKE_PG_ISREADY_FAILS=2
+DOLLHOUSE_TEST_BACKUP_RETRIES=3
+DOLLHOUSE_TEST_BACKUP_RETRY_DELAY=2
+run_remote update > "${READINESS_BACKOFF_OUTPUT}" 2>&1
+unset DOLLHOUSE_FAKE_PG_ISREADY_FAILS DOLLHOUSE_TEST_BACKUP_RETRIES DOLLHOUSE_TEST_BACKUP_RETRY_DELAY
+assert_contains "${READINESS_BACKOFF_OUTPUT}" "postgres not ready for backup attempt 1/3; retrying in 2s"
+assert_contains "${READINESS_BACKOFF_OUTPUT}" "postgres not ready for backup attempt 2/3; retrying in 4s"
+assert_contains "${READINESS_BACKOFF_OUTPUT}" "postgres ready for backup on attempt 3/3"
+assert_contains "${REMOTE_LOG}" "sleep 2"
+assert_contains "${REMOTE_LOG}" "sleep 4"
+assert_contains "${REMOTE_LOG}" "${EXPECTED_HOSTED_ACTION}"
+
+log "checking pg_dump retry quarantines partial backup"
+reset_fake_state
+rm -R "${DEPLOY_DIR}/backups" 2>/dev/null || true
+DUMP_RETRY_OUTPUT="${TMP_ROOT}/dump-retry.out"
+DOLLHOUSE_FAKE_PG_DUMP_FAILS=1
+DOLLHOUSE_TEST_BACKUP_RETRIES=2
+run_remote update > "${DUMP_RETRY_OUTPUT}" 2>&1
+unset DOLLHOUSE_FAKE_PG_DUMP_FAILS DOLLHOUSE_TEST_BACKUP_RETRIES
+assert_contains "${DUMP_RETRY_OUTPUT}" "partial database backup from attempt 1 moved"
+assert_contains "${DUMP_RETRY_OUTPUT}" "database backup attempt 1/2 failed"
+assert_contains "${REMOTE_LOG}" "${EXPECTED_HOSTED_ACTION}"
+partial_backup="$(find "${DEPLOY_DIR}/backups" -name 'pre-remote-update-*.sql.failed-attempt-1' -print | head -n 1)"
+[[ -n "${partial_backup}" ]] || fail "expected quarantined partial backup"
+assert_contains "${partial_backup}" "partial sql backup attempt 1"
+successful_retry_backup="$(find "${DEPLOY_DIR}/backups" -name 'pre-remote-update-*.sql' -print | head -n 1)"
+[[ -n "${successful_retry_backup}" ]] || fail "expected successful retry backup"
+assert_contains "${successful_retry_backup}" "fake sql backup"
+
+log "checking permanent postgres readiness failure"
+reset_fake_state
+rm -R "${DEPLOY_DIR}/backups" 2>/dev/null || true
+READINESS_FAIL_OUTPUT="${TMP_ROOT}/readiness-fail.out"
+DOLLHOUSE_FAKE_PG_ISREADY_FAILS=9
+DOLLHOUSE_TEST_BACKUP_RETRIES=2
+if run_remote update > "${READINESS_FAIL_OUTPUT}" 2>&1; then
+  fail "permanent postgres readiness failure unexpectedly succeeded"
+fi
+unset DOLLHOUSE_FAKE_PG_ISREADY_FAILS DOLLHOUSE_TEST_BACKUP_RETRIES
+assert_contains "${READINESS_FAIL_OUTPUT}" "postgres is not ready for pre-update backup after 2 attempt(s)"
+assert_not_contains "${REMOTE_LOG}" "pg_dump"
+assert_not_contains "${REMOTE_LOG}" "hosted action=update"
+
+log "checking permanent pg_dump failure blocks update"
+reset_fake_state
+rm -R "${DEPLOY_DIR}/backups" 2>/dev/null || true
+DUMP_FAIL_OUTPUT="${TMP_ROOT}/dump-fail.out"
+DOLLHOUSE_FAKE_PG_DUMP_FAILS=9
+DOLLHOUSE_TEST_BACKUP_RETRIES=2
+if run_remote update > "${DUMP_FAIL_OUTPUT}" 2>&1; then
+  fail "permanent pg_dump failure unexpectedly succeeded"
+fi
+unset DOLLHOUSE_FAKE_PG_DUMP_FAILS DOLLHOUSE_TEST_BACKUP_RETRIES
+assert_contains "${DUMP_FAIL_OUTPUT}" "failed to create database backup"
+assert_contains "${DUMP_FAIL_OUTPUT}" "after 2 attempt(s)"
+assert_not_contains "${REMOTE_LOG}" "hosted action=update"
+partial_count="$(
+  find "${DEPLOY_DIR}/backups" -name 'pre-remote-update-*.sql.failed-attempt-*' -print |
+    wc -l |
+    tr -d ' '
+)"
+[[ "${partial_count}" == "2" ]] || fail "expected 2 quarantined partial backups, got ${partial_count}"
+success_count="$(
+  find "${DEPLOY_DIR}/backups" -name 'pre-remote-update-*.sql' -print |
+    wc -l |
+    tr -d ' '
+)"
+if [[ "${success_count}" != "0" ]]; then
+  fail "expected no finalized backup after permanent pg_dump failure, got ${success_count}"
+fi
 
 log "checking missing target error"
 MISSING_TARGET_OUTPUT="${TMP_ROOT}/missing-target.out"


### PR DESCRIPTION
## Summary

Closes #2235.

Hardens the hosted remote wrapper's pre-action backup path for production-like use.

- adds bounded retry settings for remote backup readiness and `pg_dump`
- keeps the safe default: `update`, `migrate`, and `rollback` still stop if a required backup cannot be created
- quarantines partial dump output as `.failed-attempt-<n>` instead of leaving it as a finalized `.sql` backup
- improves failure messages for backup directory setup, env backup copying, Postgres readiness, dump finalization, and backup file permissions
- fixes a real bug found by the new tests: `remote_compose()` previously masked Docker Compose failures by always returning `0`
- documents retry settings and partial-backup quarantine behavior

## Validation

- `npm run lint:shell`
- `npm run test:hosted-deploy`
- `bash -n scripts/hosted-deploy.sh scripts/hosted-deploy/*.sh scripts/hosted-remote-deploy.sh tests/scripts/hosted-deploy-render.test.sh tests/scripts/hosted-deploy-workflow.test.sh tests/scripts/hosted-remote-deploy.test.sh && git diff --check`
- `npm pack --dry-run --json | rg 'scripts/hosted-remote-deploy.sh|scripts/hosted-deploy.sh|package.json'`

## Notes

The retry tests cover transient Postgres readiness failure, transient `pg_dump` failure with quarantined partial output, permanent readiness failure, and permanent dump failure that blocks the update before the hosted helper runs.
