### PR TITLE
[codex] Add hosted LAN and enterprise deployment modes

### DIFF
--- a/docs/guides/hosted-deployment-automation.md
+++ b/docs/guides/hosted-deployment-automation.md
@@ -37,6 +37,35 @@ DOLLHOUSE_HOSTED_HOSTNAME=mcp.example.com \
   npm run hosted:deploy -- install
 ```
 
+Render a conservative local/LAN deployment that listens on loopback only:
+
+```bash
+DOLLHOUSE_HOSTED_MODE=lan \
+DOLLHOUSE_HOSTED_HOSTNAME=localhost \
+  npm run hosted:deploy -- render
+```
+
+Expose the LAN deployment on all host interfaces:
+
+```bash
+DOLLHOUSE_HOSTED_MODE=lan \
+DOLLHOUSE_HOSTED_HOSTNAME=dollhouse.local \
+DOLLHOUSE_HOSTED_BIND_ADDRESS=0.0.0.0 \
+  npm run hosted:deploy -- install
+```
+
+Render an enterprise deployment that validates tokens from an external OIDC IdP:
+
+```bash
+DOLLHOUSE_HOSTED_MODE=enterprise \
+DOLLHOUSE_HOSTED_HOSTNAME=mcp.example.com \
+DOLLHOUSE_AUTH_PROVIDER=oidc \
+DOLLHOUSE_AUTH_METHODS='' \
+DOLLHOUSE_AUTH_ISSUER=https://idp.example.com \
+DOLLHOUSE_AUTH_AUDIENCE=dollhouse-mcp \
+  npm run hosted:deploy -- render
+```
+
 Update an existing install:
 
 ```bash
@@ -74,6 +103,19 @@ DOLLHOUSE_REMOTE_KNOWN_HOSTS_FILE=./dollhouse_known_hosts \
 DOLLHOUSE_HOSTED_HOSTNAME=mcp.example.com \
 DOLLHOUSE_HOSTED_GIT_REF=codex/hosted-http-integration \
   npm run hosted:remote -- update
+```
+
+Run a side-by-side canary on the same host without taking over the production stack:
+
+```bash
+DOLLHOUSE_REMOTE_SSH_TARGET=root@203.0.113.10 \
+DOLLHOUSE_REMOTE_KNOWN_HOSTS_FILE=./dollhouse_known_hosts \
+DOLLHOUSE_HOSTED_DEPLOY_DIR=/opt/dollhousemcp-canary \
+DOLLHOUSE_HOSTED_MODE=lan \
+DOLLHOUSE_HOSTED_HOSTNAME=localhost \
+DOLLHOUSE_HOSTED_HTTP_BIND_PORT=3100 \
+DOLLHOUSE_HOSTED_GIT_REF=codex/hosted-lan-enterprise-setup \
+  npm run hosted:remote -- --skip-local-verify update
 ```
 
 The helper lives at [`scripts/hosted-deploy.sh`](../../scripts/hosted-deploy.sh).
@@ -135,19 +177,36 @@ Common environment variables:
 
 | Variable | Purpose | Default |
 |---|---|---|
+| `DOLLHOUSE_HOSTED_MODE` | Deployment preset: `cloud`, `lan`, or `enterprise` | `cloud` |
 | `DOLLHOUSE_HOSTED_DEPLOY_DIR` | Deployment root | `/opt/dollhousemcp` |
+| `DOLLHOUSE_HOSTED_INSTANCE_NAME` | Docker Compose project and container-name identity for this deployment | derived from the deployment root basename |
+| `DOLLHOUSE_HOSTED_IMAGE_TAG` | Docker image tag used for the app and migration images | `dollhousemcp-hosted:alpha` for `/opt/dollhousemcp`, otherwise `<instance>-hosted:alpha` |
 | `DOLLHOUSE_HOSTED_DRY_RUN` | Preview operations without writes, Docker, git clone, or HTTP checks | `false` |
 | `DOLLHOUSE_HOSTED_LOG_LEVEL` | Logging mode: `quiet`, `info`, or `debug` | `info` |
 | `DOLLHOUSE_HOSTED_IMPORT_LEGACY_ENV` | Import selected secrets/config from an existing `.env` into `.env.production` during upgrade | `true` |
 | `DOLLHOUSE_HOSTED_HOSTNAME` | Public hostname, for example `mcp.example.com` | none |
 | `DOLLHOUSE_PUBLIC_BASE_URL` | Public URL, for example `https://mcp.example.com` | derived from hostname |
+| `DOLLHOUSE_HOSTED_PROXY_MODE` | Reverse proxy mode: `caddy-tls` or `caddy-http` | mode-specific |
+| `DOLLHOUSE_HOSTED_BIND_ADDRESS` | IPv4 host interface for Caddy ports, for example `127.0.0.1` or `0.0.0.0` | mode-specific |
+| `DOLLHOUSE_HOSTED_HTTP_BIND_PORT` | Host HTTP port for Caddy | `80` for `cloud`/`enterprise`, `3000` for `lan` |
+| `DOLLHOUSE_HOSTED_HTTPS_BIND_PORT` | Host HTTPS port for Caddy TLS mode | `443` |
+| `DOLLHOUSE_HTTP_ALLOWED_HOSTS` | Comma-separated Host header allowlist passed to the app | `localhost,127.0.0.1,<hostname>` |
+| `DOLLHOUSE_TRUSTED_PROXIES` | Comma-separated trusted proxy CIDRs passed to the app | Docker bridge CIDR `172.16.0.0/12` |
 | `DOLLHOUSE_HOSTED_SOURCE_DIR` | Local repo source to deploy | current repo when available |
 | `DOLLHOUSE_HOSTED_GIT_URL` | Repo cloned when no source dir is available | GitHub mcp-server repo |
 | `DOLLHOUSE_HOSTED_GIT_REF` | Branch/ref cloned when no source dir is available | `codex/hosted-http-integration` |
 | `DOLLHOUSE_HOSTED_ALLOW_CREDENTIAL_GIT_URL` | Permit credentials embedded in `DOLLHOUSE_HOSTED_GIT_URL` | `false` |
+| `DOLLHOUSE_AUTH_PROVIDER` | Auth provider: `embedded`, `oidc`, or `local` | `embedded` |
+| `DOLLHOUSE_AUTH_METHODS` | Embedded-AS sign-in methods, for example `github` or `github,local-password` | `github` for `embedded`, empty for `oidc` |
+| `DOLLHOUSE_AUTH_ISSUER` | External OIDC issuer URL for `DOLLHOUSE_AUTH_PROVIDER=oidc` | none |
+| `DOLLHOUSE_AUTH_AUDIENCE` | Expected OIDC audience for `DOLLHOUSE_AUTH_PROVIDER=oidc` | none |
+| `DOLLHOUSE_AUTH_JWKS_URI` | Optional OIDC JWKS URL override | derived by server when omitted |
+| `DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP` | Require RFC 9068 `typ: at+jwt` for OIDC bridge tokens | `false` |
+| `DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED` | Require allowlist gate for user sign-in | `true` |
+| `DOLLHOUSE_AUTH_ALLOWLIST_SEED_FILE` | Optional allowlist seed JSON path for GitOps-managed installs | none |
 | `DOLLHOUSE_AUTH_GITHUB_CLIENT_ID` | GitHub OAuth app client ID | prompted or left unset |
 | `DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET` | GitHub OAuth app client secret | prompted or left unset |
-| `DOLLHOUSE_AUTH_OPEN_DCR` | Whether unauthenticated Dynamic Client Registration is enabled | `true` |
+| `DOLLHOUSE_AUTH_OPEN_DCR` | Whether unauthenticated Dynamic Client Registration is enabled | `true` in `cloud`, `false` in `lan`/`enterprise` |
 | `DOLLHOUSE_BOOTSTRAP_GITHUB_USERNAME` | Optional GitHub username to pre-claim as the first admin | none |
 | `DOLLHOUSE_BOOTSTRAP_GITHUB_ID` | Optional numeric GitHub ID to pre-claim as the first admin and skip API lookup | none |
 | `DOLLHOUSE_HOSTED_POSTGRES_READY_TIMEOUT` | Seconds to wait for Postgres readiness | `60` |
@@ -176,6 +235,61 @@ All helper-managed Docker Compose commands run with `--env-file .env.production`
 The generated Postgres init script is a shell script (`init-db.sh`) rather than a password-filled SQL file. It receives the app role password through `DOLLHOUSE_APP_DB_PASSWORD` at container init time and passes it to `psql` as a variable, so the generated init script itself does not contain the app database password.
 
 The helper rejects credential-bearing `DOLLHOUSE_HOSTED_GIT_URL` values by default because credentials embedded in command arguments can leak through process listings or logs. The remote wrapper applies the same check before opening SSH. Use a git credential helper, deploy key, or `DOLLHOUSE_HOSTED_SOURCE_DIR` instead. If an operator has an explicit reason to allow this, set `DOLLHOUSE_HOSTED_ALLOW_CREDENTIAL_GIT_URL=true`.
+
+## Side-by-Side Canaries
+
+Multiple hosted deployments can run on the same Docker host when each deployment uses a distinct deployment root and instance name. If `DOLLHOUSE_HOSTED_INSTANCE_NAME` is not supplied, the helper derives it from the basename of `DOLLHOUSE_HOSTED_DEPLOY_DIR`. For example:
+
+- `/opt/dollhousemcp` derives `dollhousemcp`
+- `/opt/dollhousemcp-canary` derives `dollhousemcp-canary`
+
+The instance name is written to `.env.production` and used for:
+
+- the Docker Compose project name
+- generated container names: `<instance>`, `<instance>-postgres`, and `<instance>-caddy`
+- the default image tag, using `<instance>-hosted:alpha` except for the backward-compatible default `dollhousemcp-hosted:alpha`
+
+This prevents Docker container, network, volume, and image-tag collisions between production and canary stacks. Host ports are still exclusive. A canary on the same VPS must use alternate ports or a separate fronting proxy route; for example, LAN mode with `DOLLHOUSE_HOSTED_HTTP_BIND_PORT=3100`.
+
+## Deployment Modes
+
+The helper supports three presets. The selected mode, hostname, public URL, proxy mode, bind address, and auth posture are written into `.env.production`, so a later `install`, `update`, or `render` can preserve the deployment shape even if the operator does not pass every variable again.
+
+### `cloud`
+
+`cloud` is the Dollhouse-operated alpha/demo shape. It renders:
+
+- Caddy with automatic HTTPS on host ports `80` and `443`
+- embedded Dollhouse OAuth/OIDC authorization server
+- GitHub sign-in
+- allowlist required
+- open DCR enabled for alpha MCP-client compatibility
+
+Use it for Dollhouse-managed cloud deployments where the server has a public hostname and Caddy can obtain certificates.
+
+### `lan`
+
+`lan` is for local or private-network installs. It renders:
+
+- Caddy HTTP on `DOLLHOUSE_HOSTED_HTTP_BIND_PORT`, defaulting to `3000`
+- loopback-only host binding by default: `DOLLHOUSE_HOSTED_BIND_ADDRESS=127.0.0.1`
+- embedded Dollhouse OAuth/OIDC authorization server
+- GitHub sign-in by default
+- allowlist required
+- open DCR disabled by default
+
+To expose the server to other machines on the network, set `DOLLHOUSE_HOSTED_BIND_ADDRESS=0.0.0.0` or a specific IPv4 interface address and set `DOLLHOUSE_HOSTED_HOSTNAME` to the DNS name or IP address clients will use. For real enterprise or untrusted LAN use, put TLS in front of this path or use the `enterprise` preset with a proper hostname.
+
+### `enterprise`
+
+`enterprise` is for organization-controlled single-tenant deployments. It renders:
+
+- Caddy with automatic HTTPS on host ports `80` and `443`
+- allowlist required
+- open DCR disabled by default
+- configurable auth provider
+
+Use `DOLLHOUSE_AUTH_PROVIDER=embedded` with `DOLLHOUSE_AUTH_METHODS=github` when the organization wants DollhouseMCP to run its own authorization server and use GitHub as the user sign-in method. Use `DOLLHOUSE_AUTH_PROVIDER=oidc` with `DOLLHOUSE_AUTH_ISSUER` and `DOLLHOUSE_AUTH_AUDIENCE` when the organization wants DollhouseMCP to validate access tokens issued by an external IdP such as Okta, Auth0, Keycloak, Google Workspace, or Microsoft Entra ID.
 
 ## Actions
 
@@ -361,7 +475,7 @@ DOLLHOUSE_BOOTSTRAP_GITHUB_USERNAME=octocat \
 
 ## Dynamic Client Registration
 
-The generated Compose file defaults to:
+In `cloud` mode, the generated Compose file defaults to:
 
 ```yaml
 DOLLHOUSE_AUTH_OPEN_DCR: "true"
@@ -369,12 +483,18 @@ DOLLHOUSE_AUTH_OPEN_DCR: "true"
 
 This is the alpha compatibility shape for MCP clients such as claude.ai web and Gemini CLI that auto-register through Dynamic Client Registration. The server-side DCR policy validates redirect shape and records audit metadata, and user access is still governed by GitHub authentication plus the Dollhouse allowlist gate.
 
-For a stricter enterprise deployment where MCP clients are pre-registered or issued Initial Access Tokens, set `DOLLHOUSE_AUTH_OPEN_DCR=false` before `render`, `install`, or `update`. Future enterprise presets should make that choice explicit.
+`lan` and `enterprise` default to:
+
+```yaml
+DOLLHOUSE_AUTH_OPEN_DCR: "false"
+```
+
+For clients that require unauthenticated DCR in a private test, explicitly set `DOLLHOUSE_AUTH_OPEN_DCR=true` before `render`, `install`, or `update`. Do that only when the endpoint is bound to loopback, protected by a trusted tunnel, or otherwise unreachable by untrusted clients.
 
 ## Current Limitations
 
 - The public `curl | sh` installer URL does not exist yet.
-- Local/LAN self-hosting and enterprise IdP presets still need dedicated modes.
+- Local/LAN and enterprise modes currently cover generated deployment shape and docs; they still need real-container install/update validation in representative environments.
 - The helper assumes Docker Compose and Caddy for the first production-like shape.
 - Allowlist management still uses the existing `dollhouse-allowlist` CLI.
 
@@ -396,7 +516,5 @@ This runs both the generated-file render test and a Docker-stubbed workflow test
 
 ## Next Steps
 
-- Add local/LAN mode with clear binding and TLS choices.
-- Add enterprise mode presets for external OIDC/IdP configuration.
 - Add a wrapper installer that can be served from a stable URL.
 - Add optional real-container integration coverage for Docker environments.

--- a/docs/guides/hosted-deployment-automation.md
+++ b/docs/guides/hosted-deployment-automation.md
@@ -251,6 +251,9 @@ The instance name is written to `.env.production` and used for:
 
 This prevents Docker container, network, volume, and image-tag collisions between production and canary stacks. Host ports are still exclusive. A canary on the same VPS must use alternate ports or a separate fronting proxy route; for example, LAN mode with `DOLLHOUSE_HOSTED_HTTP_BIND_PORT=3100`.
 
+Once `.env.production` records an instance name, the helper rejects attempts to rename that instance inside the same deployment root.
+Create a new deployment root for side-by-side canaries or migrations that need a different instance name.
+
 ## Deployment Modes
 
 The helper supports three presets. The selected mode, hostname, public URL, proxy mode, bind address, and auth posture are written into `.env.production`, so a later `install`, `update`, or `render` can preserve the deployment shape even if the operator does not pass every variable again.

--- a/docs/guides/hosted-deployment-automation.md
+++ b/docs/guides/hosted-deployment-automation.md
@@ -348,6 +348,10 @@ Enterprise deployments can skip `enroll-host` and point `DOLLHOUSE_REMOTE_KNOWN_
 
 The wrapper does not replace `scripts/hosted-deploy.sh`; it calls it remotely after cloning the requested ref. It uploads its remote payload to a temporary `0600` script before execution so commands such as database dumps cannot consume the rest of a streamed SSH script from stdin. Use the direct helper when you are already logged into the target host or when building local/LAN and enterprise modes.
 
+For remote actions, the wrapper forwards non-secret hosted configuration such as mode, bind ports, Host allowlists, trusted proxy CIDRs, resource limits, readiness timeouts, auth posture, OIDC settings, and bootstrap admin identity.
+Those values are passed to the remote helper after the wrapper clones the requested ref.
+It does not forward OAuth client secrets or other deployment secrets; place those in the remote `.env.production` or your remote secret-management flow before running the helper.
+
 ### `render`
 
 Writes or refreshes deployment files without starting containers:

--- a/scripts/hosted-deploy.sh
+++ b/scripts/hosted-deploy.sh
@@ -16,6 +16,8 @@ HOSTED_DEPLOY_LIB_DIR="${HOSTED_DEPLOY_SCRIPT_DIR}/hosted-deploy"
 . "${HOSTED_DEPLOY_LIB_DIR}/logging.sh"
 # shellcheck source=scripts/hosted-deploy/config.sh
 . "${HOSTED_DEPLOY_LIB_DIR}/config.sh"
+# shellcheck source=scripts/hosted-deploy/modes.sh
+. "${HOSTED_DEPLOY_LIB_DIR}/modes.sh"
 # shellcheck source=scripts/hosted-deploy/validation.sh
 . "${HOSTED_DEPLOY_LIB_DIR}/validation.sh"
 # shellcheck source=scripts/hosted-deploy/env.sh

--- a/scripts/hosted-deploy/config.sh
+++ b/scripts/hosted-deploy/config.sh
@@ -1,20 +1,101 @@
 # shellcheck shell=bash
 # Configuration and CLI parsing for hosted-deploy.
 
+hosted_deploy_nonempty_env() {
+  local name="$1"
+
+  if [[ -n "${!name-}" ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
 hosted_deploy_init_config() {
   ACTION="help"
   ACTION_SET="false"
+  DEPLOY_MODE="${DOLLHOUSE_HOSTED_MODE:-cloud}"
+  DEPLOY_MODE_SET="false"
+  if hosted_deploy_nonempty_env DOLLHOUSE_HOSTED_MODE; then
+    DEPLOY_MODE_SET="true"
+  fi
   DEPLOY_DIR="${DOLLHOUSE_HOSTED_DEPLOY_DIR:-/opt/dollhousemcp}"
+  INSTANCE_NAME="${DOLLHOUSE_HOSTED_INSTANCE_NAME:-}"
+  INSTANCE_NAME_SET="false"
+  if hosted_deploy_nonempty_env DOLLHOUSE_HOSTED_INSTANCE_NAME; then
+    INSTANCE_NAME_SET="true"
+  fi
   HOSTNAME="${DOLLHOUSE_HOSTED_HOSTNAME:-}"
+  HOSTNAME_SET="false"
+  if hosted_deploy_nonempty_env DOLLHOUSE_HOSTED_HOSTNAME; then
+    HOSTNAME_SET="true"
+  fi
   PUBLIC_BASE_URL="${DOLLHOUSE_PUBLIC_BASE_URL:-}"
+  PUBLIC_BASE_URL_SET="false"
+  if hosted_deploy_nonempty_env DOLLHOUSE_PUBLIC_BASE_URL; then
+    PUBLIC_BASE_URL_SET="true"
+  fi
+  PROXY_MODE="${DOLLHOUSE_HOSTED_PROXY_MODE:-}"
+  PROXY_MODE_SET="false"
+  if hosted_deploy_nonempty_env DOLLHOUSE_HOSTED_PROXY_MODE; then
+    PROXY_MODE_SET="true"
+  fi
+  BIND_ADDRESS="${DOLLHOUSE_HOSTED_BIND_ADDRESS:-}"
+  BIND_ADDRESS_SET="false"
+  if hosted_deploy_nonempty_env DOLLHOUSE_HOSTED_BIND_ADDRESS; then
+    BIND_ADDRESS_SET="true"
+  fi
+  HTTP_BIND_PORT="${DOLLHOUSE_HOSTED_HTTP_BIND_PORT:-}"
+  HTTP_BIND_PORT_SET="false"
+  if hosted_deploy_nonempty_env DOLLHOUSE_HOSTED_HTTP_BIND_PORT; then
+    HTTP_BIND_PORT_SET="true"
+  fi
+  HTTPS_BIND_PORT="${DOLLHOUSE_HOSTED_HTTPS_BIND_PORT:-}"
+  HTTPS_BIND_PORT_SET="false"
+  if hosted_deploy_nonempty_env DOLLHOUSE_HOSTED_HTTPS_BIND_PORT; then
+    HTTPS_BIND_PORT_SET="true"
+  fi
   SOURCE_DIR="${DOLLHOUSE_HOSTED_SOURCE_DIR:-}"
   GIT_URL="${DOLLHOUSE_HOSTED_GIT_URL:-https://github.com/DollhouseMCP/mcp-server.git}"
   GIT_REF="${DOLLHOUSE_HOSTED_GIT_REF:-codex/hosted-http-integration}"
-  IMAGE_TAG="${DOLLHOUSE_HOSTED_IMAGE_TAG:-dollhousemcp-hosted:alpha}"
+  IMAGE_TAG="${DOLLHOUSE_HOSTED_IMAGE_TAG:-}"
+  IMAGE_TAG_SET="false"
+  if hosted_deploy_nonempty_env DOLLHOUSE_HOSTED_IMAGE_TAG; then
+    IMAGE_TAG_SET="true"
+  fi
   MCP_PORT="${DOLLHOUSE_HTTP_PORT:-3000}"
   MEM_LIMIT="${DOLLHOUSE_HOSTED_MEM_LIMIT:-2g}"
   CPU_LIMIT="${DOLLHOUSE_HOSTED_CPUS:-2.0}"
-  OPEN_DCR="${DOLLHOUSE_AUTH_OPEN_DCR:-true}"
+  OPEN_DCR="${DOLLHOUSE_AUTH_OPEN_DCR:-}"
+  OPEN_DCR_SET="false"
+  if hosted_deploy_nonempty_env DOLLHOUSE_AUTH_OPEN_DCR; then
+    OPEN_DCR_SET="true"
+  fi
+  AUTH_PROVIDER="${DOLLHOUSE_AUTH_PROVIDER:-}"
+  AUTH_PROVIDER_SET="false"
+  if hosted_deploy_nonempty_env DOLLHOUSE_AUTH_PROVIDER; then
+    AUTH_PROVIDER_SET="true"
+  fi
+  AUTH_METHODS="${DOLLHOUSE_AUTH_METHODS:-}"
+  AUTH_METHODS_SET="false"
+  if hosted_deploy_nonempty_env DOLLHOUSE_AUTH_METHODS; then
+    AUTH_METHODS_SET="true"
+  fi
+  ALLOWLIST_REQUIRED="${DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED:-}"
+  ALLOWLIST_REQUIRED_SET="false"
+  if hosted_deploy_nonempty_env DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED; then
+    ALLOWLIST_REQUIRED_SET="true"
+  fi
+  TRUSTED_PROXIES="${DOLLHOUSE_TRUSTED_PROXIES:-}"
+  TRUSTED_PROXIES_SET="false"
+  if hosted_deploy_nonempty_env DOLLHOUSE_TRUSTED_PROXIES; then
+    TRUSTED_PROXIES_SET="true"
+  fi
+  ALLOWED_HOSTS="${DOLLHOUSE_HTTP_ALLOWED_HOSTS:-}"
+  ALLOWED_HOSTS_SET="false"
+  if hosted_deploy_nonempty_env DOLLHOUSE_HTTP_ALLOWED_HOSTS; then
+    ALLOWED_HOSTS_SET="true"
+  fi
   DRY_RUN="${DOLLHOUSE_HOSTED_DRY_RUN:-false}"
   IMPORT_LEGACY_ENV="${DOLLHOUSE_HOSTED_IMPORT_LEGACY_ENV:-true}"
   ALLOW_CREDENTIAL_GIT_URL="${DOLLHOUSE_HOSTED_ALLOW_CREDENTIAL_GIT_URL:-false}"
@@ -30,6 +111,9 @@ hosted_deploy_init_config() {
   CADDY_FILE="${DEPLOY_DIR}/Caddyfile"
   INIT_DB_FILE="${DEPLOY_DIR}/init-db.sh"
   SERVER_DIR="${DEPLOY_DIR}/server"
+  APP_CONTAINER_NAME=""
+  POSTGRES_CONTAINER_NAME=""
+  CADDY_CONTAINER_NAME=""
 
   return 0
 }
@@ -39,7 +123,7 @@ usage() {
 DollhouseMCP hosted deployment helper
 
 Usage:
-  scripts/hosted-deploy.sh [--dry-run] [--quiet|--debug|--log-level LEVEL] render
+  scripts/hosted-deploy.sh [--mode MODE] [--dry-run] [--quiet|--debug|--log-level LEVEL] render
   scripts/hosted-deploy.sh [--dry-run] [--quiet|--debug|--log-level LEVEL] install
   scripts/hosted-deploy.sh [--dry-run] [--quiet|--debug|--log-level LEVEL] update
   scripts/hosted-deploy.sh [--dry-run] [--quiet|--debug|--log-level LEVEL] migrate
@@ -60,11 +144,20 @@ Required for render/install/update/migrate/bootstrap-admin/rollback unless DOLLH
   DOLLHOUSE_HOSTED_HOSTNAME=mcp.example.com
 
 Common environment:
+  DOLLHOUSE_HOSTED_MODE=cloud|lan|enterprise
   DOLLHOUSE_HOSTED_DEPLOY_DIR=/opt/dollhousemcp
+  DOLLHOUSE_HOSTED_INSTANCE_NAME=dollhousemcp
   DOLLHOUSE_HOSTED_DRY_RUN=false
   DOLLHOUSE_HOSTED_LOG_LEVEL=info
+  DOLLHOUSE_HOSTED_PROXY_MODE=caddy-tls|caddy-http
+  DOLLHOUSE_HOSTED_BIND_ADDRESS=0.0.0.0
+  DOLLHOUSE_HOSTED_HTTP_BIND_PORT=80
+  DOLLHOUSE_HOSTED_HTTPS_BIND_PORT=443
   DOLLHOUSE_HOSTED_SOURCE_DIR=/path/to/local/repo
   DOLLHOUSE_HOSTED_GIT_REF=codex/hosted-http-integration
+  DOLLHOUSE_HOSTED_IMAGE_TAG=dollhousemcp-hosted:alpha
+  DOLLHOUSE_AUTH_PROVIDER=embedded|oidc|local
+  DOLLHOUSE_AUTH_METHODS=github
   DOLLHOUSE_AUTH_GITHUB_CLIENT_ID=...
   DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET=...
   DOLLHOUSE_AUTH_OPEN_DCR=true
@@ -93,6 +186,30 @@ parse_args() {
     case "${arg}" in
       --dry-run)
         DRY_RUN="true"
+        ;;
+      --mode)
+        DEPLOY_MODE="${1:-}"
+        [[ -n "${DEPLOY_MODE}" ]] || die "--mode requires cloud, lan, or enterprise"
+        DEPLOY_MODE_SET="true"
+        shift
+        ;;
+      --instance-name)
+        INSTANCE_NAME="${1:-}"
+        [[ -n "${INSTANCE_NAME}" ]] || die "--instance-name requires a name such as dollhousemcp-canary"
+        INSTANCE_NAME_SET="true"
+        shift
+        ;;
+      --proxy-mode)
+        PROXY_MODE="${1:-}"
+        [[ -n "${PROXY_MODE}" ]] || die "--proxy-mode requires caddy-tls or caddy-http"
+        PROXY_MODE_SET="true"
+        shift
+        ;;
+      --bind-address)
+        BIND_ADDRESS="${1:-}"
+        [[ -n "${BIND_ADDRESS}" ]] || die "--bind-address requires an address such as 127.0.0.1 or 0.0.0.0"
+        BIND_ADDRESS_SET="true"
+        shift
         ;;
       --quiet)
         LOG_LEVEL="quiet"

--- a/scripts/hosted-deploy/dry-run.sh
+++ b/scripts/hosted-deploy/dry-run.sh
@@ -4,7 +4,11 @@
 describe_render_plan() {
   resolve_public_base_url
   resolve_hostname
+  resolve_allowed_hosts
   validate_render_inputs
+  log "dry-run: deployment mode=${DEPLOY_MODE} instance=${INSTANCE_NAME} proxy_mode=${PROXY_MODE} bind=${BIND_ADDRESS} public_url=${PUBLIC_BASE_URL}"
+  log "dry-run: compose project=${INSTANCE_NAME} image=${IMAGE_TAG}"
+  log "dry-run: auth provider=${AUTH_PROVIDER} methods=${AUTH_METHODS:-none} open_dcr=${OPEN_DCR} allowlist_required=${ALLOWLIST_REQUIRED}"
   log "dry-run: would render deployment files in ${DEPLOY_DIR}"
   log "dry-run: would preserve or create ${ENV_FILE}"
   log "dry-run: would write ${COMPOSE_FILE}"
@@ -57,7 +61,7 @@ dry_run_start_or_update() {
   log "dry-run: would run database migrations"
   describe_bootstrap_plan optional
   if [[ "${service}" == "app" ]]; then
-    log "dry-run: would restart dollhousemcp service"
+    log "dry-run: would restart dollhousemcp service and refresh caddy proxy"
   else
     log "dry-run: would start or update the full compose stack"
   fi

--- a/scripts/hosted-deploy/env.sh
+++ b/scripts/hosted-deploy/env.sh
@@ -1,9 +1,22 @@
 # shellcheck shell=bash
 # Environment-file and secret helpers for hosted-deploy.
 
+ensure_container_portfolio_permissions() {
+  if chown -R 1001:1001 "${DEPLOY_DIR}/portfolio" 2>/dev/null; then
+    return 0
+  fi
+
+  if [[ "$(id -u)" == "0" ]]; then
+    die "failed to set container ownership on ${DEPLOY_DIR}/portfolio"
+  fi
+
+  return 0
+}
+
 ensure_layout() {
   mkdir -p "${DEPLOY_DIR}" "${DEPLOY_DIR}/portfolio" "${DEPLOY_DIR}/logs"
   chmod 0750 "${DEPLOY_DIR}" "${DEPLOY_DIR}/portfolio" "${DEPLOY_DIR}/logs"
+  ensure_container_portfolio_permissions
 
   return 0
 }
@@ -16,6 +29,18 @@ random_hex() {
   fi
 
   openssl rand -hex "${bytes}" || die "failed to generate ${bytes} random bytes with openssl"
+
+  return 0
+}
+
+random_base64() {
+  local bytes="$1"
+
+  if [[ ! "${bytes}" =~ ^[0-9]+$ || "${bytes}" -le 0 ]]; then
+    die "random secret byte count must be a positive integer, got: ${bytes}"
+  fi
+
+  openssl rand -base64 "${bytes}" || die "failed to generate ${bytes} random bytes with openssl"
 
   return 0
 }
@@ -163,6 +188,19 @@ ensure_env_secret() {
   return 0
 }
 
+ensure_env_secret_base64() {
+  local key="$1"
+  local bytes="$2"
+  local existing
+  existing="$(env_value "${key}")"
+  if [[ -n "${existing}" ]]; then
+    return 0
+  fi
+  upsert_env_value "${key}" "$(random_base64 "${bytes}")"
+
+  return 0
+}
+
 maybe_set_env_from_process() {
   local key="$1"
   local value="${!key:-}"
@@ -208,17 +246,54 @@ prompt_env_if_missing() {
   return 0
 }
 
+auth_methods_include() {
+  local needle="$1"
+  local method
+
+  IFS=',' read -r -a methods <<< "${AUTH_METHODS}"
+  for method in "${methods[@]}"; do
+    if [[ "${method}" == "${needle}" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 write_env_defaults() {
   ensure_env_file
   sync_legacy_env_values
+  upsert_env_value DOLLHOUSE_HOSTED_INSTANCE_NAME "${INSTANCE_NAME}"
+  upsert_env_value DOLLHOUSE_HOSTED_IMAGE_TAG "${IMAGE_TAG}"
+  upsert_env_value DOLLHOUSE_HOSTED_MODE "${DEPLOY_MODE}"
+  upsert_env_value DOLLHOUSE_HOSTED_HOSTNAME "${HOSTNAME}"
+  upsert_env_value DOLLHOUSE_PUBLIC_BASE_URL "${PUBLIC_BASE_URL}"
+  upsert_env_value DOLLHOUSE_HOSTED_PROXY_MODE "${PROXY_MODE}"
+  upsert_env_value DOLLHOUSE_HOSTED_BIND_ADDRESS "${BIND_ADDRESS}"
+  upsert_env_value DOLLHOUSE_HOSTED_HTTP_BIND_PORT "${HTTP_BIND_PORT}"
+  upsert_env_value DOLLHOUSE_HOSTED_HTTPS_BIND_PORT "${HTTPS_BIND_PORT}"
+  upsert_env_value DOLLHOUSE_HTTP_PORT "${MCP_PORT}"
+  upsert_env_value DOLLHOUSE_HTTP_ALLOWED_HOSTS "${ALLOWED_HOSTS}"
+  upsert_env_value DOLLHOUSE_TRUSTED_PROXIES "${TRUSTED_PROXIES}"
+  upsert_env_value DOLLHOUSE_AUTH_PROVIDER "${AUTH_PROVIDER}"
+  upsert_env_value DOLLHOUSE_AUTH_METHODS "${AUTH_METHODS}"
+  upsert_env_value DOLLHOUSE_AUTH_OPEN_DCR "${OPEN_DCR}"
+  upsert_env_value DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED "${ALLOWLIST_REQUIRED}"
   ensure_env_secret POSTGRES_ADMIN_PASSWORD 24
   ensure_env_secret POSTGRES_PASSWORD 24
   ensure_env_secret DOLLHOUSE_COOKIE_SIGNING_SECRET 32
   ensure_env_secret DOLLHOUSE_INVITE_TOKEN_SECRET 32
   ensure_env_secret DOLLHOUSE_AUDIT_HMAC_SECRET 32
-  upsert_env_value DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED "true"
-  prompt_env_if_missing DOLLHOUSE_AUTH_GITHUB_CLIENT_ID "GitHub OAuth client ID" false
-  prompt_env_if_missing DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET "GitHub OAuth client secret" true
+  ensure_env_secret_base64 DOLLHOUSE_MASTER_ENCRYPTION_KEY 32
+  maybe_set_env_from_process DOLLHOUSE_AUTH_ISSUER
+  maybe_set_env_from_process DOLLHOUSE_AUTH_AUDIENCE
+  maybe_set_env_from_process DOLLHOUSE_AUTH_JWKS_URI
+  maybe_set_env_from_process DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP
+  maybe_set_env_from_process DOLLHOUSE_AUTH_ALLOWLIST_SEED_FILE
+  if [[ "${AUTH_PROVIDER}" == "embedded" ]] && auth_methods_include github; then
+    prompt_env_if_missing DOLLHOUSE_AUTH_GITHUB_CLIENT_ID "GitHub OAuth client ID" false
+    prompt_env_if_missing DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET "GitHub OAuth client secret" true
+  fi
 
   return 0
 }

--- a/scripts/hosted-deploy/modes.sh
+++ b/scripts/hosted-deploy/modes.sh
@@ -1,0 +1,413 @@
+# shellcheck shell=bash
+# Deployment-mode defaults for hosted-deploy.
+
+deployment_env_file_value() {
+  local key="$1"
+
+  [[ -f "${ENV_FILE}" ]] || return 0
+  awk -F= -v key="${key}" '$1 == key { value = substr($0, length(key) + 2) } END { print value }' "${ENV_FILE}"
+
+  return 0
+}
+
+public_base_url_scheme() {
+  case "${PUBLIC_BASE_URL}" in
+    http://*)
+      printf 'http\n'
+      ;;
+    https://*)
+      printf 'https\n'
+      ;;
+    *)
+      die "DOLLHOUSE_PUBLIC_BASE_URL must start with http:// or https://"
+      ;;
+  esac
+
+  return 0
+}
+
+public_base_url_authority() {
+  local value="${PUBLIC_BASE_URL#https://}"
+  value="${value#http://}"
+  printf '%s\n' "${value%%/*}"
+
+  return 0
+}
+
+public_base_url_port_for_scheme() {
+  local expected_scheme="$1"
+  local authority scheme
+
+  scheme="$(public_base_url_scheme)"
+  [[ "${scheme}" == "${expected_scheme}" ]] || return 0
+
+  authority="$(public_base_url_authority)"
+  if [[ "${authority}" == *:* ]]; then
+    printf '%s\n' "${authority##*:}"
+  elif [[ "${scheme}" == "http" ]]; then
+    printf '80\n'
+  else
+    printf '443\n'
+  fi
+
+  return 0
+}
+
+adopt_deployment_config_from_env_file() {
+  local value persisted_mode persisted_instance adopt_mode_dependent adopt_instance_dependent
+  adopt_mode_dependent="true"
+  adopt_instance_dependent="true"
+  persisted_mode="$(deployment_env_file_value DOLLHOUSE_HOSTED_MODE)"
+  persisted_instance="$(deployment_env_file_value DOLLHOUSE_HOSTED_INSTANCE_NAME)"
+
+  if [[ "${DEPLOY_MODE_SET}" != "true" ]]; then
+    [[ -z "${persisted_mode}" ]] || DEPLOY_MODE="${persisted_mode}"
+  elif [[ -z "${persisted_mode}" || "${persisted_mode}" != "${DEPLOY_MODE}" ]]; then
+    adopt_mode_dependent="false"
+  fi
+
+  if [[ "${INSTANCE_NAME_SET}" != "true" && -z "${INSTANCE_NAME}" ]]; then
+    [[ -z "${persisted_instance}" ]] || INSTANCE_NAME="${persisted_instance}"
+  elif [[ -z "${persisted_instance}" || "${persisted_instance}" != "${INSTANCE_NAME}" ]]; then
+    adopt_instance_dependent="false"
+  fi
+
+  if [[ "${adopt_instance_dependent}" == "true" && "${IMAGE_TAG_SET}" != "true" && -z "${IMAGE_TAG}" ]]; then
+    value="$(deployment_env_file_value DOLLHOUSE_HOSTED_IMAGE_TAG)"
+    [[ -z "${value}" ]] || IMAGE_TAG="${value}"
+  fi
+
+  if [[ "${HOSTNAME_SET}" != "true" && "${PUBLIC_BASE_URL_SET}" != "true" && -z "${HOSTNAME}" ]]; then
+    value="$(deployment_env_file_value DOLLHOUSE_HOSTED_HOSTNAME)"
+    [[ -z "${value}" ]] || HOSTNAME="${value}"
+  fi
+
+  if [[ "${adopt_mode_dependent}" == "true" && "${PUBLIC_BASE_URL_SET}" != "true" && \
+    "${HOSTNAME_SET}" != "true" && "${PROXY_MODE_SET}" != "true" && \
+    "${HTTP_BIND_PORT_SET}" != "true" && "${HTTPS_BIND_PORT_SET}" != "true" && \
+    -z "${PUBLIC_BASE_URL}" ]]; then
+    value="$(deployment_env_file_value DOLLHOUSE_PUBLIC_BASE_URL)"
+    [[ -z "${value}" ]] || PUBLIC_BASE_URL="${value}"
+  fi
+
+  if [[ "${adopt_mode_dependent}" == "true" && "${PROXY_MODE_SET}" != "true" && -z "${PROXY_MODE}" ]]; then
+    value="$(deployment_env_file_value DOLLHOUSE_HOSTED_PROXY_MODE)"
+    [[ -z "${value}" ]] || PROXY_MODE="${value}"
+  fi
+
+  if [[ "${adopt_mode_dependent}" == "true" && "${BIND_ADDRESS_SET}" != "true" && -z "${BIND_ADDRESS}" ]]; then
+    value="$(deployment_env_file_value DOLLHOUSE_HOSTED_BIND_ADDRESS)"
+    [[ -z "${value}" ]] || BIND_ADDRESS="${value}"
+  fi
+
+  if [[ "${adopt_mode_dependent}" == "true" && "${HTTP_BIND_PORT_SET}" != "true" && \
+    "${PUBLIC_BASE_URL_SET}" != "true" && -z "${HTTP_BIND_PORT}" ]]; then
+    value="$(deployment_env_file_value DOLLHOUSE_HOSTED_HTTP_BIND_PORT)"
+    [[ -z "${value}" ]] || HTTP_BIND_PORT="${value}"
+  fi
+
+  if [[ "${adopt_mode_dependent}" == "true" && "${HTTPS_BIND_PORT_SET}" != "true" && \
+    "${PUBLIC_BASE_URL_SET}" != "true" && -z "${HTTPS_BIND_PORT}" ]]; then
+    value="$(deployment_env_file_value DOLLHOUSE_HOSTED_HTTPS_BIND_PORT)"
+    [[ -z "${value}" ]] || HTTPS_BIND_PORT="${value}"
+  fi
+
+  if [[ "${adopt_mode_dependent}" == "true" && "${OPEN_DCR_SET}" != "true" && -z "${OPEN_DCR}" ]]; then
+    value="$(deployment_env_file_value DOLLHOUSE_AUTH_OPEN_DCR)"
+    [[ -z "${value}" ]] || OPEN_DCR="${value}"
+  fi
+
+  if [[ "${adopt_mode_dependent}" == "true" && "${AUTH_PROVIDER_SET}" != "true" && -z "${AUTH_PROVIDER}" ]]; then
+    value="$(deployment_env_file_value DOLLHOUSE_AUTH_PROVIDER)"
+    [[ -z "${value}" ]] || AUTH_PROVIDER="${value}"
+  fi
+
+  if [[ "${adopt_mode_dependent}" == "true" && "${AUTH_METHODS_SET}" != "true" && \
+    "${AUTH_PROVIDER_SET}" != "true" && -z "${AUTH_METHODS}" ]]; then
+    value="$(deployment_env_file_value DOLLHOUSE_AUTH_METHODS)"
+    [[ -z "${value}" ]] || AUTH_METHODS="${value}"
+  fi
+
+  if [[ "${adopt_mode_dependent}" == "true" && "${ALLOWLIST_REQUIRED_SET}" != "true" && -z "${ALLOWLIST_REQUIRED}" ]]; then
+    value="$(deployment_env_file_value DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED)"
+    [[ -z "${value}" ]] || ALLOWLIST_REQUIRED="${value}"
+  fi
+
+  if [[ "${adopt_mode_dependent}" == "true" && "${TRUSTED_PROXIES_SET}" != "true" && \
+    "${PROXY_MODE_SET}" != "true" && -z "${TRUSTED_PROXIES}" ]]; then
+    value="$(deployment_env_file_value DOLLHOUSE_TRUSTED_PROXIES)"
+    [[ -z "${value}" ]] || TRUSTED_PROXIES="${value}"
+  fi
+
+  if [[ "${adopt_mode_dependent}" == "true" && "${ALLOWED_HOSTS_SET}" != "true" && \
+    "${HOSTNAME_SET}" != "true" && "${PUBLIC_BASE_URL_SET}" != "true" && \
+    -z "${ALLOWED_HOSTS}" ]]; then
+    value="$(deployment_env_file_value DOLLHOUSE_HTTP_ALLOWED_HOSTS)"
+    [[ -z "${value}" ]] || ALLOWED_HOSTS="${value}"
+  fi
+
+  return 0
+}
+
+default_instance_name() {
+  local normalized_dir deploy_basename instance_name
+  normalized_dir="${DEPLOY_DIR%/}"
+  [[ -n "${normalized_dir}" ]] || normalized_dir="${DEPLOY_DIR}"
+  deploy_basename="$(basename "${normalized_dir}")"
+  instance_name="$(
+    printf '%s\n' "${deploy_basename}" |
+      tr '[:upper:]' '[:lower:]' |
+      sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//'
+  )"
+  if [[ -z "${instance_name}" ]]; then
+    instance_name="dollhousemcp"
+  fi
+  printf '%s\n' "${instance_name}"
+
+  return 0
+}
+
+default_image_tag() {
+  if [[ "${INSTANCE_NAME}" == "dollhousemcp" ]]; then
+    printf 'dollhousemcp-hosted:alpha\n'
+  else
+    printf '%s-hosted:alpha\n' "${INSTANCE_NAME}"
+  fi
+
+  return 0
+}
+
+resolve_instance_defaults() {
+  if [[ -z "${INSTANCE_NAME}" ]]; then
+    INSTANCE_NAME="$(default_instance_name)"
+  fi
+  validate_instance_name
+
+  if [[ -z "${IMAGE_TAG}" ]]; then
+    IMAGE_TAG="$(default_image_tag)"
+  fi
+
+  APP_CONTAINER_NAME="${INSTANCE_NAME}"
+  POSTGRES_CONTAINER_NAME="${INSTANCE_NAME}-postgres"
+  CADDY_CONTAINER_NAME="${INSTANCE_NAME}-caddy"
+
+  return 0
+}
+
+mode_default_proxy_mode() {
+  case "${DEPLOY_MODE}" in
+    cloud|enterprise)
+      printf 'caddy-tls\n'
+      ;;
+    lan)
+      printf 'caddy-http\n'
+      ;;
+    *)
+      die "unsupported DOLLHOUSE_HOSTED_MODE: ${DEPLOY_MODE}"
+      ;;
+  esac
+
+  return 0
+}
+
+mode_default_bind_address() {
+  case "${DEPLOY_MODE}" in
+    cloud|enterprise)
+      printf '0.0.0.0\n'
+      ;;
+    lan)
+      printf '127.0.0.1\n'
+      ;;
+    *)
+      die "unsupported DOLLHOUSE_HOSTED_MODE: ${DEPLOY_MODE}"
+      ;;
+  esac
+
+  return 0
+}
+
+mode_default_http_bind_port() {
+  case "${DEPLOY_MODE}" in
+    cloud|enterprise)
+      printf '80\n'
+      ;;
+    lan)
+      printf '3000\n'
+      ;;
+    *)
+      die "unsupported DOLLHOUSE_HOSTED_MODE: ${DEPLOY_MODE}"
+      ;;
+  esac
+
+  return 0
+}
+
+mode_default_open_dcr() {
+  case "${DEPLOY_MODE}" in
+    cloud)
+      printf 'true\n'
+      ;;
+    lan|enterprise)
+      printf 'false\n'
+      ;;
+    *)
+      die "unsupported DOLLHOUSE_HOSTED_MODE: ${DEPLOY_MODE}"
+      ;;
+  esac
+
+  return 0
+}
+
+mode_default_auth_provider() {
+  case "${DEPLOY_MODE}" in
+    cloud|lan|enterprise)
+      printf 'embedded\n'
+      ;;
+    *)
+      die "unsupported DOLLHOUSE_HOSTED_MODE: ${DEPLOY_MODE}"
+      ;;
+  esac
+
+  return 0
+}
+
+mode_default_auth_methods() {
+  case "${AUTH_PROVIDER}" in
+    embedded)
+      printf 'github\n'
+      ;;
+    local|oidc)
+      printf '\n'
+      ;;
+    *)
+      die "unsupported DOLLHOUSE_AUTH_PROVIDER: ${AUTH_PROVIDER}"
+      ;;
+  esac
+
+  return 0
+}
+
+mode_default_allowlist_required() {
+  case "${DEPLOY_MODE}" in
+    cloud|lan|enterprise)
+      printf 'true\n'
+      ;;
+    *)
+      die "unsupported DOLLHOUSE_HOSTED_MODE: ${DEPLOY_MODE}"
+      ;;
+  esac
+
+  return 0
+}
+
+mode_default_trusted_proxies() {
+  case "${PROXY_MODE}" in
+    caddy-http|caddy-tls)
+      printf '172.16.0.0/12\n'
+      ;;
+    *)
+      die "unsupported DOLLHOUSE_HOSTED_PROXY_MODE: ${PROXY_MODE}"
+      ;;
+  esac
+
+  return 0
+}
+
+mode_default_scheme() {
+  case "${PROXY_MODE}" in
+    caddy-tls)
+      printf 'https\n'
+      ;;
+    caddy-http)
+      printf 'http\n'
+      ;;
+    *)
+      die "unsupported DOLLHOUSE_HOSTED_PROXY_MODE: ${PROXY_MODE}"
+      ;;
+  esac
+
+  return 0
+}
+
+default_public_port() {
+  case "${PROXY_MODE}" in
+    caddy-tls)
+      printf '%s\n' "${HTTPS_BIND_PORT}"
+      ;;
+    caddy-http)
+      printf '%s\n' "${HTTP_BIND_PORT}"
+      ;;
+    *)
+      die "unsupported DOLLHOUSE_HOSTED_PROXY_MODE: ${PROXY_MODE}"
+      ;;
+  esac
+
+  return 0
+}
+
+default_public_port_suffix() {
+  local scheme="$1"
+  local port="$2"
+
+  case "${scheme}:${port}" in
+    http:80|https:443)
+      printf '\n'
+      ;;
+    *)
+      printf ':%s\n' "${port}"
+      ;;
+  esac
+
+  return 0
+}
+
+resolve_mode_defaults() {
+  adopt_deployment_config_from_env_file
+  resolve_instance_defaults
+  validate_deploy_mode
+
+  if [[ -z "${PROXY_MODE}" ]]; then
+    PROXY_MODE="$(mode_default_proxy_mode)"
+  fi
+  validate_proxy_mode
+
+  if [[ -z "${BIND_ADDRESS}" ]]; then
+    BIND_ADDRESS="$(mode_default_bind_address)"
+  fi
+
+  if [[ -z "${HTTP_BIND_PORT}" ]]; then
+    if [[ "${PUBLIC_BASE_URL_SET}" == "true" && "${PROXY_MODE}" == "caddy-http" ]]; then
+      HTTP_BIND_PORT="$(public_base_url_port_for_scheme http)"
+    fi
+    [[ -n "${HTTP_BIND_PORT}" ]] || HTTP_BIND_PORT="$(mode_default_http_bind_port)"
+  fi
+
+  if [[ -z "${HTTPS_BIND_PORT}" ]]; then
+    if [[ "${PUBLIC_BASE_URL_SET}" == "true" && "${PROXY_MODE}" == "caddy-tls" ]]; then
+      HTTPS_BIND_PORT="$(public_base_url_port_for_scheme https)"
+    fi
+    [[ -n "${HTTPS_BIND_PORT}" ]] || HTTPS_BIND_PORT="443"
+  fi
+
+  if [[ -z "${OPEN_DCR}" ]]; then
+    OPEN_DCR="$(mode_default_open_dcr)"
+  fi
+
+  if [[ -z "${AUTH_PROVIDER}" ]]; then
+    AUTH_PROVIDER="$(mode_default_auth_provider)"
+  fi
+
+  if [[ "${AUTH_METHODS_SET}" != "true" && -z "${AUTH_METHODS}" ]]; then
+    AUTH_METHODS="$(mode_default_auth_methods)"
+  fi
+
+  if [[ -z "${ALLOWLIST_REQUIRED}" ]]; then
+    ALLOWLIST_REQUIRED="$(mode_default_allowlist_required)"
+  fi
+
+  if [[ -z "${TRUSTED_PROXIES}" ]]; then
+    TRUSTED_PROXIES="$(mode_default_trusted_proxies)"
+  fi
+
+  return 0
+}

--- a/scripts/hosted-deploy/modes.sh
+++ b/scripts/hosted-deploy/modes.sh
@@ -66,6 +66,11 @@ adopt_deployment_config_from_env_file() {
     adopt_mode_dependent="false"
   fi
 
+  if [[ "${INSTANCE_NAME_SET}" == "true" && -n "${persisted_instance}" && "${persisted_instance}" != "${INSTANCE_NAME}" ]]; then
+    die "cannot rename deployment instance in-place: ${ENV_FILE} has DOLLHOUSE_HOSTED_INSTANCE_NAME=${persisted_instance}," \
+      "but ${INSTANCE_NAME} was requested; use a distinct DOLLHOUSE_HOSTED_DEPLOY_DIR for side-by-side deployments"
+  fi
+
   if [[ "${INSTANCE_NAME_SET}" != "true" && -z "${INSTANCE_NAME}" ]]; then
     [[ -z "${persisted_instance}" ]] || INSTANCE_NAME="${persisted_instance}"
   elif [[ -z "${persisted_instance}" || "${persisted_instance}" != "${INSTANCE_NAME}" ]]; then

--- a/scripts/hosted-deploy/render.sh
+++ b/scripts/hosted-deploy/render.sh
@@ -3,10 +3,12 @@
 
 write_compose() {
   cat > "${COMPOSE_FILE}" <<EOF
+name: ${INSTANCE_NAME}
+
 services:
   postgres:
     image: postgres:17-alpine
-    container_name: dollhousemcp-postgres
+    container_name: ${POSTGRES_CONTAINER_NAME}
     restart: unless-stopped
     env_file:
       - .env.production
@@ -30,7 +32,7 @@ services:
       dockerfile: docker/Dockerfile
       target: production
     image: ${IMAGE_TAG}
-    container_name: dollhousemcp
+    container_name: ${APP_CONTAINER_NAME}
     restart: unless-stopped
     depends_on:
       postgres:
@@ -44,8 +46,10 @@ services:
       DOLLHOUSE_TRANSPORT: streamable-http
       DOLLHOUSE_HTTP_HOST: 0.0.0.0
       DOLLHOUSE_HTTP_PORT: "${MCP_PORT}"
-      DOLLHOUSE_HTTP_ALLOWED_HOSTS: localhost,127.0.0.1,${HOSTNAME}
-      DOLLHOUSE_TRUSTED_PROXIES: 172.16.0.0/12
+      # The app is reachable only on the Compose network; Caddy owns the public socket.
+      DOLLHOUSE_UNSAFE_NO_TLS: "true"
+      DOLLHOUSE_HTTP_ALLOWED_HOSTS: ${ALLOWED_HOSTS}
+      DOLLHOUSE_TRUSTED_PROXIES: ${TRUSTED_PROXIES}
       DOLLHOUSE_PUBLIC_BASE_URL: ${PUBLIC_BASE_URL}
       DOLLHOUSE_STORAGE_BACKEND: database
       DOLLHOUSE_DATABASE_URL: postgres://dollhouse_app:\${POSTGRES_PASSWORD}@postgres:5432/dollhousemcp
@@ -53,12 +57,17 @@ services:
       DOLLHOUSE_DATABASE_SSL: disable
       DOLLHOUSE_DATABASE_POOL_SIZE: "20"
       DOLLHOUSE_AUTH_ENABLED: "true"
-      DOLLHOUSE_AUTH_PROVIDER: embedded
-      DOLLHOUSE_AUTH_METHODS: github
+      DOLLHOUSE_AUTH_PROVIDER: ${AUTH_PROVIDER}
+      DOLLHOUSE_AUTH_METHODS: "${AUTH_METHODS}"
+      DOLLHOUSE_AUTH_ISSUER: \${DOLLHOUSE_AUTH_ISSUER:-}
+      DOLLHOUSE_AUTH_AUDIENCE: \${DOLLHOUSE_AUTH_AUDIENCE:-}
+      DOLLHOUSE_AUTH_JWKS_URI: \${DOLLHOUSE_AUTH_JWKS_URI:-}
+      DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP: \${DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP:-false}
+      DOLLHOUSE_AUTH_ALLOWLIST_SEED_FILE: \${DOLLHOUSE_AUTH_ALLOWLIST_SEED_FILE:-}
       DOLLHOUSE_AUTH_STORAGE_BACKEND: postgres
       DOLLHOUSE_AUTH_OPEN_DCR: "${OPEN_DCR}"
       DOLLHOUSE_WEB_AUTH_ENABLED: "true"
-      DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED: \${DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED:-true}
+      DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED: "${ALLOWLIST_REQUIRED}"
     expose:
       - "${MCP_PORT}"
     volumes:
@@ -96,13 +105,12 @@ services:
 
   caddy:
     image: caddy:2
-    container_name: dollhousemcp-caddy
+    container_name: ${CADDY_CONTAINER_NAME}
     restart: unless-stopped
     depends_on:
       - dollhousemcp
     ports:
-      - "80:80"
-      - "443:443"
+$(caddy_ports_yaml)
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
@@ -116,14 +124,49 @@ EOF
   return 0
 }
 
+caddy_ports_yaml() {
+  # TLS mode maps host HTTP/HTTPS ports to Caddy's standard ports.
+  # HTTP mode maps the selected LAN port through unchanged because Caddy
+  # listens on that same port inside the container.
+  case "${PROXY_MODE}" in
+    caddy-tls)
+      printf '      - "%s:%s:80"\n' "${BIND_ADDRESS}" "${HTTP_BIND_PORT}"
+      printf '      - "%s:%s:443"\n' "${BIND_ADDRESS}" "${HTTPS_BIND_PORT}"
+      ;;
+    caddy-http)
+      printf '      - "%s:%s:%s"\n' "${BIND_ADDRESS}" "${HTTP_BIND_PORT}" "${HTTP_BIND_PORT}"
+      ;;
+    *)
+      die "unsupported DOLLHOUSE_HOSTED_PROXY_MODE: ${PROXY_MODE}"
+      ;;
+  esac
+
+  return 0
+}
+
 write_caddyfile() {
+  local site_address forwarded_proto
+  case "${PROXY_MODE}" in
+    caddy-tls)
+      site_address="${HOSTNAME}"
+      forwarded_proto="https"
+      ;;
+    caddy-http)
+      site_address="http://${HOSTNAME}:${HTTP_BIND_PORT}"
+      forwarded_proto="http"
+      ;;
+    *)
+      die "unsupported DOLLHOUSE_HOSTED_PROXY_MODE: ${PROXY_MODE}"
+      ;;
+  esac
+
   cat > "${CADDY_FILE}" <<EOF
-${HOSTNAME} {
+${site_address} {
     encode gzip
 
     reverse_proxy dollhousemcp:${MCP_PORT} {
         header_up Host {host}
-        header_up X-Forwarded-Proto https
+        header_up X-Forwarded-Proto ${forwarded_proto}
         transport http {
             read_timeout 1h
             write_timeout 1h
@@ -172,6 +215,7 @@ EOF
 render_files() {
   resolve_public_base_url
   resolve_hostname
+  resolve_allowed_hosts
   validate_render_inputs
   ensure_layout
   write_env_defaults

--- a/scripts/hosted-deploy/runtime.sh
+++ b/scripts/hosted-deploy/runtime.sh
@@ -26,7 +26,7 @@ ensure_prerequisites() {
 compose() {
   local status=0
 
-  (cd "${DEPLOY_DIR}" && docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" "$@") || status=$?
+  (cd "${DEPLOY_DIR}" && docker compose --project-name "${INSTANCE_NAME}" --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" "$@") || status=$?
   return "${status}"
 }
 
@@ -79,6 +79,13 @@ build_app_image() {
 run_database_migrations() {
   log "running database migrations"
   compose run --rm dollhousemcp-migrate
+
+  return 0
+}
+
+restart_caddy_proxy() {
+  log "refreshing caddy proxy"
+  compose up -d --no-deps --force-recreate caddy
 
   return 0
 }
@@ -140,6 +147,7 @@ start_or_update() {
   run_bootstrap_admin optional
   if [[ "${service}" == "app" ]]; then
     compose up -d dollhousemcp
+    restart_caddy_proxy
   else
     compose up -d
   fi

--- a/scripts/hosted-deploy/validation.sh
+++ b/scripts/hosted-deploy/validation.sh
@@ -27,6 +27,96 @@ validate_bool() {
   return 0
 }
 
+validate_deploy_mode() {
+  case "${DEPLOY_MODE}" in
+    cloud|lan|enterprise)
+      ;;
+    *)
+      die "DOLLHOUSE_HOSTED_MODE must be cloud, lan, or enterprise; got: ${DEPLOY_MODE}"
+      ;;
+  esac
+
+  return 0
+}
+
+validate_proxy_mode() {
+  case "${PROXY_MODE}" in
+    caddy-http|caddy-tls)
+      ;;
+    *)
+      die "DOLLHOUSE_HOSTED_PROXY_MODE must be caddy-tls or caddy-http; got: ${PROXY_MODE}"
+      ;;
+  esac
+
+  return 0
+}
+
+validate_auth_provider() {
+  case "${AUTH_PROVIDER}" in
+    embedded|oidc|local)
+      ;;
+    *)
+      die "DOLLHOUSE_AUTH_PROVIDER must be embedded, oidc, or local; got: ${AUTH_PROVIDER}"
+      ;;
+  esac
+
+  return 0
+}
+
+validate_auth_methods() {
+  validate_no_whitespace DOLLHOUSE_AUTH_METHODS "${AUTH_METHODS}"
+  if [[ -n "${AUTH_METHODS}" && ! "${AUTH_METHODS}" =~ ^[A-Za-z0-9,_-]+$ ]]; then
+    die "DOLLHOUSE_AUTH_METHODS contains unsupported characters: ${AUTH_METHODS}"
+  fi
+  if [[ "${AUTH_PROVIDER}" == "embedded" && -z "${AUTH_METHODS}" ]]; then
+    die "DOLLHOUSE_AUTH_METHODS must not be empty when DOLLHOUSE_AUTH_PROVIDER=embedded"
+  fi
+
+  return 0
+}
+
+effective_config_value() {
+  local key="$1"
+  local value="${!key:-}"
+
+  if [[ -z "${value}" ]]; then
+    value="$(deployment_env_file_value "${key}")"
+  fi
+  printf '%s\n' "${value}"
+
+  return 0
+}
+
+validate_oidc_url() {
+  local key="$1"
+  local value="$2"
+
+  validate_no_whitespace "${key}" "${value}"
+  case "${value}" in
+    http://*|https://*)
+      ;;
+    *)
+      die "${key} must start with http:// or https:// when DOLLHOUSE_AUTH_PROVIDER=oidc"
+      ;;
+  esac
+
+  return 0
+}
+
+validate_oidc_inputs() {
+  [[ "${AUTH_PROVIDER}" == "oidc" ]] || return 0
+
+  local issuer audience
+  issuer="$(effective_config_value DOLLHOUSE_AUTH_ISSUER)"
+  audience="$(effective_config_value DOLLHOUSE_AUTH_AUDIENCE)"
+  [[ -n "${issuer}" ]] || die "DOLLHOUSE_AUTH_ISSUER is required when DOLLHOUSE_AUTH_PROVIDER=oidc"
+  [[ -n "${audience}" ]] || die "DOLLHOUSE_AUTH_AUDIENCE is required when DOLLHOUSE_AUTH_PROVIDER=oidc"
+  validate_oidc_url DOLLHOUSE_AUTH_ISSUER "${issuer}"
+  validate_no_whitespace DOLLHOUSE_AUTH_AUDIENCE "${audience}"
+
+  return 0
+}
+
 is_dry_run() {
   if [[ "${DRY_RUN}" == "true" ]]; then
     return 0
@@ -41,6 +131,15 @@ validate_no_whitespace() {
 
   if [[ "${value}" =~ [[:space:]] ]]; then
     die "${key} must not contain whitespace"
+  fi
+
+  return 0
+}
+
+validate_instance_name() {
+  validate_no_whitespace DOLLHOUSE_HOSTED_INSTANCE_NAME "${INSTANCE_NAME}"
+  if [[ ! "${INSTANCE_NAME}" =~ ^[a-z0-9][a-z0-9-]{0,47}$ ]]; then
+    die "DOLLHOUSE_HOSTED_INSTANCE_NAME must be 1-48 lowercase letters, numbers, or hyphens and start with a letter or number; got: ${INSTANCE_NAME}"
   fi
 
   return 0
@@ -85,9 +184,71 @@ validate_public_base_url() {
   return 0
 }
 
+validate_public_base_url_matches_proxy_mode() {
+  local scheme
+
+  scheme="$(public_base_url_scheme)"
+  case "${PROXY_MODE}:${scheme}" in
+    caddy-http:http|caddy-tls:https)
+      ;;
+    caddy-http:*)
+      die "DOLLHOUSE_PUBLIC_BASE_URL must use http:// when DOLLHOUSE_HOSTED_PROXY_MODE=caddy-http"
+      ;;
+    caddy-tls:*)
+      die "DOLLHOUSE_PUBLIC_BASE_URL must use https:// when DOLLHOUSE_HOSTED_PROXY_MODE=caddy-tls"
+      ;;
+    *)
+      die "unsupported DOLLHOUSE_HOSTED_PROXY_MODE: ${PROXY_MODE}"
+      ;;
+  esac
+
+  return 0
+}
+
+validate_port_value() {
+  local key="$1"
+  local value="$2"
+
+  if [[ ! "${value}" =~ ^[0-9]+$ || "${value}" -lt 1 || "${value}" -gt 65535 ]]; then
+    die "${key} must be an integer from 1 to 65535, got: ${value}"
+  fi
+
+  return 0
+}
+
 validate_port() {
-  if [[ ! "${MCP_PORT}" =~ ^[0-9]+$ || "${MCP_PORT}" -lt 1 || "${MCP_PORT}" -gt 65535 ]]; then
-    die "DOLLHOUSE_HTTP_PORT must be an integer from 1 to 65535, got: ${MCP_PORT}"
+  validate_port_value DOLLHOUSE_HTTP_PORT "${MCP_PORT}"
+
+  return 0
+}
+
+validate_bind_ports() {
+  validate_port_value DOLLHOUSE_HOSTED_HTTP_BIND_PORT "${HTTP_BIND_PORT}"
+  validate_port_value DOLLHOUSE_HOSTED_HTTPS_BIND_PORT "${HTTPS_BIND_PORT}"
+
+  return 0
+}
+
+is_ipv4_address() {
+  local value="$1"
+  local octet
+  local -a octets
+
+  [[ "${value}" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]] || return 1
+  IFS=. read -r -a octets <<< "${value}"
+  for octet in "${octets[@]}"; do
+    if (( 10#${octet} > 255 )); then
+      return 1
+    fi
+  done
+
+  return 0
+}
+
+validate_bind_address() {
+  validate_no_whitespace DOLLHOUSE_HOSTED_BIND_ADDRESS "${BIND_ADDRESS}"
+  if ! is_ipv4_address "${BIND_ADDRESS}"; then
+    die "DOLLHOUSE_HOSTED_BIND_ADDRESS must be an IPv4 address such as 127.0.0.1 or 0.0.0.0; got: ${BIND_ADDRESS}"
   fi
 
   return 0
@@ -106,10 +267,20 @@ validate_render_value() {
 }
 
 validate_render_inputs() {
+  resolve_mode_defaults
   validate_bool DOLLHOUSE_AUTH_OPEN_DCR "${OPEN_DCR}"
+  validate_bool DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED "${ALLOWLIST_REQUIRED}"
+  validate_auth_provider
+  validate_auth_methods
+  validate_oidc_inputs
   validate_hostname
   validate_public_base_url
+  validate_public_base_url_matches_proxy_mode
   validate_port
+  validate_bind_ports
+  validate_bind_address
+  validate_no_whitespace DOLLHOUSE_HTTP_ALLOWED_HOSTS "${ALLOWED_HOSTS}"
+  validate_no_whitespace DOLLHOUSE_TRUSTED_PROXIES "${TRUSTED_PROXIES}"
   validate_render_value DOLLHOUSE_HOSTED_IMAGE_TAG "${IMAGE_TAG}"
   validate_render_value DOLLHOUSE_HOSTED_MEM_LIMIT "${MEM_LIMIT}"
   validate_render_value DOLLHOUSE_HOSTED_CPUS "${CPU_LIMIT}"
@@ -136,23 +307,38 @@ validate_git_url_for_clone() {
 }
 
 resolve_public_base_url() {
+  resolve_mode_defaults
   if [[ -n "${PUBLIC_BASE_URL}" ]]; then
     return 0
   fi
   [[ -n "${HOSTNAME}" ]] || die "set DOLLHOUSE_HOSTED_HOSTNAME or DOLLHOUSE_PUBLIC_BASE_URL"
-  PUBLIC_BASE_URL="https://${HOSTNAME}"
+  local scheme port suffix
+  scheme="$(mode_default_scheme)"
+  port="$(default_public_port)"
+  suffix="$(default_public_port_suffix "${scheme}" "${port}")"
+  PUBLIC_BASE_URL="${scheme}://${HOSTNAME}${suffix}"
 
   return 0
 }
 
 resolve_hostname() {
+  resolve_mode_defaults
   if [[ -n "${HOSTNAME}" ]]; then
     return 0
   fi
   [[ -n "${PUBLIC_BASE_URL}" ]] || die "set DOLLHOUSE_HOSTED_HOSTNAME or DOLLHOUSE_PUBLIC_BASE_URL"
-  HOSTNAME="${PUBLIC_BASE_URL#https://}"
-  HOSTNAME="${HOSTNAME#http://}"
-  HOSTNAME="${HOSTNAME%%/*}"
+  HOSTNAME="$(public_base_url_authority)"
+  HOSTNAME="${HOSTNAME%%:*}"
+
+  return 0
+}
+
+resolve_allowed_hosts() {
+  resolve_hostname
+  if [[ -n "${ALLOWED_HOSTS}" ]]; then
+    return 0
+  fi
+  ALLOWED_HOSTS="localhost,127.0.0.1,${HOSTNAME}"
 
   return 0
 }

--- a/scripts/hosted-remote-deploy.sh
+++ b/scripts/hosted-remote-deploy.sh
@@ -17,8 +17,39 @@ REMOTE_KNOWN_HOSTS_FILE="${DOLLHOUSE_REMOTE_KNOWN_HOSTS_FILE:-}"
 REMOTE_ACCEPT_HOST_KEY="${DOLLHOUSE_REMOTE_ACCEPT_HOST_KEY:-false}"
 SSH_HOST=""
 DEPLOY_DIR="${DOLLHOUSE_HOSTED_DEPLOY_DIR:-/opt/dollhousemcp}"
+INSTANCE_NAME="${DOLLHOUSE_HOSTED_INSTANCE_NAME:-}"
+INSTANCE_NAME_SET="false"
+[[ -z "${INSTANCE_NAME}" ]] || INSTANCE_NAME_SET="true"
+DEPLOY_MODE="${DOLLHOUSE_HOSTED_MODE:-}"
+DEPLOY_MODE_SET="false"
+[[ -z "${DEPLOY_MODE}" ]] || DEPLOY_MODE_SET="true"
+PROXY_MODE="${DOLLHOUSE_HOSTED_PROXY_MODE:-}"
+PROXY_MODE_SET="false"
+[[ -z "${PROXY_MODE}" ]] || PROXY_MODE_SET="true"
+BIND_ADDRESS="${DOLLHOUSE_HOSTED_BIND_ADDRESS:-}"
+BIND_ADDRESS_SET="false"
+[[ -z "${BIND_ADDRESS}" ]] || BIND_ADDRESS_SET="true"
+HTTP_BIND_PORT="${DOLLHOUSE_HOSTED_HTTP_BIND_PORT:-}"
+HTTP_BIND_PORT_SET="false"
+[[ -z "${HTTP_BIND_PORT}" ]] || HTTP_BIND_PORT_SET="true"
+HTTPS_BIND_PORT="${DOLLHOUSE_HOSTED_HTTPS_BIND_PORT:-}"
+HTTPS_BIND_PORT_SET="false"
+[[ -z "${HTTPS_BIND_PORT}" ]] || HTTPS_BIND_PORT_SET="true"
+AUTH_PROVIDER="${DOLLHOUSE_AUTH_PROVIDER:-}"
+AUTH_METHODS="${DOLLHOUSE_AUTH_METHODS:-}"
+AUTH_OPEN_DCR="${DOLLHOUSE_AUTH_OPEN_DCR:-}"
+AUTH_ALLOWLIST_REQUIRED="${DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED:-}"
+AUTH_ISSUER="${DOLLHOUSE_AUTH_ISSUER:-}"
+AUTH_AUDIENCE="${DOLLHOUSE_AUTH_AUDIENCE:-}"
+AUTH_JWKS_URI="${DOLLHOUSE_AUTH_JWKS_URI:-}"
+AUTH_OIDC_REQUIRE_TYP="${DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP:-}"
+AUTH_ALLOWLIST_SEED_FILE="${DOLLHOUSE_AUTH_ALLOWLIST_SEED_FILE:-}"
 HOSTNAME="${DOLLHOUSE_HOSTED_HOSTNAME:-}"
+HOSTNAME_SET="false"
+[[ -z "${HOSTNAME}" ]] || HOSTNAME_SET="true"
 PUBLIC_BASE_URL="${DOLLHOUSE_PUBLIC_BASE_URL:-}"
+PUBLIC_BASE_URL_SET="false"
+[[ -z "${PUBLIC_BASE_URL}" ]] || PUBLIC_BASE_URL_SET="true"
 GIT_URL="${DOLLHOUSE_HOSTED_GIT_URL:-https://github.com/DollhouseMCP/mcp-server.git}"
 GIT_REF="${DOLLHOUSE_HOSTED_GIT_REF:-codex/hosted-http-integration}"
 ALLOW_CREDENTIAL_GIT_URL="${DOLLHOUSE_HOSTED_ALLOW_CREDENTIAL_GIT_URL:-false}"
@@ -52,6 +83,12 @@ Options:
   --hostname HOSTNAME       Public hostname. Env: DOLLHOUSE_HOSTED_HOSTNAME
   --public-base-url URL     Public origin. Env: DOLLHOUSE_PUBLIC_BASE_URL
   --deploy-dir DIR          Remote deploy dir. Env: DOLLHOUSE_HOSTED_DEPLOY_DIR
+  --instance-name NAME      Compose/container name prefix. Env: DOLLHOUSE_HOSTED_INSTANCE_NAME
+  --mode MODE               Hosted mode: cloud, lan, or enterprise
+  --proxy-mode MODE         Hosted proxy mode: caddy-tls or caddy-http
+  --bind-address ADDRESS    IPv4 host bind address for Caddy
+  --http-bind-port PORT     Host HTTP port for Caddy
+  --https-bind-port PORT    Host HTTPS port for Caddy
   --git-url URL             Repository URL cloned remotely. Env: DOLLHOUSE_HOSTED_GIT_URL
   --ref REF                 Branch/ref cloned remotely. Env: DOLLHOUSE_HOSTED_GIT_REF
   --skip-backup             Skip DB/env backup before remote action
@@ -190,11 +227,47 @@ redact_url() {
   return 0
 }
 
+shell_quote() {
+  local value="$1"
+
+  printf "'"
+  printf '%s' "${value}" | sed "s/'/'\\\\''/g"
+  printf "'"
+
+  return 0
+}
+
 validate_git_url_for_clone() {
   validate_bool DOLLHOUSE_HOSTED_ALLOW_CREDENTIAL_GIT_URL "${ALLOW_CREDENTIAL_GIT_URL}"
   if git_url_has_credentials "${GIT_URL}" && [[ "${ALLOW_CREDENTIAL_GIT_URL}" != "true" ]]; then
     die "DOLLHOUSE_HOSTED_GIT_URL must not embed credentials; use a git credential helper or deploy key on the remote host instead"
   fi
+
+  return 0
+}
+
+adopt_remote_public_base_url() {
+  local output_file="$1"
+  local remote_public_base_url
+
+  remote_public_base_url="$(
+    sed -n 's/^\[hosted-remote\] effective public URL: //p' "${output_file}" |
+      tail -n 1
+  )"
+  [[ -n "${remote_public_base_url}" ]] || return 0
+  if [[ "${remote_public_base_url}" =~ [[:space:]] ]]; then
+    die "remote helper returned a public URL containing whitespace: ${remote_public_base_url}"
+  fi
+  case "${remote_public_base_url}" in
+    http://*|https://*)
+      ;;
+    *)
+      die "remote helper returned an unsupported public URL: ${remote_public_base_url}"
+      ;;
+  esac
+
+  PUBLIC_BASE_URL="${remote_public_base_url}"
+  log "using remote effective public URL for verification: ${PUBLIC_BASE_URL}"
 
   return 0
 }
@@ -230,16 +303,54 @@ parse_args() {
       --hostname)
         HOSTNAME="${1:-}"
         [[ -n "${HOSTNAME}" ]] || die "--hostname requires a hostname"
+        HOSTNAME_SET="true"
         shift
         ;;
       --public-base-url)
         PUBLIC_BASE_URL="${1:-}"
         [[ -n "${PUBLIC_BASE_URL}" ]] || die "--public-base-url requires a URL"
+        PUBLIC_BASE_URL_SET="true"
         shift
         ;;
       --deploy-dir)
         DEPLOY_DIR="${1:-}"
         [[ -n "${DEPLOY_DIR}" ]] || die "--deploy-dir requires a directory"
+        shift
+        ;;
+      --instance-name)
+        INSTANCE_NAME="${1:-}"
+        [[ -n "${INSTANCE_NAME}" ]] || die "--instance-name requires a name such as dollhousemcp-canary"
+        INSTANCE_NAME_SET="true"
+        shift
+        ;;
+      --mode)
+        DEPLOY_MODE="${1:-}"
+        [[ -n "${DEPLOY_MODE}" ]] || die "--mode requires cloud, lan, or enterprise"
+        DEPLOY_MODE_SET="true"
+        shift
+        ;;
+      --proxy-mode)
+        PROXY_MODE="${1:-}"
+        [[ -n "${PROXY_MODE}" ]] || die "--proxy-mode requires caddy-tls or caddy-http"
+        PROXY_MODE_SET="true"
+        shift
+        ;;
+      --bind-address)
+        BIND_ADDRESS="${1:-}"
+        [[ -n "${BIND_ADDRESS}" ]] || die "--bind-address requires an address such as 127.0.0.1 or 0.0.0.0"
+        BIND_ADDRESS_SET="true"
+        shift
+        ;;
+      --http-bind-port)
+        HTTP_BIND_PORT="${1:-}"
+        [[ -n "${HTTP_BIND_PORT}" ]] || die "--http-bind-port requires a port number"
+        HTTP_BIND_PORT_SET="true"
+        shift
+        ;;
+      --https-bind-port)
+        HTTPS_BIND_PORT="${1:-}"
+        [[ -n "${HTTPS_BIND_PORT}" ]] || die "--https-bind-port requires a port number"
+        HTTPS_BIND_PORT_SET="true"
         shift
         ;;
       --git-url)
@@ -361,11 +472,28 @@ resolve_known_hosts_file_for_enroll() {
 }
 
 resolve_public_base_url() {
+  local scheme port suffix
+
   if [[ -n "${PUBLIC_BASE_URL}" ]]; then
     return 0
   fi
   [[ -n "${HOSTNAME}" ]] || die "set --hostname, DOLLHOUSE_HOSTED_HOSTNAME, or DOLLHOUSE_PUBLIC_BASE_URL"
-  PUBLIC_BASE_URL="https://${HOSTNAME}"
+  if [[ "${DEPLOY_MODE}" == "lan" || "${PROXY_MODE}" == "caddy-http" ]]; then
+    scheme="http"
+    port="${HTTP_BIND_PORT:-3000}"
+  else
+    scheme="https"
+    port="${HTTPS_BIND_PORT:-443}"
+  fi
+  case "${scheme}:${port}" in
+    http:80|https:443)
+      suffix=""
+      ;;
+    *)
+      suffix=":${port}"
+      ;;
+  esac
+  PUBLIC_BASE_URL="${scheme}://${HOSTNAME}${suffix}"
 
   return 0
 }
@@ -378,6 +506,104 @@ resolve_hostname() {
   HOSTNAME="${PUBLIC_BASE_URL#https://}"
   HOSTNAME="${HOSTNAME#http://}"
   HOSTNAME="${HOSTNAME%%/*}"
+
+  return 0
+}
+
+default_instance_name() {
+  local normalized_dir deploy_basename instance_name
+  normalized_dir="${DEPLOY_DIR%/}"
+  [[ -n "${normalized_dir}" ]] || normalized_dir="${DEPLOY_DIR}"
+  deploy_basename="$(basename "${normalized_dir}")"
+  instance_name="$(
+    printf '%s\n' "${deploy_basename}" |
+      tr '[:upper:]' '[:lower:]' |
+      sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//'
+  )"
+  if [[ -z "${instance_name}" ]]; then
+    instance_name="dollhousemcp"
+  fi
+  printf '%s\n' "${instance_name}"
+
+  return 0
+}
+
+resolve_instance_name() {
+  if [[ -z "${INSTANCE_NAME}" ]]; then
+    INSTANCE_NAME="$(default_instance_name)"
+  fi
+
+  return 0
+}
+
+validate_no_whitespace() {
+  local key="$1"
+  local value="$2"
+
+  if [[ "${value}" =~ [[:space:]] ]]; then
+    die "${key} must not contain whitespace"
+  fi
+
+  return 0
+}
+
+validate_instance_name() {
+  validate_no_whitespace DOLLHOUSE_HOSTED_INSTANCE_NAME "${INSTANCE_NAME}"
+  if [[ ! "${INSTANCE_NAME}" =~ ^[a-z0-9][a-z0-9-]{0,47}$ ]]; then
+    die "DOLLHOUSE_HOSTED_INSTANCE_NAME must be 1-48 lowercase letters, numbers, or hyphens and start with a letter or number; got: ${INSTANCE_NAME}"
+  fi
+
+  return 0
+}
+
+validate_optional_deploy_mode() {
+  [[ -n "${DEPLOY_MODE}" ]] || return 0
+  case "${DEPLOY_MODE}" in
+    cloud|lan|enterprise)
+      ;;
+    *)
+      die "DOLLHOUSE_HOSTED_MODE must be cloud, lan, or enterprise; got: ${DEPLOY_MODE}"
+      ;;
+  esac
+
+  return 0
+}
+
+validate_optional_proxy_mode() {
+  [[ -n "${PROXY_MODE}" ]] || return 0
+  case "${PROXY_MODE}" in
+    caddy-tls|caddy-http)
+      ;;
+    *)
+      die "DOLLHOUSE_HOSTED_PROXY_MODE must be caddy-tls or caddy-http; got: ${PROXY_MODE}"
+      ;;
+  esac
+
+  return 0
+}
+
+is_ipv4_address() {
+  local value="$1"
+  local octet
+  local -a octets
+
+  [[ "${value}" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]] || return 1
+  IFS=. read -r -a octets <<< "${value}"
+  for octet in "${octets[@]}"; do
+    if (( 10#${octet} > 255 )); then
+      return 1
+    fi
+  done
+
+  return 0
+}
+
+validate_optional_bind_address() {
+  [[ -n "${BIND_ADDRESS}" ]] || return 0
+  validate_no_whitespace DOLLHOUSE_HOSTED_BIND_ADDRESS "${BIND_ADDRESS}"
+  if ! is_ipv4_address "${BIND_ADDRESS}"; then
+    die "DOLLHOUSE_HOSTED_BIND_ADDRESS must be an IPv4 address such as 127.0.0.1 or 0.0.0.0; got: ${BIND_ADDRESS}"
+  fi
 
   return 0
 }
@@ -403,6 +629,11 @@ validate_config() {
   validate_bool DOLLHOUSE_REMOTE_DRY_RUN "${DRY_RUN}"
   validate_bool DOLLHOUSE_REMOTE_ACCEPT_HOST_KEY "${REMOTE_ACCEPT_HOST_KEY}"
   validate_port_value DOLLHOUSE_REMOTE_SSH_PORT "${REMOTE_SSH_PORT}"
+  validate_optional_deploy_mode
+  validate_optional_proxy_mode
+  validate_optional_bind_address
+  validate_port_value DOLLHOUSE_HOSTED_HTTP_BIND_PORT "${HTTP_BIND_PORT}"
+  validate_port_value DOLLHOUSE_HOSTED_HTTPS_BIND_PORT "${HTTPS_BIND_PORT}"
   validate_positive_integer DOLLHOUSE_REMOTE_BACKUP_RETRIES "${BACKUP_RETRIES}"
   validate_nonnegative_integer DOLLHOUSE_REMOTE_BACKUP_RETRY_DELAY "${BACKUP_RETRY_DELAY}"
   [[ -n "${REMOTE_SSH_TARGET}" ]] || die "set --target or DOLLHOUSE_REMOTE_SSH_TARGET"
@@ -415,6 +646,8 @@ validate_config() {
     return 0
   fi
   validate_git_url_for_clone
+  resolve_instance_name
+  validate_instance_name
   if [[ -n "${REMOTE_KNOWN_HOSTS_FILE}" ]]; then
     REMOTE_KNOWN_HOSTS_FILE="$(expand_path "${REMOTE_KNOWN_HOSTS_FILE}")"
     [[ -f "${REMOTE_KNOWN_HOSTS_FILE}" ]] || \
@@ -455,7 +688,10 @@ run_dry_plan() {
   fi
 
   log "dry-run: would connect to ${REMOTE_SSH_TARGET}"
-  log "dry-run: action=${ACTION} deploy_dir=${DEPLOY_DIR} hostname=${HOSTNAME} ref=${GIT_REF}"
+  log "dry-run: action=${ACTION} deploy_dir=${DEPLOY_DIR} instance=${INSTANCE_NAME} hostname=${HOSTNAME} ref=${GIT_REF}"
+  if [[ -n "${DEPLOY_MODE}${PROXY_MODE}${BIND_ADDRESS}${HTTP_BIND_PORT}${HTTPS_BIND_PORT}" ]]; then
+    log "dry-run: hosted overrides mode=${DEPLOY_MODE:-default} proxy_mode=${PROXY_MODE:-default} bind=${BIND_ADDRESS:-default} http_port=${HTTP_BIND_PORT:-default} https_port=${HTTPS_BIND_PORT:-default}"
+  fi
   if [[ "${SKIP_BACKUP}" == "true" ]]; then
     log "dry-run: would skip remote DB/env backups"
   else
@@ -532,24 +768,85 @@ run_enroll_host() {
 run_remote_action() {
   local ssh_command=()
   local ssh_arg
+  local remote_command
+  local remote_payload_arg
+  local remote_payload_args=()
+  local remote_output
+  local helper_hostname helper_public_base_url helper_instance_name
+  local helper_deploy_mode helper_proxy_mode helper_bind_address
+  local helper_http_bind_port helper_https_bind_port
+  local helper_auth_provider helper_auth_methods helper_auth_open_dcr
+  local helper_auth_allowlist_required helper_auth_issuer helper_auth_audience
+  local helper_auth_jwks_uri helper_auth_oidc_require_typ helper_auth_allowlist_seed_file
+
+  helper_hostname=""
+  helper_public_base_url=""
+  helper_instance_name=""
+  helper_deploy_mode=""
+  helper_proxy_mode=""
+  helper_bind_address=""
+  helper_http_bind_port=""
+  helper_https_bind_port=""
+  helper_auth_provider="${AUTH_PROVIDER}"
+  helper_auth_methods="${AUTH_METHODS}"
+  helper_auth_open_dcr="${AUTH_OPEN_DCR}"
+  helper_auth_allowlist_required="${AUTH_ALLOWLIST_REQUIRED}"
+  helper_auth_issuer="${AUTH_ISSUER}"
+  helper_auth_audience="${AUTH_AUDIENCE}"
+  helper_auth_jwks_uri="${AUTH_JWKS_URI}"
+  helper_auth_oidc_require_typ="${AUTH_OIDC_REQUIRE_TYP}"
+  helper_auth_allowlist_seed_file="${AUTH_ALLOWLIST_SEED_FILE}"
+  [[ "${HOSTNAME_SET}" != "true" ]] || helper_hostname="${HOSTNAME}"
+  [[ "${PUBLIC_BASE_URL_SET}" != "true" ]] || helper_public_base_url="${PUBLIC_BASE_URL}"
+  [[ "${INSTANCE_NAME_SET}" != "true" ]] || helper_instance_name="${INSTANCE_NAME}"
+  [[ "${DEPLOY_MODE_SET}" != "true" ]] || helper_deploy_mode="${DEPLOY_MODE}"
+  [[ "${PROXY_MODE_SET}" != "true" ]] || helper_proxy_mode="${PROXY_MODE}"
+  [[ "${BIND_ADDRESS_SET}" != "true" ]] || helper_bind_address="${BIND_ADDRESS}"
+  [[ "${HTTP_BIND_PORT_SET}" != "true" ]] || helper_http_bind_port="${HTTP_BIND_PORT}"
+  [[ "${HTTPS_BIND_PORT_SET}" != "true" ]] || helper_https_bind_port="${HTTPS_BIND_PORT}"
 
   while IFS= read -r -d '' ssh_arg; do
     ssh_command+=("${ssh_arg}")
   done < <(ssh_args)
 
+  remote_payload_args=(
+    "${ACTION}"
+    "${DEPLOY_DIR}"
+    "${helper_hostname}"
+    "${helper_public_base_url}"
+    "${GIT_URL}"
+    "${GIT_REF}"
+    "${LOG_LEVEL}"
+    "${SKIP_BACKUP}"
+    "${KEEP_WORKDIR}"
+    "${BACKUP_RETRIES}"
+    "${BACKUP_RETRY_DELAY}"
+    "${helper_instance_name}"
+    "${helper_deploy_mode}"
+    "${helper_proxy_mode}"
+    "${helper_bind_address}"
+    "${helper_http_bind_port}"
+    "${helper_https_bind_port}"
+    "${helper_auth_provider}"
+    "${helper_auth_methods}"
+    "${helper_auth_open_dcr}"
+    "${helper_auth_allowlist_required}"
+    "${helper_auth_issuer}"
+    "${helper_auth_audience}"
+    "${helper_auth_jwks_uri}"
+    "${helper_auth_oidc_require_typ}"
+    "${helper_auth_allowlist_seed_file}"
+  )
+  remote_command="bash -s --"
+  for remote_payload_arg in "${remote_payload_args[@]}"; do
+    remote_command+=" $(shell_quote "${remote_payload_arg}")"
+  done
+
   log "connecting to ${REMOTE_SSH_TARGET}"
-  ssh "${ssh_command[@]}" "${REMOTE_SSH_TARGET}" bash -s -- \
-    "${ACTION}" \
-    "${DEPLOY_DIR}" \
-    "${HOSTNAME}" \
-    "${PUBLIC_BASE_URL}" \
-    "${GIT_URL}" \
-    "${GIT_REF}" \
-    "${LOG_LEVEL}" \
-    "${SKIP_BACKUP}" \
-    "${KEEP_WORKDIR}" \
-    "${BACKUP_RETRIES}" \
-    "${BACKUP_RETRY_DELAY}" <<'REMOTE_BOOTSTRAP'
+  remote_output="$(mktemp /tmp/dollhouse-remote-output.XXXXXX)"
+  if ! {
+    # shellcheck disable=SC2029 # remote_command is intentionally quoted locally to preserve empty arguments over SSH.
+    ssh "${ssh_command[@]}" "${REMOTE_SSH_TARGET}" "${remote_command}" <<'REMOTE_BOOTSTRAP'
 set -euo pipefail
 
 # Run the payload from a file so stdin-consuming remote commands cannot consume
@@ -581,6 +878,21 @@ skip_backup="$8"
 keep_workdir="$9"
 backup_retries="${10}"
 backup_retry_delay="${11}"
+instance_name="${12}"
+deploy_mode="${13}"
+proxy_mode="${14}"
+bind_address="${15}"
+http_bind_port="${16}"
+https_bind_port="${17}"
+auth_provider="${18}"
+auth_methods="${19}"
+auth_open_dcr="${20}"
+auth_allowlist_required="${21}"
+auth_issuer="${22}"
+auth_audience="${23}"
+auth_jwks_uri="${24}"
+auth_oidc_require_typ="${25}"
+auth_allowlist_seed_file="${26}"
 workdir=""
 
 remote_log() {
@@ -689,6 +1001,15 @@ backup_env_files() {
       remote_log "backed up ${file} to ${backup_name}"
     fi
   done
+
+  return 0
+}
+
+remote_env_file_value() {
+  local key="$1"
+
+  [[ -f "${deploy_dir}/.env.production" ]] || return 0
+  awk -F= -v key="${key}" '$1 == key { value = substr($0, length(key) + 2) } END { print value }' "${deploy_dir}/.env.production"
 
   return 0
 }
@@ -830,22 +1151,58 @@ clone_source() {
 }
 
 run_hosted_helper() {
+  local helper_env=()
+
   cd "${workdir}"
   remote_log "running hosted helper action: ${action}"
-  DOLLHOUSE_HOSTED_DEPLOY_DIR="${deploy_dir}" \
-  DOLLHOUSE_HOSTED_HOSTNAME="${hostname}" \
-  DOLLHOUSE_PUBLIC_BASE_URL="${public_base_url}" \
-  DOLLHOUSE_HOSTED_SOURCE_DIR="${workdir}" \
-  DOLLHOUSE_HOSTED_GIT_URL="${git_url}" \
-  DOLLHOUSE_HOSTED_GIT_REF="${git_ref}" \
-  DOLLHOUSE_HOSTED_LOG_LEVEL="${log_level}" \
-    bash scripts/hosted-deploy.sh "${action}"
+  helper_env+=("DOLLHOUSE_HOSTED_DEPLOY_DIR=${deploy_dir}")
+  [[ -z "${instance_name}" ]] || helper_env+=("DOLLHOUSE_HOSTED_INSTANCE_NAME=${instance_name}")
+  [[ -z "${hostname}" ]] || helper_env+=("DOLLHOUSE_HOSTED_HOSTNAME=${hostname}")
+  [[ -z "${public_base_url}" ]] || helper_env+=("DOLLHOUSE_PUBLIC_BASE_URL=${public_base_url}")
+  helper_env+=("DOLLHOUSE_HOSTED_SOURCE_DIR=${workdir}")
+  helper_env+=("DOLLHOUSE_HOSTED_GIT_URL=${git_url}")
+  helper_env+=("DOLLHOUSE_HOSTED_GIT_REF=${git_ref}")
+  helper_env+=("DOLLHOUSE_HOSTED_LOG_LEVEL=${log_level}")
+  [[ -z "${deploy_mode}" ]] || helper_env+=("DOLLHOUSE_HOSTED_MODE=${deploy_mode}")
+  [[ -z "${proxy_mode}" ]] || helper_env+=("DOLLHOUSE_HOSTED_PROXY_MODE=${proxy_mode}")
+  [[ -z "${bind_address}" ]] || helper_env+=("DOLLHOUSE_HOSTED_BIND_ADDRESS=${bind_address}")
+  [[ -z "${http_bind_port}" ]] || helper_env+=("DOLLHOUSE_HOSTED_HTTP_BIND_PORT=${http_bind_port}")
+  [[ -z "${https_bind_port}" ]] || helper_env+=("DOLLHOUSE_HOSTED_HTTPS_BIND_PORT=${https_bind_port}")
+  [[ -z "${auth_provider}" ]] || helper_env+=("DOLLHOUSE_AUTH_PROVIDER=${auth_provider}")
+  [[ -z "${auth_methods}" ]] || helper_env+=("DOLLHOUSE_AUTH_METHODS=${auth_methods}")
+  [[ -z "${auth_open_dcr}" ]] || helper_env+=("DOLLHOUSE_AUTH_OPEN_DCR=${auth_open_dcr}")
+  [[ -z "${auth_allowlist_required}" ]] || helper_env+=("DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED=${auth_allowlist_required}")
+  [[ -z "${auth_issuer}" ]] || helper_env+=("DOLLHOUSE_AUTH_ISSUER=${auth_issuer}")
+  [[ -z "${auth_audience}" ]] || helper_env+=("DOLLHOUSE_AUTH_AUDIENCE=${auth_audience}")
+  [[ -z "${auth_jwks_uri}" ]] || helper_env+=("DOLLHOUSE_AUTH_JWKS_URI=${auth_jwks_uri}")
+  [[ -z "${auth_oidc_require_typ}" ]] || helper_env+=("DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP=${auth_oidc_require_typ}")
+  [[ -z "${auth_allowlist_seed_file}" ]] || helper_env+=("DOLLHOUSE_AUTH_ALLOWLIST_SEED_FILE=${auth_allowlist_seed_file}")
+  (
+    unset DOLLHOUSE_HOSTED_INSTANCE_NAME
+    unset DOLLHOUSE_HOSTED_HOSTNAME
+    unset DOLLHOUSE_PUBLIC_BASE_URL
+    unset DOLLHOUSE_HOSTED_MODE
+    unset DOLLHOUSE_HOSTED_PROXY_MODE
+    unset DOLLHOUSE_HOSTED_BIND_ADDRESS
+    unset DOLLHOUSE_HOSTED_HTTP_BIND_PORT
+    unset DOLLHOUSE_HOSTED_HTTPS_BIND_PORT
+    unset DOLLHOUSE_AUTH_PROVIDER
+    unset DOLLHOUSE_AUTH_METHODS
+    unset DOLLHOUSE_AUTH_OPEN_DCR
+    unset DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED
+    unset DOLLHOUSE_AUTH_ISSUER
+    unset DOLLHOUSE_AUTH_AUDIENCE
+    unset DOLLHOUSE_AUTH_JWKS_URI
+    unset DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP
+    unset DOLLHOUSE_AUTH_ALLOWLIST_SEED_FILE
+    env "${helper_env[@]}" bash scripts/hosted-deploy.sh "${action}"
+  )
 
   return 0
 }
 
 print_remote_summary() {
-  local portfolio_files portfolio_kib
+  local portfolio_files portfolio_kib summary_instance_name
 
   if [[ -f "${deploy_dir}/DEPLOYED_REVISION" ]]; then
     remote_log "deployed revision: $(cat "${deploy_dir}/DEPLOYED_REVISION")"
@@ -859,8 +1216,25 @@ print_remote_summary() {
     remote_log "portfolio: ${portfolio_files} file(s), ${portfolio_kib} KiB"
   fi
   if command -v docker >/dev/null 2>&1; then
-    docker ps --format '[hosted-remote] container: {{.Names}} {{.Status}}' | grep 'dollhousemcp' || true
+    summary_instance_name="$(remote_env_file_value DOLLHOUSE_HOSTED_INSTANCE_NAME)"
+    [[ -n "${summary_instance_name}" ]] || summary_instance_name="${instance_name}"
+    if [[ -n "${summary_instance_name}" ]]; then
+      docker ps --format '[hosted-remote] container: {{.Names}} {{.Status}}' | grep -F "${summary_instance_name}" || true
+    else
+      docker ps --format '[hosted-remote] container: {{.Names}} {{.Status}}' | grep 'dollhousemcp' || true
+    fi
   fi
+
+  return 0
+}
+
+print_effective_public_base_url() {
+  local effective_public_base_url
+
+  effective_public_base_url="$(remote_env_file_value DOLLHOUSE_PUBLIC_BASE_URL)"
+  [[ -n "${effective_public_base_url}" ]] || effective_public_base_url="${public_base_url}"
+  [[ -n "${effective_public_base_url}" ]] || return 0
+  printf '[hosted-remote] effective public URL: %s\n' "${effective_public_base_url}"
 
   return 0
 }
@@ -870,11 +1244,18 @@ docker compose version >/dev/null 2>&1 || remote_die "Docker Compose is required
 backup_existing_deploy
 clone_source
 run_hosted_helper
+print_effective_public_base_url
 print_remote_summary
 REMOTE_PAYLOAD
 
 bash "${remote_payload}" "$@"
 REMOTE_BOOTSTRAP
+  } | tee "${remote_output}"; then
+    rm -f "${remote_output}"
+    return 1
+  fi
+  adopt_remote_public_base_url "${remote_output}"
+  rm -f "${remote_output}"
 
   return 0
 }
@@ -903,7 +1284,7 @@ verify_public_endpoint() {
 main() {
   parse_args "$@"
   validate_config
-  debug "action=${ACTION} target=${REMOTE_SSH_TARGET} ref=${GIT_REF} deploy_dir=${DEPLOY_DIR}"
+  debug "action=${ACTION} target=${REMOTE_SSH_TARGET} ref=${GIT_REF} deploy_dir=${DEPLOY_DIR} instance=${INSTANCE_NAME}"
   if [[ "${DRY_RUN}" == "true" ]]; then
     run_dry_plan
   elif [[ "${ACTION}" == "enroll-host" ]]; then

--- a/scripts/hosted-remote-deploy.sh
+++ b/scripts/hosted-remote-deploy.sh
@@ -44,6 +44,17 @@ AUTH_AUDIENCE="${DOLLHOUSE_AUTH_AUDIENCE:-}"
 AUTH_JWKS_URI="${DOLLHOUSE_AUTH_JWKS_URI:-}"
 AUTH_OIDC_REQUIRE_TYP="${DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP:-}"
 AUTH_ALLOWLIST_SEED_FILE="${DOLLHOUSE_AUTH_ALLOWLIST_SEED_FILE:-}"
+MCP_PORT="${DOLLHOUSE_HTTP_PORT:-}"
+IMAGE_TAG="${DOLLHOUSE_HOSTED_IMAGE_TAG:-}"
+MEM_LIMIT="${DOLLHOUSE_HOSTED_MEM_LIMIT:-}"
+CPU_LIMIT="${DOLLHOUSE_HOSTED_CPUS:-}"
+IMPORT_LEGACY_ENV="${DOLLHOUSE_HOSTED_IMPORT_LEGACY_ENV:-}"
+POSTGRES_READY_TIMEOUT="${DOLLHOUSE_HOSTED_POSTGRES_READY_TIMEOUT:-}"
+VERIFY_READY_TIMEOUT="${DOLLHOUSE_HOSTED_VERIFY_READY_TIMEOUT:-}"
+ALLOWED_HOSTS="${DOLLHOUSE_HTTP_ALLOWED_HOSTS:-}"
+TRUSTED_PROXIES="${DOLLHOUSE_TRUSTED_PROXIES:-}"
+BOOTSTRAP_GITHUB_USERNAME="${DOLLHOUSE_BOOTSTRAP_GITHUB_USERNAME:-}"
+BOOTSTRAP_GITHUB_ID="${DOLLHOUSE_BOOTSTRAP_GITHUB_ID:-}"
 HOSTNAME="${DOLLHOUSE_HOSTED_HOSTNAME:-}"
 HOSTNAME_SET="false"
 [[ -z "${HOSTNAME}" ]] || HOSTNAME_SET="true"
@@ -608,6 +619,28 @@ validate_optional_bind_address() {
   return 0
 }
 
+validate_forwarded_hosted_inputs() {
+  validate_port_value DOLLHOUSE_HTTP_PORT "${MCP_PORT}"
+  validate_no_whitespace DOLLHOUSE_HOSTED_IMAGE_TAG "${IMAGE_TAG}"
+  validate_no_whitespace DOLLHOUSE_HOSTED_MEM_LIMIT "${MEM_LIMIT}"
+  validate_no_whitespace DOLLHOUSE_HOSTED_CPUS "${CPU_LIMIT}"
+  validate_no_whitespace DOLLHOUSE_HTTP_ALLOWED_HOSTS "${ALLOWED_HOSTS}"
+  validate_no_whitespace DOLLHOUSE_TRUSTED_PROXIES "${TRUSTED_PROXIES}"
+  validate_no_whitespace DOLLHOUSE_BOOTSTRAP_GITHUB_USERNAME "${BOOTSTRAP_GITHUB_USERNAME}"
+  validate_no_whitespace DOLLHOUSE_BOOTSTRAP_GITHUB_ID "${BOOTSTRAP_GITHUB_ID}"
+  if [[ -n "${IMPORT_LEGACY_ENV}" ]]; then
+    validate_bool DOLLHOUSE_HOSTED_IMPORT_LEGACY_ENV "${IMPORT_LEGACY_ENV}"
+  fi
+  if [[ -n "${POSTGRES_READY_TIMEOUT}" ]]; then
+    validate_nonnegative_integer DOLLHOUSE_HOSTED_POSTGRES_READY_TIMEOUT "${POSTGRES_READY_TIMEOUT}"
+  fi
+  if [[ -n "${VERIFY_READY_TIMEOUT}" ]]; then
+    validate_nonnegative_integer DOLLHOUSE_HOSTED_VERIFY_READY_TIMEOUT "${VERIFY_READY_TIMEOUT}"
+  fi
+
+  return 0
+}
+
 validate_log_level() {
   case "${LOG_LEVEL}" in
     quiet|info|debug)
@@ -634,6 +667,7 @@ validate_config() {
   validate_optional_bind_address
   validate_port_value DOLLHOUSE_HOSTED_HTTP_BIND_PORT "${HTTP_BIND_PORT}"
   validate_port_value DOLLHOUSE_HOSTED_HTTPS_BIND_PORT "${HTTPS_BIND_PORT}"
+  validate_forwarded_hosted_inputs
   validate_positive_integer DOLLHOUSE_REMOTE_BACKUP_RETRIES "${BACKUP_RETRIES}"
   validate_nonnegative_integer DOLLHOUSE_REMOTE_BACKUP_RETRY_DELAY "${BACKUP_RETRY_DELAY}"
   [[ -n "${REMOTE_SSH_TARGET}" ]] || die "set --target or DOLLHOUSE_REMOTE_SSH_TARGET"
@@ -691,6 +725,14 @@ run_dry_plan() {
   log "dry-run: action=${ACTION} deploy_dir=${DEPLOY_DIR} instance=${INSTANCE_NAME} hostname=${HOSTNAME} ref=${GIT_REF}"
   if [[ -n "${DEPLOY_MODE}${PROXY_MODE}${BIND_ADDRESS}${HTTP_BIND_PORT}${HTTPS_BIND_PORT}" ]]; then
     log "dry-run: hosted overrides mode=${DEPLOY_MODE:-default} proxy_mode=${PROXY_MODE:-default} bind=${BIND_ADDRESS:-default} http_port=${HTTP_BIND_PORT:-default} https_port=${HTTPS_BIND_PORT:-default}"
+  fi
+  if [[ -n "${MCP_PORT}${IMAGE_TAG}${MEM_LIMIT}${CPU_LIMIT}${IMPORT_LEGACY_ENV}${POSTGRES_READY_TIMEOUT}${VERIFY_READY_TIMEOUT}${ALLOWED_HOSTS}${TRUSTED_PROXIES}" ]]; then
+    log "dry-run: hosted runtime overrides mcp_port=${MCP_PORT:-default} image_tag=${IMAGE_TAG:-default} mem=${MEM_LIMIT:-default} cpus=${CPU_LIMIT:-default}"
+    log "dry-run: hosted config overrides import_legacy_env=${IMPORT_LEGACY_ENV:-default} postgres_ready_timeout=${POSTGRES_READY_TIMEOUT:-default} verify_ready_timeout=${VERIFY_READY_TIMEOUT:-default}"
+    log "dry-run: hosted network overrides allowed_hosts=${ALLOWED_HOSTS:-default} trusted_proxies=${TRUSTED_PROXIES:-default}"
+  fi
+  if [[ -n "${BOOTSTRAP_GITHUB_USERNAME}${BOOTSTRAP_GITHUB_ID}" ]]; then
+    log "dry-run: hosted bootstrap override github_username=${BOOTSTRAP_GITHUB_USERNAME:-default} github_id=${BOOTSTRAP_GITHUB_ID:-default}"
   fi
   if [[ "${SKIP_BACKUP}" == "true" ]]; then
     log "dry-run: would skip remote DB/env backups"
@@ -778,6 +820,10 @@ run_remote_action() {
   local helper_auth_provider helper_auth_methods helper_auth_open_dcr
   local helper_auth_allowlist_required helper_auth_issuer helper_auth_audience
   local helper_auth_jwks_uri helper_auth_oidc_require_typ helper_auth_allowlist_seed_file
+  local helper_mcp_port helper_image_tag helper_mem_limit helper_cpu_limit
+  local helper_import_legacy_env helper_postgres_ready_timeout helper_verify_ready_timeout
+  local helper_allowed_hosts helper_trusted_proxies
+  local helper_bootstrap_github_username helper_bootstrap_github_id
 
   helper_hostname=""
   helper_public_base_url=""
@@ -796,6 +842,17 @@ run_remote_action() {
   helper_auth_jwks_uri="${AUTH_JWKS_URI}"
   helper_auth_oidc_require_typ="${AUTH_OIDC_REQUIRE_TYP}"
   helper_auth_allowlist_seed_file="${AUTH_ALLOWLIST_SEED_FILE}"
+  helper_mcp_port="${MCP_PORT}"
+  helper_image_tag="${IMAGE_TAG}"
+  helper_mem_limit="${MEM_LIMIT}"
+  helper_cpu_limit="${CPU_LIMIT}"
+  helper_import_legacy_env="${IMPORT_LEGACY_ENV}"
+  helper_postgres_ready_timeout="${POSTGRES_READY_TIMEOUT}"
+  helper_verify_ready_timeout="${VERIFY_READY_TIMEOUT}"
+  helper_allowed_hosts="${ALLOWED_HOSTS}"
+  helper_trusted_proxies="${TRUSTED_PROXIES}"
+  helper_bootstrap_github_username="${BOOTSTRAP_GITHUB_USERNAME}"
+  helper_bootstrap_github_id="${BOOTSTRAP_GITHUB_ID}"
   [[ "${HOSTNAME_SET}" != "true" ]] || helper_hostname="${HOSTNAME}"
   [[ "${PUBLIC_BASE_URL_SET}" != "true" ]] || helper_public_base_url="${PUBLIC_BASE_URL}"
   [[ "${INSTANCE_NAME_SET}" != "true" ]] || helper_instance_name="${INSTANCE_NAME}"
@@ -836,6 +893,17 @@ run_remote_action() {
     "${helper_auth_jwks_uri}"
     "${helper_auth_oidc_require_typ}"
     "${helper_auth_allowlist_seed_file}"
+    "${helper_mcp_port}"
+    "${helper_image_tag}"
+    "${helper_mem_limit}"
+    "${helper_cpu_limit}"
+    "${helper_import_legacy_env}"
+    "${helper_postgres_ready_timeout}"
+    "${helper_verify_ready_timeout}"
+    "${helper_allowed_hosts}"
+    "${helper_trusted_proxies}"
+    "${helper_bootstrap_github_username}"
+    "${helper_bootstrap_github_id}"
   )
   remote_command="bash -s --"
   for remote_payload_arg in "${remote_payload_args[@]}"; do
@@ -893,6 +961,17 @@ auth_audience="${23}"
 auth_jwks_uri="${24}"
 auth_oidc_require_typ="${25}"
 auth_allowlist_seed_file="${26}"
+mcp_port="${27}"
+image_tag="${28}"
+mem_limit="${29}"
+cpu_limit="${30}"
+import_legacy_env="${31}"
+postgres_ready_timeout="${32}"
+verify_ready_timeout="${33}"
+allowed_hosts="${34}"
+trusted_proxies="${35}"
+bootstrap_github_username="${36}"
+bootstrap_github_id="${37}"
 workdir=""
 
 remote_log() {
@@ -1163,6 +1242,17 @@ run_hosted_helper() {
   helper_env+=("DOLLHOUSE_HOSTED_GIT_URL=${git_url}")
   helper_env+=("DOLLHOUSE_HOSTED_GIT_REF=${git_ref}")
   helper_env+=("DOLLHOUSE_HOSTED_LOG_LEVEL=${log_level}")
+  [[ -z "${mcp_port}" ]] || helper_env+=("DOLLHOUSE_HTTP_PORT=${mcp_port}")
+  [[ -z "${image_tag}" ]] || helper_env+=("DOLLHOUSE_HOSTED_IMAGE_TAG=${image_tag}")
+  [[ -z "${mem_limit}" ]] || helper_env+=("DOLLHOUSE_HOSTED_MEM_LIMIT=${mem_limit}")
+  [[ -z "${cpu_limit}" ]] || helper_env+=("DOLLHOUSE_HOSTED_CPUS=${cpu_limit}")
+  [[ -z "${import_legacy_env}" ]] || helper_env+=("DOLLHOUSE_HOSTED_IMPORT_LEGACY_ENV=${import_legacy_env}")
+  [[ -z "${postgres_ready_timeout}" ]] || helper_env+=("DOLLHOUSE_HOSTED_POSTGRES_READY_TIMEOUT=${postgres_ready_timeout}")
+  [[ -z "${verify_ready_timeout}" ]] || helper_env+=("DOLLHOUSE_HOSTED_VERIFY_READY_TIMEOUT=${verify_ready_timeout}")
+  [[ -z "${allowed_hosts}" ]] || helper_env+=("DOLLHOUSE_HTTP_ALLOWED_HOSTS=${allowed_hosts}")
+  [[ -z "${trusted_proxies}" ]] || helper_env+=("DOLLHOUSE_TRUSTED_PROXIES=${trusted_proxies}")
+  [[ -z "${bootstrap_github_username}" ]] || helper_env+=("DOLLHOUSE_BOOTSTRAP_GITHUB_USERNAME=${bootstrap_github_username}")
+  [[ -z "${bootstrap_github_id}" ]] || helper_env+=("DOLLHOUSE_BOOTSTRAP_GITHUB_ID=${bootstrap_github_id}")
   [[ -z "${deploy_mode}" ]] || helper_env+=("DOLLHOUSE_HOSTED_MODE=${deploy_mode}")
   [[ -z "${proxy_mode}" ]] || helper_env+=("DOLLHOUSE_HOSTED_PROXY_MODE=${proxy_mode}")
   [[ -z "${bind_address}" ]] || helper_env+=("DOLLHOUSE_HOSTED_BIND_ADDRESS=${bind_address}")
@@ -1186,6 +1276,17 @@ run_hosted_helper() {
     unset DOLLHOUSE_HOSTED_BIND_ADDRESS
     unset DOLLHOUSE_HOSTED_HTTP_BIND_PORT
     unset DOLLHOUSE_HOSTED_HTTPS_BIND_PORT
+    unset DOLLHOUSE_HTTP_PORT
+    unset DOLLHOUSE_HOSTED_IMAGE_TAG
+    unset DOLLHOUSE_HOSTED_MEM_LIMIT
+    unset DOLLHOUSE_HOSTED_CPUS
+    unset DOLLHOUSE_HOSTED_IMPORT_LEGACY_ENV
+    unset DOLLHOUSE_HOSTED_POSTGRES_READY_TIMEOUT
+    unset DOLLHOUSE_HOSTED_VERIFY_READY_TIMEOUT
+    unset DOLLHOUSE_HTTP_ALLOWED_HOSTS
+    unset DOLLHOUSE_TRUSTED_PROXIES
+    unset DOLLHOUSE_BOOTSTRAP_GITHUB_USERNAME
+    unset DOLLHOUSE_BOOTSTRAP_GITHUB_ID
     unset DOLLHOUSE_AUTH_PROVIDER
     unset DOLLHOUSE_AUTH_METHODS
     unset DOLLHOUSE_AUTH_OPEN_DCR

--- a/tests/scripts/hosted-deploy-render.test.sh
+++ b/tests/scripts/hosted-deploy-render.test.sh
@@ -29,6 +29,20 @@ assert_contains() {
   grep -Fq "${expected}" "${file}" || fail "expected ${file} to contain: ${expected}"
 }
 
+assert_line() {
+  local file="$1"
+  local expected="$2"
+  grep -Fxq "${expected}" "${file}" || fail "expected ${file} to contain line: ${expected}"
+}
+
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+  if grep -Fq "${unexpected}" "${file}"; then
+    fail "expected ${file} not to contain: ${unexpected}"
+  fi
+}
+
 env_value() {
   local key="$1"
   local file="$2"
@@ -85,23 +99,47 @@ render_with_dcr "${DEPLOY_DIR}" ""
 [[ -f "${CADDY_FILE}" ]] || fail "missing ${CADDY_FILE}"
 [[ -f "${INIT_DB_FILE}" ]] || fail "missing ${INIT_DB_FILE}"
 
+assert_line "${COMPOSE_FILE}" 'name: deploy'
+assert_line "${COMPOSE_FILE}" '    container_name: deploy-postgres'
+assert_line "${COMPOSE_FILE}" '    container_name: deploy'
+assert_line "${COMPOSE_FILE}" '    container_name: deploy-caddy'
+assert_contains "${COMPOSE_FILE}" 'image: deploy-hosted:alpha'
+assert_contains "${COMPOSE_FILE}" 'image: deploy-hosted:alpha-migrate'
 assert_contains "${COMPOSE_FILE}" 'DOLLHOUSE_AUTH_OPEN_DCR: "true"'
 assert_contains "${COMPOSE_FILE}" "DOLLHOUSE_APP_DB_PASSWORD: \${POSTGRES_PASSWORD}"
 assert_contains "${COMPOSE_FILE}" "DOLLHOUSE_DATABASE_URL: postgres://dollhouse_app:\${POSTGRES_PASSWORD}@postgres:5432/dollhousemcp"
 assert_contains "${COMPOSE_FILE}" "DOLLHOUSE_HTTP_ALLOWED_HOSTS: localhost,127.0.0.1,mcp.example.com"
-assert_contains "${COMPOSE_FILE}" "DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED: \${DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED:-true}"
+assert_contains "${COMPOSE_FILE}" 'DOLLHOUSE_UNSAFE_NO_TLS: "true"'
+assert_contains "${COMPOSE_FILE}" 'DOLLHOUSE_AUTH_PROVIDER: embedded'
+assert_contains "${COMPOSE_FILE}" 'DOLLHOUSE_AUTH_METHODS: "github"'
+assert_contains "${COMPOSE_FILE}" 'DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED: "true"'
+assert_contains "${COMPOSE_FILE}" '      - "0.0.0.0:80:80"'
+assert_contains "${COMPOSE_FILE}" '      - "0.0.0.0:443:443"'
 assert_contains "${COMPOSE_FILE}" "dollhousemcp-migrate:"
 assert_contains "${COMPOSE_FILE}" "target: builder"
 assert_contains "${CADDY_FILE}" 'mcp.example.com {'
 assert_contains "${INIT_DB_FILE}" 'CREATE ROLE dollhouse_app'
 assert_contains "${INIT_DB_FILE}" 'DOLLHOUSE_APP_DB_PASSWORD'
+assert_contains "${ENV_FILE}" 'DOLLHOUSE_HOSTED_MODE=cloud'
+assert_contains "${ENV_FILE}" 'DOLLHOUSE_HOSTED_INSTANCE_NAME=deploy'
+assert_contains "${ENV_FILE}" 'DOLLHOUSE_HOSTED_IMAGE_TAG=deploy-hosted:alpha'
+assert_contains "${ENV_FILE}" 'DOLLHOUSE_HOSTED_PROXY_MODE=caddy-tls'
+assert_contains "${ENV_FILE}" 'DOLLHOUSE_HOSTED_BIND_ADDRESS=0.0.0.0'
+assert_contains "${ENV_FILE}" 'DOLLHOUSE_HOSTED_HOSTNAME=mcp.example.com'
+assert_contains "${ENV_FILE}" 'DOLLHOUSE_PUBLIC_BASE_URL=https://mcp.example.com'
 assert_contains "${ENV_FILE}" 'DOLLHOUSE_AUTH_GITHUB_CLIENT_ID=dummy-client'
 assert_contains "${ENV_FILE}" 'DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET=dummy-secret'
 
 first_postgres_password="$(env_value POSTGRES_PASSWORD "${ENV_FILE}")"
 first_cookie_secret="$(env_value DOLLHOUSE_COOKIE_SIGNING_SECRET "${ENV_FILE}")"
+first_master_key="$(env_value DOLLHOUSE_MASTER_ENCRYPTION_KEY "${ENV_FILE}")"
 [[ -n "${first_postgres_password}" ]] || fail "POSTGRES_PASSWORD was not generated"
 [[ -n "${first_cookie_secret}" ]] || fail "DOLLHOUSE_COOKIE_SIGNING_SECRET was not generated"
+[[ -n "${first_master_key}" ]] || fail "DOLLHOUSE_MASTER_ENCRYPTION_KEY was not generated"
+[[ "${#first_master_key}" == "44" ]] || fail "DOLLHOUSE_MASTER_ENCRYPTION_KEY should be a 32-byte base64 value"
+if [[ ! "${first_master_key}" =~ ^[A-Za-z0-9+/]+={0,2}$ ]]; then
+  fail "DOLLHOUSE_MASTER_ENCRYPTION_KEY should be base64"
+fi
 if grep -Fq "${first_postgres_password}" "${INIT_DB_FILE}"; then
   fail "init-db.sh should not contain the generated app database password"
 fi
@@ -112,8 +150,309 @@ assert_contains "${COMPOSE_FILE}" 'DOLLHOUSE_AUTH_OPEN_DCR: "false"'
 
 second_postgres_password="$(env_value POSTGRES_PASSWORD "${ENV_FILE}")"
 second_cookie_secret="$(env_value DOLLHOUSE_COOKIE_SIGNING_SECRET "${ENV_FILE}")"
+second_master_key="$(env_value DOLLHOUSE_MASTER_ENCRYPTION_KEY "${ENV_FILE}")"
 [[ "${first_postgres_password}" == "${second_postgres_password}" ]] || fail "POSTGRES_PASSWORD changed on re-render"
 [[ "${first_cookie_secret}" == "${second_cookie_secret}" ]] || fail "DOLLHOUSE_COOKIE_SIGNING_SECRET changed on re-render"
+[[ "${first_master_key}" == "${second_master_key}" ]] || fail "DOLLHOUSE_MASTER_ENCRYPTION_KEY changed on re-render"
+
+log "rendering side-by-side canary with derived instance names"
+CANARY_DEPLOY_DIR="${TMP_ROOT}/dollhousemcp-canary"
+CANARY_ENV_FILE="${CANARY_DEPLOY_DIR}/.env.production"
+CANARY_COMPOSE_FILE="${CANARY_DEPLOY_DIR}/compose.yml"
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${CANARY_DEPLOY_DIR}" \
+DOLLHOUSE_HOSTED_MODE=lan \
+DOLLHOUSE_HOSTED_HOSTNAME=canary.local \
+DOLLHOUSE_HOSTED_HTTP_BIND_PORT=3100 \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_ID=dummy-client \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET=dummy-secret \
+  bash "${HOSTED_DEPLOY}" render
+assert_line "${CANARY_COMPOSE_FILE}" 'name: dollhousemcp-canary'
+assert_line "${CANARY_COMPOSE_FILE}" '    container_name: dollhousemcp-canary-postgres'
+assert_line "${CANARY_COMPOSE_FILE}" '    container_name: dollhousemcp-canary'
+assert_line "${CANARY_COMPOSE_FILE}" '    container_name: dollhousemcp-canary-caddy'
+assert_contains "${CANARY_COMPOSE_FILE}" 'image: dollhousemcp-canary-hosted:alpha'
+assert_contains "${CANARY_COMPOSE_FILE}" 'image: dollhousemcp-canary-hosted:alpha-migrate'
+assert_contains "${CANARY_COMPOSE_FILE}" 'DOLLHOUSE_PUBLIC_BASE_URL: http://canary.local:3100'
+assert_contains "${CANARY_COMPOSE_FILE}" '      - "127.0.0.1:3100:3100"'
+assert_contains "${CANARY_ENV_FILE}" 'DOLLHOUSE_HOSTED_INSTANCE_NAME=dollhousemcp-canary'
+assert_contains "${CANARY_ENV_FILE}" 'DOLLHOUSE_HOSTED_IMAGE_TAG=dollhousemcp-canary-hosted:alpha'
+
+log "rendering local/LAN configuration"
+LAN_DEPLOY_DIR="${TMP_ROOT}/lan-deploy"
+LAN_ENV_FILE="${LAN_DEPLOY_DIR}/.env.production"
+LAN_COMPOSE_FILE="${LAN_DEPLOY_DIR}/compose.yml"
+LAN_CADDY_FILE="${LAN_DEPLOY_DIR}/Caddyfile"
+LAN_PUBLIC_BASE_URL_LINE='DOLLHOUSE_PUBLIC_BASE_URL: http://lanbox.local:3000'
+LAN_LOOPBACK_PORT_MAPPING='      - "127.0.0.1:3000:3000"'
+LAN_CADDY_SITE='http://lanbox.local:3000 {'
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${LAN_DEPLOY_DIR}" \
+DOLLHOUSE_HOSTED_MODE=lan \
+DOLLHOUSE_HOSTED_HOSTNAME=lanbox.local \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_ID=dummy-client \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET=dummy-secret \
+  bash "${HOSTED_DEPLOY}" render
+assert_contains "${LAN_COMPOSE_FILE}" "${LAN_PUBLIC_BASE_URL_LINE}"
+assert_contains "${LAN_COMPOSE_FILE}" 'DOLLHOUSE_UNSAFE_NO_TLS: "true"'
+assert_contains "${LAN_COMPOSE_FILE}" 'DOLLHOUSE_AUTH_PROVIDER: embedded'
+assert_contains "${LAN_COMPOSE_FILE}" 'DOLLHOUSE_AUTH_METHODS: "github"'
+assert_contains "${LAN_COMPOSE_FILE}" 'DOLLHOUSE_AUTH_OPEN_DCR: "false"'
+assert_contains "${LAN_COMPOSE_FILE}" 'DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED: "true"'
+assert_contains "${LAN_COMPOSE_FILE}" "${LAN_LOOPBACK_PORT_MAPPING}"
+assert_contains "${LAN_CADDY_FILE}" "${LAN_CADDY_SITE}"
+assert_contains "${LAN_CADDY_FILE}" 'header_up X-Forwarded-Proto http'
+assert_contains "${LAN_ENV_FILE}" 'DOLLHOUSE_HOSTED_MODE=lan'
+assert_contains "${LAN_ENV_FILE}" 'DOLLHOUSE_HOSTED_PROXY_MODE=caddy-http'
+assert_contains "${LAN_ENV_FILE}" 'DOLLHOUSE_HOSTED_BIND_ADDRESS=127.0.0.1'
+assert_contains "${LAN_ENV_FILE}" 'DOLLHOUSE_AUTH_OPEN_DCR=false'
+
+log "checking LAN deployment mode persists on re-render"
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${LAN_DEPLOY_DIR}" \
+  bash "${HOSTED_DEPLOY}" render
+assert_contains "${LAN_COMPOSE_FILE}" "${LAN_PUBLIC_BASE_URL_LINE}"
+assert_contains "${LAN_COMPOSE_FILE}" "${LAN_LOOPBACK_PORT_MAPPING}"
+assert_contains "${LAN_CADDY_FILE}" "${LAN_CADDY_SITE}"
+
+log "checking empty mode env preserves persisted deployment mode"
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${LAN_DEPLOY_DIR}" \
+DOLLHOUSE_HOSTED_MODE='' \
+  bash "${HOSTED_DEPLOY}" render
+assert_contains "${LAN_COMPOSE_FILE}" "${LAN_PUBLIC_BASE_URL_LINE}"
+assert_contains "${LAN_COMPOSE_FILE}" "${LAN_LOOPBACK_PORT_MAPPING}"
+assert_contains "${LAN_CADDY_FILE}" "${LAN_CADDY_SITE}"
+assert_contains "${LAN_ENV_FILE}" 'DOLLHOUSE_HOSTED_MODE=lan'
+
+log "checking empty hostname env preserves persisted hostname"
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${LAN_DEPLOY_DIR}" \
+DOLLHOUSE_HOSTED_HOSTNAME='' \
+  bash "${HOSTED_DEPLOY}" render
+assert_contains "${LAN_COMPOSE_FILE}" "${LAN_PUBLIC_BASE_URL_LINE}"
+assert_contains "${LAN_COMPOSE_FILE}" "${LAN_LOOPBACK_PORT_MAPPING}"
+assert_contains "${LAN_CADDY_FILE}" "${LAN_CADDY_SITE}"
+assert_contains "${LAN_ENV_FILE}" 'DOLLHOUSE_HOSTED_HOSTNAME=lanbox.local'
+
+log "checking explicit mode switch recomputes dependent defaults"
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${LAN_DEPLOY_DIR}" \
+  bash "${HOSTED_DEPLOY}" --mode enterprise render
+assert_contains "${LAN_COMPOSE_FILE}" 'DOLLHOUSE_PUBLIC_BASE_URL: https://lanbox.local'
+assert_contains "${LAN_COMPOSE_FILE}" '      - "0.0.0.0:80:80"'
+assert_contains "${LAN_COMPOSE_FILE}" '      - "0.0.0.0:443:443"'
+assert_contains "${LAN_CADDY_FILE}" 'lanbox.local {'
+assert_not_contains "${LAN_CADDY_FILE}" "${LAN_CADDY_SITE}"
+assert_contains "${LAN_ENV_FILE}" 'DOLLHOUSE_HOSTED_MODE=enterprise'
+assert_contains "${LAN_ENV_FILE}" 'DOLLHOUSE_HOSTED_PROXY_MODE=caddy-tls'
+assert_contains "${LAN_ENV_FILE}" 'DOLLHOUSE_HOSTED_BIND_ADDRESS=0.0.0.0'
+assert_contains "${LAN_ENV_FILE}" 'DOLLHOUSE_PUBLIC_BASE_URL=https://lanbox.local'
+
+log "checking explicit public URL switch derives hostname"
+LAN_URL_SWITCH_DEPLOY_DIR="${TMP_ROOT}/lan-url-switch-deploy"
+LAN_URL_SWITCH_ENV_FILE="${LAN_URL_SWITCH_DEPLOY_DIR}/.env.production"
+LAN_URL_SWITCH_COMPOSE_FILE="${LAN_URL_SWITCH_DEPLOY_DIR}/compose.yml"
+LAN_URL_SWITCH_CADDY_FILE="${LAN_URL_SWITCH_DEPLOY_DIR}/Caddyfile"
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${LAN_URL_SWITCH_DEPLOY_DIR}" \
+DOLLHOUSE_HOSTED_MODE=lan \
+DOLLHOUSE_HOSTED_HOSTNAME=lanbox.local \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_ID=dummy-client \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET=dummy-secret \
+  bash "${HOSTED_DEPLOY}" render
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${LAN_URL_SWITCH_DEPLOY_DIR}" \
+DOLLHOUSE_PUBLIC_BASE_URL=https://mcp.enterprise.test \
+  bash "${HOSTED_DEPLOY}" --mode enterprise render
+assert_contains "${LAN_URL_SWITCH_COMPOSE_FILE}" 'DOLLHOUSE_PUBLIC_BASE_URL: https://mcp.enterprise.test'
+assert_contains "${LAN_URL_SWITCH_CADDY_FILE}" 'mcp.enterprise.test {'
+assert_not_contains "${LAN_URL_SWITCH_CADDY_FILE}" 'lanbox.local {'
+assert_contains "${LAN_URL_SWITCH_ENV_FILE}" 'DOLLHOUSE_HOSTED_HOSTNAME=mcp.enterprise.test'
+assert_contains "${LAN_URL_SWITCH_ENV_FILE}" 'DOLLHOUSE_PUBLIC_BASE_URL=https://mcp.enterprise.test'
+assert_contains "${LAN_URL_SWITCH_ENV_FILE}" 'DOLLHOUSE_HOSTED_PROXY_MODE=caddy-tls'
+assert_contains "${LAN_URL_SWITCH_ENV_FILE}" 'DOLLHOUSE_HOSTED_BIND_ADDRESS=0.0.0.0'
+
+log "checking explicit LAN public URL port drives HTTP bind port"
+LAN_URL_PORT_DEPLOY_DIR="${TMP_ROOT}/lan-url-port-deploy"
+LAN_URL_PORT_ENV_FILE="${LAN_URL_PORT_DEPLOY_DIR}/.env.production"
+LAN_URL_PORT_COMPOSE_FILE="${LAN_URL_PORT_DEPLOY_DIR}/compose.yml"
+LAN_URL_PORT_CADDY_FILE="${LAN_URL_PORT_DEPLOY_DIR}/Caddyfile"
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${LAN_URL_PORT_DEPLOY_DIR}" \
+DOLLHOUSE_HOSTED_MODE=lan \
+DOLLHOUSE_PUBLIC_BASE_URL=http://lanbox.local:3100 \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_ID=dummy-client \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET=dummy-secret \
+  bash "${HOSTED_DEPLOY}" render
+assert_contains "${LAN_URL_PORT_COMPOSE_FILE}" 'DOLLHOUSE_PUBLIC_BASE_URL: http://lanbox.local:3100'
+assert_contains "${LAN_URL_PORT_COMPOSE_FILE}" '      - "127.0.0.1:3100:3100"'
+assert_contains "${LAN_URL_PORT_CADDY_FILE}" 'http://lanbox.local:3100 {'
+assert_contains "${LAN_URL_PORT_ENV_FILE}" 'DOLLHOUSE_HOSTED_HOSTNAME=lanbox.local'
+assert_contains "${LAN_URL_PORT_ENV_FILE}" 'DOLLHOUSE_HOSTED_HTTP_BIND_PORT=3100'
+
+log "checking explicit LAN public URL default port drives HTTP bind port"
+LAN_URL_DEFAULT_PORT_DEPLOY_DIR="${TMP_ROOT}/lan-url-default-port-deploy"
+LAN_URL_DEFAULT_PORT_ENV_FILE="${LAN_URL_DEFAULT_PORT_DEPLOY_DIR}/.env.production"
+LAN_URL_DEFAULT_PORT_COMPOSE_FILE="${LAN_URL_DEFAULT_PORT_DEPLOY_DIR}/compose.yml"
+LAN_URL_DEFAULT_PORT_CADDY_FILE="${LAN_URL_DEFAULT_PORT_DEPLOY_DIR}/Caddyfile"
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${LAN_URL_DEFAULT_PORT_DEPLOY_DIR}" \
+DOLLHOUSE_HOSTED_MODE=lan \
+DOLLHOUSE_PUBLIC_BASE_URL=http://lanbox.local \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_ID=dummy-client \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET=dummy-secret \
+  bash "${HOSTED_DEPLOY}" render
+assert_contains "${LAN_URL_DEFAULT_PORT_COMPOSE_FILE}" 'DOLLHOUSE_PUBLIC_BASE_URL: http://lanbox.local'
+assert_contains "${LAN_URL_DEFAULT_PORT_COMPOSE_FILE}" '      - "127.0.0.1:80:80"'
+assert_contains "${LAN_URL_DEFAULT_PORT_CADDY_FILE}" 'http://lanbox.local:80 {'
+assert_contains "${LAN_URL_DEFAULT_PORT_ENV_FILE}" 'DOLLHOUSE_HOSTED_HTTP_BIND_PORT=80'
+
+log "checking explicit enterprise public URL port drives HTTPS bind port"
+ENTERPRISE_URL_PORT_DEPLOY_DIR="${TMP_ROOT}/enterprise-url-port-deploy"
+ENTERPRISE_URL_PORT_ENV_FILE="${ENTERPRISE_URL_PORT_DEPLOY_DIR}/.env.production"
+ENTERPRISE_URL_PORT_COMPOSE_FILE="${ENTERPRISE_URL_PORT_DEPLOY_DIR}/compose.yml"
+ENTERPRISE_URL_PORT_CADDY_FILE="${ENTERPRISE_URL_PORT_DEPLOY_DIR}/Caddyfile"
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${ENTERPRISE_URL_PORT_DEPLOY_DIR}" \
+DOLLHOUSE_HOSTED_MODE=enterprise \
+DOLLHOUSE_PUBLIC_BASE_URL=https://mcp.enterprise.test:8443 \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_ID=dummy-client \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET=dummy-secret \
+  bash "${HOSTED_DEPLOY}" render
+assert_contains "${ENTERPRISE_URL_PORT_COMPOSE_FILE}" 'DOLLHOUSE_PUBLIC_BASE_URL: https://mcp.enterprise.test:8443'
+assert_contains "${ENTERPRISE_URL_PORT_COMPOSE_FILE}" '      - "0.0.0.0:8443:443"'
+assert_contains "${ENTERPRISE_URL_PORT_CADDY_FILE}" 'mcp.enterprise.test {'
+assert_contains "${ENTERPRISE_URL_PORT_ENV_FILE}" 'DOLLHOUSE_HOSTED_HOSTNAME=mcp.enterprise.test'
+assert_contains "${ENTERPRISE_URL_PORT_ENV_FILE}" 'DOLLHOUSE_HOSTED_HTTPS_BIND_PORT=8443'
+
+log "checking public URL scheme must match proxy mode"
+LAN_URL_SCHEME_OUTPUT="${TMP_ROOT}/lan-url-scheme.out"
+if DOLLHOUSE_HOSTED_DEPLOY_DIR="${TMP_ROOT}/lan-url-scheme-deploy" \
+  DOLLHOUSE_HOSTED_MODE=lan \
+  DOLLHOUSE_PUBLIC_BASE_URL=https://lanbox.local \
+  DOLLHOUSE_AUTH_GITHUB_CLIENT_ID=dummy-client \
+  DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET=dummy-secret \
+    bash "${HOSTED_DEPLOY}" --dry-run render > "${LAN_URL_SCHEME_OUTPUT}" 2>&1; then
+  fail "LAN render with HTTPS public URL unexpectedly succeeded"
+fi
+assert_contains "${LAN_URL_SCHEME_OUTPUT}" "DOLLHOUSE_PUBLIC_BASE_URL must use http:// when DOLLHOUSE_HOSTED_PROXY_MODE=caddy-http"
+
+log "checking explicit hostname switch derives public URL and allowed hosts"
+LAN_HOST_SWITCH_DEPLOY_DIR="${TMP_ROOT}/lan-host-switch-deploy"
+LAN_HOST_SWITCH_ENV_FILE="${LAN_HOST_SWITCH_DEPLOY_DIR}/.env.production"
+LAN_HOST_SWITCH_COMPOSE_FILE="${LAN_HOST_SWITCH_DEPLOY_DIR}/compose.yml"
+LAN_HOST_SWITCH_CADDY_FILE="${LAN_HOST_SWITCH_DEPLOY_DIR}/Caddyfile"
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${LAN_HOST_SWITCH_DEPLOY_DIR}" \
+DOLLHOUSE_HOSTED_MODE=lan \
+DOLLHOUSE_HOSTED_HOSTNAME=oldbox.local \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_ID=dummy-client \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET=dummy-secret \
+  bash "${HOSTED_DEPLOY}" render
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${LAN_HOST_SWITCH_DEPLOY_DIR}" \
+DOLLHOUSE_HOSTED_HOSTNAME=newbox.local \
+  bash "${HOSTED_DEPLOY}" render
+assert_contains "${LAN_HOST_SWITCH_COMPOSE_FILE}" 'DOLLHOUSE_PUBLIC_BASE_URL: http://newbox.local:3000'
+assert_contains "${LAN_HOST_SWITCH_COMPOSE_FILE}" 'DOLLHOUSE_HTTP_ALLOWED_HOSTS: localhost,127.0.0.1,newbox.local'
+assert_contains "${LAN_HOST_SWITCH_CADDY_FILE}" 'http://newbox.local:3000 {'
+assert_not_contains "${LAN_HOST_SWITCH_CADDY_FILE}" 'http://oldbox.local:3000 {'
+assert_contains "${LAN_HOST_SWITCH_ENV_FILE}" 'DOLLHOUSE_HOSTED_HOSTNAME=newbox.local'
+assert_contains "${LAN_HOST_SWITCH_ENV_FILE}" 'DOLLHOUSE_PUBLIC_BASE_URL=http://newbox.local:3000'
+assert_contains "${LAN_HOST_SWITCH_ENV_FILE}" 'DOLLHOUSE_HTTP_ALLOWED_HOSTS=localhost,127.0.0.1,newbox.local'
+
+log "checking explicit auth provider switch recomputes auth methods"
+AUTH_PROVIDER_SWITCH_DEPLOY_DIR="${TMP_ROOT}/auth-provider-switch-deploy"
+AUTH_PROVIDER_SWITCH_ENV_FILE="${AUTH_PROVIDER_SWITCH_DEPLOY_DIR}/.env.production"
+AUTH_PROVIDER_SWITCH_COMPOSE_FILE="${AUTH_PROVIDER_SWITCH_DEPLOY_DIR}/compose.yml"
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${AUTH_PROVIDER_SWITCH_DEPLOY_DIR}" \
+DOLLHOUSE_HOSTED_MODE=enterprise \
+DOLLHOUSE_HOSTED_HOSTNAME=mcp.enterprise.test \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_ID=dummy-client \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET=dummy-secret \
+  bash "${HOSTED_DEPLOY}" render
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${AUTH_PROVIDER_SWITCH_DEPLOY_DIR}" \
+DOLLHOUSE_AUTH_PROVIDER=oidc \
+DOLLHOUSE_AUTH_ISSUER=https://idp.enterprise.test \
+DOLLHOUSE_AUTH_AUDIENCE=dollhouse-mcp \
+  bash "${HOSTED_DEPLOY}" render
+assert_contains "${AUTH_PROVIDER_SWITCH_COMPOSE_FILE}" 'DOLLHOUSE_AUTH_PROVIDER: oidc'
+assert_contains "${AUTH_PROVIDER_SWITCH_COMPOSE_FILE}" 'DOLLHOUSE_AUTH_METHODS: ""'
+assert_contains "${AUTH_PROVIDER_SWITCH_ENV_FILE}" 'DOLLHOUSE_AUTH_PROVIDER=oidc'
+assert_contains "${AUTH_PROVIDER_SWITCH_ENV_FILE}" 'DOLLHOUSE_AUTH_METHODS='
+assert_contains "${AUTH_PROVIDER_SWITCH_ENV_FILE}" 'DOLLHOUSE_AUTH_ISSUER=https://idp.enterprise.test'
+assert_contains "${AUTH_PROVIDER_SWITCH_ENV_FILE}" 'DOLLHOUSE_AUTH_AUDIENCE=dollhouse-mcp'
+
+log "checking restated mode preserves persisted dependent settings"
+RESTATED_MODE_DEPLOY_DIR="${TMP_ROOT}/restated-mode-deploy"
+RESTATED_MODE_ENV_FILE="${RESTATED_MODE_DEPLOY_DIR}/.env.production"
+RESTATED_MODE_COMPOSE_FILE="${RESTATED_MODE_DEPLOY_DIR}/compose.yml"
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${RESTATED_MODE_DEPLOY_DIR}" \
+DOLLHOUSE_HOSTED_MODE=enterprise \
+DOLLHOUSE_HOSTED_HOSTNAME=mcp.enterprise.test \
+DOLLHOUSE_HOSTED_BIND_ADDRESS=127.0.0.1 \
+DOLLHOUSE_HOSTED_HTTP_BIND_PORT=8080 \
+DOLLHOUSE_HOSTED_HTTPS_BIND_PORT=8443 \
+DOLLHOUSE_AUTH_PROVIDER=oidc \
+DOLLHOUSE_AUTH_METHODS='' \
+DOLLHOUSE_AUTH_ISSUER=https://idp.enterprise.test \
+DOLLHOUSE_AUTH_AUDIENCE=dollhouse-mcp \
+  bash "${HOSTED_DEPLOY}" render
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${RESTATED_MODE_DEPLOY_DIR}" \
+  bash "${HOSTED_DEPLOY}" --mode enterprise render
+assert_contains "${RESTATED_MODE_COMPOSE_FILE}" 'DOLLHOUSE_PUBLIC_BASE_URL: https://mcp.enterprise.test:8443'
+assert_contains "${RESTATED_MODE_COMPOSE_FILE}" 'DOLLHOUSE_AUTH_PROVIDER: oidc'
+assert_contains "${RESTATED_MODE_COMPOSE_FILE}" 'DOLLHOUSE_AUTH_METHODS: ""'
+assert_contains "${RESTATED_MODE_COMPOSE_FILE}" '      - "127.0.0.1:8080:80"'
+assert_contains "${RESTATED_MODE_COMPOSE_FILE}" '      - "127.0.0.1:8443:443"'
+assert_contains "${RESTATED_MODE_ENV_FILE}" 'DOLLHOUSE_HOSTED_MODE=enterprise'
+assert_contains "${RESTATED_MODE_ENV_FILE}" 'DOLLHOUSE_HOSTED_BIND_ADDRESS=127.0.0.1'
+assert_contains "${RESTATED_MODE_ENV_FILE}" 'DOLLHOUSE_HOSTED_HTTP_BIND_PORT=8080'
+assert_contains "${RESTATED_MODE_ENV_FILE}" 'DOLLHOUSE_HOSTED_HTTPS_BIND_PORT=8443'
+assert_contains "${RESTATED_MODE_ENV_FILE}" 'DOLLHOUSE_AUTH_PROVIDER=oidc'
+assert_contains "${RESTATED_MODE_ENV_FILE}" 'DOLLHOUSE_AUTH_METHODS='
+
+log "rendering LAN configuration exposed on a network interface"
+LAN_EXPOSED_DEPLOY_DIR="${TMP_ROOT}/lan-exposed-deploy"
+LAN_EXPOSED_COMPOSE_FILE="${LAN_EXPOSED_DEPLOY_DIR}/compose.yml"
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${LAN_EXPOSED_DEPLOY_DIR}" \
+DOLLHOUSE_HOSTED_MODE=lan \
+DOLLHOUSE_HOSTED_HOSTNAME=lanbox.local \
+DOLLHOUSE_HOSTED_BIND_ADDRESS=0.0.0.0 \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_ID=dummy-client \
+DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET=dummy-secret \
+  bash "${HOSTED_DEPLOY}" render
+assert_contains "${LAN_EXPOSED_COMPOSE_FILE}" '      - "0.0.0.0:3000:3000"'
+
+log "rendering enterprise OIDC configuration"
+ENTERPRISE_DEPLOY_DIR="${TMP_ROOT}/enterprise-deploy"
+ENTERPRISE_ENV_FILE="${ENTERPRISE_DEPLOY_DIR}/.env.production"
+ENTERPRISE_COMPOSE_FILE="${ENTERPRISE_DEPLOY_DIR}/compose.yml"
+ENTERPRISE_CADDY_FILE="${ENTERPRISE_DEPLOY_DIR}/Caddyfile"
+DOLLHOUSE_HOSTED_DEPLOY_DIR="${ENTERPRISE_DEPLOY_DIR}" \
+DOLLHOUSE_HOSTED_MODE=enterprise \
+DOLLHOUSE_HOSTED_HOSTNAME=mcp.enterprise.test \
+DOLLHOUSE_AUTH_PROVIDER=oidc \
+DOLLHOUSE_AUTH_METHODS='' \
+DOLLHOUSE_AUTH_ISSUER=https://idp.enterprise.test \
+DOLLHOUSE_AUTH_AUDIENCE=dollhouse-mcp \
+  bash "${HOSTED_DEPLOY}" render
+assert_contains "${ENTERPRISE_COMPOSE_FILE}" 'DOLLHOUSE_PUBLIC_BASE_URL: https://mcp.enterprise.test'
+assert_contains "${ENTERPRISE_COMPOSE_FILE}" 'DOLLHOUSE_UNSAFE_NO_TLS: "true"'
+assert_contains "${ENTERPRISE_COMPOSE_FILE}" 'DOLLHOUSE_AUTH_PROVIDER: oidc'
+assert_contains "${ENTERPRISE_COMPOSE_FILE}" 'DOLLHOUSE_AUTH_METHODS: ""'
+assert_contains "${ENTERPRISE_COMPOSE_FILE}" 'DOLLHOUSE_AUTH_OPEN_DCR: "false"'
+assert_contains "${ENTERPRISE_COMPOSE_FILE}" '      - "0.0.0.0:80:80"'
+assert_contains "${ENTERPRISE_COMPOSE_FILE}" '      - "0.0.0.0:443:443"'
+assert_contains "${ENTERPRISE_CADDY_FILE}" 'mcp.enterprise.test {'
+assert_contains "${ENTERPRISE_CADDY_FILE}" 'header_up X-Forwarded-Proto https'
+assert_contains "${ENTERPRISE_ENV_FILE}" 'DOLLHOUSE_HOSTED_MODE=enterprise'
+assert_contains "${ENTERPRISE_ENV_FILE}" 'DOLLHOUSE_AUTH_PROVIDER=oidc'
+assert_contains "${ENTERPRISE_ENV_FILE}" 'DOLLHOUSE_AUTH_ISSUER=https://idp.enterprise.test'
+assert_contains "${ENTERPRISE_ENV_FILE}" 'DOLLHOUSE_AUTH_AUDIENCE=dollhouse-mcp'
+assert_not_contains "${ENTERPRISE_ENV_FILE}" 'DOLLHOUSE_AUTH_GITHUB_CLIENT_ID='
+assert_not_contains "${ENTERPRISE_ENV_FILE}" 'DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET='
+
+log "checking enterprise OIDC missing issuer rejection"
+ENTERPRISE_BAD_OIDC_OUTPUT="${TMP_ROOT}/enterprise-bad-oidc.out"
+if DOLLHOUSE_HOSTED_DEPLOY_DIR="${TMP_ROOT}/enterprise-bad-oidc-deploy" \
+  DOLLHOUSE_HOSTED_MODE=enterprise \
+  DOLLHOUSE_HOSTED_HOSTNAME=mcp.enterprise.test \
+  DOLLHOUSE_AUTH_PROVIDER=oidc \
+  DOLLHOUSE_AUTH_METHODS='' \
+  DOLLHOUSE_AUTH_AUDIENCE=dollhouse-mcp \
+    bash "${HOSTED_DEPLOY}" --dry-run render > "${ENTERPRISE_BAD_OIDC_OUTPUT}" 2>&1; then
+  fail "enterprise OIDC render without issuer unexpectedly succeeded"
+fi
+assert_contains "${ENTERPRISE_BAD_OIDC_OUTPUT}" "DOLLHOUSE_AUTH_ISSUER is required when DOLLHOUSE_AUTH_PROVIDER=oidc"
 
 log "checking legacy .env import for existing deployments"
 LEGACY_DEPLOY_DIR="${TMP_ROOT}/legacy-deploy"
@@ -191,6 +530,8 @@ DOLLHOUSE_HOSTED_HOSTNAME=mcp.example.com \
   bash "${HOSTED_DEPLOY}" --dry-run render > "${DRY_RUN_OUTPUT}"
 [[ ! -e "${DRY_RUN_DEPLOY_DIR}" ]] || fail "dry-run render should not create ${DRY_RUN_DEPLOY_DIR}"
 assert_contains "${DRY_RUN_OUTPUT}" "dry-run: would render deployment files"
+assert_contains "${DRY_RUN_OUTPUT}" "dry-run: deployment mode=cloud"
+assert_contains "${DRY_RUN_OUTPUT}" "dry-run: auth provider=embedded methods=github open_dcr=true allowlist_required=true"
 
 log "checking quiet logging mode"
 QUIET_OUTPUT="${TMP_ROOT}/quiet.out"
@@ -216,5 +557,35 @@ if DOLLHOUSE_HOSTED_DEPLOY_DIR="${TMP_ROOT}/bad-url-deploy" \
   fail "dry-run render with path-bearing public URL unexpectedly succeeded"
 fi
 assert_contains "${BAD_URL_OUTPUT}" "DOLLHOUSE_PUBLIC_BASE_URL must be an origin only"
+
+log "checking invalid instance name rejection"
+BAD_INSTANCE_OUTPUT="${TMP_ROOT}/bad-instance.out"
+if DOLLHOUSE_HOSTED_DEPLOY_DIR="${TMP_ROOT}/bad-instance-deploy" \
+  DOLLHOUSE_HOSTED_INSTANCE_NAME=Bad_Name \
+  DOLLHOUSE_HOSTED_HOSTNAME=mcp.example.com \
+    bash "${HOSTED_DEPLOY}" --dry-run render > "${BAD_INSTANCE_OUTPUT}" 2>&1; then
+  fail "dry-run render with invalid instance name unexpectedly succeeded"
+fi
+assert_contains "${BAD_INSTANCE_OUTPUT}" "DOLLHOUSE_HOSTED_INSTANCE_NAME must be 1-48 lowercase letters"
+
+log "checking invalid deployment mode rejection"
+BAD_MODE_OUTPUT="${TMP_ROOT}/bad-mode.out"
+if DOLLHOUSE_HOSTED_DEPLOY_DIR="${TMP_ROOT}/bad-mode-deploy" \
+  DOLLHOUSE_HOSTED_MODE=spaceship \
+  DOLLHOUSE_HOSTED_HOSTNAME=mcp.example.com \
+    bash "${HOSTED_DEPLOY}" --dry-run render > "${BAD_MODE_OUTPUT}" 2>&1; then
+  fail "dry-run render with invalid mode unexpectedly succeeded"
+fi
+assert_contains "${BAD_MODE_OUTPUT}" "DOLLHOUSE_HOSTED_MODE must be cloud, lan, or enterprise"
+
+log "checking bind address rejects hostnames"
+BAD_BIND_OUTPUT="${TMP_ROOT}/bad-bind.out"
+if DOLLHOUSE_HOSTED_DEPLOY_DIR="${TMP_ROOT}/bad-bind-deploy" \
+  DOLLHOUSE_HOSTED_HOSTNAME=mcp.example.com \
+  DOLLHOUSE_HOSTED_BIND_ADDRESS=localhost \
+    bash "${HOSTED_DEPLOY}" --dry-run render > "${BAD_BIND_OUTPUT}" 2>&1; then
+  fail "dry-run render with hostname bind address unexpectedly succeeded"
+fi
+assert_contains "${BAD_BIND_OUTPUT}" "DOLLHOUSE_HOSTED_BIND_ADDRESS must be an IPv4 address"
 
 log "render behavior passed"

--- a/tests/scripts/hosted-deploy-render.test.sh
+++ b/tests/scripts/hosted-deploy-render.test.sh
@@ -148,6 +148,16 @@ log "rendering stricter DCR override"
 render_with_dcr "${DEPLOY_DIR}" "false"
 assert_contains "${COMPOSE_FILE}" 'DOLLHOUSE_AUTH_OPEN_DCR: "false"'
 
+log "checking in-place instance rename rejection"
+INSTANCE_RENAME_OUTPUT="${TMP_ROOT}/instance-rename.out"
+if DOLLHOUSE_HOSTED_DEPLOY_DIR="${DEPLOY_DIR}" \
+  DOLLHOUSE_HOSTED_INSTANCE_NAME=renamed-deploy \
+    bash "${HOSTED_DEPLOY}" --dry-run render > "${INSTANCE_RENAME_OUTPUT}" 2>&1; then
+  fail "in-place instance rename unexpectedly succeeded"
+fi
+assert_contains "${INSTANCE_RENAME_OUTPUT}" "cannot rename deployment instance in-place"
+assert_contains "${INSTANCE_RENAME_OUTPUT}" "DOLLHOUSE_HOSTED_INSTANCE_NAME=deploy"
+
 second_postgres_password="$(env_value POSTGRES_PASSWORD "${ENV_FILE}")"
 second_cookie_secret="$(env_value DOLLHOUSE_COOKIE_SIGNING_SECRET "${ENV_FILE}")"
 second_master_key="$(env_value DOLLHOUSE_MASTER_ENCRYPTION_KEY "${ENV_FILE}")"

--- a/tests/scripts/hosted-deploy-workflow.test.sh
+++ b/tests/scripts/hosted-deploy-workflow.test.sh
@@ -63,7 +63,7 @@ fi
 
 if [[ "${1:-}" == "compose" ]]; then
   shift
-  while [[ "${1:-}" == "--env-file" || "${1:-}" == "-f" ]]; do
+  while [[ "${1:-}" == "--project-name" || "${1:-}" == "--env-file" || "${1:-}" == "-f" ]]; do
     shift 2
   done
   case "${1:-}" in
@@ -207,6 +207,7 @@ write_fake_commands
 create_source_repo
 
 DEPLOY_DIR="${TMP_ROOT}/deploy"
+COMPOSE_CMD="docker compose --project-name deploy --env-file ${DEPLOY_DIR}/.env.production -f ${DEPLOY_DIR}/compose.yml"
 
 log "checking dry-run install workflow"
 DRY_RUN_DEPLOY_DIR="${TMP_ROOT}/dry-run-deploy"
@@ -279,9 +280,9 @@ assert_contains "${BOOTSTRAP_OUTPUT}" "/readyz reports bootstrap_required"
 log "running install workflow"
 run_hosted install
 assert_file_equals "${DEPLOY_DIR}/server/version.txt" "v1"
-assert_contains "${DOCKER_LOG}" "docker compose --env-file ${DEPLOY_DIR}/.env.production -f ${DEPLOY_DIR}/compose.yml build dollhousemcp dollhousemcp-migrate"
-assert_contains "${DOCKER_LOG}" "docker compose --env-file ${DEPLOY_DIR}/.env.production -f ${DEPLOY_DIR}/compose.yml run --rm dollhousemcp-migrate"
-assert_contains "${DOCKER_LOG}" "docker compose --env-file ${DEPLOY_DIR}/.env.production -f ${DEPLOY_DIR}/compose.yml up -d"
+assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} build dollhousemcp dollhousemcp-migrate"
+assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} run --rm dollhousemcp-migrate"
+assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} up -d"
 assert_contains "${CURL_LOG}" "https://mcp.example.com/healthz"
 
 log "running update workflow"
@@ -291,7 +292,8 @@ assert_file_equals "${DEPLOY_DIR}/server/version.txt" "v2"
 previous_bundle="$(latest_dir 'server.prev-*')"
 [[ -n "${previous_bundle}" ]] || fail "expected update to retain a previous server bundle"
 assert_file_equals "${previous_bundle}/version.txt" "v1"
-assert_contains "${DOCKER_LOG}" "docker compose --env-file ${DEPLOY_DIR}/.env.production -f ${DEPLOY_DIR}/compose.yml up -d dollhousemcp"
+assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} up -d dollhousemcp"
+assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} up -d --no-deps --force-recreate caddy"
 
 log "running rollback workflow"
 run_hosted rollback
@@ -299,7 +301,7 @@ assert_file_equals "${DEPLOY_DIR}/server/version.txt" "v1"
 rollback_bundle="$(latest_dir 'server.rollback-from-*')"
 [[ -n "${rollback_bundle}" ]] || fail "expected rollback to retain the rolled-back current bundle"
 assert_file_equals "${rollback_bundle}/version.txt" "v2"
-assert_contains "${DOCKER_LOG}" "docker compose --env-file ${DEPLOY_DIR}/.env.production -f ${DEPLOY_DIR}/compose.yml up -d dollhousemcp caddy"
+assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} up -d dollhousemcp caddy"
 
 log "checking invalid source error"
 bad_output="${TMP_ROOT}/bad-source.out"

--- a/tests/scripts/hosted-remote-deploy.test.sh
+++ b/tests/scripts/hosted-remote-deploy.test.sh
@@ -88,7 +88,9 @@ done
 target="${args[$index]}"
 index=$((index + 1))
 printf 'target=%s\n' "${target}" >> "${DOLLHOUSE_FAKE_SSH_LOG:?}"
-"${args[@]:$index}"
+command_args=("${args[@]:$index}")
+remote_command="${command_args[*]}"
+bash -c "${remote_command}"
 EOF
 
   cat > "${FAKE_BIN}/ssh-keyscan" <<'EOF'
@@ -201,7 +203,13 @@ if [[ "${1:-}" == "clone" ]]; then
 #!/usr/bin/env bash
 set -euo pipefail
 
-printf 'hosted action=%s ref=%s source=%s deploy=%s\n' "${1:-}" "${DOLLHOUSE_HOSTED_GIT_REF:-}" "${DOLLHOUSE_HOSTED_SOURCE_DIR:-}" "${DOLLHOUSE_HOSTED_DEPLOY_DIR:-}" >> "${DOLLHOUSE_FAKE_REMOTE_LOG:?}"
+{
+  printf 'hosted action=%s ref=%s source=%s deploy=%s ' "${1:-}" "${DOLLHOUSE_HOSTED_GIT_REF:-}" "${DOLLHOUSE_HOSTED_SOURCE_DIR:-}" "${DOLLHOUSE_HOSTED_DEPLOY_DIR:-}"
+  printf 'hostname_set=%s hostname=%s public_url_set=%s public_url=%s ' "${DOLLHOUSE_HOSTED_HOSTNAME+x}" "${DOLLHOUSE_HOSTED_HOSTNAME:-}" "${DOLLHOUSE_PUBLIC_BASE_URL+x}" "${DOLLHOUSE_PUBLIC_BASE_URL:-}"
+  printf 'instance_set=%s instance=%s mode_set=%s mode=%s http_port_set=%s http_port=%s ' "${DOLLHOUSE_HOSTED_INSTANCE_NAME+x}" "${DOLLHOUSE_HOSTED_INSTANCE_NAME:-}" "${DOLLHOUSE_HOSTED_MODE+x}" "${DOLLHOUSE_HOSTED_MODE:-}" "${DOLLHOUSE_HOSTED_HTTP_BIND_PORT+x}" "${DOLLHOUSE_HOSTED_HTTP_BIND_PORT:-}"
+  printf 'auth_provider_set=%s auth_provider=%s auth_issuer_set=%s auth_issuer=%s auth_audience_set=%s auth_audience=%s ' "${DOLLHOUSE_AUTH_PROVIDER+x}" "${DOLLHOUSE_AUTH_PROVIDER:-}" "${DOLLHOUSE_AUTH_ISSUER+x}" "${DOLLHOUSE_AUTH_ISSUER:-}" "${DOLLHOUSE_AUTH_AUDIENCE+x}" "${DOLLHOUSE_AUTH_AUDIENCE:-}"
+  printf 'open_dcr_set=%s open_dcr=%s allowlist_required_set=%s allowlist_required=%s oidc_typ_set=%s oidc_typ=%s\n' "${DOLLHOUSE_AUTH_OPEN_DCR+x}" "${DOLLHOUSE_AUTH_OPEN_DCR:-}" "${DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED+x}" "${DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED:-}" "${DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP+x}" "${DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP:-}"
+} >> "${DOLLHOUSE_FAKE_REMOTE_LOG:?}"
 mkdir -p "${DOLLHOUSE_HOSTED_DEPLOY_DIR}/portfolio/personas"
 printf '%s\n' "${DOLLHOUSE_HOSTED_GIT_REF:-unknown-ref}" > "${DOLLHOUSE_HOSTED_DEPLOY_DIR}/DEPLOYED_REVISION"
 date -u +%Y-%m-%dT%H:%M:%SZ > "${DOLLHOUSE_HOSTED_DEPLOY_DIR}/DEPLOYED_AT"
@@ -311,7 +319,22 @@ run_remote() {
   DOLLHOUSE_REMOTE_KNOWN_HOSTS_FILE="${DOLLHOUSE_TEST_KNOWN_HOSTS_FILE:-${KNOWN_HOSTS_FILE}}" \
   DOLLHOUSE_REMOTE_BACKUP_RETRIES="${DOLLHOUSE_TEST_BACKUP_RETRIES:-3}" \
   DOLLHOUSE_REMOTE_BACKUP_RETRY_DELAY="${DOLLHOUSE_TEST_BACKUP_RETRY_DELAY:-0}" \
-  DOLLHOUSE_HOSTED_DEPLOY_DIR="${DEPLOY_DIR}" \
+  DOLLHOUSE_HOSTED_DEPLOY_DIR="${DOLLHOUSE_TEST_DEPLOY_DIR:-${DEPLOY_DIR}}" \
+  DOLLHOUSE_HOSTED_INSTANCE_NAME="${DOLLHOUSE_TEST_INSTANCE_NAME:-${DOLLHOUSE_HOSTED_INSTANCE_NAME:-}}" \
+  DOLLHOUSE_HOSTED_MODE="${DOLLHOUSE_TEST_HOSTED_MODE:-${DOLLHOUSE_HOSTED_MODE:-}}" \
+  DOLLHOUSE_HOSTED_PROXY_MODE="${DOLLHOUSE_TEST_PROXY_MODE:-${DOLLHOUSE_HOSTED_PROXY_MODE:-}}" \
+  DOLLHOUSE_HOSTED_BIND_ADDRESS="${DOLLHOUSE_TEST_BIND_ADDRESS:-${DOLLHOUSE_HOSTED_BIND_ADDRESS:-}}" \
+  DOLLHOUSE_HOSTED_HTTP_BIND_PORT="${DOLLHOUSE_TEST_HTTP_BIND_PORT:-${DOLLHOUSE_HOSTED_HTTP_BIND_PORT:-}}" \
+  DOLLHOUSE_HOSTED_HTTPS_BIND_PORT="${DOLLHOUSE_TEST_HTTPS_BIND_PORT:-${DOLLHOUSE_HOSTED_HTTPS_BIND_PORT:-}}" \
+  DOLLHOUSE_AUTH_PROVIDER="${DOLLHOUSE_TEST_AUTH_PROVIDER:-${DOLLHOUSE_AUTH_PROVIDER:-}}" \
+  DOLLHOUSE_AUTH_METHODS="${DOLLHOUSE_TEST_AUTH_METHODS:-${DOLLHOUSE_AUTH_METHODS:-}}" \
+  DOLLHOUSE_AUTH_OPEN_DCR="${DOLLHOUSE_TEST_AUTH_OPEN_DCR:-${DOLLHOUSE_AUTH_OPEN_DCR:-}}" \
+  DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED="${DOLLHOUSE_TEST_AUTH_ALLOWLIST_REQUIRED:-${DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED:-}}" \
+  DOLLHOUSE_AUTH_ISSUER="${DOLLHOUSE_TEST_AUTH_ISSUER:-${DOLLHOUSE_AUTH_ISSUER:-}}" \
+  DOLLHOUSE_AUTH_AUDIENCE="${DOLLHOUSE_TEST_AUTH_AUDIENCE:-${DOLLHOUSE_AUTH_AUDIENCE:-}}" \
+  DOLLHOUSE_AUTH_JWKS_URI="${DOLLHOUSE_TEST_AUTH_JWKS_URI:-${DOLLHOUSE_AUTH_JWKS_URI:-}}" \
+  DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP="${DOLLHOUSE_TEST_AUTH_OIDC_REQUIRE_TYP:-${DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP:-}}" \
+  DOLLHOUSE_AUTH_ALLOWLIST_SEED_FILE="${DOLLHOUSE_TEST_AUTH_ALLOWLIST_SEED_FILE:-${DOLLHOUSE_AUTH_ALLOWLIST_SEED_FILE:-}}" \
   DOLLHOUSE_HOSTED_HOSTNAME=mcp.example.com \
   DOLLHOUSE_HOSTED_GIT_URL="${DOLLHOUSE_TEST_GIT_URL:-https://github.com/DollhouseMCP/mcp-server.git}" \
   DOLLHOUSE_HOSTED_GIT_REF="${DOLLHOUSE_TEST_GIT_REF:-codex/test-ref}" \
@@ -325,7 +348,19 @@ log "checking dry-run does not open ssh"
 DRY_OUTPUT="${TMP_ROOT}/dry-run.out"
 run_remote --dry-run update > "${DRY_OUTPUT}"
 assert_contains "${DRY_OUTPUT}" "dry-run: would connect to root@example.test"
+assert_contains "${DRY_OUTPUT}" "instance=remote-deploy"
 [[ ! -s "${SSH_LOG}" ]] || fail "dry-run should not call ssh"
+
+log "checking remote canary derives instance from deploy dir"
+CANARY_DRY_OUTPUT="${TMP_ROOT}/canary-dry-run.out"
+DOLLHOUSE_TEST_DEPLOY_DIR="${TMP_ROOT}/dollhousemcp-canary" \
+DOLLHOUSE_TEST_HOSTED_MODE=lan \
+DOLLHOUSE_TEST_HTTP_BIND_PORT=3100 \
+  run_remote --dry-run update > "${CANARY_DRY_OUTPUT}"
+assert_contains "${CANARY_DRY_OUTPUT}" "deploy_dir=${TMP_ROOT}/dollhousemcp-canary"
+assert_contains "${CANARY_DRY_OUTPUT}" "instance=dollhousemcp-canary"
+assert_contains "${CANARY_DRY_OUTPUT}" "hosted overrides mode=lan"
+assert_contains "${CANARY_DRY_OUTPUT}" "would check http://mcp.example.com:3100/healthz"
 
 log "checking host key enrollment dry-run"
 ENROLL_DRY_OUTPUT="${TMP_ROOT}/enroll-dry-run.out"
@@ -376,6 +411,7 @@ assert_contains "${SSH_LOG}" "UserKnownHostsFile=${KNOWN_HOSTS_FILE}"
 assert_not_contains "${SSH_LOG}" "StrictHostKeyChecking=accept-new"
 assert_contains "${REMOTE_LOG}" "git clone --depth 1 --branch codex/test-ref"
 assert_contains "${REMOTE_LOG}" "${EXPECTED_HOSTED_ACTION}"
+assert_contains "${REMOTE_LOG}" "hostname_set=x hostname=mcp.example.com public_url_set= public_url= instance_set= instance= mode_set= mode= http_port_set= http_port="
 assert_contains "${REMOTE_LOG}" "pg_dump"
 assert_contains "${OUTPUT}" "backed up .env.production"
 assert_contains "${OUTPUT}" "creating database backup"
@@ -388,6 +424,66 @@ assert_contains "${DEPLOY_DIR}/DEPLOYED_REVISION" "codex/test-ref"
 latest_db_backup="$(find "${DEPLOY_DIR}/backups" -name 'pre-remote-update-*.sql' -print | head -n 1)"
 [[ -n "${latest_db_backup}" ]] || fail "expected database backup"
 assert_contains "${latest_db_backup}" "fake sql backup"
+
+log "checking remote effective public URL drives local verification"
+reset_fake_state
+: > "${CURL_LOG}"
+cat > "${DEPLOY_DIR}/.env.production" <<'EOF'
+POSTGRES_PASSWORD=existing
+DOLLHOUSE_HOSTED_MODE=lan
+DOLLHOUSE_HOSTED_HTTP_BIND_PORT=3000
+DOLLHOUSE_PUBLIC_BASE_URL=http://mcp.example.com:3000
+EOF
+PERSISTED_URL_OUTPUT="${TMP_ROOT}/persisted-url.out"
+run_remote --skip-backup update > "${PERSISTED_URL_OUTPUT}"
+assert_contains "${PERSISTED_URL_OUTPUT}" "effective public URL: http://mcp.example.com:3000"
+assert_contains "${PERSISTED_URL_OUTPUT}" "using remote effective public URL for verification: http://mcp.example.com:3000"
+assert_contains "${CURL_LOG}" "http://mcp.example.com:3000/healthz"
+assert_contains "${CURL_LOG}" "http://mcp.example.com:3000/readyz"
+assert_contains "${CURL_LOG}" "http://mcp.example.com:3000/mcp"
+assert_not_contains "${CURL_LOG}" "https://mcp.example.com/healthz"
+
+log "checking remote canary overrides reach hosted helper"
+reset_fake_state
+CANARY_UPDATE_OUTPUT="${TMP_ROOT}/canary-update.out"
+DOLLHOUSE_TEST_DEPLOY_DIR="${TMP_ROOT}/dollhousemcp-canary" \
+DOLLHOUSE_TEST_HOSTED_MODE=lan \
+DOLLHOUSE_TEST_HTTP_BIND_PORT=3100 \
+  run_remote --skip-backup update > "${CANARY_UPDATE_OUTPUT}"
+assert_contains "${REMOTE_LOG}" "deploy=${TMP_ROOT}/dollhousemcp-canary"
+assert_contains "${REMOTE_LOG}" "instance_set= instance="
+assert_contains "${REMOTE_LOG}" "mode_set=x mode=lan"
+assert_contains "${REMOTE_LOG}" "http_port_set=x http_port=3100"
+assert_contains "${CURL_LOG}" "http://mcp.example.com:3100/healthz"
+
+log "checking explicit remote instance override reaches hosted helper"
+reset_fake_state
+EXPLICIT_INSTANCE_OUTPUT="${TMP_ROOT}/explicit-instance.out"
+DOLLHOUSE_TEST_INSTANCE_NAME=dollhousemcp-canary \
+  run_remote --skip-backup update > "${EXPLICIT_INSTANCE_OUTPUT}"
+assert_contains "${REMOTE_LOG}" "instance_set=x instance=dollhousemcp-canary"
+
+log "checking remote enterprise OIDC auth overrides reach hosted helper"
+reset_fake_state
+OIDC_REMOTE_OUTPUT="${TMP_ROOT}/oidc-remote.out"
+DOLLHOUSE_TEST_DEPLOY_DIR="${TMP_ROOT}/remote-oidc-deploy" \
+DOLLHOUSE_TEST_HOSTED_MODE=enterprise \
+DOLLHOUSE_TEST_AUTH_PROVIDER=oidc \
+DOLLHOUSE_TEST_AUTH_ISSUER=https://login.example.test \
+DOLLHOUSE_TEST_AUTH_AUDIENCE=dollhouse-enterprise \
+DOLLHOUSE_TEST_AUTH_JWKS_URI=https://login.example.test/.well-known/jwks.json \
+DOLLHOUSE_TEST_AUTH_OIDC_REQUIRE_TYP=true \
+DOLLHOUSE_TEST_AUTH_OPEN_DCR=false \
+DOLLHOUSE_TEST_AUTH_ALLOWLIST_REQUIRED=true \
+  run_remote --skip-backup update > "${OIDC_REMOTE_OUTPUT}"
+assert_contains "${REMOTE_LOG}" "deploy=${TMP_ROOT}/remote-oidc-deploy"
+assert_contains "${REMOTE_LOG}" "mode_set=x mode=enterprise"
+assert_contains "${REMOTE_LOG}" "auth_provider_set=x auth_provider=oidc"
+assert_contains "${REMOTE_LOG}" "auth_issuer_set=x auth_issuer=https://login.example.test"
+assert_contains "${REMOTE_LOG}" "auth_audience_set=x auth_audience=dollhouse-enterprise"
+assert_contains "${REMOTE_LOG}" "open_dcr_set=x open_dcr=false"
+assert_contains "${REMOTE_LOG}" "allowlist_required_set=x allowlist_required=true"
+assert_contains "${REMOTE_LOG}" "oidc_typ_set=x oidc_typ=true"
 
 log "checking postgres readiness retry"
 reset_fake_state
@@ -487,6 +583,20 @@ if PATH="${FAKE_BIN}:${PATH}" \
   fail "missing target unexpectedly succeeded"
 fi
 assert_contains "${MISSING_TARGET_OUTPUT}" "set --target or DOLLHOUSE_REMOTE_SSH_TARGET"
+
+log "checking remote invalid instance name rejection"
+BAD_REMOTE_INSTANCE_OUTPUT="${TMP_ROOT}/bad-remote-instance.out"
+if DOLLHOUSE_HOSTED_INSTANCE_NAME=Bad_Name run_remote --dry-run update > "${BAD_REMOTE_INSTANCE_OUTPUT}" 2>&1; then
+  fail "remote dry-run with invalid instance name unexpectedly succeeded"
+fi
+assert_contains "${BAD_REMOTE_INSTANCE_OUTPUT}" "DOLLHOUSE_HOSTED_INSTANCE_NAME must be 1-48 lowercase letters"
+
+log "checking remote bind address rejects hostnames"
+BAD_REMOTE_BIND_OUTPUT="${TMP_ROOT}/bad-remote-bind.out"
+if DOLLHOUSE_HOSTED_BIND_ADDRESS=localhost run_remote --dry-run update > "${BAD_REMOTE_BIND_OUTPUT}" 2>&1; then
+  fail "remote dry-run with hostname bind address unexpectedly succeeded"
+fi
+assert_contains "${BAD_REMOTE_BIND_OUTPUT}" "DOLLHOUSE_HOSTED_BIND_ADDRESS must be an IPv4 address"
 
 log "checking credential-bearing git URL rejection"
 : > "${SSH_LOG}"

--- a/tests/scripts/hosted-remote-deploy.test.sh
+++ b/tests/scripts/hosted-remote-deploy.test.sh
@@ -204,11 +204,35 @@ if [[ "${1:-}" == "clone" ]]; then
 set -euo pipefail
 
 {
-  printf 'hosted action=%s ref=%s source=%s deploy=%s ' "${1:-}" "${DOLLHOUSE_HOSTED_GIT_REF:-}" "${DOLLHOUSE_HOSTED_SOURCE_DIR:-}" "${DOLLHOUSE_HOSTED_DEPLOY_DIR:-}"
-  printf 'hostname_set=%s hostname=%s public_url_set=%s public_url=%s ' "${DOLLHOUSE_HOSTED_HOSTNAME+x}" "${DOLLHOUSE_HOSTED_HOSTNAME:-}" "${DOLLHOUSE_PUBLIC_BASE_URL+x}" "${DOLLHOUSE_PUBLIC_BASE_URL:-}"
-  printf 'instance_set=%s instance=%s mode_set=%s mode=%s http_port_set=%s http_port=%s ' "${DOLLHOUSE_HOSTED_INSTANCE_NAME+x}" "${DOLLHOUSE_HOSTED_INSTANCE_NAME:-}" "${DOLLHOUSE_HOSTED_MODE+x}" "${DOLLHOUSE_HOSTED_MODE:-}" "${DOLLHOUSE_HOSTED_HTTP_BIND_PORT+x}" "${DOLLHOUSE_HOSTED_HTTP_BIND_PORT:-}"
-  printf 'auth_provider_set=%s auth_provider=%s auth_issuer_set=%s auth_issuer=%s auth_audience_set=%s auth_audience=%s ' "${DOLLHOUSE_AUTH_PROVIDER+x}" "${DOLLHOUSE_AUTH_PROVIDER:-}" "${DOLLHOUSE_AUTH_ISSUER+x}" "${DOLLHOUSE_AUTH_ISSUER:-}" "${DOLLHOUSE_AUTH_AUDIENCE+x}" "${DOLLHOUSE_AUTH_AUDIENCE:-}"
-  printf 'open_dcr_set=%s open_dcr=%s allowlist_required_set=%s allowlist_required=%s oidc_typ_set=%s oidc_typ=%s\n' "${DOLLHOUSE_AUTH_OPEN_DCR+x}" "${DOLLHOUSE_AUTH_OPEN_DCR:-}" "${DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED+x}" "${DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED:-}" "${DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP+x}" "${DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP:-}"
+  printf 'hosted action=%s ref=%s source=%s deploy=%s ' \
+    "${1:-}" "${DOLLHOUSE_HOSTED_GIT_REF:-}" "${DOLLHOUSE_HOSTED_SOURCE_DIR:-}" "${DOLLHOUSE_HOSTED_DEPLOY_DIR:-}"
+  printf 'hostname_set=%s hostname=%s public_url_set=%s public_url=%s ' \
+    "${DOLLHOUSE_HOSTED_HOSTNAME+x}" "${DOLLHOUSE_HOSTED_HOSTNAME:-}" "${DOLLHOUSE_PUBLIC_BASE_URL+x}" "${DOLLHOUSE_PUBLIC_BASE_URL:-}"
+  printf 'instance_set=%s instance=%s mode_set=%s mode=%s http_port_set=%s http_port=%s ' \
+    "${DOLLHOUSE_HOSTED_INSTANCE_NAME+x}" "${DOLLHOUSE_HOSTED_INSTANCE_NAME:-}" \
+    "${DOLLHOUSE_HOSTED_MODE+x}" "${DOLLHOUSE_HOSTED_MODE:-}" \
+    "${DOLLHOUSE_HOSTED_HTTP_BIND_PORT+x}" "${DOLLHOUSE_HOSTED_HTTP_BIND_PORT:-}"
+  printf 'mcp_port_set=%s mcp_port=%s image_tag_set=%s image_tag=%s mem_set=%s mem=%s cpus_set=%s cpus=%s ' \
+    "${DOLLHOUSE_HTTP_PORT+x}" "${DOLLHOUSE_HTTP_PORT:-}" \
+    "${DOLLHOUSE_HOSTED_IMAGE_TAG+x}" "${DOLLHOUSE_HOSTED_IMAGE_TAG:-}" \
+    "${DOLLHOUSE_HOSTED_MEM_LIMIT+x}" "${DOLLHOUSE_HOSTED_MEM_LIMIT:-}" \
+    "${DOLLHOUSE_HOSTED_CPUS+x}" "${DOLLHOUSE_HOSTED_CPUS:-}"
+  printf 'import_legacy_set=%s import_legacy=%s postgres_timeout_set=%s postgres_timeout=%s verify_timeout_set=%s verify_timeout=%s ' \
+    "${DOLLHOUSE_HOSTED_IMPORT_LEGACY_ENV+x}" "${DOLLHOUSE_HOSTED_IMPORT_LEGACY_ENV:-}" \
+    "${DOLLHOUSE_HOSTED_POSTGRES_READY_TIMEOUT+x}" "${DOLLHOUSE_HOSTED_POSTGRES_READY_TIMEOUT:-}" \
+    "${DOLLHOUSE_HOSTED_VERIFY_READY_TIMEOUT+x}" "${DOLLHOUSE_HOSTED_VERIFY_READY_TIMEOUT:-}"
+  printf 'allowed_hosts_set=%s allowed_hosts=%s trusted_proxies_set=%s trusted_proxies=%s ' \
+    "${DOLLHOUSE_HTTP_ALLOWED_HOSTS+x}" "${DOLLHOUSE_HTTP_ALLOWED_HOSTS:-}" "${DOLLHOUSE_TRUSTED_PROXIES+x}" "${DOLLHOUSE_TRUSTED_PROXIES:-}"
+  printf 'bootstrap_username_set=%s bootstrap_username=%s bootstrap_id_set=%s bootstrap_id=%s ' \
+    "${DOLLHOUSE_BOOTSTRAP_GITHUB_USERNAME+x}" "${DOLLHOUSE_BOOTSTRAP_GITHUB_USERNAME:-}" "${DOLLHOUSE_BOOTSTRAP_GITHUB_ID+x}" "${DOLLHOUSE_BOOTSTRAP_GITHUB_ID:-}"
+  printf 'auth_provider_set=%s auth_provider=%s auth_issuer_set=%s auth_issuer=%s auth_audience_set=%s auth_audience=%s ' \
+    "${DOLLHOUSE_AUTH_PROVIDER+x}" "${DOLLHOUSE_AUTH_PROVIDER:-}" \
+    "${DOLLHOUSE_AUTH_ISSUER+x}" "${DOLLHOUSE_AUTH_ISSUER:-}" \
+    "${DOLLHOUSE_AUTH_AUDIENCE+x}" "${DOLLHOUSE_AUTH_AUDIENCE:-}"
+  printf 'open_dcr_set=%s open_dcr=%s allowlist_required_set=%s allowlist_required=%s oidc_typ_set=%s oidc_typ=%s\n' \
+    "${DOLLHOUSE_AUTH_OPEN_DCR+x}" "${DOLLHOUSE_AUTH_OPEN_DCR:-}" \
+    "${DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED+x}" "${DOLLHOUSE_AUTH_ALLOWLIST_REQUIRED:-}" \
+    "${DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP+x}" "${DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP:-}"
 } >> "${DOLLHOUSE_FAKE_REMOTE_LOG:?}"
 mkdir -p "${DOLLHOUSE_HOSTED_DEPLOY_DIR}/portfolio/personas"
 printf '%s\n' "${DOLLHOUSE_HOSTED_GIT_REF:-unknown-ref}" > "${DOLLHOUSE_HOSTED_DEPLOY_DIR}/DEPLOYED_REVISION"
@@ -335,6 +359,17 @@ run_remote() {
   DOLLHOUSE_AUTH_JWKS_URI="${DOLLHOUSE_TEST_AUTH_JWKS_URI:-${DOLLHOUSE_AUTH_JWKS_URI:-}}" \
   DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP="${DOLLHOUSE_TEST_AUTH_OIDC_REQUIRE_TYP:-${DOLLHOUSE_AUTH_OIDC_REQUIRE_TYP:-}}" \
   DOLLHOUSE_AUTH_ALLOWLIST_SEED_FILE="${DOLLHOUSE_TEST_AUTH_ALLOWLIST_SEED_FILE:-${DOLLHOUSE_AUTH_ALLOWLIST_SEED_FILE:-}}" \
+  DOLLHOUSE_HTTP_PORT="${DOLLHOUSE_TEST_MCP_PORT:-${DOLLHOUSE_HTTP_PORT:-}}" \
+  DOLLHOUSE_HOSTED_IMAGE_TAG="${DOLLHOUSE_TEST_IMAGE_TAG:-${DOLLHOUSE_HOSTED_IMAGE_TAG:-}}" \
+  DOLLHOUSE_HOSTED_MEM_LIMIT="${DOLLHOUSE_TEST_MEM_LIMIT:-${DOLLHOUSE_HOSTED_MEM_LIMIT:-}}" \
+  DOLLHOUSE_HOSTED_CPUS="${DOLLHOUSE_TEST_CPUS:-${DOLLHOUSE_HOSTED_CPUS:-}}" \
+  DOLLHOUSE_HOSTED_IMPORT_LEGACY_ENV="${DOLLHOUSE_TEST_IMPORT_LEGACY_ENV:-${DOLLHOUSE_HOSTED_IMPORT_LEGACY_ENV:-}}" \
+  DOLLHOUSE_HOSTED_POSTGRES_READY_TIMEOUT="${DOLLHOUSE_TEST_POSTGRES_READY_TIMEOUT:-${DOLLHOUSE_HOSTED_POSTGRES_READY_TIMEOUT:-}}" \
+  DOLLHOUSE_HOSTED_VERIFY_READY_TIMEOUT="${DOLLHOUSE_TEST_VERIFY_READY_TIMEOUT:-${DOLLHOUSE_HOSTED_VERIFY_READY_TIMEOUT:-}}" \
+  DOLLHOUSE_HTTP_ALLOWED_HOSTS="${DOLLHOUSE_TEST_ALLOWED_HOSTS:-${DOLLHOUSE_HTTP_ALLOWED_HOSTS:-}}" \
+  DOLLHOUSE_TRUSTED_PROXIES="${DOLLHOUSE_TEST_TRUSTED_PROXIES:-${DOLLHOUSE_TRUSTED_PROXIES:-}}" \
+  DOLLHOUSE_BOOTSTRAP_GITHUB_USERNAME="${DOLLHOUSE_TEST_BOOTSTRAP_GITHUB_USERNAME:-${DOLLHOUSE_BOOTSTRAP_GITHUB_USERNAME:-}}" \
+  DOLLHOUSE_BOOTSTRAP_GITHUB_ID="${DOLLHOUSE_TEST_BOOTSTRAP_GITHUB_ID:-${DOLLHOUSE_BOOTSTRAP_GITHUB_ID:-}}" \
   DOLLHOUSE_HOSTED_HOSTNAME=mcp.example.com \
   DOLLHOUSE_HOSTED_GIT_URL="${DOLLHOUSE_TEST_GIT_URL:-https://github.com/DollhouseMCP/mcp-server.git}" \
   DOLLHOUSE_HOSTED_GIT_REF="${DOLLHOUSE_TEST_GIT_REF:-codex/test-ref}" \
@@ -456,12 +491,50 @@ assert_contains "${REMOTE_LOG}" "mode_set=x mode=lan"
 assert_contains "${REMOTE_LOG}" "http_port_set=x http_port=3100"
 assert_contains "${CURL_LOG}" "http://mcp.example.com:3100/healthz"
 
+log "checking remote host allowlist and proxy overrides reach hosted helper"
+reset_fake_state
+HOST_PROXY_OUTPUT="${TMP_ROOT}/host-proxy-overrides.out"
+DOLLHOUSE_TEST_ALLOWED_HOSTS=localhost,127.0.0.1,mcp.example.com,alt.example.com \
+DOLLHOUSE_TEST_TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12 \
+  run_remote --skip-backup update > "${HOST_PROXY_OUTPUT}"
+assert_contains "${REMOTE_LOG}" "allowed_hosts_set=x allowed_hosts=localhost,127.0.0.1,mcp.example.com,alt.example.com"
+assert_contains "${REMOTE_LOG}" "trusted_proxies_set=x trusted_proxies=10.0.0.0/8,172.16.0.0/12"
+
+log "checking remote runtime overrides reach hosted helper"
+reset_fake_state
+RUNTIME_OVERRIDE_OUTPUT="${TMP_ROOT}/runtime-overrides.out"
+DOLLHOUSE_TEST_MCP_PORT=3333 \
+DOLLHOUSE_TEST_IMAGE_TAG=dollhousemcp/custom:alpha \
+DOLLHOUSE_TEST_MEM_LIMIT=4g \
+DOLLHOUSE_TEST_CPUS=1.5 \
+DOLLHOUSE_TEST_IMPORT_LEGACY_ENV=false \
+DOLLHOUSE_TEST_POSTGRES_READY_TIMEOUT=120 \
+DOLLHOUSE_TEST_VERIFY_READY_TIMEOUT=90 \
+  run_remote --skip-backup update > "${RUNTIME_OVERRIDE_OUTPUT}"
+assert_contains "${REMOTE_LOG}" "mcp_port_set=x mcp_port=3333"
+assert_contains "${REMOTE_LOG}" "image_tag_set=x image_tag=dollhousemcp/custom:alpha"
+assert_contains "${REMOTE_LOG}" "mem_set=x mem=4g"
+assert_contains "${REMOTE_LOG}" "cpus_set=x cpus=1.5"
+assert_contains "${REMOTE_LOG}" "import_legacy_set=x import_legacy=false"
+assert_contains "${REMOTE_LOG}" "postgres_timeout_set=x postgres_timeout=120"
+assert_contains "${REMOTE_LOG}" "verify_timeout_set=x verify_timeout=90"
+
 log "checking explicit remote instance override reaches hosted helper"
 reset_fake_state
 EXPLICIT_INSTANCE_OUTPUT="${TMP_ROOT}/explicit-instance.out"
 DOLLHOUSE_TEST_INSTANCE_NAME=dollhousemcp-canary \
   run_remote --skip-backup update > "${EXPLICIT_INSTANCE_OUTPUT}"
 assert_contains "${REMOTE_LOG}" "instance_set=x instance=dollhousemcp-canary"
+
+log "checking remote bootstrap overrides reach hosted helper"
+reset_fake_state
+BOOTSTRAP_OUTPUT="${TMP_ROOT}/bootstrap-admin.out"
+DOLLHOUSE_TEST_BOOTSTRAP_GITHUB_USERNAME=octocat \
+DOLLHOUSE_TEST_BOOTSTRAP_GITHUB_ID=184286 \
+  run_remote --skip-backup bootstrap-admin > "${BOOTSTRAP_OUTPUT}"
+assert_contains "${REMOTE_LOG}" "hosted action=bootstrap-admin"
+assert_contains "${REMOTE_LOG}" "bootstrap_username_set=x bootstrap_username=octocat"
+assert_contains "${REMOTE_LOG}" "bootstrap_id_set=x bootstrap_id=184286"
 
 log "checking remote enterprise OIDC auth overrides reach hosted helper"
 reset_fake_state


### PR DESCRIPTION
## Summary

Adds the first LAN and enterprise deployment-mode slice for the hosted deployment helper.

This PR covers #2225 and #2226 by making the generated Docker Compose/Caddy/env output mode-aware:

- `DOLLHOUSE_HOSTED_MODE=cloud` keeps the current Dollhouse-operated alpha/demo shape.
- `DOLLHOUSE_HOSTED_MODE=lan` renders a local/private-network HTTP Caddy shape with conservative loopback binding by default and opt-in LAN exposure through `DOLLHOUSE_HOSTED_BIND_ADDRESS`.
- `DOLLHOUSE_HOSTED_MODE=enterprise` renders a stricter organization-controlled HTTPS shape with open DCR off by default and configurable `embedded` or `oidc` auth provider posture.

## Details

- Adds `scripts/hosted-deploy/modes.sh` for deployment-mode defaults and persisted-mode adoption from `.env.production`.
- Persists hostname, public base URL, proxy mode, bind address, auth provider/methods, DCR posture, allowlist posture, allowed hosts, and trusted proxies into `.env.production` so later updates preserve the install shape.
- Adds mode-aware Caddy port rendering:
  - cloud/enterprise: Caddy TLS on host `80`/`443`
  - LAN: Caddy HTTP on host `3000` by default
- Adds enterprise OIDC validation so missing issuer/audience fail before rendering or starting containers.
- Prompts for GitHub OAuth credentials only when the embedded auth method includes `github`.
- Updates hosted deployment docs with mode examples, configuration variables, defaults, and DCR guidance.
- Expands generated-config tests for cloud defaults, LAN defaults, LAN exposed bind, LAN re-render persistence, enterprise OIDC happy path, enterprise OIDC missing issuer, and invalid mode rejection.

## Validation

- `npm run lint:shell`
- `npm run test:hosted-deploy`
- `git diff --check`
- `npm pack --dry-run --json` confirms `scripts/hosted-deploy/modes.sh` is included

## Notes

This intentionally leaves the public `curl | sh` installer wrapper for the next slice. Real-container LAN/enterprise validation remains tracked as follow-up confidence work.
