### PR TITLE
[codex] Fix hosted fresh install bootstrap

### DIFF
--- a/scripts/hosted-deploy/config.sh
+++ b/scripts/hosted-deploy/config.sh
@@ -124,6 +124,8 @@ hosted_deploy_init_config() {
   CADDY_FILE="${DEPLOY_DIR}/Caddyfile"
   INIT_DB_FILE="${DEPLOY_DIR}/init-db.sh"
   POST_MIGRATION_GRANTS_FILE="${DEPLOY_DIR}/post-migration-grants.sql"
+  POST_MIGRATION_GRANTS_SCRIPT_FILE="${DEPLOY_DIR}/apply-post-migration-grants.sh"
+  BOOTSTRAP_ADMIN_SCRIPT_FILE="${DEPLOY_DIR}/bootstrap-admin.sh"
   SERVER_DIR="${DEPLOY_DIR}/server"
   APP_CONTAINER_NAME=""
   POSTGRES_CONTAINER_NAME=""

--- a/scripts/hosted-deploy/config.sh
+++ b/scripts/hosted-deploy/config.sh
@@ -123,6 +123,7 @@ hosted_deploy_init_config() {
   COMPOSE_FILE="${DEPLOY_DIR}/compose.yml"
   CADDY_FILE="${DEPLOY_DIR}/Caddyfile"
   INIT_DB_FILE="${DEPLOY_DIR}/init-db.sh"
+  POST_MIGRATION_GRANTS_FILE="${DEPLOY_DIR}/post-migration-grants.sql"
   SERVER_DIR="${DEPLOY_DIR}/server"
   APP_CONTAINER_NAME=""
   POSTGRES_CONTAINER_NAME=""

--- a/scripts/hosted-deploy/dry-run.sh
+++ b/scripts/hosted-deploy/dry-run.sh
@@ -14,7 +14,9 @@ describe_render_plan() {
   log "dry-run: would write ${COMPOSE_FILE}"
   log "dry-run: would write ${CADDY_FILE}"
   log "dry-run: would write ${INIT_DB_FILE} without embedding the app database password"
-  log "dry-run: would write ${POST_MIGRATION_GRANTS_FILE}"
+  log "dry-run: would write ${POST_MIGRATION_GRANTS_FILE} without embedding the app database password"
+  log "dry-run: would write ${POST_MIGRATION_GRANTS_SCRIPT_FILE} to pass grant passwords through container environment"
+  log "dry-run: would write ${BOOTSTRAP_ADMIN_SCRIPT_FILE} to use the admin database URL inside the maintenance container"
 
   return 0
 }

--- a/scripts/hosted-deploy/dry-run.sh
+++ b/scripts/hosted-deploy/dry-run.sh
@@ -14,6 +14,7 @@ describe_render_plan() {
   log "dry-run: would write ${COMPOSE_FILE}"
   log "dry-run: would write ${CADDY_FILE}"
   log "dry-run: would write ${INIT_DB_FILE} without embedding the app database password"
+  log "dry-run: would write ${POST_MIGRATION_GRANTS_FILE}"
 
   return 0
 }
@@ -59,6 +60,7 @@ dry_run_start_or_update() {
   log "dry-run: would build dollhousemcp image"
   log "dry-run: would start postgres and wait up to ${POSTGRES_READY_TIMEOUT}s"
   log "dry-run: would run database migrations"
+  log "dry-run: would apply post-migration database grants"
   describe_bootstrap_plan optional
   if [[ "${service}" == "app" ]]; then
     log "dry-run: would restart dollhousemcp service and refresh caddy proxy"
@@ -77,6 +79,7 @@ dry_run_migrations() {
   log "dry-run: would build dollhousemcp image"
   log "dry-run: would start postgres and wait up to ${POSTGRES_READY_TIMEOUT}s"
   log "dry-run: would run database migrations"
+  log "dry-run: would apply post-migration database grants"
 
   return 0
 }
@@ -87,6 +90,7 @@ dry_run_bootstrap_admin() {
   log "dry-run: would build dollhousemcp image"
   log "dry-run: would start postgres and wait up to ${POSTGRES_READY_TIMEOUT}s"
   log "dry-run: would run database migrations"
+  log "dry-run: would apply post-migration database grants"
   describe_bootstrap_plan required
 
   return 0

--- a/scripts/hosted-deploy/render.sh
+++ b/scripts/hosted-deploy/render.sh
@@ -308,13 +308,13 @@ EOF
 
 validate_rendered_runtime_files() {
   [[ -r "${INIT_DB_FILE}" && -x "${INIT_DB_FILE}" ]] || \
-    die "rendered ${INIT_DB_FILE} must be readable and executable by the Postgres entrypoint"
+    die "rendered ${INIT_DB_FILE} must be readable and executable by the Postgres entrypoint; expected mode 0755 or equivalent"
   [[ -r "${POST_MIGRATION_GRANTS_FILE}" ]] || \
-    die "rendered ${POST_MIGRATION_GRANTS_FILE} must be readable for post-migration grants"
+    die "rendered ${POST_MIGRATION_GRANTS_FILE} must be readable for post-migration grants; expected mode 0644 or equivalent"
   [[ -r "${POST_MIGRATION_GRANTS_SCRIPT_FILE}" && -x "${POST_MIGRATION_GRANTS_SCRIPT_FILE}" ]] || \
-    die "rendered ${POST_MIGRATION_GRANTS_SCRIPT_FILE} must be readable and executable in the Postgres container"
+    die "rendered ${POST_MIGRATION_GRANTS_SCRIPT_FILE} must be readable and executable in the Postgres container; expected mode 0755 or equivalent"
   [[ -r "${BOOTSTRAP_ADMIN_SCRIPT_FILE}" && -x "${BOOTSTRAP_ADMIN_SCRIPT_FILE}" ]] || \
-    die "rendered ${BOOTSTRAP_ADMIN_SCRIPT_FILE} must be readable and executable in the maintenance container"
+    die "rendered ${BOOTSTRAP_ADMIN_SCRIPT_FILE} must be readable and executable in the maintenance container; expected mode 0755 or equivalent"
 
   return 0
 }

--- a/scripts/hosted-deploy/render.sh
+++ b/scripts/hosted-deploy/render.sh
@@ -20,6 +20,7 @@ services:
     volumes:
       - ./pgdata:/var/lib/postgresql/data
       - ./init-db.sh:/docker-entrypoint-initdb.d/00-create-roles.sh:ro
+      - ./apply-post-migration-grants.sh:/usr/local/bin/apply-post-migration-grants:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U dollhouse -d dollhousemcp"]
       interval: 10s
@@ -101,6 +102,8 @@ services:
       DOLLHOUSE_DATABASE_URL: postgres://dollhouse_app:\${POSTGRES_PASSWORD}@postgres:5432/dollhousemcp
       DOLLHOUSE_DATABASE_ADMIN_URL: postgres://dollhouse:\${POSTGRES_ADMIN_PASSWORD}@postgres:5432/dollhousemcp
       DOLLHOUSE_DATABASE_SSL: disable
+    volumes:
+      - ./bootstrap-admin.sh:/usr/local/bin/dollhouse-bootstrap-admin:ro
     command: ["npm", "run", "db:migrate"]
 
   caddy:
@@ -238,8 +241,8 @@ EOF
 
 write_init_db() {
   cat > "${INIT_DB_FILE}" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 : "${POSTGRES_USER:?POSTGRES_USER is required}"
 : "${POSTGRES_DB:?POSTGRES_DB is required}"
@@ -265,6 +268,53 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public
 SQL
 EOF
   chmod 0755 "${INIT_DB_FILE}"
+
+  return 0
+}
+
+write_post_migration_grants_script() {
+  cat > "${POST_MIGRATION_GRANTS_SCRIPT_FILE}" <<'EOF'
+#!/bin/sh
+set -eu
+
+: "${POSTGRES_USER:?POSTGRES_USER is required}"
+: "${POSTGRES_DB:?POSTGRES_DB is required}"
+: "${DOLLHOUSE_APP_DB_PASSWORD:?DOLLHOUSE_APP_DB_PASSWORD is required}"
+
+psql -v ON_ERROR_STOP=1 \
+  --username "${POSTGRES_USER}" \
+  --dbname "${POSTGRES_DB}" \
+  -v app_password="${DOLLHOUSE_APP_DB_PASSWORD}"
+EOF
+  chmod 0755 "${POST_MIGRATION_GRANTS_SCRIPT_FILE}"
+
+  return 0
+}
+
+write_bootstrap_admin_script() {
+  cat > "${BOOTSTRAP_ADMIN_SCRIPT_FILE}" <<'EOF'
+#!/bin/sh
+set -eu
+
+: "${DOLLHOUSE_DATABASE_ADMIN_URL:?DOLLHOUSE_DATABASE_ADMIN_URL is required}"
+
+export DOLLHOUSE_DATABASE_URL="${DOLLHOUSE_DATABASE_ADMIN_URL}"
+exec node dist/cli/admin-bootstrap.js "$@"
+EOF
+  chmod 0755 "${BOOTSTRAP_ADMIN_SCRIPT_FILE}"
+
+  return 0
+}
+
+validate_rendered_runtime_files() {
+  [[ -r "${INIT_DB_FILE}" && -x "${INIT_DB_FILE}" ]] || \
+    die "rendered ${INIT_DB_FILE} must be readable and executable by the Postgres entrypoint"
+  [[ -r "${POST_MIGRATION_GRANTS_FILE}" ]] || \
+    die "rendered ${POST_MIGRATION_GRANTS_FILE} must be readable for post-migration grants"
+  [[ -r "${POST_MIGRATION_GRANTS_SCRIPT_FILE}" && -x "${POST_MIGRATION_GRANTS_SCRIPT_FILE}" ]] || \
+    die "rendered ${POST_MIGRATION_GRANTS_SCRIPT_FILE} must be readable and executable in the Postgres container"
+  [[ -r "${BOOTSTRAP_ADMIN_SCRIPT_FILE}" && -x "${BOOTSTRAP_ADMIN_SCRIPT_FILE}" ]] || \
+    die "rendered ${BOOTSTRAP_ADMIN_SCRIPT_FILE} must be readable and executable in the maintenance container"
 
   return 0
 }
@@ -324,6 +374,9 @@ render_files() {
   write_caddyfile
   write_init_db
   write_post_migration_grants
+  write_post_migration_grants_script
+  write_bootstrap_admin_script
+  validate_rendered_runtime_files
   log "rendered deployment files in ${DEPLOY_DIR}"
 
   return 0

--- a/scripts/hosted-deploy/render.sh
+++ b/scripts/hosted-deploy/render.sh
@@ -102,6 +102,7 @@ services:
       DOLLHOUSE_DATABASE_URL: postgres://dollhouse_app:\${POSTGRES_PASSWORD}@postgres:5432/dollhousemcp
       DOLLHOUSE_DATABASE_ADMIN_URL: postgres://dollhouse:\${POSTGRES_ADMIN_PASSWORD}@postgres:5432/dollhousemcp
       DOLLHOUSE_DATABASE_SSL: disable
+      DOLLHOUSE_AUTH_STORAGE_BACKEND: postgres
     volumes:
       - ./bootstrap-admin.sh:/usr/local/bin/dollhouse-bootstrap-admin:ro
     command: ["npm", "run", "db:migrate"]

--- a/scripts/hosted-deploy/render.sh
+++ b/scripts/hosted-deploy/render.sh
@@ -264,7 +264,50 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT USAGE, SELECT ON SEQUENCES TO dollhouse_app;
 SQL
 EOF
-  chmod 0750 "${INIT_DB_FILE}"
+  chmod 0755 "${INIT_DB_FILE}"
+
+  return 0
+}
+
+write_post_migration_grants() {
+  cat > "${POST_MIGRATION_GRANTS_FILE}" <<'EOF'
+-- Re-apply app-role grants after migrations create or alter objects.
+--
+-- The Postgres entrypoint init script runs only on first database creation.
+-- Migrations run later, so hosted deploys re-run these grants after every
+-- migration pass to make fresh installs and updates converge on the same role
+-- privileges.
+
+SELECT format(
+  'CREATE ROLE dollhouse_app WITH LOGIN PASSWORD %L NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS',
+  :'app_password'
+)
+WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'dollhouse_app')
+\gexec
+ALTER ROLE dollhouse_app WITH PASSWORD :'app_password';
+
+GRANT CONNECT ON DATABASE dollhousemcp TO dollhouse_app;
+GRANT USAGE ON SCHEMA public TO dollhouse_app;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO dollhouse_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO dollhouse_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO dollhouse_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO dollhouse_app;
+
+REVOKE INSERT, UPDATE, DELETE ON TABLE users FROM dollhouse_app;
+
+DO $$
+BEGIN
+  EXECUTE 'GRANT USAGE ON SCHEMA drizzle TO dollhouse_app';
+  EXECUTE 'GRANT SELECT ON ALL TABLES IN SCHEMA drizzle TO dollhouse_app';
+EXCEPTION WHEN invalid_schema_name THEN
+  NULL;
+END
+$$;
+EOF
+  chmod 0644 "${POST_MIGRATION_GRANTS_FILE}"
 
   return 0
 }
@@ -280,6 +323,7 @@ render_files() {
   write_compose
   write_caddyfile
   write_init_db
+  write_post_migration_grants
   log "rendered deployment files in ${DEPLOY_DIR}"
 
   return 0

--- a/scripts/hosted-deploy/runtime.sh
+++ b/scripts/hosted-deploy/runtime.sh
@@ -80,8 +80,7 @@ run_database_migrations() {
   log "running database migrations"
   compose run --rm dollhousemcp-migrate
   log "applying post-migration database grants"
-  compose exec -T postgres sh -c \
-    'set -eu; : "${DOLLHOUSE_APP_DB_PASSWORD:?DOLLHOUSE_APP_DB_PASSWORD is required}"; psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}" -v app_password="${DOLLHOUSE_APP_DB_PASSWORD}"' \
+  compose exec -T postgres /usr/local/bin/apply-post-migration-grants \
     < "${POST_MIGRATION_GRANTS_FILE}"
 
   return 0
@@ -136,8 +135,7 @@ run_bootstrap_admin() {
   log "bootstrapping GitHub admin"
   compose run --rm \
     dollhousemcp-migrate \
-    sh -c 'DOLLHOUSE_DATABASE_URL="${DOLLHOUSE_DATABASE_ADMIN_URL}" exec node dist/cli/admin-bootstrap.js "$@"' \
-    dollhouse-admin-bootstrap "${args[@]}"
+    /usr/local/bin/dollhouse-bootstrap-admin "${args[@]}"
 
   return 0
 }

--- a/scripts/hosted-deploy/runtime.sh
+++ b/scripts/hosted-deploy/runtime.sh
@@ -79,6 +79,10 @@ build_app_image() {
 run_database_migrations() {
   log "running database migrations"
   compose run --rm dollhousemcp-migrate
+  log "applying post-migration database grants"
+  compose exec -T postgres sh -c \
+    'set -eu; : "${DOLLHOUSE_APP_DB_PASSWORD:?DOLLHOUSE_APP_DB_PASSWORD is required}"; psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER}" --dbname "${POSTGRES_DB}" -v app_password="${DOLLHOUSE_APP_DB_PASSWORD}"' \
+    < "${POST_MIGRATION_GRANTS_FILE}"
 
   return 0
 }
@@ -130,7 +134,10 @@ run_bootstrap_admin() {
   fi
 
   log "bootstrapping GitHub admin"
-  compose run --rm dollhousemcp npx dollhouse-admin-bootstrap "${args[@]}"
+  compose run --rm \
+    dollhousemcp-migrate \
+    sh -c 'DOLLHOUSE_DATABASE_URL="${DOLLHOUSE_DATABASE_ADMIN_URL}" exec node dist/cli/admin-bootstrap.js "$@"' \
+    dollhouse-admin-bootstrap "${args[@]}"
 
   return 0
 }

--- a/scripts/hosted-deploy/runtime.sh
+++ b/scripts/hosted-deploy/runtime.sh
@@ -80,6 +80,8 @@ run_database_migrations() {
   log "running database migrations"
   compose run --rm dollhousemcp-migrate
   log "applying post-migration database grants"
+  [[ -r "${POST_MIGRATION_GRANTS_FILE}" ]] || \
+    die "post-migration grants file is not readable at ${POST_MIGRATION_GRANTS_FILE}; run render or install again"
   compose exec -T postgres /usr/local/bin/apply-post-migration-grants \
     < "${POST_MIGRATION_GRANTS_FILE}"
 

--- a/tests/scripts/hosted-deploy-render.test.sh
+++ b/tests/scripts/hosted-deploy-render.test.sh
@@ -101,6 +101,8 @@ COMPOSE_FILE="${DEPLOY_DIR}/compose.yml"
 CADDY_FILE="${DEPLOY_DIR}/Caddyfile"
 INIT_DB_FILE="${DEPLOY_DIR}/init-db.sh"
 POST_MIGRATION_GRANTS_FILE="${DEPLOY_DIR}/post-migration-grants.sql"
+POST_MIGRATION_GRANTS_SCRIPT_FILE="${DEPLOY_DIR}/apply-post-migration-grants.sh"
+BOOTSTRAP_ADMIN_SCRIPT_FILE="${DEPLOY_DIR}/bootstrap-admin.sh"
 
 log "rendering default alpha configuration"
 render_with_dcr "${DEPLOY_DIR}" ""
@@ -110,6 +112,8 @@ render_with_dcr "${DEPLOY_DIR}" ""
 [[ -f "${CADDY_FILE}" ]] || fail "missing ${CADDY_FILE}"
 [[ -f "${INIT_DB_FILE}" ]] || fail "missing ${INIT_DB_FILE}"
 [[ -f "${POST_MIGRATION_GRANTS_FILE}" ]] || fail "missing ${POST_MIGRATION_GRANTS_FILE}"
+[[ -f "${POST_MIGRATION_GRANTS_SCRIPT_FILE}" ]] || fail "missing ${POST_MIGRATION_GRANTS_SCRIPT_FILE}"
+[[ -f "${BOOTSTRAP_ADMIN_SCRIPT_FILE}" ]] || fail "missing ${BOOTSTRAP_ADMIN_SCRIPT_FILE}"
 
 assert_line "${COMPOSE_FILE}" 'name: deploy'
 assert_line "${COMPOSE_FILE}" '    container_name: deploy-postgres'
@@ -121,6 +125,8 @@ assert_contains "${COMPOSE_FILE}" 'image: caddy:2.8'
 assert_contains "${COMPOSE_FILE}" 'DOLLHOUSE_AUTH_OPEN_DCR: "true"'
 assert_contains "${COMPOSE_FILE}" "DOLLHOUSE_APP_DB_PASSWORD: \${POSTGRES_PASSWORD}"
 assert_contains "${COMPOSE_FILE}" "DOLLHOUSE_DATABASE_URL: postgres://dollhouse_app:\${POSTGRES_PASSWORD}@postgres:5432/dollhousemcp"
+assert_contains "${COMPOSE_FILE}" "./apply-post-migration-grants.sh:/usr/local/bin/apply-post-migration-grants:ro"
+assert_contains "${COMPOSE_FILE}" "./bootstrap-admin.sh:/usr/local/bin/dollhouse-bootstrap-admin:ro"
 assert_contains "${COMPOSE_FILE}" "DOLLHOUSE_HTTP_ALLOWED_HOSTS: localhost,127.0.0.1,mcp.example.com"
 assert_contains "${COMPOSE_FILE}" "DOLLHOUSE_TRUSTED_PROXIES: 172.16.0.0/12"
 assert_contains "${COMPOSE_FILE}" 'DOLLHOUSE_UNSAFE_NO_TLS: "true"'
@@ -153,11 +159,17 @@ assert_contains "${INIT_DB_FILE}" 'CREATE ROLE dollhouse_app'
 assert_contains "${INIT_DB_FILE}" 'DOLLHOUSE_APP_DB_PASSWORD'
 [[ "$(file_mode "${INIT_DB_FILE}")" == "755" ]] || fail "init-db.sh should be mode 0755"
 [[ "$(file_mode "${POST_MIGRATION_GRANTS_FILE}")" == "644" ]] || fail "post-migration-grants.sql should be mode 0644"
+[[ "$(file_mode "${POST_MIGRATION_GRANTS_SCRIPT_FILE}")" == "755" ]] || fail "apply-post-migration-grants.sh should be mode 0755"
+[[ "$(file_mode "${BOOTSTRAP_ADMIN_SCRIPT_FILE}")" == "755" ]] || fail "bootstrap-admin.sh should be mode 0755"
 assert_contains "${POST_MIGRATION_GRANTS_FILE}" 'CREATE ROLE dollhouse_app'
 assert_contains "${POST_MIGRATION_GRANTS_FILE}" ":'app_password'"
 assert_contains "${POST_MIGRATION_GRANTS_FILE}" 'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO dollhouse_app'
 assert_contains "${POST_MIGRATION_GRANTS_FILE}" 'REVOKE INSERT, UPDATE, DELETE ON TABLE users FROM dollhouse_app'
 assert_contains "${POST_MIGRATION_GRANTS_FILE}" 'GRANT SELECT ON ALL TABLES IN SCHEMA drizzle TO dollhouse_app'
+assert_contains "${POST_MIGRATION_GRANTS_SCRIPT_FILE}" 'DOLLHOUSE_APP_DB_PASSWORD'
+assert_contains "${POST_MIGRATION_GRANTS_SCRIPT_FILE}" 'psql -v ON_ERROR_STOP=1'
+assert_contains "${BOOTSTRAP_ADMIN_SCRIPT_FILE}" 'DOLLHOUSE_DATABASE_ADMIN_URL'
+assert_contains "${BOOTSTRAP_ADMIN_SCRIPT_FILE}" 'exec node dist/cli/admin-bootstrap.js "$@"'
 assert_contains "${ENV_FILE}" 'DOLLHOUSE_HOSTED_MODE=cloud'
 assert_contains "${ENV_FILE}" 'DOLLHOUSE_HOSTED_INSTANCE_NAME=deploy'
 assert_contains "${ENV_FILE}" 'DOLLHOUSE_HOSTED_IMAGE_TAG=deploy-hosted:alpha'
@@ -185,6 +197,12 @@ if grep -Fq "${first_postgres_password}" "${INIT_DB_FILE}"; then
 fi
 if grep -Fq "${first_postgres_password}" "${POST_MIGRATION_GRANTS_FILE}"; then
   fail "post-migration-grants.sql should not contain the generated app database password"
+fi
+if grep -Fq "${first_postgres_password}" "${POST_MIGRATION_GRANTS_SCRIPT_FILE}"; then
+  fail "apply-post-migration-grants.sh should not contain the generated app database password"
+fi
+if grep -Fq "${first_postgres_password}" "${BOOTSTRAP_ADMIN_SCRIPT_FILE}"; then
+  fail "bootstrap-admin.sh should not contain the generated app database password"
 fi
 
 log "rendering stricter DCR override"

--- a/tests/scripts/hosted-deploy-render.test.sh
+++ b/tests/scripts/hosted-deploy-render.test.sh
@@ -43,6 +43,15 @@ assert_not_contains() {
   fi
 }
 
+assert_occurrences() {
+  local file="$1"
+  local expected="$2"
+  local count="$3"
+  local actual
+  actual="$(grep -Fc "${expected}" "${file}" || true)"
+  [[ "${actual}" == "${count}" ]] || fail "expected ${file} to contain '${expected}' ${count} time(s), got ${actual}"
+}
+
 file_mode() {
   local file="$1"
 
@@ -125,6 +134,7 @@ assert_contains "${COMPOSE_FILE}" 'image: caddy:2.8'
 assert_contains "${COMPOSE_FILE}" 'DOLLHOUSE_AUTH_OPEN_DCR: "true"'
 assert_contains "${COMPOSE_FILE}" "DOLLHOUSE_APP_DB_PASSWORD: \${POSTGRES_PASSWORD}"
 assert_contains "${COMPOSE_FILE}" "DOLLHOUSE_DATABASE_URL: postgres://dollhouse_app:\${POSTGRES_PASSWORD}@postgres:5432/dollhousemcp"
+assert_occurrences "${COMPOSE_FILE}" "DOLLHOUSE_AUTH_STORAGE_BACKEND: postgres" "2"
 assert_contains "${COMPOSE_FILE}" "./apply-post-migration-grants.sh:/usr/local/bin/apply-post-migration-grants:ro"
 assert_contains "${COMPOSE_FILE}" "./bootstrap-admin.sh:/usr/local/bin/dollhouse-bootstrap-admin:ro"
 assert_contains "${COMPOSE_FILE}" "DOLLHOUSE_HTTP_ALLOWED_HOSTS: localhost,127.0.0.1,mcp.example.com"

--- a/tests/scripts/hosted-deploy-render.test.sh
+++ b/tests/scripts/hosted-deploy-render.test.sh
@@ -43,6 +43,16 @@ assert_not_contains() {
   fi
 }
 
+file_mode() {
+  local file="$1"
+
+  if stat -c '%a' "${file}" >/dev/null 2>&1; then
+    stat -c '%a' "${file}"
+  else
+    stat -f '%Lp' "${file}"
+  fi
+}
+
 env_value() {
   local key="$1"
   local file="$2"
@@ -90,6 +100,7 @@ ENV_FILE="${DEPLOY_DIR}/.env.production"
 COMPOSE_FILE="${DEPLOY_DIR}/compose.yml"
 CADDY_FILE="${DEPLOY_DIR}/Caddyfile"
 INIT_DB_FILE="${DEPLOY_DIR}/init-db.sh"
+POST_MIGRATION_GRANTS_FILE="${DEPLOY_DIR}/post-migration-grants.sql"
 
 log "rendering default alpha configuration"
 render_with_dcr "${DEPLOY_DIR}" ""
@@ -98,6 +109,7 @@ render_with_dcr "${DEPLOY_DIR}" ""
 [[ -f "${COMPOSE_FILE}" ]] || fail "missing ${COMPOSE_FILE}"
 [[ -f "${CADDY_FILE}" ]] || fail "missing ${CADDY_FILE}"
 [[ -f "${INIT_DB_FILE}" ]] || fail "missing ${INIT_DB_FILE}"
+[[ -f "${POST_MIGRATION_GRANTS_FILE}" ]] || fail "missing ${POST_MIGRATION_GRANTS_FILE}"
 
 assert_line "${COMPOSE_FILE}" 'name: deploy'
 assert_line "${COMPOSE_FILE}" '    container_name: deploy-postgres'
@@ -139,6 +151,13 @@ assert_contains "${CADDY_FILE}" 'header_up X-Real-IP {client_ip}'
 assert_not_contains "${CADDY_FILE}" 'trusted_proxies static'
 assert_contains "${INIT_DB_FILE}" 'CREATE ROLE dollhouse_app'
 assert_contains "${INIT_DB_FILE}" 'DOLLHOUSE_APP_DB_PASSWORD'
+[[ "$(file_mode "${INIT_DB_FILE}")" == "755" ]] || fail "init-db.sh should be mode 0755"
+[[ "$(file_mode "${POST_MIGRATION_GRANTS_FILE}")" == "644" ]] || fail "post-migration-grants.sql should be mode 0644"
+assert_contains "${POST_MIGRATION_GRANTS_FILE}" 'CREATE ROLE dollhouse_app'
+assert_contains "${POST_MIGRATION_GRANTS_FILE}" ":'app_password'"
+assert_contains "${POST_MIGRATION_GRANTS_FILE}" 'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO dollhouse_app'
+assert_contains "${POST_MIGRATION_GRANTS_FILE}" 'REVOKE INSERT, UPDATE, DELETE ON TABLE users FROM dollhouse_app'
+assert_contains "${POST_MIGRATION_GRANTS_FILE}" 'GRANT SELECT ON ALL TABLES IN SCHEMA drizzle TO dollhouse_app'
 assert_contains "${ENV_FILE}" 'DOLLHOUSE_HOSTED_MODE=cloud'
 assert_contains "${ENV_FILE}" 'DOLLHOUSE_HOSTED_INSTANCE_NAME=deploy'
 assert_contains "${ENV_FILE}" 'DOLLHOUSE_HOSTED_IMAGE_TAG=deploy-hosted:alpha'
@@ -163,6 +182,9 @@ if [[ ! "${first_master_key}" =~ ^[A-Za-z0-9+/]+={0,2}$ ]]; then
 fi
 if grep -Fq "${first_postgres_password}" "${INIT_DB_FILE}"; then
   fail "init-db.sh should not contain the generated app database password"
+fi
+if grep -Fq "${first_postgres_password}" "${POST_MIGRATION_GRANTS_FILE}"; then
+  fail "post-migration-grants.sql should not contain the generated app database password"
 fi
 
 log "rendering stricter DCR override"

--- a/tests/scripts/hosted-deploy-workflow.test.sh
+++ b/tests/scripts/hosted-deploy-workflow.test.sh
@@ -203,6 +203,21 @@ run_hosted() {
     bash "${HOSTED_DEPLOY}" "${action}"
 }
 
+run_hosted_with_bootstrap() {
+  local action="$1"
+  local username="$2"
+  PATH="${FAKE_BIN}:${PATH}" \
+  DOLLHOUSE_FAKE_DOCKER_LOG="${DOCKER_LOG}" \
+  DOLLHOUSE_FAKE_CURL_LOG="${CURL_LOG}" \
+  DOLLHOUSE_HOSTED_DEPLOY_DIR="${DEPLOY_DIR}" \
+  DOLLHOUSE_HOSTED_HOSTNAME=mcp.example.com \
+  DOLLHOUSE_HOSTED_SOURCE_DIR="${SOURCE_REPO}" \
+  DOLLHOUSE_AUTH_GITHUB_CLIENT_ID=dummy-client \
+  DOLLHOUSE_AUTH_GITHUB_CLIENT_SECRET=dummy-secret \
+  DOLLHOUSE_BOOTSTRAP_GITHUB_USERNAME="${username}" \
+    bash "${HOSTED_DEPLOY}" "${action}"
+}
+
 write_fake_commands
 create_source_repo
 
@@ -225,6 +240,7 @@ DOLLHOUSE_HOSTED_SOURCE_DIR="${SOURCE_REPO}" \
 [[ ! -s "${DOCKER_LOG}" ]] || fail "dry-run install should not call docker"
 [[ ! -s "${CURL_LOG}" ]] || fail "dry-run install should not call curl"
 assert_contains "${DRY_RUN_OUTPUT}" "dry-run: would run database migrations"
+assert_contains "${DRY_RUN_OUTPUT}" "dry-run: would apply post-migration database grants"
 assert_contains "${DRY_RUN_OUTPUT}" "dry-run: would verify https://mcp.example.com/healthz"
 assert_contains "${DRY_RUN_OUTPUT}" "dry-run: would warn, not fail, if /readyz reports bootstrap_required"
 
@@ -282,6 +298,7 @@ run_hosted install
 assert_file_equals "${DEPLOY_DIR}/server/version.txt" "v1"
 assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} build dollhousemcp dollhousemcp-migrate"
 assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} run --rm dollhousemcp-migrate"
+assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} exec -T postgres sh -c set -eu; : \"\${DOLLHOUSE_APP_DB_PASSWORD:?DOLLHOUSE_APP_DB_PASSWORD is required}\"; psql -v ON_ERROR_STOP=1 --username \"\${POSTGRES_USER}\" --dbname \"\${POSTGRES_DB}\" -v app_password=\"\${DOLLHOUSE_APP_DB_PASSWORD}\""
 assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} pull caddy"
 assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} up -d"
 assert_contains "${CURL_LOG}" "https://mcp.example.com/healthz"
@@ -296,6 +313,11 @@ assert_file_equals "${previous_bundle}/version.txt" "v1"
 assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} up -d dollhousemcp"
 assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} pull caddy"
 assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} up -d --no-deps --force-recreate caddy"
+
+log "running bootstrap-admin workflow"
+run_hosted_with_bootstrap bootstrap-admin octocat
+assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} run --rm dollhousemcp-migrate sh -c DOLLHOUSE_DATABASE_URL=\"\${DOLLHOUSE_DATABASE_ADMIN_URL}\" exec node dist/cli/admin-bootstrap.js \"\$@\" dollhouse-admin-bootstrap --method github --github-username octocat"
+assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} exec -T postgres sh -c set -eu; : \"\${DOLLHOUSE_APP_DB_PASSWORD:?DOLLHOUSE_APP_DB_PASSWORD is required}\"; psql -v ON_ERROR_STOP=1 --username \"\${POSTGRES_USER}\" --dbname \"\${POSTGRES_DB}\" -v app_password=\"\${DOLLHOUSE_APP_DB_PASSWORD}\""
 
 log "running rollback workflow"
 run_hosted rollback

--- a/tests/scripts/hosted-deploy-workflow.test.sh
+++ b/tests/scripts/hosted-deploy-workflow.test.sh
@@ -241,6 +241,8 @@ DOLLHOUSE_HOSTED_SOURCE_DIR="${SOURCE_REPO}" \
 [[ ! -s "${CURL_LOG}" ]] || fail "dry-run install should not call curl"
 assert_contains "${DRY_RUN_OUTPUT}" "dry-run: would run database migrations"
 assert_contains "${DRY_RUN_OUTPUT}" "dry-run: would apply post-migration database grants"
+assert_contains "${DRY_RUN_OUTPUT}" "dry-run: would write ${DRY_RUN_DEPLOY_DIR}/apply-post-migration-grants.sh to pass grant passwords through container environment"
+assert_contains "${DRY_RUN_OUTPUT}" "dry-run: would write ${DRY_RUN_DEPLOY_DIR}/bootstrap-admin.sh to use the admin database URL inside the maintenance container"
 assert_contains "${DRY_RUN_OUTPUT}" "dry-run: would verify https://mcp.example.com/healthz"
 assert_contains "${DRY_RUN_OUTPUT}" "dry-run: would warn, not fail, if /readyz reports bootstrap_required"
 
@@ -298,7 +300,7 @@ run_hosted install
 assert_file_equals "${DEPLOY_DIR}/server/version.txt" "v1"
 assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} build dollhousemcp dollhousemcp-migrate"
 assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} run --rm dollhousemcp-migrate"
-assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} exec -T postgres sh -c set -eu; : \"\${DOLLHOUSE_APP_DB_PASSWORD:?DOLLHOUSE_APP_DB_PASSWORD is required}\"; psql -v ON_ERROR_STOP=1 --username \"\${POSTGRES_USER}\" --dbname \"\${POSTGRES_DB}\" -v app_password=\"\${DOLLHOUSE_APP_DB_PASSWORD}\""
+assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} exec -T postgres /usr/local/bin/apply-post-migration-grants"
 assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} pull caddy"
 assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} up -d"
 assert_contains "${CURL_LOG}" "https://mcp.example.com/healthz"
@@ -316,8 +318,8 @@ assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} up -d --no-deps --force-recreate
 
 log "running bootstrap-admin workflow"
 run_hosted_with_bootstrap bootstrap-admin octocat
-assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} run --rm dollhousemcp-migrate sh -c DOLLHOUSE_DATABASE_URL=\"\${DOLLHOUSE_DATABASE_ADMIN_URL}\" exec node dist/cli/admin-bootstrap.js \"\$@\" dollhouse-admin-bootstrap --method github --github-username octocat"
-assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} exec -T postgres sh -c set -eu; : \"\${DOLLHOUSE_APP_DB_PASSWORD:?DOLLHOUSE_APP_DB_PASSWORD is required}\"; psql -v ON_ERROR_STOP=1 --username \"\${POSTGRES_USER}\" --dbname \"\${POSTGRES_DB}\" -v app_password=\"\${DOLLHOUSE_APP_DB_PASSWORD}\""
+assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} run --rm dollhousemcp-migrate /usr/local/bin/dollhouse-bootstrap-admin --method github --github-username octocat"
+assert_contains "${DOCKER_LOG}" "${COMPOSE_CMD} exec -T postgres /usr/local/bin/apply-post-migration-grants"
 
 log "running rollback workflow"
 run_hosted rollback


### PR DESCRIPTION
## Summary

Fixes #2255.

This repairs the hosted fresh-install path that failed when alpha was reset to an empty runtime state:

- renders the Postgres init script as `0755` so the official Postgres entrypoint can read/execute the bind-mounted role setup script
- renders a `post-migration-grants.sql` file and applies it after every migration pass so fresh installs and updates converge on the same `dollhouse_app` privileges
- runs `bootstrap-admin` from the maintenance/migrate image instead of the production app image
- forces bootstrap to use `DOLLHOUSE_DATABASE_ADMIN_URL` as `DOLLHOUSE_DATABASE_URL`, which keeps the RLS bootstrap path in the admin DB context
- expands hosted deploy tests to cover the grant pass, file modes, dry-run messaging, and bootstrap command shape

## Verification

- `npm run test:hosted-deploy`
- `npm run lint:shell`
- `git diff --check`
- `bash -n scripts/hosted-deploy.sh scripts/hosted-deploy/*.sh tests/scripts/hosted-deploy-render.test.sh tests/scripts/hosted-deploy-workflow.test.sh tests/scripts/hosted-remote-deploy.test.sh`

Build note:

- `npm run build` is blocked in this local checkout because `tsc` is not installed in `node_modules` (`sh: tsc: command not found`).
