### PR TITLE
Fail closed on volatile storage and await security-decision persistence

### DIFF
--- a/src/handlers/mcp-aql/Gatekeeper.ts
+++ b/src/handlers/mcp-aql/Gatekeeper.ts
@@ -187,10 +187,14 @@ export class Gatekeeper {
 
   /**
    * Remove a session's GatekeeperSession.
-   * Called by Container during session disconnect.
+   * Called by Container during session disconnect. Cancellation persistence is
+   * not awaited here — no caller is waiting on an acknowledgement during
+   * teardown, and disposal must not block on storage — but failures are logged.
    */
   disposeSession(sessionId: string): void {
-    this.sessionRegistry.get(sessionId)?.cancelPendingCliApprovals();
+    this.sessionRegistry.get(sessionId)?.cancelPendingCliApprovals().catch((error: unknown) => {
+      logger.warn('[Gatekeeper] Failed to persist pending-approval cancellation during session disposal', { error });
+    });
     this.sessionRegistry.dispose(sessionId);
   }
 
@@ -454,14 +458,15 @@ export class Gatekeeper {
 
   /**
    * Approve a pending CLI approval request.
+   * Resolves once the decision is durably persisted.
    */
-  approveCliRequest(
+  async approveCliRequest(
     requestId: string,
     scope: CliApprovalScope = 'single',
     approvedAt?: string,
-  ): CliApprovalRecord | undefined {
+  ): Promise<CliApprovalRecord | undefined> {
     const session = this.resolveSession();
-    const record = session.approveCliRequest(requestId, scope, approvedAt);
+    const record = await session.approveCliRequest(requestId, scope, approvedAt);
 
     if (record) {
       SecurityMonitor.logSecurityEvent({

--- a/src/handlers/mcp-aql/GatekeeperHandler.ts
+++ b/src/handlers/mcp-aql/GatekeeperHandler.ts
@@ -98,7 +98,7 @@ export class GatekeeperHandler {
   constructor(private readonly deps: GatekeeperHandlerDeps) {}
 
   async dispatch(method: string, params: Record<string, unknown>): Promise<unknown> {
-    const handlers: Record<string, () => unknown> = {
+    const handlers: Partial<Record<string, () => unknown>> = {
       confirm: () => this.confirm(params),
       verify: () => this.verify(params),
       releaseDeadlock: () => this.releaseDeadlock(params),
@@ -114,7 +114,7 @@ export class GatekeeperHandler {
     if (!handler) {
       throw new Error(`Unknown Gatekeeper method: ${method}`);
     }
-    return handler();
+    return await handler();
   }
 
   private async confirm(params: Record<string, unknown>): Promise<unknown> {
@@ -204,7 +204,7 @@ export class GatekeeperHandler {
     }
   }
 
-  private async verify(params: Record<string, unknown>): Promise<unknown> {
+  private verify(params: Record<string, unknown>): unknown {
     this.deps.verificationMetrics.recordAttempt();
     const attemptTimestamp = Date.now();
     const challengeId = validateRequiredString(params, 'challenge_id', 'the verification challenge ID');
@@ -607,7 +607,7 @@ export class GatekeeperHandler {
       return null;
     }
     const policySource = activeElements
-      .filter(el => el.metadata?.gatekeeper?.externalRestrictions?.approvalPolicy?.requireApproval?.length)
+      .filter(el => el.metadata.gatekeeper?.externalRestrictions?.approvalPolicy?.requireApproval?.length)
       .map(el => `${el.type}:${el.name}`)
       .join(', ') || 'env:DOLLHOUSE_CLI_APPROVAL_POLICY';
     return this.createApprovalRequest(toolName, toolInput, classification, activeElements, {
@@ -713,7 +713,7 @@ export class GatekeeperHandler {
 
   private async getEffectiveCliPolicies(params: Record<string, unknown>): Promise<unknown> {
     const toolName = params.tool_name as string | undefined;
-    const toolInput = (params.tool_input as Record<string, unknown>) ?? {};
+    const toolInput = (params.tool_input as Record<string, unknown> | undefined) ?? {};
     const reportSessionId = typeof params.session_id === 'string' ? params.session_id : undefined;
     const reportingScope = params.reporting_scope === 'dashboard';
     const policyElements = reportingScope && !toolName
@@ -750,16 +750,16 @@ export class GatekeeperHandler {
       return {
         type: el.type,
         name: el.name,
-        allowPatterns: el.metadata?.gatekeeper?.externalRestrictions?.allowPatterns ?? [],
-        confirmPatterns: el.metadata?.gatekeeper?.externalRestrictions?.confirmPatterns ?? [],
-        denyPatterns: el.metadata?.gatekeeper?.externalRestrictions?.denyPatterns ?? [],
-        allowOperations: el.metadata?.gatekeeper?.allow ?? [],
-        confirmOperations: el.metadata?.gatekeeper?.confirm ?? [],
-        denyOperations: el.metadata?.gatekeeper?.deny ?? [],
-        description: el.metadata?.gatekeeper?.externalRestrictions?.description ?? null,
+        allowPatterns: el.metadata.gatekeeper?.externalRestrictions?.allowPatterns ?? [],
+        confirmPatterns: el.metadata.gatekeeper?.externalRestrictions?.confirmPatterns ?? [],
+        denyPatterns: el.metadata.gatekeeper?.externalRestrictions?.denyPatterns ?? [],
+        allowOperations: el.metadata.gatekeeper?.allow ?? [],
+        confirmOperations: el.metadata.gatekeeper?.confirm ?? [],
+        denyOperations: el.metadata.gatekeeper?.deny ?? [],
+        description: el.metadata.gatekeeper?.externalRestrictions?.description ?? null,
         invalidGatekeeperPolicy: !!diagnostics,
         invalidGatekeeperMessage: diagnostics?.message,
-        sessionIds: (el.metadata as Record<string, unknown>)?.sessionIds ?? undefined,
+        sessionIds: (el.metadata as Record<string, unknown>).sessionIds ?? undefined,
       };
     });
   }
@@ -875,18 +875,19 @@ export class GatekeeperHandler {
     };
   }
 
-  private approveCliPermission(params: Record<string, unknown>): unknown {
+  private async approveCliPermission(params: Record<string, unknown>): Promise<unknown> {
     const requestId = validateRequiredString(
       params,
       'request_id',
       'the approval request ID from permission_prompt deny response (format: cli-<UUID>)'
     );
-    const scope = (params.scope as CliApprovalScope) ?? 'single';
-    if (scope !== 'single' && scope !== 'tool_session') {
-      throw new Error(`Invalid scope "${scope}". Must be "single" or "tool_session".`);
+    const rawScope = params.scope ?? 'single';
+    if (rawScope !== 'single' && rawScope !== 'tool_session') {
+      throw new Error(`Invalid scope ${JSON.stringify(rawScope)}. Must be "single" or "tool_session".`);
     }
+    const scope: CliApprovalScope = rawScope;
 
-    const record = this.deps.gatekeeper.approveCliRequest(requestId, scope);
+    const record = await this.deps.gatekeeper.approveCliRequest(requestId, scope);
     if (!record) {
       throw new Error(`No pending approval for "${requestId}". It may have expired or already been approved.`);
     }

--- a/src/handlers/mcp-aql/GatekeeperSession.ts
+++ b/src/handlers/mcp-aql/GatekeeperSession.ts
@@ -447,14 +447,16 @@ export class GatekeeperSession {
   /**
    * Approve a pending CLI approval request.
    * Sets approvedAt, and promotes to session approvals if tool_session scope.
+   * Awaits the store persist so a crash cannot lose the recorded decision
+   * after the caller has been acknowledged.
    *
    * @returns The approved record, or undefined if not found
    */
-  approveCliRequest(
+  async approveCliRequest(
     requestId: string,
     scope: CliApprovalScope = 'single',
     approvedAt: string = new Date().toISOString(),
-  ): CliApprovalRecord | undefined {
+  ): Promise<CliApprovalRecord | undefined> {
     this.touch();
     this.expireStaleApprovals(true);
     const record = this.state.cliApprovals.get(requestId);
@@ -475,7 +477,7 @@ export class GatekeeperSession {
       if (scope === 'tool_session') {
         this.confirmationStore.saveCliSessionApproval(record.toolName, record);
       }
-      this.persistToStore();
+      await this.persistDecision();
     }
 
     return record;
@@ -483,10 +485,15 @@ export class GatekeeperSession {
 
   /**
    * Deny a pending CLI approval request.
+   * Awaits the store persist so a crash cannot lose the recorded decision
+   * after the caller has been acknowledged.
    *
    * @returns The denied record, or undefined if not found or already terminal
    */
-  denyCliRequest(requestId: string, deniedAt: string = new Date().toISOString()): CliApprovalRecord | undefined {
+  async denyCliRequest(
+    requestId: string,
+    deniedAt: string = new Date().toISOString(),
+  ): Promise<CliApprovalRecord | undefined> {
     this.touch();
     this.expireStaleApprovals(true);
     const record = this.state.cliApprovals.get(requestId);
@@ -498,7 +505,7 @@ export class GatekeeperSession {
 
     if (this.confirmationStore) {
       this.confirmationStore.saveCliApproval(requestId, record);
-      this.persistToStore();
+      await this.persistDecision();
     }
 
     return record;
@@ -575,8 +582,9 @@ export class GatekeeperSession {
 
   /**
    * Mark all pending CLI approvals cancelled because the owning session ended.
+   * Awaits the store persist so the cancellation decisions are durable.
    */
-  cancelPendingCliApprovals(cancelledAt: string = new Date().toISOString()): number {
+  async cancelPendingCliApprovals(cancelledAt: string = new Date().toISOString()): Promise<number> {
     this.touch();
     let cancelledCount = 0;
     for (const record of this.state.cliApprovals.values()) {
@@ -587,7 +595,7 @@ export class GatekeeperSession {
         this.confirmationStore.saveCliApproval(record.requestId, record);
       }
     }
-    if (cancelledCount > 0) this.persistToStore();
+    if (cancelledCount > 0) await this.persistDecision();
     return cancelledCount;
   }
 
@@ -675,12 +683,24 @@ export class GatekeeperSession {
   /**
    * Fire-and-forget persist to the backing store.
    * No-op when no confirmation store is configured (in-memory only mode).
+   * Reserved for housekeeping writes (expiry sweeps, consumption, purges)
+   * whose state is re-derivable; decision paths use persistDecision instead.
    */
   private persistToStore(): void {
     if (!this.confirmationStore) return;
     this.confirmationStore.persist().catch(error => {
       logger.warn('[GatekeeperSession] Failed to persist confirmation state', { error });
     });
+  }
+
+  /**
+   * Awaited persist for security-decision paths (approve/deny/cancel).
+   * Unlike persistToStore, failures propagate so a decision is never
+   * acknowledged to the caller unless it is durable.
+   */
+  private async persistDecision(): Promise<void> {
+    if (!this.confirmationStore) return;
+    await this.confirmationStore.persist();
   }
 }
 

--- a/src/web-console/WebConsoleRegistrar.ts
+++ b/src/web-console/WebConsoleRegistrar.ts
@@ -369,7 +369,7 @@ export class WebConsoleRegistrar {
     const baseStores = await createConsoleStores(database);
     const stores = {
       ...baseStores,
-      portfolioStore: resolvePortfolioElementStore(container, this.options, baseStores.portfolioStore),
+      portfolioStore: resolvePortfolioElementStore(container, this.options, baseStores.portfolioStore, database),
       portfolioSyncJobStore: resolvePortfolioSyncJobStore(container, this.options, baseStores.portfolioSyncJobStore),
     };
     const adminAuditWriter = resolveAdminAuditWriter(database, container);
@@ -1923,10 +1923,27 @@ function resolveGitHubIntegrationProviderConfig(
   };
 }
 
+const MANAGER_BACKED_PORTFOLIO_REQUIRED_SERVICES = [
+  'UserIdResolver',
+  'PersonaManager',
+  'SkillManager',
+  'TemplateManager',
+  'AgentManager',
+  'MemoryManager',
+  'EnsembleManager',
+] as const;
+
+function missingPortfolioManagerServices(container: DiContainerFacade): string[] {
+  return MANAGER_BACKED_PORTFOLIO_REQUIRED_SERVICES.filter(
+    serviceName => !container.hasRegistration(serviceName),
+  );
+}
+
 function resolvePortfolioElementStore(
   container: DiContainerFacade,
   options: WebConsoleRegistrarOptions,
   fallback: IPortfolioElementStore,
+  database: DatabaseInstance | undefined,
 ): IPortfolioElementStore {
   if (options.portfolioStore !== undefined) return options.portfolioStore ?? fallback;
   if (container.hasRegistration(WEB_CONSOLE_SERVICE_NAMES.portfolioStore)) {
@@ -1936,22 +1953,25 @@ function resolvePortfolioElementStore(
     const store = createManagerBackedPortfolioElementStore(container);
     if (store) return markProductionAdapter(store, 'ManagerBackedPortfolioElementStore');
   }
+  if (database) {
+    // Fail closed: with a database configured every persistent store must be
+    // durable. Silently degrading the portfolio to the in-memory fallback would
+    // lose user data on restart while every sibling store persists.
+    const cause = options.enableManagerBackedPortfolioStore === false
+      ? 'the manager-backed portfolio store is disabled (enableManagerBackedPortfolioStore=false)'
+      : `missing container registrations: ${missingPortfolioManagerServices(container).join(', ')}`;
+    throw new Error(
+      `Database-backed web-console composition requires a durable portfolio store; ${cause}. ` +
+      'Register the element managers (or supply options.portfolioStore) before bootstrapping.',
+    );
+  }
   return fallback;
 }
 
 function createManagerBackedPortfolioElementStore(
   container: DiContainerFacade,
 ): ManagerBackedPortfolioElementStore | null {
-  const requiredServices = [
-    'UserIdResolver',
-    'PersonaManager',
-    'SkillManager',
-    'TemplateManager',
-    'AgentManager',
-    'MemoryManager',
-    'EnsembleManager',
-  ];
-  if (!requiredServices.every(serviceName => container.hasRegistration(serviceName))) return null;
+  if (missingPortfolioManagerServices(container).length > 0) return null;
   const managers: ManagerBackedPortfolioManagers = {
     personas: container.resolve<BaseElementManager<IElement>>('PersonaManager'),
     skills: container.resolve<BaseElementManager<IElement>>('SkillManager'),

--- a/src/web-console/modules/approvals/ApprovalStore.ts
+++ b/src/web-console/modules/approvals/ApprovalStore.ts
@@ -96,22 +96,21 @@ export class GatekeeperSessionApprovalStore implements SessionApprovalStore {
     return Promise.resolve(this.gatekeeper.getRegisteredSession(sessionId)?.getCliApproval(approvalId) ?? null);
   }
 
-  save(
+  async save(
     _userId: string,
     sessionId: string,
     approvalId: string,
     record: ConsoleApprovalRecord,
   ): Promise<void> {
     const session = this.gatekeeper.getRegisteredSession(sessionId);
-    if (!session) return Promise.resolve();
+    if (!session) return;
     if (record.deniedAt) {
-      session.denyCliRequest(approvalId, record.deniedAt);
-      return Promise.resolve();
+      await session.denyCliRequest(approvalId, record.deniedAt);
+      return;
     }
     if (record.approvedAt) {
-      session.approveCliRequest(approvalId, record.scope, record.approvedAt);
+      await session.approveCliRequest(approvalId, record.scope, record.approvedAt);
     }
-    return Promise.resolve();
   }
 }
 

--- a/src/web-console/modules/security-admin/SecurityAdminModule.ts
+++ b/src/web-console/modules/security-admin/SecurityAdminModule.ts
@@ -22,7 +22,6 @@ const SECURITY_AUDIT_IDS = [
   'security.signing_keys.rotate',
   'security.signing_keys.retire',
   'security.signing_keys.delete',
-  'security.signing_keys.jobs.show',
   'security.auth_policy.show',
   'security.auth_policy.update',
   'security.users.totp.reset',
@@ -42,7 +41,6 @@ export function createSecurityAdminModule(options: SecurityAdminModuleOptions): 
     options.factorStore,
     options.invalidationStore,
     options.authPolicyStore,
-    undefined,
     options.now,
   );
   return {
@@ -116,18 +114,6 @@ export function createSecurityAdminModule(options: SecurityAdminModuleOptions): 
           firstString(req.params.kid) ?? '',
           req.body,
         ),
-      },
-      {
-        method: 'GET',
-        path: '/api/v1/admin/security/signing-keys/jobs/:id',
-        audience: 'admin',
-        requiredCapability: SECURITY_CAPABILITY,
-        elevation: 'admin_30m',
-        privacyClass: 'security_metadata',
-        idempotency: 'not_applicable',
-        auditOperation: 'security.signing_keys.jobs.show',
-        privacyProjector: projectSecuritySigningKeyJob,
-        handler: req => service.getSigningKeyJob(firstString(req.params.id) ?? ''),
       },
       {
         method: 'GET',

--- a/src/web-console/modules/security-admin/SecurityAdminService.ts
+++ b/src/web-console/modules/security-admin/SecurityAdminService.ts
@@ -34,19 +34,12 @@ const DEFAULT_AUTH_POLICY = Object.freeze({
   max_admin_elevation_seconds: 300,
 });
 
-interface LifecycleOverlay {
-  readonly jobs: Map<string, SecuritySigningKeyJobDto>;
-}
-
 export class SecurityAdminService {
   constructor(
     private readonly signingKeyStore: ISigningKeyStore,
     private readonly factorStore: IConsoleFactorStore,
     private readonly invalidationStore: IConsoleSecurityInvalidationStore,
     private readonly authPolicyStore: IConsoleAuthPolicyStore,
-    private readonly overlay: LifecycleOverlay = {
-      jobs: new Map(),
-    },
     private readonly now: () => Date = () => new Date(),
   ) {}
 
@@ -70,8 +63,10 @@ export class SecurityAdminService {
     if (!parsed) return notFound('Unknown signing key kind.');
     const write = await createSigningKeyWrite(parsed);
     const key = await this.signingKeyStore.rotate(write);
-    const job = this.recordJob(parsed, 'rotate', null, key.kid, null);
-    return { status: 202, body: job };
+    // The store write above is the durable operation; respond with the final
+    // receipt rather than a 202 + pollable job id (the work is synchronous).
+    const job = this.jobReceipt(parsed, 'rotate', null, key.kid, null);
+    return { status: 200, body: job };
   }
 
   async retireSigningKey(kind: string, kid: string): Promise<ConsoleHandlerResult> {
@@ -80,8 +75,8 @@ export class SecurityAdminService {
     const key = await this.signingKeyStore.getByKid(kid);
     if (key?.kind !== parsed) return notFound('Signing key was not found.');
     await this.signingKeyStore.retire(kid, this.now().getTime());
-    const job = this.recordJob(parsed, 'retire', kid, null, null);
-    return { status: 202, body: job };
+    const job = this.jobReceipt(parsed, 'retire', kid, null, null);
+    return { status: 200, body: job };
   }
 
   async deleteSigningKey(kind: string, kid: string, body: unknown): Promise<ConsoleHandlerResult> {
@@ -99,13 +94,8 @@ export class SecurityAdminService {
       return conflict('Signing key is still within hard-delete grace.');
     }
     await this.signingKeyStore.delete(kid, { force });
-    const job = this.recordJob(parsed, 'delete', kid, null, null);
-    return { status: 202, body: job };
-  }
-
-  getSigningKeyJob(id: string): ConsoleHandlerResult {
-    const job = isUuid(id) ? this.overlay.jobs.get(id) : undefined;
-    return job ? { status: 200, body: job } : notFound('Signing key job was not found.');
+    const job = this.jobReceipt(parsed, 'delete', kid, null, null);
+    return { status: 200, body: job };
   }
 
   async getAuthPolicy(): Promise<ConsoleHandlerResult> {
@@ -201,7 +191,12 @@ export class SecurityAdminService {
     };
   }
 
-  private recordJob(
+  /**
+   * Build the final receipt for a synchronously completed signing-key
+   * operation. The receipt is response-only — it is not retained, because the
+   * durable outcome already lives in the signing-key store.
+   */
+  private jobReceipt(
     kind: SigningKeyKind,
     action: SecuritySigningKeyJobDto['action'],
     targetKid: string | null,
@@ -209,7 +204,7 @@ export class SecurityAdminService {
     errorCode: string | null,
   ): SecuritySigningKeyJobDto {
     const at = this.now().toISOString();
-    const job: SecuritySigningKeyJobDto = {
+    return {
       id: randomUUID(),
       kind,
       action,
@@ -220,8 +215,6 @@ export class SecurityAdminService {
       result_kid: resultKid,
       error_code: errorCode,
     };
-    this.overlay.jobs.set(job.id, job);
-    return job;
   }
 
   private authPolicyDto(policy: ConsoleAuthPolicy): SecurityAuthPolicyDto {

--- a/tests/integration/web-console-e2e/setup/provision.ts
+++ b/tests/integration/web-console-e2e/setup/provision.ts
@@ -160,7 +160,8 @@ function readinessEvidence(): unknown {
       activationProfile: 'shared-hosted', storageBackend: 'postgres', apiV1MountCreated: true, routesMounted: false,
       registeredRouteModuleIds: [
         'auth', 'health', 'accountAdmin', 'activations', 'approvals', 'audit', 'executions', 'integrations',
-        'operations', 'portfolio', 'runtimeSessions', 'security-admin', 'selfSecurity', 'selfService', 'session-telemetry',
+        'me-logs', 'operations', 'portfolio', 'runtimeSessions', 'security-admin', 'selfSecurity', 'selfService',
+        'session-telemetry',
       ],
     },
     liveChecks: ids.map(id => ({ id, ready: true, detail: 'e2e/pw: verified by harness setup.' })),

--- a/tests/integration/web-console-e2e/specs/admin-security.e2e-spec.ts
+++ b/tests/integration/web-console-e2e/specs/admin-security.e2e-spec.ts
@@ -20,16 +20,13 @@ describe('admin/security — signing keys', () => {
   // The 'invite' kind is safe to mutate in-suite: it is not used by forged
   // console sessions or the active AS token flow, and new invites use the new
   // active key after rotation (verified). We exercise the full lifecycle on it.
-  it('full lifecycle: rotate -> job -> retire superseded -> delete (force)', async () => {
+  it('full lifecycle: rotate -> retire superseded -> delete (force)', async () => {
     // Rotate twice so there is guaranteed to be a non-active (superseded) key,
     // regardless of whether the invite key existed before this spec ran.
     const rotate = await admin().post('/api/v1/admin/security/signing-keys/invite/rotate', { body: {} });
-    expect(rotate.status).toBe(202);
-    const jobId = rotate.body?.job_id ?? rotate.body?.id;
-    if (jobId) {
-      const job = await admin().get(`/api/v1/admin/security/signing-keys/jobs/${jobId}`);
-      expect(job.status).toBe(200);
-    }
+    expect(rotate.status).toBe(200);
+    // The operation completes synchronously: the response IS the final receipt.
+    expect(rotate.body?.status).toBe('completed');
     await admin().post('/api/v1/admin/security/signing-keys/invite/rotate', { body: {} });
 
     const kind = await admin().get('/api/v1/admin/security/signing-keys/invite');
@@ -40,10 +37,10 @@ describe('admin/security — signing keys', () => {
     if (!superseded) throw new Error('rotation should leave a superseded key');
 
     const retire = await admin().post(`/api/v1/admin/security/signing-keys/invite/${superseded.kid}/retire`, { body: {} });
-    expect(retire.status).toBe(202);
+    expect(retire.status).toBe(200);
 
     const del = await admin().delete(`/api/v1/admin/security/signing-keys/invite/${superseded.kid}`, { body: { force: true } });
-    expect([200, 202, 204]).toContain(del.status);
+    expect(del.status).toBe(200);
   });
 
   it('retiring an unknown signing key is 404', async () => {

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -27,12 +27,22 @@ async function csrfPost(page: Page, path: string): Promise<number> {
   return r.status();
 }
 
+// The AS shows an OAuth client-consent page after authentication; approve it
+// when present so the authorization completes and the BFF callback runs.
+async function approveClientConsentIfShown(page: Page): Promise<void> {
+  const approve = page.locator('button[value="authorize_oauth_client"]');
+  if (await approve.count()) {
+    await Promise.all([page.waitForLoadState('networkidle'), approve.click()]);
+  }
+}
+
 test('console auth lifecycle: login -> enroll TOTP -> step-up -> step-down -> logout', async ({ page }) => {
   // 1. LOGIN (local-password)
   await page.goto(`${BASE_URL}/api/v1/auth/login`, { waitUntil: 'domcontentloaded' });
   await page.fill('input[name="username"]', USER);
   await page.fill('input[name="password"]', SEED_PASSWORD);
   await Promise.all([page.waitForLoadState('networkidle'), page.click('button[value="login"]')]);
+  await approveClientConsentIfShown(page);
 
   expect(await status(page, '/api/v1/auth/me'), 'login establishes a session').toBe(200);
 
@@ -61,6 +71,7 @@ test('console auth lifecycle: login -> enroll TOTP -> step-up -> step-down -> lo
     await page.fill('input[name="code"]', totp.generate());
     await Promise.all([page.waitForLoadState('networkidle'), page.click('button[type="submit"]')]);
   }
+  await approveClientConsentIfShown(page);
 
   // 5. ADMIN now reachable with fresh elevation
   expect(await status(page, OPERATE), 'admin reachable after step-up').toBe(200);

--- a/tests/unit/handlers/mcp-aql/GatekeeperSession.cliApprovals.test.ts
+++ b/tests/unit/handlers/mcp-aql/GatekeeperSession.cliApprovals.test.ts
@@ -27,6 +27,8 @@ const moderateArgs = (
   toolName, toolInput, riskLevel: 'moderate', riskScore: 40, irreversible: false, denyReason,
 });
 
+const TEST_SESSION_ID = 'test-session';
+
 function requireRecord(record: CliApprovalRecord | undefined): CliApprovalRecord {
   if (!record) throw new Error('expected CLI approval record');
   return record;
@@ -73,38 +75,38 @@ describe('GatekeeperSession CLI approval store', () => {
   describe('approveCliRequest', () => {
     it('should set approvedAt on approval', async () => {
       const requestId = await session.createCliApprovalRequest(dangerousArgs(TOOL_BASH, NPM_INSTALL));
-      const record = requireRecord(session.approveCliRequest(requestId, 'single'));
+      const record = requireRecord(await session.approveCliRequest(requestId, 'single'));
       expect(record.approvedAt).toBeDefined();
     });
 
-    it('should return undefined for nonexistent request', () => {
-      const record = session.approveCliRequest('cli-nonexistent', 'single');
+    it('should return undefined for nonexistent request', async () => {
+      const record = await session.approveCliRequest('cli-nonexistent', 'single');
       expect(record).toBeUndefined();
     });
 
     it('should return undefined for already approved request', async () => {
       const requestId = await session.createCliApprovalRequest(dangerousArgs(TOOL_BASH, NPM_INSTALL));
-      session.approveCliRequest(requestId, 'single');
-      const secondApproval = session.approveCliRequest(requestId, 'single');
+      await session.approveCliRequest(requestId, 'single');
+      const secondApproval = await session.approveCliRequest(requestId, 'single');
       expect(secondApproval).toBeUndefined();
     });
 
     it('should refuse denied and expired requests', async () => {
       const deniedId = await session.createCliApprovalRequest(dangerousArgs(TOOL_BASH, NPM_INSTALL));
-      expect(session.denyCliRequest(deniedId)).toBeDefined();
-      expect(session.approveCliRequest(deniedId, 'single')).toBeUndefined();
+      expect(await session.denyCliRequest(deniedId)).toBeDefined();
+      expect(await session.approveCliRequest(deniedId, 'single')).toBeUndefined();
 
       const expiredId = await session.createCliApprovalRequest(dangerousArgs('Edit', {}, 'old', 1_000));
       const expired = requireRecord(session.getCliApproval(expiredId));
       expired.requestedAt = new Date(Date.now() - 5_000).toISOString();
 
-      expect(session.approveCliRequest(expiredId, 'single')).toBeUndefined();
+      expect(await session.approveCliRequest(expiredId, 'single')).toBeUndefined();
       expect(session.getCliApproval(expiredId)?.expiredAt).toBeDefined();
     });
 
     it('should promote to session approvals for tool_session scope', async () => {
       const requestId = await session.createCliApprovalRequest(dangerousArgs(TOOL_BASH, NPM_INSTALL));
-      session.approveCliRequest(requestId, 'tool_session');
+      await session.approveCliRequest(requestId, 'tool_session');
 
       // Should be findable via checkCliApproval for same tool
       const found = requireRecord(session.checkCliApproval(TOOL_BASH, { command: 'different command' }));
@@ -115,7 +117,7 @@ describe('GatekeeperSession CLI approval store', () => {
   describe('checkCliApproval', () => {
     it('should return and consume single-scope approvals', async () => {
       const requestId = await session.createCliApprovalRequest(dangerousArgs(TOOL_BASH, NPM_INSTALL));
-      session.approveCliRequest(requestId, 'single');
+      await session.approveCliRequest(requestId, 'single');
 
       // First check returns the approval
       const first = requireRecord(session.checkCliApproval(TOOL_BASH, NPM_INSTALL));
@@ -128,7 +130,7 @@ describe('GatekeeperSession CLI approval store', () => {
 
     it('should return but preserve tool_session-scope approvals', async () => {
       const requestId = await session.createCliApprovalRequest(dangerousArgs(TOOL_BASH, NPM_INSTALL));
-      session.approveCliRequest(requestId, 'tool_session');
+      await session.approveCliRequest(requestId, 'tool_session');
 
       // Multiple checks should all succeed
       const first = session.checkCliApproval(TOOL_BASH, NPM_INSTALL);
@@ -149,7 +151,7 @@ describe('GatekeeperSession CLI approval store', () => {
 
     it('should not consume denied, cancelled, or expired approvals', async () => {
       const deniedId = await session.createCliApprovalRequest(dangerousArgs(TOOL_BASH, NPM_INSTALL));
-      session.denyCliRequest(deniedId);
+      await session.denyCliRequest(deniedId);
       expect(session.checkCliApproval(TOOL_BASH, NPM_INSTALL)).toBeUndefined();
 
       const cancelledId = await session.createCliApprovalRequest(dangerousArgs('Edit', { file_path: 'a.ts' }));
@@ -167,7 +169,7 @@ describe('GatekeeperSession CLI approval store', () => {
 
     it('should ignore terminal session-scoped fast-path approvals', async () => {
       const requestId = await session.createCliApprovalRequest(dangerousArgs(TOOL_BASH, NPM_INSTALL));
-      const approved = requireRecord(session.approveCliRequest(requestId, 'tool_session'));
+      const approved = requireRecord(await session.approveCliRequest(requestId, 'tool_session'));
       approved.deniedAt = new Date().toISOString();
 
       expect(session.checkCliApproval(TOOL_BASH, NPM_INSTALL)).toBeUndefined();
@@ -175,7 +177,7 @@ describe('GatekeeperSession CLI approval store', () => {
 
     it('should not match different tool names', async () => {
       const requestId = await session.createCliApprovalRequest(dangerousArgs(TOOL_BASH, NPM_INSTALL));
-      session.approveCliRequest(requestId, 'single');
+      await session.approveCliRequest(requestId, 'single');
 
       const result = session.checkCliApproval('Edit', { file_path: 'foo.ts' });
       expect(result).toBeUndefined();
@@ -186,7 +188,7 @@ describe('GatekeeperSession CLI approval store', () => {
     it('should return only unapproved records', async () => {
       const id1 = await session.createCliApprovalRequest(dangerousArgs(TOOL_BASH));
       await session.createCliApprovalRequest(moderateArgs('Edit'));
-      session.approveCliRequest(id1, 'single');
+      await session.approveCliRequest(id1, 'single');
 
       const pending = session.getPendingCliApprovals();
       expect(pending).toHaveLength(1);
@@ -201,7 +203,7 @@ describe('GatekeeperSession CLI approval store', () => {
       const requestId = await session.createCliApprovalRequest(dangerousArgs(TOOL_BASH, NPM_INSTALL));
       const cancelledAt = new Date().toISOString();
 
-      expect(session.cancelPendingCliApprovals(cancelledAt)).toBe(1);
+      expect(await session.cancelPendingCliApprovals(cancelledAt)).toBe(1);
 
       expect(session.getPendingCliApprovals()).toEqual([]);
       expect(session.getCliApproval(requestId)).toMatchObject({
@@ -290,11 +292,11 @@ describe('GatekeeperSession CLI approval store', () => {
         findApprovals: jest.fn().mockResolvedValue([]),
         getRawApprovalDetail: jest.fn().mockResolvedValue(null),
         savePermissionPromptActive: jest.fn(),
-        getSessionId: jest.fn().mockReturnValue('test-session'),
+        getSessionId: jest.fn().mockReturnValue(TEST_SESSION_ID),
       };
-      const durableSession = new GatekeeperSession(undefined, 100, 50, store, 'test-session', auditResolver);
+      const durableSession = new GatekeeperSession(undefined, 100, 50, store, TEST_SESSION_ID, auditResolver);
       const requestId = await durableSession.createCliApprovalRequest(dangerousArgs(TOOL_BASH, NPM_INSTALL));
-      const denied = durableSession.denyCliRequest(requestId);
+      const denied = await durableSession.denyCliRequest(requestId);
       expect(denied).toBeDefined();
       if (!denied) throw new Error('expected denied approval');
       denied.deniedAt = new Date(Date.now() - 90_000_000).toISOString();
@@ -303,6 +305,50 @@ describe('GatekeeperSession CLI approval store', () => {
 
       expect(durableSession.getCliApproval(requestId)).toBeUndefined();
       expect(store.deleteCliApproval).toHaveBeenCalledWith(requestId);
+    });
+  });
+
+  describe('decision durability', () => {
+    const decisionStore = (persist: () => Promise<void>) => ({
+      initialize: jest.fn<() => Promise<void>>().mockResolvedValue(),
+      persist: jest.fn<() => Promise<void>>().mockImplementation(persist),
+      getAllConfirmations: jest.fn().mockReturnValue([]),
+      getAllCliApprovals: jest.fn().mockReturnValue([]),
+      getAllCliSessionApprovals: jest.fn().mockReturnValue([]),
+      getPermissionPromptActive: jest.fn().mockReturnValue(false),
+      saveConfirmation: jest.fn(),
+      getConfirmation: jest.fn(),
+      deleteConfirmation: jest.fn(),
+      clearAllConfirmations: jest.fn(),
+      saveCliApproval: jest.fn(),
+      getCliApproval: jest.fn(),
+      deleteCliApproval: jest.fn(),
+      saveCliSessionApproval: jest.fn(),
+      getCliSessionApproval: jest.fn(),
+      findApprovals: jest.fn().mockResolvedValue([]),
+      getRawApprovalDetail: jest.fn().mockResolvedValue(null),
+      savePermissionPromptActive: jest.fn(),
+      getSessionId: jest.fn().mockReturnValue(TEST_SESSION_ID),
+    });
+
+    it('awaits the store persist before acknowledging an approval', async () => {
+      const store = decisionStore(() => Promise.resolve());
+      const durableSession = new GatekeeperSession(undefined, 100, 50, store, TEST_SESSION_ID, auditResolver);
+      const requestId = await durableSession.createCliApprovalRequest(dangerousArgs(TOOL_BASH, NPM_INSTALL));
+      store.persist.mockClear();
+
+      const record = await durableSession.approveCliRequest(requestId, 'single');
+
+      expect(record?.approvedAt).toBeDefined();
+      expect(store.persist).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates a persist failure instead of acknowledging the decision', async () => {
+      const store = decisionStore(() => Promise.reject(new Error('disk full')));
+      const durableSession = new GatekeeperSession(undefined, 100, 50, store, TEST_SESSION_ID, auditResolver);
+      const requestId = await durableSession.createCliApprovalRequest(dangerousArgs(TOOL_BASH, NPM_INSTALL));
+
+      await expect(durableSession.denyCliRequest(requestId)).rejects.toThrow('disk full');
     });
   });
 

--- a/tests/unit/web-console/WebConsoleRegistrar.test.ts
+++ b/tests/unit/web-console/WebConsoleRegistrar.test.ts
@@ -849,6 +849,7 @@ describe('WebConsoleRegistrar', () => {
     container.seed('UserConfigStore', productionAdapter());
     container.seed('SigningKeyStore', productionAdapter());
     container.seed('LifecycleService', { registerPeriodicTask: jest.fn() });
+    seedCanonicalPortfolioManagers(container);
 
     const composition = await new WebConsoleRegistrar({
       activationProfile: SHARED_HOSTED_PROFILE,
@@ -1393,6 +1394,7 @@ describe('WebConsoleRegistrar', () => {
     container.seed('SigningKeyStore', new InMemorySigningKeyStore());
     const lifecycle = { registerPeriodicTask: jest.fn() };
     container.seed('LifecycleService', lifecycle);
+    seedCanonicalPortfolioManagers(container);
     const { WebConsoleRegistrar } = await import('../../../src/web-console/index.js');
 
     const composition = await new WebConsoleRegistrar({
@@ -1417,7 +1419,7 @@ describe('WebConsoleRegistrar', () => {
     expect(composition.accountAdminStore.constructor.name).toBe('PostgresConsoleAccountAdminStore');
     expect(composition.accountAllowlistStore.constructor.name).toBe('PostgresConsoleAccountAllowlistStore');
     expect(composition.integrationStore.constructor.name).toBe('PostgresUserIntegrationStore');
-    expect(composition.portfolioStore.constructor.name).toBe('InMemoryPortfolioElementStore');
+    expect(composition.portfolioStore.constructor.name).toBe('ManagerBackedPortfolioElementStore');
     expect(composition.sessionActivationStateAdapter.constructor.name).toBe('PostgresSessionActivationStateAdapter');
     expect(composition.sessionActivationEventSink.constructor.name).toBe('PostgresSessionActivationEventSink');
     expect(composition.runtimeSessionControlStore.constructor.name).toBe('PostgresRuntimeSessionControlStore');
@@ -1435,6 +1437,7 @@ describe('WebConsoleRegistrar', () => {
     container.seed('SystemDatabaseInstance', {});
     container.seed('AuditHmacResolver', { resolve: jest.fn() });
     container.seed('LifecycleService', { registerPeriodicTask: jest.fn() });
+    seedCanonicalPortfolioManagers(container);
     const { WebConsoleRegistrar } = await import('../../../src/web-console/index.js');
 
     await expect(new WebConsoleRegistrar({
@@ -1447,11 +1450,49 @@ describe('WebConsoleRegistrar', () => {
     const container = new TestContainer();
     container.seed('SystemDatabaseInstance', {});
     container.seed('LifecycleService', { registerPeriodicTask: jest.fn() });
+    seedCanonicalPortfolioManagers(container);
     const { WebConsoleRegistrar } = await import('../../../src/web-console/index.js');
 
     await expect(new WebConsoleRegistrar({
       opaqueValueHmacKey: Buffer.alloc(32, 16),
       reportCleanupError: jest.fn(),
     }).bootstrapAndRegister(container)).rejects.toThrow('AuditHmacResolver');
+  });
+
+  it('fails clearly when a database is configured but the element managers are unregistered', async () => {
+    const container = new TestContainer();
+    container.seed('SystemDatabaseInstance', {});
+    container.seed('AuditHmacResolver', { resolve: jest.fn() });
+    container.seed('UserConfigStore', { load: jest.fn(), save: jest.fn() });
+    container.seed('SigningKeyStore', new InMemorySigningKeyStore());
+    container.seed('LifecycleService', { registerPeriodicTask: jest.fn() });
+    const { WebConsoleRegistrar } = await import('../../../src/web-console/index.js');
+
+    await expect(new WebConsoleRegistrar({
+      opaqueValueHmacKey: Buffer.alloc(32, 18),
+      reportCleanupError: jest.fn(),
+    }).bootstrapAndRegister(container)).rejects.toThrow(
+      'Database-backed web-console composition requires a durable portfolio store; ' +
+      'missing container registrations: UserIdResolver, PersonaManager',
+    );
+  });
+
+  it('fails clearly when a database is configured and the manager-backed portfolio store is disabled', async () => {
+    const container = new TestContainer();
+    container.seed('SystemDatabaseInstance', {});
+    container.seed('AuditHmacResolver', { resolve: jest.fn() });
+    container.seed('UserConfigStore', { load: jest.fn(), save: jest.fn() });
+    container.seed('SigningKeyStore', new InMemorySigningKeyStore());
+    container.seed('LifecycleService', { registerPeriodicTask: jest.fn() });
+    seedCanonicalPortfolioManagers(container);
+    const { WebConsoleRegistrar } = await import('../../../src/web-console/index.js');
+
+    await expect(new WebConsoleRegistrar({
+      enableManagerBackedPortfolioStore: false,
+      opaqueValueHmacKey: Buffer.alloc(32, 19),
+      reportCleanupError: jest.fn(),
+    }).bootstrapAndRegister(container)).rejects.toThrow(
+      'the manager-backed portfolio store is disabled (enableManagerBackedPortfolioStore=false)',
+    );
   });
 });

--- a/tests/unit/web-console/WebConsoleRouteManifestParity.test.ts
+++ b/tests/unit/web-console/WebConsoleRouteManifestParity.test.ts
@@ -141,7 +141,6 @@ const CONTRACT_ROUTES = [
   'POST /api/v1/admin/security/signing-keys/:kind/rotate',
   'POST /api/v1/admin/security/signing-keys/:kind/:kid/retire',
   'DELETE /api/v1/admin/security/signing-keys/:kind/:kid',
-  'GET /api/v1/admin/security/signing-keys/jobs/:id',
   'GET /api/v1/admin/security/auth-policy',
   'PUT /api/v1/admin/security/auth-policy',
   'POST /api/v1/admin/security/users/:user_id/factors/totp/reset',

--- a/tests/unit/web-console/modules/SecurityAdminModule.test.ts
+++ b/tests/unit/web-console/modules/SecurityAdminModule.test.ts
@@ -99,7 +99,6 @@ describe('SecurityAdminModule', () => {
       { id: 'security.signing_keys.rotate' },
       { id: 'security.signing_keys.retire' },
       { id: 'security.signing_keys.delete' },
-      { id: 'security.signing_keys.jobs.show' },
       { id: 'security.auth_policy.show' },
       { id: 'security.auth_policy.update' },
       { id: 'security.users.totp.reset' },
@@ -133,18 +132,15 @@ describe('SecurityAdminModule', () => {
     });
   });
 
-  it('rotates signing keys, exposes a job, and never returns generated secret bytes', async () => {
+  it('rotates signing keys, returns the completed receipt synchronously, and never returns generated secret bytes', async () => {
     const { module, signingKeyStore } = await createModule();
     const rotateRoute = findRoute(module.routes, 'POST', '/api/v1/admin/security/signing-keys/:kind/rotate');
-    const jobRoute = findRoute(module.routes, 'GET', '/api/v1/admin/security/signing-keys/jobs/:id');
 
     const result = await rotateRoute.handler({ query: {}, params: { kind: 'cookie' } } as never);
     const job = projectSecuritySigningKeyJob(result.body);
-    const jobResult = await jobRoute.handler({ query: {}, params: { id: job.id } } as never);
 
-    expect(result.status).toBe(202);
+    expect(result.status).toBe(200);
     expect(job).toMatchObject({ kind: 'cookie', action: 'rotate', status: 'completed' });
-    expect(projectSecuritySigningKeyJob(jobResult.body)).toEqual(job);
     expect(JSON.stringify(result.body)).not.toContain('secret');
     expect(JSON.stringify(await signingKeyStore.getActive('cookie'))).toContain('secret');
     expect(JSON.stringify(projectSecuritySigningKeyList((await findRoute(
@@ -203,7 +199,7 @@ describe('SecurityAdminModule', () => {
       query: {},
       params: { kind: 'invite', kid },
       body: { emergency: true },
-    } as never)).resolves.toMatchObject({ status: 202 });
+    } as never)).resolves.toMatchObject({ status: 200 });
     await expect(signingKeyStore.getByKid(kid)).resolves.toBeNull();
   });
 


### PR DESCRIPTION
## Summary

- **Web-console DB mode fails closed when no durable portfolio store can be built.** `resolvePortfolioElementStore` now throws at composition time, naming the missing element-manager registrations, instead of silently returning the in-memory store. Previously a database-configured deployment could end up with a volatile portfolio (lost on restart) while every sibling store persisted — with no error surfaced. The shared-hosted activation gate already caught this; the throw closes the same hole for database-configured development-profile deployments and gives a clearer error everywhere.
- **Gatekeeper approve/deny/cancel decisions await their durable persist before acknowledging.** The decision paths previously fired the store persist without awaiting it, so a crash between the in-memory mutation and the async write could lose a security decision the caller had already been told succeeded. A persist failure now rejects the decision instead of being swallowed. Housekeeping writes (expiry sweeps, purges, consumption) deliberately remain fire-and-forget — their state is re-derivable, and awaiting them would push async through every read path.
- **Signing-key rotate/retire/delete respond `200` with the final receipt instead of `202` + a pollable job id.** The key operation already completed synchronously and durably in the signing-key store before the response; only the job receipt lived in an in-process map, so `GET …/jobs/:id` returned 404 after a restart or on another replica. The response body keeps the same receipt shape (`status: completed`); the jobs route and its audit operation are removed.
- **E2E harness repairs surfaced by running the suites:** the Playwright boot evidence was missing the `me-logs` route module (the jest harness had it), and the browser auth spec now approves the OAuth client-consent page introduced with constrained DCR.

## Verification

- `npm run lint` — clean, zero warnings
- eslint with the SonarCloud rule mirror over all touched files — zero issues (16 pre-existing findings in `GatekeeperHandler.ts` fixed along the way: unnecessary optional chains, type-cast-masked validation, `require-await`)
- `npm run build`
- `npm test` / `npm run test:integration` / `npm run test:e2e` — all passing
- `npm run test:console-e2e` (HTTP breadth suite against a real PostgreSQL + booted app) — all passing
- `npm run test:console-e2e:auth` (real browser: login → TOTP enroll → step-up → step-down → logout) — passing
- `npm run pre-commit` — security tests and typecheck pass; `npm audit` flags upstream advisories (`shell-quote` via `@modelcontextprotocol/inspector`, `ws`, `qs`) that are present on the base branch independent of this change
