### PR TITLE
Enforce route ownership policy at the platform layer

### DIFF
--- a/src/web-console/WebConsoleRegistrar.ts
+++ b/src/web-console/WebConsoleRegistrar.ts
@@ -627,6 +627,7 @@ export class WebConsoleRegistrar {
       integrationPublicBaseUrl,
       adminAuditWriter,
       idempotencyStore: stores.idempotencyStore,
+      runtimeStore: stores.runtimeSessionControlStore,
       authPolicyStore,
       protectedCorrelationRateLimiter,
       apiV1MountState,
@@ -979,6 +980,7 @@ function createApiV1Mount(options: {
   readonly integrationPublicBaseUrl: string | null;
   readonly adminAuditWriter: IAdminAuditWriter;
   readonly idempotencyStore: IIdempotencyStore;
+  readonly runtimeStore: IRuntimeSessionControlStore;
   readonly authPolicyStore: IConsoleAuthPolicyStore;
   readonly protectedCorrelationRateLimiter: ConsoleProtectedCorrelationRateLimiter | null;
   readonly apiV1MountState: Pick<WebConsoleApiV1Mount, 'mounted' | 'markMounted'>;
@@ -996,6 +998,7 @@ function createApiV1Mount(options: {
     consoleOrigin,
     adminAuditWriter: options.adminAuditWriter,
     idempotencyStore: options.idempotencyStore,
+    runtimeStore: options.runtimeStore,
     authPolicyStore: options.authPolicyStore,
     protectedCorrelationRateLimiter: options.protectedCorrelationRateLimiter,
     idleTimeoutMs: options.options.consoleSessionIdleTimeoutMs ?? 30 * 60 * 1000,

--- a/src/web-console/middleware/ConsoleOwnership.ts
+++ b/src/web-console/middleware/ConsoleOwnership.ts
@@ -1,0 +1,63 @@
+import type { RequestHandler } from 'express';
+
+import { requireConsoleRequestContext } from '../platform/ConsoleRequestContext.js';
+import {
+  type ConsoleRequest,
+  type ConsoleRouteDefinition,
+} from '../platform/ConsolePlatformTypes.js';
+import { sendProblemResponse } from '../platform/ProblemResponses.js';
+import type { IRuntimeSessionControlStore } from '../services/runtime/IRuntimeSessionControlStore.js';
+import { requireConsoleAuthentication } from './ConsoleAuthentication.js';
+
+export interface ConsoleOwnershipOptions {
+  readonly runtimeStore: IRuntimeSessionControlStore;
+  readonly now?: () => Date;
+}
+
+export function createConsoleOwnershipMiddleware(
+  route: ConsoleRouteDefinition,
+  options: ConsoleOwnershipOptions,
+): RequestHandler {
+  return (request, response, next): void => {
+    const req = request as ConsoleRequest;
+    void (async (): Promise<void> => {
+      const policy = route.ownership ?? 'none';
+      if (policy === 'none' || policy === 'flow_transaction') {
+        next();
+        return;
+      }
+
+      const authentication = requireConsoleAuthentication(req);
+      if (policy === 'authenticated_user') {
+        next();
+        return;
+      }
+
+      const sessionId = req.params.session_id;
+      if (typeof sessionId !== 'string' || sessionId.trim() === '') {
+        sendProblemResponse(response, notFoundProblem(), requireConsoleRequestContext(req).correlationId);
+        return;
+      }
+      const presence = await options.runtimeStore.findPresence(sessionId, options.now?.() ?? new Date());
+      if (presence?.userId !== authentication.userId) {
+        sendProblemResponse(response, notFoundProblem(), requireConsoleRequestContext(req).correlationId);
+        return;
+      }
+      next();
+    })().catch(next);
+  };
+}
+
+function notFoundProblem(): {
+  readonly status: 404;
+  readonly code: 'not_found';
+  readonly title: 'Not found';
+  readonly detail: string;
+} {
+  return {
+    status: 404,
+    code: 'not_found',
+    title: 'Not found',
+    detail: 'Runtime session was not found.',
+  };
+}

--- a/src/web-console/middleware/index.ts
+++ b/src/web-console/middleware/index.ts
@@ -9,5 +9,6 @@ export * from './ConsoleAdminAudit.js';
 export * from './ConsoleCookies.js';
 export * from './ConsoleCsrfProtection.js';
 export * from './ConsoleIdempotency.js';
+export * from './ConsoleOwnership.js';
 export * from './ConsoleRateLimit.js';
 export * from './ConsoleSecurityHeaders.js';

--- a/src/web-console/modules/executions/ExecutionModule.ts
+++ b/src/web-console/modules/executions/ExecutionModule.ts
@@ -16,6 +16,7 @@ import {
 } from './ExecutionPrivacyProjectors.js';
 
 const SELF_CAPABILITY = 'console:self';
+const SESSION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u;
 const EXECUTION_STREAM_POLICY = {
   lastEventId: 'unsupported',
   heartbeatMs: 15_000,
@@ -131,6 +132,9 @@ function withSessionId(
   if (typeof sessionId !== 'string' || sessionId.trim() === '') {
     return invalidRequest('session_id path parameter is required.');
   }
+  if (!isSessionId(sessionId)) {
+    return invalidRequest('session_id path parameter is invalid.');
+  }
   return action(sessionId);
 }
 
@@ -144,7 +148,14 @@ function withExecutionParams(
       typeof goalId !== 'string' || goalId.trim() === '') {
     return invalidRequest('session_id and goal_id path parameters are required.');
   }
+  if (!isSessionId(sessionId)) {
+    return invalidRequest('session_id path parameter is invalid.');
+  }
   return action(sessionId, goalId);
+}
+
+function isSessionId(value: string): boolean {
+  return SESSION_ID_PATTERN.test(value);
 }
 
 function invalidRequest(detail: string): ConsoleHandlerResult {

--- a/src/web-console/platform/ConsoleSecuredRouterAssembler.ts
+++ b/src/web-console/platform/ConsoleSecuredRouterAssembler.ts
@@ -9,6 +9,7 @@ import {
   createConsoleAuthenticationMiddleware,
   createConsoleAuthorizationMiddleware,
   createConsoleCsrfProtectionMiddleware,
+  createConsoleOwnershipMiddleware,
   createConsoleRateLimitMiddleware,
   createConsoleSecurityHeadersMiddleware,
   executeWithConsoleIdempotency,
@@ -18,6 +19,7 @@ import type { IConsoleOpaqueValueService } from '../security/ConsoleOpaqueValues
 import type { IConsoleSessionStore } from '../stores/IConsoleSessionStore.js';
 import type { IConsoleAuthPolicyStore } from '../stores/IConsoleAuthPolicyStore.js';
 import type { IIdempotencyStore } from '../stores/IIdempotencyStore.js';
+import type { IRuntimeSessionControlStore } from '../services/runtime/IRuntimeSessionControlStore.js';
 import type { ConsoleProtectedCorrelationRateLimiter } from '../services/rate-limit/ConsoleProtectedCorrelationRateLimiter.js';
 import type { ConsoleHttpMethod, ConsoleRouteDefinition , ConsoleRequest } from './ConsolePlatformTypes.js';
 import { isElevationValidForRoute } from './ConsolePlatformTypes.js';
@@ -38,6 +40,7 @@ export interface SecuredConsoleRouterOptions {
   readonly consoleOrigin: string;
   readonly adminAuditWriter: IAdminAuditWriter;
   readonly idempotencyStore: IIdempotencyStore;
+  readonly runtimeStore: IRuntimeSessionControlStore;
   readonly authPolicyStore?: IConsoleAuthPolicyStore;
   readonly protectedCorrelationRateLimiter?: ConsoleProtectedCorrelationRateLimiter | null;
   readonly idleTimeoutMs: number;
@@ -123,6 +126,7 @@ function middlewareForRoute(input: {
     ...(input.userContext ? [input.userContext] : []),
     input.csrf,
     createConsoleAuthorizationMiddleware(input.route, input.options),
+    createConsoleOwnershipMiddleware(input.route, input.options),
     createConsoleRateLimitMiddleware(input.route, input.options),
     createSecuredHandler(input.route, input.options),
   ];

--- a/tests/unit/web-console/auth/ConsoleBffAuthModule.test.ts
+++ b/tests/unit/web-console/auth/ConsoleBffAuthModule.test.ts
@@ -13,6 +13,7 @@ import {
   InMemoryConsoleSessionStore,
   InMemoryIdempotencyStore,
   InMemoryLoginTransactionStore,
+  InMemoryRuntimeSessionControlStore,
   type ConsoleLoginFlowKind,
   type ConsolePrincipalSecurityState,
   type ConsoleOAuthCodeExchangeRequest,
@@ -123,6 +124,7 @@ function buildFixture(options: FixtureOptions = {}): {
     consoleOrigin: ORIGIN,
     adminAuditWriter: new InMemoryAdminAuditWriter(),
     idempotencyStore: new InMemoryIdempotencyStore(),
+    runtimeStore: new InMemoryRuntimeSessionControlStore(),
     idleTimeoutMs: 60 * 60 * 1000,
     now: options.now ?? (() => NOW),
   }));

--- a/tests/unit/web-console/middleware/ConsoleSecuredRouter.test.ts
+++ b/tests/unit/web-console/middleware/ConsoleSecuredRouter.test.ts
@@ -12,6 +12,7 @@ import {
   InMemoryConsoleSessionStore,
   InMemoryConsoleAuthPolicyStore,
   InMemoryIdempotencyStore,
+  InMemoryRuntimeSessionControlStore,
   ConsoleStoreValidationError,
   ConsoleProtectedCorrelationRateLimitDependencyError,
   ConsoleProtectedCorrelationRateLimiter,
@@ -35,6 +36,10 @@ const AUDIT_CAPABILITY = 'console:admin:audit' as const;
 const CONTEXT_PATH = '/api/v1/me/context';
 const CHANGE_PATH = '/api/v1/me/change';
 const HEALTH_PATH = '/api/v1/health/ready';
+const OWNED_SESSION_ID = 'mcp-session-owned';
+const OTHER_SESSION_ID = 'mcp-session-other';
+const OWNED_SESSION_PATH = `/api/v1/me/sessions/${OWNED_SESSION_ID}/owned-fixture`;
+const OTHER_SESSION_PATH = `/api/v1/me/sessions/${OTHER_SESSION_ID}/owned-fixture`;
 const ADMIN_AUDIT_PATH = '/api/v1/admin/audit';
 const ADMIN_EXPORT_PATH = '/api/v1/admin/audit/export';
 const ADMIN_STREAM_PATH = '/api/v1/admin/audit/stream';
@@ -107,6 +112,19 @@ function fixtureModules(
           },
         };
       },
+    }, {
+      method: 'GET',
+      path: '/api/v1/me/sessions/:session_id/owned-fixture',
+      audience: 'self',
+      requiredCapability: SELF_CAPABILITY,
+      ownership: 'owned_session',
+      elevation: 'none',
+      privacyClass: 'self_private',
+      idempotency: 'not_applicable',
+      handler: req => ({
+        status: 200,
+        body: { session_id: req.params.session_id },
+      }),
     }, {
       method: 'POST',
       path: CHANGE_PATH,
@@ -306,11 +324,32 @@ async function buildApp(
   nowProvider: () => Date = () => NOW,
 ) {
   const sessionStore = new InMemoryConsoleSessionStore();
+  const runtimeStore = new InMemoryRuntimeSessionControlStore();
   const idempotencyStore = new InMemoryIdempotencyStore();
   const onChange = jest.fn();
   const onAdminMutation = jest.fn();
   const onProtectedCorrelation = jest.fn();
   if (session) await sessionStore.create(session);
+  await runtimeStore.registerPresence({
+    sessionId: OWNED_SESSION_ID,
+    userId: USER_ID,
+    accountCorrelationId: '018f3d47-73ae-7f10-a0de-0742618d4fb3',
+    replicaId: 'replica-a',
+    transport: 'streamable-http',
+    startedAt: NOW,
+    lastActiveAt: NOW,
+    leaseUntil: IDLE_EXPIRY,
+  });
+  await runtimeStore.registerPresence({
+    sessionId: OTHER_SESSION_ID,
+    userId: '118f3d47-73ae-7f10-a0de-0742618d4fb4',
+    accountCorrelationId: '118f3d47-73ae-7f10-a0de-0742618d4fb5',
+    replicaId: 'replica-b',
+    transport: 'streamable-http',
+    startedAt: NOW,
+    lastActiveAt: NOW,
+    leaseUntil: IDLE_EXPIRY,
+  });
   const registry = new ConsoleModuleRegistry();
   fixtureModules(onChange, onAdminMutation, onProtectedCorrelation).forEach(module => registry.register(module));
   const adminAuditWriter = new InMemoryAdminAuditWriter();
@@ -323,6 +362,7 @@ async function buildApp(
     consoleOrigin: ORIGIN,
     adminAuditWriter,
     idempotencyStore,
+    runtimeStore,
     authPolicyStore,
     protectedCorrelationRateLimiter,
     idleTimeoutMs: 60 * 60 * 1000,
@@ -332,6 +372,7 @@ async function buildApp(
   return {
     app,
     sessionStore,
+    runtimeStore,
     adminAuditWriter,
     idempotencyStore,
     onChange,
@@ -452,6 +493,32 @@ describe('secured console router authentication', () => {
     expect(response.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
     expect(response.headers['permissions-policy']).toBe('geolocation=(), microphone=(), camera=()');
     expect(adminAuditWriter.getEvents()).toEqual([]);
+  });
+
+  it('allows owned-session routes only for sessions owned by the caller', async () => {
+    const { app, runtimeStore } = await buildApp();
+    const lookup = jest.spyOn(runtimeStore, 'findPresence');
+
+    const accepted = await request(app).get(OWNED_SESSION_PATH).set('Cookie', sessionCookie());
+    const rejected = await request(app).get(OTHER_SESSION_PATH).set('Cookie', sessionCookie());
+
+    expect(accepted.status).toBe(200);
+    expect(accepted.body).toEqual({ session_id: OWNED_SESSION_ID });
+    expect(rejected.status).toBe(404);
+    expect(rejected.body.code).toBe('not_found');
+    expect(lookup).toHaveBeenCalledWith(OWNED_SESSION_ID, NOW);
+    expect(lookup).toHaveBeenCalledWith(OTHER_SESSION_ID, NOW);
+  });
+
+  it('rejects owned-session routes for an unknown session with no presence', async () => {
+    const { app } = await buildApp();
+
+    const response = await request(app)
+      .get('/api/v1/me/sessions/mcp-session-does-not-exist/owned-fixture')
+      .set('Cookie', sessionCookie());
+
+    expect(response.status).toBe(404);
+    expect(response.body.code).toBe('not_found');
   });
 
   it.each([

--- a/tests/unit/web-console/modules/ExecutionModule.test.ts
+++ b/tests/unit/web-console/modules/ExecutionModule.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 
 import {
   ConsoleModuleRegistry,
@@ -224,6 +224,26 @@ describe('ExecutionModule', () => {
     }))).resolves.toMatchObject({ status: 404, body: { code: 'not_found' } });
   });
 
+  it('rejects invalid execution session IDs before service ownership checks', async () => {
+    const { module, runtimeStore } = await fixture();
+    const listRoute = findRoute(module.routes, 'GET', EXECUTION_LIST_PATH);
+    const detailRoute = findRoute(module.routes, 'GET', EXECUTION_DETAIL_PATH);
+    const lookup = jest.spyOn(runtimeStore, 'findPresence');
+
+    await expect(Promise.resolve(listRoute.handler(request({ params: { session_id: 'bad session id' } }))))
+      .resolves.toMatchObject({
+        status: 400,
+        body: { code: 'invalid_request', detail: 'session_id path parameter is invalid.' },
+      });
+    await expect(Promise.resolve(detailRoute.handler(request({
+      params: { session_id: '../bad', goal_id: GOAL_ID },
+    })))).resolves.toMatchObject({
+      status: 400,
+      body: { code: 'invalid_request', detail: 'session_id path parameter is invalid.' },
+    });
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
   it('streams owner-private execution updates with projection and owned-session revalidation', async () => {
     const { module, runtimeStore } = await fixture();
     const route = findRoute(module.routes, 'GET', EXECUTION_STREAM_PATH);
@@ -317,6 +337,21 @@ describe('ExecutionModule', () => {
       params: { session_id: SESSION_ID, goal_id: 'bad goal id' },
       headers: {},
     }))).resolves.toMatchObject({ status: 422 });
+  });
+
+  it('rejects invalid execution stream session IDs before opening a stream', async () => {
+    const { module, runtimeStore } = await fixture();
+    const route = findRoute(module.routes, 'GET', EXECUTION_STREAM_PATH);
+    const lookup = jest.spyOn(runtimeStore, 'findPresence');
+
+    await expect(Promise.resolve(route.handler(request({
+      params: { session_id: 'bad session id', goal_id: GOAL_ID },
+      headers: {},
+    })))).resolves.toMatchObject({
+      status: 400,
+      body: { code: 'invalid_request', detail: 'session_id path parameter is invalid.' },
+    });
+    expect(lookup).not.toHaveBeenCalled();
   });
 
   it('returns not found when the execution stream target does not exist', async () => {


### PR DESCRIPTION
## Summary

Routes can declare an ownership policy (`none` / `flow_transaction` / `authenticated_user` / `owned_session`), but until now that policy was only validated at registration and never enforced at request time — instance ownership was left to ad-hoc checks inside each service. This adds a runtime ownership middleware so the declared policy is load-bearing:

- **`owned_session`** — resolves the route's `:session_id` and verifies the session belongs to the caller via the runtime presence store; returns `404` on mismatch or unknown session (matching the services, so session existence isn't leaked). Uses the same presence oracle the services use, so it's consistent and replica-safe.
- **`authenticated_user`** — requires an authenticated console context.
- **`none` / `flow_transaction`** — pass through.

The gate sits in the secured-router chain after authorization and before the handler. Existing per-service ownership checks are intentionally left in place as defense-in-depth.

Also brings `session_id` path validation to parity with `goal_id` in the executions module (both now charset-validated, previously `session_id` was only checked for non-emptiness).

## Verification

- `npm run lint` — zero warnings; SonarCloud-rule mirror over all touched source and test files — zero issues
- `npm run build`
- `npm test` / `npm run test:integration` / `npm run test:e2e`
- `npm run test:console-e2e` (HTTP breadth, real PostgreSQL) and `npm run test:console-e2e:auth` (real browser login → step-up lifecycle) — all passing; these exercise the live `/me/sessions/:session_id/...` routes end-to-end through the new middleware
- New tests cover an owned session (200), another user's session (404), and an unknown session with no presence (404)
