### PR TITLE
fix: repair OAuth helper token storage and status reporting

### DIFF
--- a/oauth-helper.mjs
+++ b/oauth-helper.mjs
@@ -27,6 +27,11 @@ const __dirname = dirname(__filename);
 const DEFAULT_POLL_INTERVAL = 5;
 const DEFAULT_EXPIRES_IN = 900; // 15 minutes
 const MAX_TOKEN_SIZE = 10000; // Maximum reasonable token size
+const DOLLHOUSE_HOME_DIR = process.env.DOLLHOUSE_HOME_DIR || homedir();
+const AUTH_DIR = join(DOLLHOUSE_HOME_DIR, '.dollhouse', '.auth');
+const PID_FILE = join(AUTH_DIR, 'oauth-helper.pid');
+const STATE_FILE = join(AUTH_DIR, 'oauth-helper-state.json');
+const RESULT_FILE = join(AUTH_DIR, 'oauth-helper-result.json');
 
 // Parse command line arguments
 const args = process.argv.slice(2);
@@ -51,7 +56,7 @@ if (!clientId || clientId === 'undefined') {
 }
 
 // Log file for debugging (optional, can be disabled in production)
-const LOG_FILE = join(homedir(), '.dollhouse', 'oauth-helper.log');
+const LOG_FILE = join(DOLLHOUSE_HOME_DIR, '.dollhouse', 'oauth-helper.log');
 const LOG_ENABLED = process.env.DOLLHOUSE_OAUTH_DEBUG === 'true';
 
 async function log(message) {
@@ -127,47 +132,46 @@ async function storeToken(token) {
     const { TokenManager } = await import('./dist/security/tokenManager.js');
     
     // Store the token using the secure storage mechanism
-    await TokenManager.storeGitHubToken(token);
+    const tokenManager = new TokenManager(createHelperFileOperations());
+    await tokenManager.storeGitHubToken(token);
     await log('Token stored successfully using TokenManager');
     return true;
-  } catch {
-    await log('Failed to store token using TokenManager');
-    
-    // Fallback: Write to a temporary file for the MCP server to pick up
-    try {
-      const tempTokenFile = join(homedir(), '.dollhouse', '.auth', 'pending_token.txt');
-      const tempDir = dirname(tempTokenFile);
-      
-      // Create directory with secure permissions
-      await fs.mkdir(tempDir, { recursive: true, mode: 0o700 });
-      
-      // Verify directory permissions
-      const dirStats = await fs.stat(tempDir);
-      const dirMode = dirStats.mode & parseInt('777', 8);
-      if (dirMode !== parseInt('700', 8)) {
-        await fs.chmod(tempDir, 0o700);
-      }
-      
-      // Write token with secure permissions
-      await fs.writeFile(tempTokenFile, token, { mode: 0o600 });
-      
-      // Verify file permissions
-      await fs.chmod(tempTokenFile, 0o600);
-      
-      await log('Token written to fallback file with secure permissions');
-      return true;
-    } catch (fallbackError) {
-      await log('Fallback storage also failed');
-      throw fallbackError;
-    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    await log(`Failed to store token using TokenManager: ${message}`);
+    console.error(`OAUTH_TOKEN_STORAGE_FAILED: ${message}`);
+    throw error;
   }
+}
+
+function createHelperFileOperations() {
+  return {
+    async createDirectory(directoryPath) {
+      await fs.mkdir(directoryPath, { recursive: true });
+    },
+    async writeFile(filePath, content) {
+      await fs.writeFile(filePath, content, { encoding: 'utf8' });
+    },
+    async chmod(filePath, mode) {
+      await fs.chmod(filePath, mode);
+    }
+  };
 }
 
 function cleanupPidFileSync() {
   try {
-    const pidFile = join(homedir(), '.dollhouse', '.auth', 'oauth-helper.pid');
-    if (fsSync.existsSync(pidFile)) {
-      fsSync.unlinkSync(pidFile);
+    if (fsSync.existsSync(PID_FILE)) {
+      fsSync.unlinkSync(PID_FILE);
+    }
+  } catch (error) {
+    // Ignore cleanup errors
+  }
+}
+
+function cleanupStateFileSync() {
+  try {
+    if (fsSync.existsSync(STATE_FILE)) {
+      fsSync.unlinkSync(STATE_FILE);
     }
   } catch (error) {
     // Ignore cleanup errors
@@ -176,22 +180,48 @@ function cleanupPidFileSync() {
 
 async function cleanupPidFile() {
   try {
-    const pidFile = join(homedir(), '.dollhouse', '.auth', 'oauth-helper.pid');
-    await fs.unlink(pidFile).catch(() => {});
+    await fs.unlink(PID_FILE).catch(() => {});
     await log('PID file cleaned up');
   } catch (error) {
     // Ignore cleanup errors
   }
 }
 
+async function cleanupStateFile() {
+  try {
+    await fs.unlink(STATE_FILE).catch(() => {});
+    await log('OAuth helper state file cleaned up');
+  } catch (error) {
+    // Ignore cleanup errors
+  }
+}
+
+async function writeTerminalResult(status, attempts, error) {
+  try {
+    await fs.mkdir(AUTH_DIR, { recursive: true, mode: 0o700 });
+    const result = {
+      status,
+      attempts,
+      completedAt: new Date().toISOString()
+    };
+
+    if (error) {
+      result.error = error;
+    }
+
+    await fs.writeFile(RESULT_FILE, JSON.stringify(result, null, 2), { mode: 0o600 });
+    await fs.chmod(RESULT_FILE, 0o600).catch(() => {});
+    await log(`Terminal result written: ${status}`);
+  } catch (resultError) {
+    await log('Failed to write terminal result');
+  }
+}
+
 async function writePidFile() {
   try {
-    const pidFile = join(homedir(), '.dollhouse', '.auth', 'oauth-helper.pid');
-    const pidDir = dirname(pidFile);
-    
-    await fs.mkdir(pidDir, { recursive: true, mode: 0o700 });
-    await fs.writeFile(pidFile, process.pid.toString(), { mode: 0o600 });
-    await log(`PID file written: ${pidFile}`);
+    await fs.mkdir(AUTH_DIR, { recursive: true, mode: 0o700 });
+    await fs.writeFile(PID_FILE, process.pid.toString(), { mode: 0o600 });
+    await log(`PID file written: ${PID_FILE}`);
   } catch {
     await log('Failed to write PID file');
   }
@@ -233,14 +263,24 @@ async function main() {
   });
   
   process.on('SIGINT', () => {
+    cleanupStateFileSync();
     cleanupPidFileSync();
     process.exit(0);
   });
   
   process.on('SIGTERM', () => {
+    cleanupStateFileSync();
     cleanupPidFileSync();
     process.exit(0);
   });
+
+  async function finish(status, error, exitCode) {
+    clearInterval(heartbeatInterval);
+    await writeTerminalResult(status, attempts, error);
+    await cleanupStateFile();
+    await cleanupPidFile();
+    process.exit(exitCode);
+  }
   
   while (Date.now() < timeout) {
     attempts++;
@@ -266,16 +306,12 @@ async function main() {
           case 'expired_token':
             await log('OAUTH_HELPER_264: Device code expired - authentication window closed');
             console.error('OAUTH_EXPIRED: Device code expired at line 264 - authentication window closed');
-            clearInterval(heartbeatInterval);
-            await cleanupPidFile();
-            process.exit(1);
+            await finish('expired', 'Device code expired - authentication window closed', 1);
             
           case 'access_denied':
             await log('OAUTH_HELPER_270: User denied authorization request');
             console.error('OAUTH_ACCESS_DENIED: User denied authorization at line 270');
-            clearInterval(heartbeatInterval);
-            await cleanupPidFile();
-            process.exit(1);
+            await finish('denied', 'User denied authorization', 1);
             
           default:
             await log('OAUTH_HELPER_276: Unknown error from GitHub during device flow polling');
@@ -294,15 +330,11 @@ async function main() {
           await log('[SUCCESS] ✅ OAuth authentication completed successfully');
           await log(`[STATS] Total attempts: ${attempts}, Time elapsed: ${Math.round((Date.now() - startTime) / 1000)}s`);
           console.log('✅ GitHub authentication successful! Token has been stored.');
-          clearInterval(heartbeatInterval);
-          await cleanupPidFile();
-          process.exit(0);
+          await finish('success', '', 0);
         } else {
           await log('[ERROR] ❌ Failed to store token');
           console.error('❌ Failed to store authentication token');
-          clearInterval(heartbeatInterval);
-          await cleanupPidFile();
-          process.exit(1);
+          await finish('failed', 'Failed to store authentication token', 1);
         }
       } else {
         // Reset error counter on successful communication
@@ -327,17 +359,14 @@ async function main() {
         if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
           await log('OAUTH_HELPER_323: Too many consecutive network errors, exiting');
           console.error(`OAUTH_NETWORK_FAILURE: Too many network errors (${MAX_CONSECUTIVE_ERRORS}) at line 323 - check internet connection`);
-          clearInterval(heartbeatInterval);
-          await cleanupPidFile();
-          process.exit(1);
+          await finish('failed', `Too many network errors (${MAX_CONSECUTIVE_ERRORS}) - check internet connection`, 1);
         }
       } else {
         // Non-network error, likely fatal
         await log('OAUTH_HELPER_330: Non-recoverable error');
         console.error('OAUTH_FATAL_ERROR: Non-recoverable error at line 330');
-        clearInterval(heartbeatInterval);
-        await cleanupPidFile();
-        process.exit(1);
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        await finish('failed', `Non-recoverable error: ${message}`, 1);
       }
     }
     
@@ -349,15 +378,15 @@ async function main() {
   await log('OAUTH_HELPER_342: OAuth authorization timed out');
   await log(`[STATS] Total attempts: ${attempts}, Time elapsed: ${Math.round((Date.now() - startTime) / 1000)}s`);
   console.error(`OAUTH_TIMEOUT: Authorization timed out at line 342 after ${Math.round((Date.now() - startTime) / 1000)}s - user did not authorize in time`);
-  clearInterval(heartbeatInterval);
-  await cleanupPidFile();
-  process.exit(1);
+  await finish('timeout', 'Authorization timed out - user did not authorize in time', 1);
 }
 
 // Run the main function
 main().catch(async () => {
   await log('Fatal error');
   console.error('Fatal error in OAuth helper');
+  await writeTerminalResult('failed', 0, 'Fatal error in OAuth helper');
+  await cleanupStateFile();
   await cleanupPidFile();
   process.exit(1);
 });

--- a/src/handlers/GitHubAuthHandler.ts
+++ b/src/handlers/GitHubAuthHandler.ts
@@ -18,6 +18,15 @@ import { PersonaIndicatorService } from '../services/PersonaIndicatorService.js'
 import { SecurityMonitor } from '../security/securityMonitor.js';
 import { FileOperationsService } from '../services/FileOperationsService.js';
 
+type OAuthHelperTerminalStatus = 'success' | 'failed' | 'expired' | 'denied' | 'timeout';
+
+interface OAuthHelperTerminalResult {
+    status: OAuthHelperTerminalStatus;
+    attempts?: number;
+    completedAt?: string;
+    error?: string;
+}
+
 export class GitHubAuthHandler {
     constructor(
         private readonly githubAuthManager: GitHubAuthManager,
@@ -155,8 +164,10 @@ export class GitHubAuthHandler {
             });
             
             const stateFile = path.join(this.getDollhouseHomeDir(), '.dollhouse', '.auth', 'oauth-helper-state.json');
+            const resultFile = path.join(this.getDollhouseHomeDir(), '.dollhouse', '.auth', 'oauth-helper-result.json');
             const stateDir = path.dirname(stateFile);
             await this.fileOperations.createDirectory(stateDir);
+            await this.fileOperations.deleteFile(resultFile).catch(() => {});
             
             const state = {
               pid: helper.pid,
@@ -249,8 +260,10 @@ export class GitHubAuthHandler {
           if (status.isAuthenticated) {
             if (helperHealth.exists) {
               const stateFile = path.join(this.getDollhouseHomeDir(), '.dollhouse', '.auth', 'oauth-helper-state.json');
+              const resultFile = path.join(this.getDollhouseHomeDir(), '.dollhouse', '.auth', 'oauth-helper-result.json');
               // FileOperationsService.deleteFile already handles ENOENT gracefully
               await this.fileOperations.deleteFile(stateFile).catch(() => {}); // Preserve error swallowing pattern
+              await this.fileOperations.deleteFile(resultFile).catch(() => {});
             }
             
             return {
@@ -266,6 +279,41 @@ export class GitHubAuthHandler {
                   `✅ Submit content\n\n` +
                   `Everything is working properly!`
                 )
+              }]
+            };
+          } else if (helperHealth.resultStatus === 'success') {
+            return {
+              content: [{
+                type: "text",
+                text: this.prefix(
+                  `✅ **GitHub Authentication Completed**\n\n` +
+                  `The OAuth helper finished successfully, but the GitHub token is not available to this server process.\n\n` +
+                  `**To fix this:**\n` +
+                  `1. Run \`check_github_auth\` again after the server refreshes\n` +
+                  `2. If it still fails, run \`setup_github_auth\` to authenticate again`
+                )
+              }]
+            };
+          } else if (helperHealth.resultStatus) {
+            const statusLabel = this.formatOAuthHelperTerminalStatus(helperHealth.resultStatus);
+            const lines = [
+              `${statusLabel.icon} **GitHub Authentication ${statusLabel.title}**`,
+              '',
+              helperHealth.resultError || statusLabel.defaultMessage,
+              '',
+              '**To try again:**',
+              'Run: `setup_github_auth` to get a new code',
+              ''
+            ];
+
+            if (helperHealth.errorLog) {
+              lines.push('**Error Log:**', '```', helperHealth.errorLog, '```', '');
+            }
+
+            return {
+              content: [{
+                type: "text",
+                text: this.prefix(lines.join('\n'))
               }]
             };
           } else if (helperHealth.isActive) {
@@ -355,6 +403,7 @@ export class GitHubAuthHandler {
           const stateFile = path.join(homeDir, '.dollhouse', '.auth', 'oauth-helper-state.json');
           const logFile = path.join(homeDir, '.dollhouse', 'oauth-helper.log');
           const pidFile = path.join(homeDir, '.dollhouse', '.auth', 'oauth-helper.pid');
+          const resultFile = path.join(homeDir, '.dollhouse', '.auth', 'oauth-helper-result.json');
           
           let statusText = `📊 **OAuth Helper Process Diagnostics**\n\n`;
           
@@ -362,6 +411,25 @@ export class GitHubAuthHandler {
             statusText += `**Status:** No OAuth process detected\n`
             statusText += `**State File:** Not found\n\n`
             statusText += `No active authentication process. Run \`setup_github_auth\` to start one.\n`;
+          } else if (health.resultStatus) {
+            const statusLabel = this.formatOAuthHelperTerminalStatus(health.resultStatus);
+            statusText += `**Status:** ${statusLabel.icon} ${statusLabel.title.toUpperCase()}\n`
+            if (health.userCode) {
+              statusText += `**User Code:** ${health.userCode}\n`
+            }
+            if (health.pid) {
+              statusText += `**Process ID:** ${health.pid}\n`
+            }
+            if (health.completedAt) {
+              statusText += `**Completed:** ${health.completedAt.toLocaleString()}\n`
+            }
+            if (health.resultAttempts !== undefined) {
+              statusText += `**Attempts:** ${health.resultAttempts}\n`
+            }
+            if (health.resultError) {
+              statusText += `**Result:** ${health.resultError}\n`
+            }
+            statusText += '\n';
           } else if (health.isActive) {
             statusText += `**Status:** 🟢 ACTIVE - Authentication in progress\n`
             statusText += `**User Code:** ${health.userCode}\n`
@@ -391,6 +459,7 @@ setup_github_auth
           
           statusText += `**📁 File Locations:**\n`
           statusText += `• State: ${stateFile}\n`
+          statusText += `• Result: ${resultFile} ${health.hasResult ? '(exists)' : '(not found)'}\n`
           statusText += `• Log: ${logFile} ${health.hasLog ? '(exists)' : '(not found)'}\n`
           statusText += `• PID: ${pidFile}\n\n`
           
@@ -414,21 +483,26 @@ setup_github_auth
             }
           }
           
-          if (health.exists && !health.processAlive && !health.expired) {
+          if (health.exists && !health.processAlive && !health.expired && !health.resultStatus) {
             statusText += `**🔧 Troubleshooting Tips:**\n`
             statusText += `1. The helper process may have crashed\n`
-            statusText += `2. Check the log file for errors: ${logFile}\n`
-            statusText += `3. Try running 
-setup_github_auth
- again\n`
-            statusText += `4. Ensure DOLLHOUSE_GITHUB_CLIENT_ID is set\n`
-            statusText += `5. Check your internet connection\n`
+            if (health.hasLog) {
+              statusText += `2. Check the log file for errors: ${logFile}\n`
+              statusText += `3. Try running \`setup_github_auth\` again\n`
+              statusText += `4. Ensure DOLLHOUSE_GITHUB_CLIENT_ID is set\n`
+              statusText += `5. Check your internet connection\n`
+            } else {
+              statusText += `2. Try running \`setup_github_auth\` again\n`
+              statusText += `3. Ensure DOLLHOUSE_GITHUB_CLIENT_ID is set\n`
+              statusText += `4. Check your internet connection\n`
+            }
           }
           
           if (health.exists && (health.expired || !health.processAlive)) {
             statusText += `\n**🧹 Manual Cleanup (if needed):**\n`
             statusText += '```bash'
             statusText += `rm "${stateFile}"\n`
+            statusText += `rm "${resultFile}"\n`
             statusText += `rm "${logFile}"\n`
             statusText += `rm "${pidFile}"\n`
             statusText += '```';
@@ -457,20 +531,45 @@ setup_github_auth
         const homeDir = this.getDollhouseHomeDir();
         const stateFile = path.join(homeDir, '.dollhouse', '.auth', 'oauth-helper-state.json');
         const logFile = path.join(homeDir, '.dollhouse', 'oauth-helper.log');
+        const resultFile = path.join(homeDir, '.dollhouse', '.auth', 'oauth-helper-result.json');
         
         const health = {
           exists: false,
           isActive: false,
           expired: false,
           processAlive: false,
+          hasResult: false,
           hasLog: false,
           userCode: '',
           timeRemaining: 0,
           pid: 0,
           startTime: null as Date | null,
           expiresAt: null as Date | null,
+          completedAt: null as Date | null,
+          resultStatus: null as OAuthHelperTerminalStatus | null,
+          resultError: '',
+          resultAttempts: undefined as number | undefined,
           errorLog: ''
         };
+
+        try {
+          const resultData = await this.fileOperations.readFile(resultFile, {
+            source: 'GitHubAuthHandler.checkOAuthHelperHealth'
+          });
+          const result = JSON.parse(resultData) as Partial<OAuthHelperTerminalResult>;
+          if (this.isOAuthHelperTerminalStatus(result.status)) {
+            health.exists = true;
+            health.hasResult = true;
+            health.resultStatus = result.status;
+            health.resultError = typeof result.error === 'string' ? result.error : '';
+            health.resultAttempts = typeof result.attempts === 'number' ? result.attempts : undefined;
+            health.completedAt = typeof result.completedAt === 'string' ? new Date(result.completedAt) : null;
+          }
+        } catch (error) {
+          if (!(error instanceof Error && error.message.includes('ENOENT'))) {
+            logger.debug('Error reading OAuth helper result', { error });
+          }
+        }
         
         try {
           const stateData = await this.fileOperations.readFile(stateFile, {
@@ -484,7 +583,9 @@ setup_github_auth
           health.expiresAt = new Date(state.expiresAt);
 
           const now = new Date();
-          if (health.expiresAt > now) {
+          if (health.resultStatus) {
+            health.isActive = false;
+          } else if (health.expiresAt > now) {
             health.isActive = true;
             health.timeRemaining = Math.ceil((health.expiresAt.getTime() - now.getTime()) / 1000);
 
@@ -505,32 +606,6 @@ setup_github_auth
           } else {
             health.expired = true;
           }
-
-          // Check if log file exists
-          health.hasLog = await this.fileOperations.exists(logFile);
-
-          // Read error log if process is dead or expired, or if verbose mode is on
-          if (health.hasLog && (!health.processAlive || health.expired)) {
-            try {
-              const logContent = await this.fileOperations.readFile(logFile, {
-                source: 'GitHubAuthHandler.checkOAuthHelperHealth'
-              });
-              const lines = logContent.split('\n');
-              const importantLines = lines.filter(line =>
-                line.toLowerCase().includes('error') ||
-                line.toLowerCase().includes('fail') ||
-                line.includes('❌') ||
-                line.includes('⚠️')
-              ).slice(-10); // Get last 10 relevant lines
-
-              if (importantLines.length > 0) {
-                health.errorLog = importantLines.join('\n');
-              }
-            } catch {
-              // Intentionally empty - ignore if log file read fails
-            }
-          }
-
         } catch (error) {
           // If state file is not found (ENOENT), it's expected, so don't log as debug
           if (error instanceof Error && error.message.includes('ENOENT')) {
@@ -539,8 +614,75 @@ setup_github_auth
             logger.debug('Error reading OAuth helper state', { error });
           }
         }
+
+        health.hasLog = await this.fileOperations.exists(logFile);
+
+        if (health.hasLog && (!health.processAlive || health.expired || health.resultStatus)) {
+          try {
+            const logContent = await this.fileOperations.readFile(logFile, {
+              source: 'GitHubAuthHandler.checkOAuthHelperHealth'
+            });
+            const lines = logContent.split('\n');
+            const importantLines = lines.filter(line =>
+              line.toLowerCase().includes('error') ||
+              line.toLowerCase().includes('fail') ||
+              line.includes('❌') ||
+              line.includes('⚠️')
+            ).slice(-10);
+
+            if (importantLines.length > 0) {
+              health.errorLog = importantLines.join('\n');
+            }
+          } catch {
+            // Intentionally empty - ignore if log file read fails
+          }
+        }
         
         return health;
+    }
+
+    private isOAuthHelperTerminalStatus(status: unknown): status is OAuthHelperTerminalStatus {
+        return status === 'success' ||
+               status === 'failed' ||
+               status === 'expired' ||
+               status === 'denied' ||
+               status === 'timeout';
+    }
+
+    private formatOAuthHelperTerminalStatus(status: OAuthHelperTerminalStatus) {
+        switch (status) {
+          case 'success':
+            return {
+              icon: '✅',
+              title: 'Completed',
+              defaultMessage: 'The OAuth helper completed successfully.'
+            };
+          case 'expired':
+            return {
+              icon: '⏱️',
+              title: 'Expired',
+              defaultMessage: 'The GitHub authentication request expired.'
+            };
+          case 'denied':
+            return {
+              icon: '🚫',
+              title: 'Denied',
+              defaultMessage: 'The GitHub authentication request was denied.'
+            };
+          case 'timeout':
+            return {
+              icon: '⏱️',
+              title: 'Timed Out',
+              defaultMessage: 'The GitHub authentication request timed out.'
+            };
+          case 'failed':
+          default:
+            return {
+              icon: '❌',
+              title: 'Failed',
+              defaultMessage: 'The OAuth helper failed before authentication completed.'
+            };
+        }
     }
 
     async clearGitHubAuth() {

--- a/tests/unit/auth/oauth-helper.test.ts
+++ b/tests/unit/auth/oauth-helper.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from '@jest/globals';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+describe('oauth-helper token handoff', () => {
+  async function withTempHome(fn: (homeDir: string) => Promise<void>) {
+    const tempHome = await fsp.mkdtemp(path.join(os.tmpdir(), 'oauth-helper-'));
+    try {
+      await fn(tempHome);
+    } finally {
+      await fsp.rm(tempHome, { recursive: true, force: true });
+    }
+  }
+
+  it('stores device-flow tokens where GitHubAuthManager can read them', async () => {
+    await withTempHome(async (homeDir) => {
+      const mockFetchPath = path.join(homeDir, 'mock-fetch.mjs');
+      await fsp.writeFile(
+        mockFetchPath,
+        [
+          'globalThis.fetch = async () => ({',
+          '  async json() {',
+          "    return { access_token: 'gho_fake_token_for_repro_1234567890' };",
+          '  }',
+          '});',
+          ''
+        ].join('\n'),
+        'utf8'
+      );
+
+      const authDir = path.join(homeDir, '.dollhouse', '.auth');
+      await fsp.mkdir(authDir, { recursive: true });
+      const statePath = path.join(authDir, 'oauth-helper-state.json');
+      await fsp.writeFile(
+        statePath,
+        JSON.stringify({
+          pid: 12345,
+          deviceCode: 'device-code',
+          userCode: 'TEST-CODE',
+          startTime: new Date().toISOString(),
+          expiresAt: new Date(Date.now() + 60_000).toISOString()
+        }),
+        'utf8'
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          '--import',
+          mockFetchPath,
+          path.join(process.cwd(), 'oauth-helper.mjs'),
+          'device-code',
+          '1',
+          '3',
+          'Ov23liClient'
+        ],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            HOME: homeDir,
+            USERPROFILE: homeDir,
+            DOLLHOUSE_HOME_DIR: homeDir,
+            DOLLHOUSE_TOKEN_SECRET: 'test-secret-only'
+          },
+          encoding: 'utf8',
+          timeout: 10_000
+        }
+      );
+
+      const pendingTokenPath = path.join(authDir, 'pending_token.txt');
+      const encryptedTokenPath = path.join(authDir, 'github_token.enc');
+      const resultPath = path.join(authDir, 'oauth-helper-result.json');
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain('GitHub authentication successful');
+      expect(fs.existsSync(encryptedTokenPath)).toBe(true);
+      expect(fs.existsSync(pendingTokenPath)).toBe(false);
+      expect(fs.existsSync(statePath)).toBe(false);
+      expect(fs.existsSync(resultPath)).toBe(true);
+
+      const terminalResult = JSON.parse(await fsp.readFile(resultPath, 'utf8'));
+      expect(terminalResult.status).toBe('success');
+      expect(terminalResult.attempts).toBe(1);
+      expect(terminalResult.completedAt).toBeTruthy();
+      expect(JSON.stringify(terminalResult)).not.toContain('gho_fake_token_for_repro_1234567890');
+
+      const readTokenPath = path.join(homeDir, 'read-token.mjs');
+      const tokenManagerUrl = pathToFileURL(
+        path.join(process.cwd(), 'dist/security/tokenManager.js')
+      ).href;
+      await fsp.writeFile(
+        readTokenPath,
+        [
+          "import fs from 'node:fs/promises';",
+          `const { TokenManager } = await import(${JSON.stringify(tokenManagerUrl)});`,
+          '',
+          'const tokenManager = new TokenManager({',
+          '  async createDirectory(directoryPath) {',
+          '    await fs.mkdir(directoryPath, { recursive: true });',
+          '  },',
+          '  async readFile(filePath) {',
+          "    return fs.readFile(filePath, 'utf8');",
+          '  },',
+          '  async writeFile(filePath, content) {',
+          "    await fs.writeFile(filePath, content, { encoding: 'utf8' });",
+          '  },',
+          '  async chmod(filePath, mode) {',
+          '    await fs.chmod(filePath, mode);',
+          '  },',
+          '  async exists(filePath) {',
+          '    try {',
+          '      await fs.access(filePath);',
+          '      return true;',
+          '    } catch {',
+          '      return false;',
+          '    }',
+          '  }',
+          '});',
+          '',
+          'const token = await tokenManager.retrieveGitHubToken();',
+          'process.stdout.write(token ?? "");',
+          ''
+        ].join('\n'),
+        'utf8'
+      );
+
+      const readResult = spawnSync(process.execPath, [readTokenPath], {
+        cwd: homeDir,
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          USERPROFILE: homeDir,
+          DOLLHOUSE_HOME_DIR: homeDir,
+          DOLLHOUSE_TOKEN_SECRET: 'test-secret-only'
+        },
+        encoding: 'utf8',
+        timeout: 10_000
+      });
+
+      expect(readResult.status).toBe(0);
+      expect(readResult.stderr).toBe('');
+      expect(readResult.stdout).toBe('gho_fake_token_for_repro_1234567890');
+    });
+  });
+
+  it('records access denial as a terminal result without token data', async () => {
+    await withTempHome(async (homeDir) => {
+      const mockFetchPath = path.join(homeDir, 'mock-fetch.mjs');
+      await fsp.writeFile(
+        mockFetchPath,
+        [
+          'globalThis.fetch = async () => ({',
+          '  async json() {',
+          "    return { error: 'access_denied' };",
+          '  }',
+          '});',
+          ''
+        ].join('\n'),
+        'utf8'
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          '--import',
+          mockFetchPath,
+          path.join(process.cwd(), 'oauth-helper.mjs'),
+          'device-code',
+          '1',
+          '3',
+          'Ov23liClient'
+        ],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            HOME: homeDir,
+            USERPROFILE: homeDir,
+            DOLLHOUSE_HOME_DIR: homeDir,
+            DOLLHOUSE_TOKEN_SECRET: 'test-secret-only'
+          },
+          encoding: 'utf8',
+          timeout: 10_000
+        }
+      );
+
+      const resultPath = path.join(homeDir, '.dollhouse', '.auth', 'oauth-helper-result.json');
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('OAUTH_ACCESS_DENIED');
+      expect(fs.existsSync(resultPath)).toBe(true);
+
+      const terminalResult = JSON.parse(await fsp.readFile(resultPath, 'utf8'));
+      expect(terminalResult.status).toBe('denied');
+      expect(terminalResult.error).toContain('User denied authorization');
+      expect(JSON.stringify(terminalResult)).not.toContain('access_token');
+      expect(JSON.stringify(terminalResult)).not.toContain('device-code');
+    });
+  });
+
+  it('writes helper state and result files under DOLLHOUSE_HOME_DIR when configured', async () => {
+    await withTempHome(async (homeDir) => {
+      const dollhouseHome = path.join(homeDir, 'custom-dollhouse-home');
+      const mockFetchPath = path.join(homeDir, 'mock-fetch.mjs');
+      await fsp.writeFile(
+        mockFetchPath,
+        [
+          'globalThis.fetch = async () => ({',
+          '  async json() {',
+          "    return { error: 'access_denied' };",
+          '  }',
+          '});',
+          ''
+        ].join('\n'),
+        'utf8'
+      );
+
+      const authDir = path.join(dollhouseHome, '.dollhouse', '.auth');
+      await fsp.mkdir(authDir, { recursive: true });
+      const statePath = path.join(authDir, 'oauth-helper-state.json');
+      await fsp.writeFile(
+        statePath,
+        JSON.stringify({
+          pid: 12345,
+          deviceCode: 'device-code',
+          userCode: 'TEST-CODE',
+          startTime: new Date().toISOString(),
+          expiresAt: new Date(Date.now() + 60_000).toISOString()
+        }),
+        'utf8'
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          '--import',
+          mockFetchPath,
+          path.join(process.cwd(), 'oauth-helper.mjs'),
+          'device-code',
+          '1',
+          '3',
+          'Ov23liClient'
+        ],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            HOME: homeDir,
+            USERPROFILE: homeDir,
+            DOLLHOUSE_HOME_DIR: dollhouseHome,
+            DOLLHOUSE_TOKEN_SECRET: 'test-secret-only'
+          },
+          encoding: 'utf8',
+          timeout: 10_000
+        }
+      );
+
+      const resultPath = path.join(authDir, 'oauth-helper-result.json');
+      const defaultHomeResultPath = path.join(homeDir, '.dollhouse', '.auth', 'oauth-helper-result.json');
+
+      expect(result.status).toBe(1);
+      expect(fs.existsSync(statePath)).toBe(false);
+      expect(fs.existsSync(resultPath)).toBe(true);
+      expect(fs.existsSync(defaultHomeResultPath)).toBe(false);
+    });
+  });
+});

--- a/tests/unit/handlers/GitHubAuthHandler.test.ts
+++ b/tests/unit/handlers/GitHubAuthHandler.test.ts
@@ -345,5 +345,82 @@ describe('GitHubAuthHandler (DI)', () => {
         expect(response.content[0].text).toContain('ERROR polling failed');
       });
     });
+
+    it('reports helper completion from terminal result without crash language', async () => {
+      await withTempHome(async (homeDir) => {
+        const stateDir = path.join(homeDir, '.dollhouse', '.auth');
+        await fs.mkdir(stateDir, { recursive: true });
+        await fs.writeFile(
+          path.join(stateDir, 'oauth-helper-state.json'),
+          JSON.stringify({
+            pid: 7777,
+            deviceCode: 'device',
+            userCode: 'DONE-1234',
+            startTime: new Date().toISOString(),
+            expiresAt: new Date(Date.now() + 120_000).toISOString()
+          }, null, 2),
+          'utf-8'
+        );
+        await fs.writeFile(
+          path.join(stateDir, 'oauth-helper-result.json'),
+          JSON.stringify({
+            status: 'success',
+            attempts: 1,
+            completedAt: new Date().toISOString()
+          }, null, 2),
+          'utf-8'
+        );
+
+        const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => {
+          throw new Error('dead process');
+        });
+
+        authManager.getAuthStatus.mockResolvedValue({ isAuthenticated: false, hasToken: false } as any);
+        const response = await handler.checkGitHubAuth();
+
+        expect(response.content[0].text).toContain('Authentication Completed');
+        expect(response.content[0].text).toContain('token is not available');
+        expect(response.content[0].text).not.toContain('Authentication In Progress');
+        expect(response.content[0].text).not.toContain('crashed');
+
+        killSpy.mockRestore();
+      });
+    });
+
+    it('reports terminal helper failure without missing-log troubleshooting', async () => {
+      await withTempHome(async (homeDir) => {
+        const stateDir = path.join(homeDir, '.dollhouse', '.auth');
+        await fs.mkdir(stateDir, { recursive: true });
+        await fs.writeFile(
+          path.join(stateDir, 'oauth-helper-state.json'),
+          JSON.stringify({
+            pid: 8888,
+            deviceCode: 'device',
+            userCode: 'FAIL-1234',
+            startTime: new Date().toISOString(),
+            expiresAt: new Date(Date.now() + 120_000).toISOString()
+          }, null, 2),
+          'utf-8'
+        );
+        await fs.writeFile(
+          path.join(stateDir, 'oauth-helper-result.json'),
+          JSON.stringify({
+            status: 'failed',
+            error: 'OAUTH_TOKEN_STORAGE_FAILED: disk full',
+            attempts: 1,
+            completedAt: new Date().toISOString()
+          }, null, 2),
+          'utf-8'
+        );
+
+        authManager.getAuthStatus.mockResolvedValue({ isAuthenticated: false, hasToken: false } as any);
+        const response = await handler.getOAuthHelperStatus();
+
+        expect(response.content[0].text).toContain('FAILED');
+        expect(response.content[0].text).toContain('OAUTH_TOKEN_STORAGE_FAILED: disk full');
+        expect(response.content[0].text).not.toContain('may have crashed');
+        expect(response.content[0].text).not.toContain('Check the log file for errors');
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #2262.

This updates the detached device-flow helper so it stores OAuth tokens through the current `TokenManager` instance API, removes the unconsumed `pending_token.txt` success fallback, and records explicit terminal helper results for status reporting.

## Changes

- Instantiate `TokenManager` inside `oauth-helper.mjs` with the helper's file-operations adapter before storing device-flow tokens.
- Remove the plaintext `pending_token.txt` success fallback from the helper path and report storage failures as non-zero helper failures.
- Write a small non-sensitive `oauth-helper-result.json` on terminal helper paths and clean stale helper state when the helper finishes.
- Teach `GitHubAuthHandler` to report completed, failed, expired, denied, and timed-out helper results without inferring a crash from expected process exit.
- Avoid pointing users at a missing debug log when OAuth debug logging is disabled.
- Keep helper state/result/pid/log files aligned with `DOLLHOUSE_HOME_DIR` when it is configured.
- Add subprocess and handler regressions for token storage, terminal result files, state cleanup, and diagnostics.

## Verification

```bash
npm test -- tests/unit/auth/oauth-helper.test.ts --runInBand
npm test -- tests/unit/auth/oauth-helper.test.ts tests/unit/handlers/GitHubAuthHandler.test.ts tests/unit/auth/GitHubAuthManager.test.ts tests/unit/security/tokenManager.storage.test.ts --runInBand
npm run build
```
