### PR TITLE
Fix beta security audit findings

### DIFF
--- a/.security-suppressions.json
+++ b/.security-suppressions.json
@@ -88,6 +88,11 @@
       "reason": "Delegates to specialized services - logging happens in CollectionBrowser/ElementInstaller"
     },
     {
+      "rule": "DMCP-SEC-006",
+      "file": "src/auth/instrumentAuthProvider.ts",
+      "reason": "Performance-only instrumentation wrapper. Concrete auth providers own TOKEN_VALIDATION_FAILURE audit logging with issuer/key/provider context, and this wrapper intentionally avoids duplicate security events."
+    },
+    {
       "rule": "DMCP-SEC-004",
       "file": "src/auto-dollhouse/operationExtensions.ts",
       "reason": "Static schema/route definitions only — no runtime user input processing. Actual Unicode normalization is in evaluatePermission.ts and permissionRoutes.ts."

--- a/scripts/run-security-audit.ts
+++ b/scripts/run-security-audit.ts
@@ -76,8 +76,11 @@ async function runSecurityAudit() {
     // Suppressions file doesn't exist or is invalid - that's OK
   }
 
-  // Add suppressions for test files and custom suppressions
+  // Add suppressions for test files and custom suppressions without dropping
+  // the default CI suppressions loaded by SecurityAuditor.getDefaultConfig().
+  const defaultSuppressions = config.suppressions ?? [];
   config.suppressions = [
+    ...defaultSuppressions,
     {
       rule: 'CWE-89-001',
       file: '__tests__/**/*',

--- a/src/auth/OidcAuthProvider.ts
+++ b/src/auth/OidcAuthProvider.ts
@@ -129,18 +129,26 @@ export class OidcAuthProvider implements IAuthProvider {
         algorithms: [...this.algorithms],
         ...(this.requireAccessTokenTyp ? { typ: 'at+jwt' } : {}),
       });
-      return buildOidcAuthResult(payload);
+      const result = buildOidcAuthResult(payload);
+      if (!result.ok) {
+        this.logTokenValidationFailure(result.reason);
+      }
+      return result;
     } catch (error) {
       const reason = mapOidcVerifyError(error);
-      SecurityMonitor.logSecurityEvent({
-        type: 'TOKEN_VALIDATION_FAILURE',
-        severity: 'MEDIUM',
-        source: 'OidcAuthProvider.validate',
-        details: 'OIDC access token validation failed',
-        additionalData: { provider: this.name, issuer: this.issuer, reason },
-      });
+      this.logTokenValidationFailure(reason);
       return { ok: false, reason };
     }
+  }
+
+  private logTokenValidationFailure(reason: string): void {
+    SecurityMonitor.logSecurityEvent({
+      type: 'TOKEN_VALIDATION_FAILURE',
+      severity: 'MEDIUM',
+      source: 'OidcAuthProvider.validate',
+      details: 'OIDC access token validation failed',
+      additionalData: { provider: this.name, issuer: this.issuer, reason },
+    });
   }
 }
 

--- a/src/auth/OidcAuthProvider.ts
+++ b/src/auth/OidcAuthProvider.ts
@@ -19,6 +19,7 @@ import { jwtVerify, createRemoteJWKSet, errors as joseErrors } from 'jose';
 import type { JWTVerifyGetKey } from 'jose';
 import { logger } from '../utils/logger.js';
 import type { IAuthProvider, AuthResult, AuthClaims } from './IAuthProvider.js';
+import { SecurityMonitor } from '../security/securityMonitor.js';
 
 export interface OidcAuthProviderOptions {
   /** OIDC issuer URL (e.g. "https://tenant.auth0.com/"). */
@@ -130,7 +131,15 @@ export class OidcAuthProvider implements IAuthProvider {
       });
       return buildOidcAuthResult(payload);
     } catch (error) {
-      return { ok: false, reason: mapOidcVerifyError(error) };
+      const reason = mapOidcVerifyError(error);
+      SecurityMonitor.logSecurityEvent({
+        type: 'TOKEN_VALIDATION_FAILURE',
+        severity: 'MEDIUM',
+        source: 'OidcAuthProvider.validate',
+        details: 'OIDC access token validation failed',
+        additionalData: { provider: this.name, issuer: this.issuer, reason },
+      });
+      return { ok: false, reason };
     }
   }
 }

--- a/src/auth/OidcAuthProvider.ts
+++ b/src/auth/OidcAuthProvider.ts
@@ -146,7 +146,7 @@ export class OidcAuthProvider implements IAuthProvider {
       type: 'TOKEN_VALIDATION_FAILURE',
       severity: 'MEDIUM',
       source: 'OidcAuthProvider.validate',
-      details: 'OIDC access token validation failed',
+      details: `OIDC access token validation failed: ${reason} [provider:${this.name}]`,
       additionalData: { provider: this.name, issuer: this.issuer, reason },
     });
   }

--- a/src/auth/embedded-as/EmbeddedASTokens.ts
+++ b/src/auth/embedded-as/EmbeddedASTokens.ts
@@ -94,10 +94,18 @@ export class EmbeddedASTokens {
     await this.ensureInitialized();
     try {
       const protectedHeader = decodeProtectedHeader(token);
-      if (!protectedHeader.kid) return { ok: false, reason: 'token missing kid header' };
+      if (!protectedHeader.kid) {
+        return logEmbeddedTokenValidationResult(
+          { ok: false, reason: 'token missing kid header' },
+          'EmbeddedASTokens.validateWithStore',
+        );
+      }
       const key = await requiredSigningKeyStore(this.signingKeyStore).getByKid(protectedHeader.kid);
       if (!(key?.kind === 'jwks' && key.retiredAt === undefined)) {
-        return { ok: false, reason: 'unknown key id' };
+        return logEmbeddedTokenValidationResult(
+          { ok: false, reason: 'unknown key id' },
+          'EmbeddedASTokens.validateWithStore',
+        );
       }
       const keyset = signingKeyToKeyset(key);
       const { publicSigningKey } = await importSigningKeys(keyset);

--- a/src/auth/embedded-as/EmbeddedASTokens.ts
+++ b/src/auth/embedded-as/EmbeddedASTokens.ts
@@ -20,6 +20,7 @@ import type {
   ISigningKeyStore,
   SigningKey,
 } from '../../storage/signingKeys/ISigningKeyStore.js';
+import { SecurityMonitor } from '../../security/securityMonitor.js';
 
 export const ALGORITHM = 'ES256';
 export const DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 3600;
@@ -56,9 +57,15 @@ export class EmbeddedASTokens {
         typ: 'at+jwt',
         crit: {},
       });
-      return buildEmbeddedAsAuthResult(payload, protectedHeader, keyset.kid);
+      return logEmbeddedTokenValidationResult(
+        buildEmbeddedAsAuthResult(payload, protectedHeader, keyset.kid),
+        'EmbeddedASTokens.validate',
+      );
     } catch (error) {
-      return { ok: false, reason: mapEmbeddedAsVerifyError(error) };
+      return logEmbeddedTokenValidationResult(
+        { ok: false, reason: mapEmbeddedAsVerifyError(error) },
+        'EmbeddedASTokens.validate',
+      );
     }
   }
 
@@ -101,9 +108,15 @@ export class EmbeddedASTokens {
         typ: 'at+jwt',
         crit: {},
       });
-      return buildEmbeddedAsAuthResult(payload, protectedHeader, keyset.kid);
+      return logEmbeddedTokenValidationResult(
+        buildEmbeddedAsAuthResult(payload, protectedHeader, keyset.kid),
+        'EmbeddedASTokens.validateWithStore',
+      );
     } catch (error) {
-      return { ok: false, reason: mapEmbeddedAsVerifyError(error) };
+      return logEmbeddedTokenValidationResult(
+        { ok: false, reason: mapEmbeddedAsVerifyError(error) },
+        'EmbeddedASTokens.validateWithStore',
+      );
     }
   }
 
@@ -239,4 +252,17 @@ function signingKeyToKeyset(key: SigningKey): SigningKeyset {
 function requiredSigningKeyStore(store: ISigningKeyStore | undefined): ISigningKeyStore {
   if (!store) throw new Error('Signing key store is required');
   return store;
+}
+
+function logEmbeddedTokenValidationResult(result: AuthResult, source: string): AuthResult {
+  if (!result.ok) {
+    SecurityMonitor.logSecurityEvent({
+      type: 'TOKEN_VALIDATION_FAILURE',
+      severity: 'MEDIUM',
+      source,
+      details: 'Embedded authorization server token validation failed',
+      additionalData: { reason: result.reason },
+    });
+  }
+  return result;
 }

--- a/src/auth/embedded-as/totp/AdminTotpService.ts
+++ b/src/auth/embedded-as/totp/AdminTotpService.ts
@@ -258,9 +258,13 @@ function logTotpEvent(
     type,
     severity,
     source: 'AdminTotpService',
-    details,
+    details: `${details} [principal:${auditPrincipalFingerprint(userId)}]`,
     additionalData: { userId },
   });
+}
+
+function auditPrincipalFingerprint(userId: string): string {
+  return createHash('sha256').update(userId, 'utf8').digest('hex').slice(0, 16);
 }
 
 function secretOwnerId(userId: string, factorId: string): string {

--- a/src/auth/embedded-as/totp/AdminTotpService.ts
+++ b/src/auth/embedded-as/totp/AdminTotpService.ts
@@ -4,6 +4,7 @@ import { Secret, TOTP } from 'otpauth';
 import type { IAuthStorageLayer } from '../storage/IAuthStorageLayer.js';
 import type { ISecretEncryptionService } from '../../../web-console/security/SecretEncryption.js';
 import type { IConsoleFactorStore } from '../../../web-console/stores/IConsoleFactorStore.js';
+import { SecurityMonitor } from '../../../security/securityMonitor.js';
 
 const ENROLLMENT_MODEL = 'ConsoleTotpEnrollment';
 const ENROLLMENT_TTL_SECONDS = 10 * 60;
@@ -131,6 +132,7 @@ export class AdminTotpService {
     const pending = await this.readPendingEnrollment(userId, pendingId);
     const secretBase32 = this.decryptPendingSecret(pending);
     if (!verifyTotpCode(secretBase32, pending.label, code, this.now())) {
+      logTotpEvent('TOTP_VERIFICATION_FAILED', 'MEDIUM', 'Admin TOTP enrollment confirmation failed', userId);
       throw new AdminTotpError('Invalid TOTP code', 'invalid_totp_code');
     }
 
@@ -153,6 +155,7 @@ export class AdminTotpService {
       lastUsedAt: null,
     }, backupCodeHashes);
     await this.authStorage.genericDestroy(ENROLLMENT_MODEL, pendingId);
+    logTotpEvent('TOTP_ENROLLED', 'LOW', 'Admin TOTP factor enrolled', userId);
 
     return { factorId, enrolledAt, backupCodes };
   }
@@ -179,6 +182,11 @@ export class AdminTotpService {
       hashBackupCode(normalizeBackupCode(code)),
       authTime,
     );
+    if (consumed) {
+      logTotpEvent('TOTP_BACKUP_CODE_CONSUMED', 'LOW', 'Admin TOTP backup code consumed', userId);
+    } else {
+      logTotpEvent('TOTP_VERIFICATION_FAILED', 'MEDIUM', 'Admin TOTP proof failed', userId);
+    }
     return consumed ? { ok: true, method: 'backup', authTime } : { ok: false };
   }
 
@@ -195,18 +203,25 @@ export class AdminTotpService {
       { secretClass: 'console_totp_seed', ownerId: secretOwnerId(userId, factor.factorId) },
     ).toString('utf8');
     if (verifyTotpCode(secretBase32, userId, code, authTime)) {
-      return await this.factorStore.disableActiveTotp(userId, authTime)
-        ? { ok: true, method: 'totp', authTime }
-        : { ok: false };
+      const disabled = await this.factorStore.disableActiveTotp(userId, authTime);
+      if (disabled) {
+        logTotpEvent('TOTP_DISABLED', 'LOW', 'Admin TOTP factor disabled', userId);
+      }
+      return disabled ? { ok: true, method: 'totp', authTime } : { ok: false };
     }
-    return await this.factorStore.disableActiveTotpWithBackupCode(
+    const disabled = await this.factorStore.disableActiveTotpWithBackupCode(
       userId,
       factor.factorId,
       hashBackupCode(normalizeBackupCode(code)),
       authTime,
-    )
-      ? { ok: true, method: 'backup', authTime }
-      : { ok: false };
+    );
+    if (disabled) {
+      logTotpEvent('TOTP_BACKUP_CODE_CONSUMED', 'LOW', 'Admin TOTP backup code consumed for disable', userId);
+      logTotpEvent('TOTP_DISABLED', 'LOW', 'Admin TOTP factor disabled', userId);
+    } else {
+      logTotpEvent('TOTP_VERIFICATION_FAILED', 'MEDIUM', 'Admin TOTP disable proof failed', userId);
+    }
+    return disabled ? { ok: true, method: 'backup', authTime } : { ok: false };
   }
 
   private async readPendingEnrollment(userId: string, pendingId: string): Promise<PendingEnrollment> {
@@ -231,6 +246,21 @@ function validateLabel(label: string): string {
     throw new AdminTotpError('Invalid TOTP label', 'invalid_label');
   }
   return trimmed;
+}
+
+function logTotpEvent(
+  type: 'TOTP_ENROLLED' | 'TOTP_DISABLED' | 'TOTP_BACKUP_CODE_CONSUMED' | 'TOTP_VERIFICATION_FAILED',
+  severity: 'LOW' | 'MEDIUM',
+  details: string,
+  userId: string,
+): void {
+  SecurityMonitor.logSecurityEvent({
+    type,
+    severity,
+    source: 'AdminTotpService',
+    details,
+    additionalData: { userId },
+  });
 }
 
 function secretOwnerId(userId: string, factorId: string): string {

--- a/src/auth/instrumentAuthProvider.ts
+++ b/src/auth/instrumentAuthProvider.ts
@@ -20,6 +20,7 @@
 
 import type { IAuthProvider, AuthResult } from './IAuthProvider.js';
 import type { PerformanceMonitor } from '../utils/PerformanceMonitor.js';
+import { SecurityMonitor } from '../security/securityMonitor.js';
 
 const OP_VALIDATE = 'auth.validateToken';
 
@@ -36,8 +37,19 @@ export function instrumentAuthProvider(
   return new Proxy(provider, {
     get(target, prop, receiver) {
       if (prop === 'validate') {
-        return (token: string): Promise<AuthResult> =>
-          monitor.timeAuthOp(OP_VALIDATE, () => target.validate(token), target.name);
+        return async (token: string): Promise<AuthResult> => {
+          const result = await monitor.timeAuthOp(OP_VALIDATE, () => target.validate(token), target.name);
+          if (!result.ok) {
+            SecurityMonitor.logSecurityEvent({
+              type: 'TOKEN_VALIDATION_FAILURE',
+              severity: 'LOW',
+              source: 'instrumentAuthProvider',
+              details: `Instrumented provider token validation failed: ${target.name}`,
+              additionalData: { provider: target.name, reason: result.reason },
+            });
+          }
+          return result;
+        };
       }
       const value = Reflect.get(target, prop, receiver);
       return typeof value === 'function' ? value.bind(target) : value;

--- a/src/auth/instrumentAuthProvider.ts
+++ b/src/auth/instrumentAuthProvider.ts
@@ -9,9 +9,10 @@
  * because IAuthProvider is the outer abstraction the HTTP middleware
  * calls on every request.
  *
- * Same design intent as instrumentAuthMethod: wrap from outside so the
- * concrete provider class file is untouched (no SonarCloud complexity
- * re-flag on the existing validate() bodies).
+ * Audit logging remains owned by concrete providers because they have the
+ * issuer/key/source context operators need. This wrapper is performance-only
+ * so one validation failure does not emit duplicate TOKEN_VALIDATION_FAILURE
+ * events when a concrete provider already logged the failure.
  *
  * When `monitor` is undefined, returns the original provider untouched.
  *
@@ -20,7 +21,6 @@
 
 import type { IAuthProvider, AuthResult } from './IAuthProvider.js';
 import type { PerformanceMonitor } from '../utils/PerformanceMonitor.js';
-import { SecurityMonitor } from '../security/securityMonitor.js';
 
 const OP_VALIDATE = 'auth.validateToken';
 
@@ -37,19 +37,8 @@ export function instrumentAuthProvider(
   return new Proxy(provider, {
     get(target, prop, receiver) {
       if (prop === 'validate') {
-        return async (token: string): Promise<AuthResult> => {
-          const result = await monitor.timeAuthOp(OP_VALIDATE, () => target.validate(token), target.name);
-          if (!result.ok) {
-            SecurityMonitor.logSecurityEvent({
-              type: 'TOKEN_VALIDATION_FAILURE',
-              severity: 'LOW',
-              source: 'instrumentAuthProvider',
-              details: `Instrumented provider token validation failed: ${target.name}`,
-              additionalData: { provider: target.name, reason: result.reason },
-            });
-          }
-          return result;
-        };
+        return (token: string): Promise<AuthResult> =>
+          monitor.timeAuthOp(OP_VALIDATE, () => target.validate(token), target.name);
       }
       const value = Reflect.get(target, prop, receiver);
       return typeof value === 'function' ? value.bind(target) : value;

--- a/src/cli/allowlist.ts
+++ b/src/cli/allowlist.ts
@@ -35,6 +35,7 @@
 import { Command } from 'commander';
 import { openCliAuthStorage, type CliAuthStorageHandle } from './cliAuthStorage.js';
 import type { AuthAllowlistEntry, AuthAllowlistKind } from '../auth/embedded-as/storage/IAuthStorageLayer.js';
+import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
 
 const VALID_KINDS: readonly AuthAllowlistKind[] = ['email', 'github_username', 'github_id'];
 
@@ -68,6 +69,10 @@ function assertValidKind(kind: string): asserts kind is AuthAllowlistKind {
   }
 }
 
+function normalizeCliInput(value: string): string {
+  return UnicodeValidator.normalize(value).normalizedContent;
+}
+
 function formatEntry(e: AuthAllowlistEntry): string {
   const note = e.note ? ` — ${e.note}` : '';
   const by = e.createdBy ? ` (added by ${e.createdBy})` : '';
@@ -76,23 +81,26 @@ function formatEntry(e: AuthAllowlistEntry): string {
 }
 
 async function runAdd(handle: CliAuthStorageHandle, opts: AddOptions): Promise<void> {
-  assertValidKind(opts.kind);
-  if (!opts.value || opts.value.trim().length === 0) {
+  const kind = normalizeCliInput(opts.kind).trim();
+  const value = normalizeCliInput(opts.value).trim();
+  const note = opts.note === undefined ? undefined : normalizeCliInput(opts.note);
+  assertValidKind(kind);
+  if (!value) {
     process.stderr.write('--value is required.\n');
     process.exit(1);
   }
   try {
     const entry = await handle.storage.allowlistAdd({
-      kind: opts.kind,
-      value: opts.value,
-      note: opts.note ?? null,
+      kind,
+      value,
+      note: note ?? null,
       createdBy: 'cli',
     });
     process.stdout.write(`Added: ${formatEntry(entry)}\n`);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes('already exists')) {
-      process.stderr.write(`Entry already exists for kind=${opts.kind} value=${opts.value.toLowerCase()}\n`);
+      process.stderr.write(`Entry already exists for kind=${kind} value=${value.toLowerCase()}\n`);
       process.exit(1);
     }
     throw err;
@@ -100,15 +108,16 @@ async function runAdd(handle: CliAuthStorageHandle, opts: AddOptions): Promise<v
 }
 
 async function runList(handle: CliAuthStorageHandle, opts: ListOptions): Promise<void> {
-  if (opts.kind !== undefined) {
-    assertValidKind(opts.kind);
+  const kind = opts.kind === undefined ? undefined : normalizeCliInput(opts.kind).trim();
+  if (kind !== undefined) {
+    assertValidKind(kind);
   }
   const all = await handle.storage.allowlistList();
-  const filtered = opts.kind ? all.filter(e => e.kind === opts.kind) : all;
+  const filtered = kind ? all.filter(e => e.kind === kind) : all;
   if (filtered.length === 0) {
     process.stdout.write(
-      opts.kind
-        ? `No allowlist entries of kind '${opts.kind}'.\n`
+      kind
+        ? `No allowlist entries of kind '${kind}'.\n`
         : 'Allowlist is empty.\n',
     );
     return;
@@ -139,18 +148,19 @@ async function runRemove(handle: CliAuthStorageHandle, opts: RemoveOptions): Pro
 
   let targetId: string;
   if (byId) {
-    targetId = opts.id!;
+    targetId = normalizeCliInput(opts.id!).trim();
   } else {
     if (opts.kind === undefined || opts.value === undefined) {
       process.stderr.write('--kind and --value are both required when removing by value.\n');
       process.exit(1);
     }
-    assertValidKind(opts.kind);
-    const value = opts.value.toLowerCase();
+    const kind = normalizeCliInput(opts.kind).trim();
+    assertValidKind(kind);
+    const value = normalizeCliInput(opts.value).trim().toLowerCase();
     const all = await handle.storage.allowlistList();
-    const found = all.find(e => e.kind === opts.kind && e.value === value);
+    const found = all.find(e => e.kind === kind && e.value === value);
     if (!found) {
-      process.stderr.write(`No allowlist entry found for kind=${opts.kind} value=${value}\n`);
+      process.stderr.write(`No allowlist entry found for kind=${kind} value=${value}\n`);
       process.exit(1);
     }
     targetId = found.id;
@@ -165,7 +175,8 @@ async function runRemove(handle: CliAuthStorageHandle, opts: RemoveOptions): Pro
 }
 
 async function runUpdate(handle: CliAuthStorageHandle, opts: UpdateOptions): Promise<void> {
-  if (!opts.id || opts.id.trim().length === 0) {
+  const id = normalizeCliInput(opts.id).trim();
+  if (!id) {
     process.stderr.write('--id is required.\n');
     process.exit(1);
   }
@@ -173,11 +184,12 @@ async function runUpdate(handle: CliAuthStorageHandle, opts: UpdateOptions): Pro
     process.stderr.write('Nothing to update. Pass --note <text> (or empty string to clear).\n');
     process.exit(1);
   }
-  const updated = await handle.storage.allowlistUpdate(opts.id, {
-    note: opts.note === '' ? null : opts.note,
+  const note = normalizeCliInput(opts.note);
+  const updated = await handle.storage.allowlistUpdate(id, {
+    note: note === '' ? null : note,
   });
   if (!updated) {
-    process.stderr.write(`No allowlist entry found with id '${opts.id}'.\n`);
+    process.stderr.write(`No allowlist entry found with id '${id}'.\n`);
     process.exit(1);
   }
   process.stdout.write(`Updated: ${formatEntry(updated)}\n`);

--- a/src/security/audit/SecurityAuditor.ts
+++ b/src/security/audit/SecurityAuditor.ts
@@ -429,7 +429,7 @@ function toProjectRelativeAuditPath(filePath: string): string {
 
 function globPatternToRegex(pattern: string): RegExp {
   const escaped = pattern
-    .replaceAll(/[\\^$.()+?{}[\]|]/g, '\\$&')
+    .replaceAll(/[\\^$.()+?{}[\]|]/g, String.raw`\$&`)
     .replaceAll('**', '\0')
     .replaceAll('*', '[^/]*')
     .replaceAll('\0/', '(?:.*/)?')

--- a/src/security/audit/SecurityAuditor.ts
+++ b/src/security/audit/SecurityAuditor.ts
@@ -3,7 +3,6 @@
  * Implements automated security auditing for DollhouseMCP (Issue #53)
  */
 
-// import { SecurityMonitor } from '../securityMonitor.js';
 import { logger } from '../../utils/logger.js';
 import type { 
   SecurityAuditConfig, 

--- a/src/security/audit/SecurityAuditor.ts
+++ b/src/security/audit/SecurityAuditor.ts
@@ -180,7 +180,7 @@ export class SecurityAuditor {
 
           if (finding.file) {
             const fileSuppressions = this.suppressions.get(finding.file);
-            if (fileSuppressions?.has(finding.ruleId)) {
+            if (fileSuppressions?.has(finding.ruleId) || this.matchesConfiguredSuppression(finding)) {
               if (this.config.reporting?.verbose) {
                 suppressedFindings.push({
                   rule: finding.ruleId,
@@ -213,6 +213,23 @@ export class SecurityAuditor {
     }
     
     return filtered;
+  }
+
+  private matchesConfiguredSuppression(finding: SecurityFinding): boolean {
+    if (!finding.file || !this.config.suppressions?.length) return false;
+
+    for (const suppression of this.config.suppressions) {
+      if (suppression.rule !== '*' && suppression.rule !== finding.ruleId) {
+        continue;
+      }
+      if (!suppression.file) {
+        return true;
+      }
+      if (configuredSuppressionFileMatches(suppression.file, finding.file)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -383,4 +400,39 @@ export class SecurityAuditor {
       ]
     };
   }
+}
+
+function configuredSuppressionFileMatches(pattern: string, filePath: string): boolean {
+  const normalizedPattern = normalizeAuditPath(pattern);
+  const normalizedFile = normalizeAuditPath(filePath);
+  const relativeFile = toProjectRelativeAuditPath(normalizedFile);
+  const candidates = new Set([normalizedFile, relativeFile]);
+
+  for (const candidate of candidates) {
+    if (candidate === normalizedPattern) return true;
+    if (normalizedPattern.includes('*') && globPatternToRegex(normalizedPattern).test(candidate)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function normalizeAuditPath(value: string): string {
+  return value.replaceAll('\\', '/').replaceAll(/\/+/g, '/').replace(/\/$/, '');
+}
+
+function toProjectRelativeAuditPath(filePath: string): string {
+  if (!path.isAbsolute(filePath)) return filePath;
+  const relative = normalizeAuditPath(path.relative(process.cwd(), filePath));
+  return relative.startsWith('..') ? filePath : relative;
+}
+
+function globPatternToRegex(pattern: string): RegExp {
+  const escaped = pattern
+    .replaceAll(/[\\^$.()+?{}[\]|]/g, '\\$&')
+    .replaceAll('**', '\0')
+    .replaceAll('*', '[^/]*')
+    .replaceAll('\0/', '(?:.*/)?')
+    .replaceAll('\0', '.*');
+  return new RegExp(`^${escaped}$`);
 }

--- a/src/security/audit/config/security-suppressions.json
+++ b/src/security/audit/config/security-suppressions.json
@@ -157,8 +157,243 @@
     },
     {
       "rule": "DMCP-SEC-004",
-      "file": "src/web-console/modules/**/*.ts",
-      "reason": "CENTRALIZED WEB-CONSOLE NORMALIZATION: Route-served console modules receive request params, query values, and JSON body keys through ConsoleUnicodeNormalization before handlers run. New non-route-served module files require manual DMCP-SEC-004 review."
+      "file": "src/web-console/modules/account-admin/AccountAdminBootstrapService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/account-admin/AccountAdminCredentialRevocationService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/account-admin/AccountAdminDeletionService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/account-admin/AccountAdminIdentityService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/account-admin/AccountAdminInviteService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/account-admin/AccountAdminLifecycleMutationService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/account-admin/AccountAdminModule.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/account-admin/AccountAdminReadService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/account-admin/AccountAdminRoleMutationService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/activations/ActivationModule.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/activations/ActivationService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/approvals/ApprovalModule.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/approvals/ApprovalService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/audit/AuditModule.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/audit/AuditQueries.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/audit/PostgresAdminAuditQuery.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/audit/PostgresProductionAuditQueries.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/executions/ExecutionModule.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/executions/ExecutionService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/health/HealthService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/integrations/GitHubAppIntegrationProvider.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/integrations/GitHubIntegrationProvider.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/integrations/IntegrationDtos.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/integrations/IntegrationPrivacyProjectors.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/integrations/IntegrationService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/me-logs/MeLogsModule.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/me-logs/MemoryConsoleLogSource.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/operations/OperationsConfig.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/operations/OperationsModule.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/operations/OperationsService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/operations/OperationsTelemetry.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/operations/SystemMetricsSource.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/portfolio/PortfolioDtos.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/portfolio/PortfolioModule.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/portfolio/PortfolioPrivacyProjectors.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/portfolio/PortfolioService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/runtime-sessions/RuntimeSessionModule.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/security-admin/SecurityAdminModule.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/security-admin/SecurityAdminService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/self-security/SelfSecurityModule.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/self-security/SelfSecurityService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/self-service/SelfServiceModule.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/self-service/SelfServiceProfileService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/self-service/SelfServiceSettingsService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/session-telemetry/OwnedActivityQuery.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/session-telemetry/OwnedMetricQuery.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/session-telemetry/SessionTelemetryModule.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/session-telemetry/SessionTelemetryService.ts",
+      "reason": "WEB-CONSOLE ROUTE MODULE: This existing route-served module is reached through ConsoleSecuredRouterAssembler, which normalizes route params, query values, and JSON body keys before handlers run. Security-sensitive body values must be normalized or strictly validated at their parser boundary; future module files are intentionally not covered by this exact-file suppression."
     },
     {
       "rule": "DMCP-SEC-004",

--- a/src/security/audit/config/security-suppressions.json
+++ b/src/security/audit/config/security-suppressions.json
@@ -109,6 +109,91 @@
       "rule": "DMCP-SEC-004",
       "file": "**/src/auto-dollhouse/index.ts",
       "reason": "Registration entry point only — resolves DI container references and wires deferred startup. No user input processing. All user input flows through MCPAQLHandler which normalizes at its boundary."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/**/*.ts",
+      "reason": "CENTRALIZED WEB-CONSOLE NORMALIZATION: ConsoleUnicodeNormalization middleware normalizes route params, query values, and JSON body strings for both secured and fixture console routers before handlers, modules, stores, or services run. Cookie/header credentials intentionally remain exact-match opaque values."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/ui/*.js",
+      "reason": "Browser console modules send requests through ui/api.js, which applies native NFC normalization to API paths and JSON payload strings before fetch. Server-side ConsoleUnicodeNormalization remains the authoritative boundary for all console route params, query values, and bodies."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/auth/authMiddleware.ts",
+      "reason": "Bearer Authorization values are opaque credentials and must be exact-match validated, not Unicode-folded. MCP request payloads are normalized after authentication by StreamableHttpServer/ServerSetup before tool handlers see user content."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/auth/IAuthProvider.ts",
+      "reason": "Interface contract only for auth providers. Concrete providers validate opaque token strings exactly; payload/user content normalization happens at HTTP/MCP request boundaries after authentication."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/auth/instrumentAuthProvider.ts",
+      "reason": "Instrumentation decorator for IAuthProvider.validate(). It times and audit-logs provider validation outcomes but does not interpret user content; bearer tokens remain opaque exact-match credentials by design."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/auth/embedded-as/**/*.ts",
+      "reason": "Embedded OAuth/OIDC authorization-server layer handles exact protocol artifacts (code, state, verifier, token, cookie bindings) where Unicode normalization would weaken comparisons. Human-visible fields are validated by method-specific policies; MCP/console payload content is normalized at its own ingress boundary."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/context/**/*.ts",
+      "reason": "Context policy/session context helpers receive normalized/validated identities from the auth and MCP ingress layers. They do not parse raw request bodies or free-form user text."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/database/**/*.ts",
+      "reason": "Database schema/RLS/user-context layer consumes typed IDs and records after validation at auth, console, or MCP boundaries. It does not accept raw request payloads directly."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/di/registrars/*.ts",
+      "reason": "DI registrar wiring only. Any strings here are service IDs/config keys; raw user input is normalized by the services/routes registered through the container."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/paths/**/*.ts",
+      "reason": "Path helpers validate strict ASCII identifier/path segments and reject unsafe Unicode rather than normalizing it into acceptable filesystem names. Upstream identity and request payload normalization happens before path resolution."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/server/sseTickets.ts",
+      "reason": "SSE tickets are random base64url opaque credentials bound to a stream name and must be exact-match redeemed once. Normalizing ticket values would weaken token comparison semantics."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/state/**/*.ts",
+      "reason": "State stores persist typed challenge/confirmation records after upstream validation. They do not parse raw request payload text; MCP/console ingress normalization happens before records reach this layer."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/storage/**/*.ts",
+      "reason": "Storage layers persist typed element/config/state records after MCP, web-console, or element-manager validation. They are not raw ingress points; Unicode normalization is enforced before persistence."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "eslint.config.js",
+      "reason": "Build-time ESLint configuration only. Contains rule metadata and file patterns, not production request handling or user-input processing."
+    },
+    {
+      "rule": "DMCP-SEC-006",
+      "file": "src/auth/embedded-as/EmbeddedAuthorizationServer.ts",
+      "reason": "validate() delegates token verification to EmbeddedASTokens, which now emits TOKEN_VALIDATION_FAILURE events via SecurityMonitor. This wrapper only composes the authorization-server routes and provider facade."
+    },
+    {
+      "rule": "DMCP-SEC-006",
+      "file": "src/elements/base/BaseElementManager.ts",
+      "reason": "BaseElementManager.validate() delegates to element-specific validators; load/save/delete audit events are emitted by composed element services and subtype hooks. This method is a pure validation facade, not an authorization decision point."
+    },
+    {
+      "rule": "DMCP-SEC-006",
+      "file": "src/web-console/stores/ManagerBackedPortfolioElementStore.ts",
+      "reason": "Read-side portfolio projection calls manager.validate() to compute validationStatus only. Console administrative mutations are audit-written by ConsoleSecuredRouterAssembler; element persistence operations retain their own element audit events."
     }
   ],
   "_comment": "Paths use glob patterns to match in both local and CI environments"

--- a/src/security/audit/config/security-suppressions.json
+++ b/src/security/audit/config/security-suppressions.json
@@ -112,13 +112,73 @@
     },
     {
       "rule": "DMCP-SEC-004",
-      "file": "src/web-console/**/*.ts",
-      "reason": "CENTRALIZED WEB-CONSOLE NORMALIZATION: ConsoleUnicodeNormalization middleware normalizes route params, query values, and JSON body strings for both secured and fixture console routers before handlers, modules, stores, or services run. Cookie/header credentials intentionally remain exact-match opaque values."
+      "file": "src/web-console/WebConsoleRegistrar.ts",
+      "reason": "WEB-CONSOLE COMPOSITION: Registrar wires stores, modules, and the secured router. Runtime request input is normalized by ConsoleUnicodeNormalization before route handlers; deployment/configuration secrets and OAuth identifiers remain exact-match opaque values."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/auth/ConsoleBffAuthModule.ts",
+      "reason": "OPAQUE OAUTH FLOW VALUES: Login state, PKCE verifier, authorization code, session cookies, and JWT values are credentials/protocol values that must be exact-match validated. Return paths are normalized through ConsoleReturnPaths and route payloads pass through ConsoleUnicodeNormalization."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/auth/EmbeddedAsConsoleOAuthClient.ts",
+      "reason": "OPAQUE OAUTH CLIENT VALUES: Authorization codes, code verifiers, redirect URIs, and JWTs are protocol credentials and must not be Unicode-folded. JWT claims are validated after jose verification and are not free-form request payloads."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/identity/provisionConsoleAdmin.ts",
+      "reason": "OPERATOR BOOTSTRAP IDENTITY: Admin provisioning keys users by exact OAuth subject identifiers. Normalizing subject strings would break identity binding; display names are free-form and not used for authorization decisions."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/middleware/ConsoleAdminAudit.ts",
+      "reason": "AUDIT CONTEXT ONLY: Admin audit events record authenticated session context, route metadata, normalized path/query/body-derived handler summaries, and opaque request headers for traceability. It does not authorize from raw user text."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/middleware/ConsoleAuthentication.ts",
+      "reason": "OPAQUE SESSION VALUES: Session cookies and stored hashes are exact-match credentials and must not be Unicode-normalized. Request path/query/body values are normalized after authentication by the secured router."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/middleware/ConsoleCsrfProtection.ts",
+      "reason": "OPAQUE CSRF VALUES: CSRF cookie/header values, Origin, Sec-Fetch-Site, and X-Console-Request are browser protocol values checked by exact comparison. They are not free-form user payloads."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/middleware/ConsoleOwnership.ts",
+      "reason": "NORMALIZED ROUTE PARAM CONSUMER: Ownership checks run after ConsoleUnicodeNormalization and authentication. Runtime session ids are read from normalized route params and compared as exact stored identifiers."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/middleware/ConsoleRateLimit.ts",
+      "reason": "NORMALIZED ROUTE PARAM CONSUMER: Protected-correlation rate limits run after ConsoleUnicodeNormalization and authentication. Account correlation ids are normalized route params before limiter consumption."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/modules/**/*.ts",
+      "reason": "CENTRALIZED WEB-CONSOLE NORMALIZATION: Route-served console modules receive request params, query values, and JSON body keys through ConsoleUnicodeNormalization before handlers run. New non-route-served module files require manual DMCP-SEC-004 review."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/platform/**/*.ts",
+      "reason": "CENTRALIZED WEB-CONSOLE NORMALIZATION: Platform routing owns ConsoleUnicodeNormalization and request canonicalization. New non-route middleware must be reviewed before relying on this suppression."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/services/**/*.ts",
+      "reason": "CENTRALIZED WEB-CONSOLE NORMALIZATION: Web-console services are invoked from normalized console routes or trusted lifecycle jobs. New externally reachable service entry points require manual DMCP-SEC-004 review."
+    },
+    {
+      "rule": "DMCP-SEC-004",
+      "file": "src/web-console/stores/**/*.ts",
+      "reason": "CENTRALIZED WEB-CONSOLE NORMALIZATION: Web-console stores are reached from normalized console route handlers or trusted server composition. New direct external-input store entry points require manual DMCP-SEC-004 review."
     },
     {
       "rule": "DMCP-SEC-004",
       "file": "src/web-console/ui/*.js",
-      "reason": "Browser console modules send requests through ui/api.js, which applies native NFC normalization to API paths and JSON payload strings before fetch. Server-side ConsoleUnicodeNormalization remains the authoritative boundary for all console route params, query values, and bodies."
+      "reason": "Browser console modules send requests through ui/api.js, which applies native NFC normalization to API paths and JSON payload keys before fetch. Server-side ConsoleUnicodeNormalization remains the authoritative boundary for all console route params, query values, and bodies."
     },
     {
       "rule": "DMCP-SEC-004",

--- a/src/security/audit/config/security-suppressions.json
+++ b/src/security/audit/config/security-suppressions.json
@@ -133,7 +133,12 @@
     {
       "rule": "DMCP-SEC-004",
       "file": "src/auth/instrumentAuthProvider.ts",
-      "reason": "Instrumentation decorator for IAuthProvider.validate(). It times and audit-logs provider validation outcomes but does not interpret user content; bearer tokens remain opaque exact-match credentials by design."
+      "reason": "Instrumentation decorator for IAuthProvider.validate(). It times provider validation outcomes but does not interpret user content; bearer tokens remain opaque exact-match credentials by design."
+    },
+    {
+      "rule": "DMCP-SEC-006",
+      "file": "src/auth/instrumentAuthProvider.ts",
+      "reason": "Performance-only instrumentation wrapper. Concrete auth providers own TOKEN_VALIDATION_FAILURE audit logging with issuer/key/provider context, and this wrapper intentionally avoids duplicate security events."
     },
     {
       "rule": "DMCP-SEC-004",

--- a/src/security/audit/config/suppressions.ts
+++ b/src/security/audit/config/suppressions.ts
@@ -1044,6 +1044,16 @@ export const suppressions: Suppression[] = [
     file: '**/scripts/test-capability-index.js',
     reason: 'Test script loading test personas with hardcoded paths - not production code'
   },
+  {
+    rule: 'DMCP-SEC-006',
+    file: 'src/auth/instrumentAuthProvider.ts',
+    reason: 'Performance-only instrumentation wrapper. Concrete auth providers own TOKEN_VALIDATION_FAILURE audit logging with issuer/key/provider context, and this wrapper intentionally avoids duplicate security events.'
+  },
+  {
+    rule: 'DMCP-SEC-006',
+    file: '**/src/auth/instrumentAuthProvider.ts',
+    reason: 'Performance-only instrumentation wrapper. Concrete auth providers own TOKEN_VALIDATION_FAILURE audit logging with issuer/key/provider context, and this wrapper intentionally avoids duplicate security events.'
+  },
 
   // ========================================
   // packages/safety Suppressions

--- a/src/web-console/auth/ConsoleBffAuthModule.ts
+++ b/src/web-console/auth/ConsoleBffAuthModule.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from 'node:crypto';
 
 import { logger } from '../../utils/logger.js';
+import { SecurityMonitor } from '../../security/securityMonitor.js';
 
 import type { IConsoleIdentityResolver } from '../identity/IConsoleIdentityResolver.js';
 import {
@@ -178,6 +179,7 @@ class ConsoleBffAuthService {
     const code = singleQueryValue(req.query.code);
     const state = singleQueryValue(req.query.state);
     if (!transactionId || !code || !state) {
+      logConsoleAuthEvent('OPERATION_FAILED', 'MEDIUM', 'Console login callback rejected: missing parameters');
       return failedCallback();
     }
 
@@ -187,6 +189,7 @@ class ConsoleBffAuthService {
       this.now(),
     );
     if (transaction?.flowKind !== 'login') {
+      logConsoleAuthEvent('OPERATION_FAILED', 'MEDIUM', 'Console login callback rejected: invalid transaction');
       return failedCallback();
     }
 
@@ -202,6 +205,7 @@ class ConsoleBffAuthService {
         redirectUri: this.redirectUri,
       });
     } catch {
+      logConsoleAuthEvent('OPERATION_FAILED', 'MEDIUM', 'Console login callback rejected: code exchange failed');
       return failedCallback();
     }
     // Link this identity to its users row before resolving (idempotent). Lets a
@@ -210,6 +214,7 @@ class ConsoleBffAuthService {
     await this.options.identityResolver.linkAccount(claims.sub, claims.displayName);
     const principal = await this.options.identityResolver.resolveEnabledPrincipal(claims.sub);
     if (!principal) {
+      logConsoleAuthEvent('OPERATION_FAILED', 'MEDIUM', 'Console login callback rejected: principal unavailable');
       return failedCallback();
     }
 
@@ -231,6 +236,7 @@ class ConsoleBffAuthService {
       lastIp: typeof req.ip === 'string' ? req.ip : null,
       userAgent: typeof req.headers['user-agent'] === 'string' ? req.headers['user-agent'] : null,
     });
+    logConsoleAuthEvent('OPERATION_COMPLETED', 'LOW', 'Console login completed', { userId: principal.userId });
 
     return {
       status: 302,
@@ -247,6 +253,9 @@ class ConsoleBffAuthService {
     const authentication = requireAuthentication(req);
     const capability = readRequestedAdminCapability(req);
     if (!capability) {
+      logConsoleAuthEvent('OPERATION_FAILED', 'MEDIUM', 'Console step-up rejected: invalid capability', {
+        userId: authentication.userId,
+      });
       return invalidCapability();
     }
     const now = this.now();
@@ -292,6 +301,9 @@ class ConsoleBffAuthService {
     const code = singleQueryValue(req.query.code);
     const state = singleQueryValue(req.query.state);
     if (!transactionId || !code || !state) {
+      logConsoleAuthEvent('OPERATION_FAILED', 'MEDIUM', 'Console step-up rejected: missing parameters', {
+        userId: authentication.userId,
+      });
       logger.warn('[ConsoleBffAuthModule] step-up rejected: missing params', {
         hasTransactionId: !!transactionId, hasCode: !!code, hasState: !!state,
       });
@@ -319,6 +331,10 @@ class ConsoleBffAuthService {
         sessionMatch: !!transaction?.consoleSessionIdHash &&
           buffersEqual(transaction.consoleSessionIdHash, authentication.sessionIdHash),
       });
+      logConsoleAuthEvent('OPERATION_FAILED', 'MEDIUM', 'Console step-up rejected: invalid transaction', {
+        userId: authentication.userId,
+        flowKind: transaction?.flowKind ?? null,
+      });
       return failedCallback();
     }
 
@@ -334,6 +350,9 @@ class ConsoleBffAuthService {
         redirectUri: this.stepUpRedirectUri,
       });
     } catch (error) {
+      logConsoleAuthEvent('OPERATION_FAILED', 'MEDIUM', 'Console step-up rejected: code exchange failed', {
+        userId: authentication.userId,
+      });
       logger.warn('[ConsoleBffAuthModule] step-up rejected: code exchange failed', {
         error: error instanceof Error ? error.message : String(error),
       });
@@ -356,6 +375,10 @@ class ConsoleBffAuthService {
         `inFuture=${claims.authTime ? claims.authTime > now : 'n/a'} ` +
         `stale=${claims.authTime ? claims.authTime.getTime() + AUTH_TIME_FRESHNESS_MAX_MS <= now.getTime() : 'n/a'}`,
       );
+      logConsoleAuthEvent('OPERATION_FAILED', 'MEDIUM', 'Console step-up rejected: claims check failed', {
+        userId: authentication.userId,
+        acr: claims.acr ?? null,
+      });
       return failedCallback();
     }
     // One step-up elevates the session to the principal's FULL role-entitled
@@ -375,8 +398,15 @@ class ConsoleBffAuthService {
       authTime: claims.authTime,
     }, now);
     if (!attached) {
+      logConsoleAuthEvent('OPERATION_FAILED', 'MEDIUM', 'Console step-up rejected: session elevation update failed', {
+        userId: authentication.userId,
+      });
       return failedCallback();
     }
+    logConsoleAuthEvent('OPERATION_COMPLETED', 'LOW', 'Console step-up completed', {
+      userId: authentication.userId,
+      requestedCapability: transaction.requestedCapability,
+    });
     return {
       status: 302,
       redirectTo: transaction.returnTo ?? '/',
@@ -387,12 +417,18 @@ class ConsoleBffAuthService {
   async stepDown(req: ConsoleRequest): Promise<ConsoleHandlerResult> {
     const authentication = requireAuthentication(req);
     await this.options.sessionStore.clearElevation(authentication.sessionIdHash, this.now());
+    logConsoleAuthEvent('OPERATION_COMPLETED', 'LOW', 'Console step-down completed', {
+      userId: authentication.userId,
+    });
     return { status: 204 };
   }
 
   async logout(req: ConsoleRequest): Promise<ConsoleHandlerResult> {
     const authentication = requireAuthentication(req);
     await this.options.sessionStore.revoke(authentication.sessionIdHash, this.now());
+    logConsoleAuthEvent('OPERATION_COMPLETED', 'LOW', 'Console logout completed', {
+      userId: authentication.userId,
+    });
     return {
       status: 204,
       cookies: [
@@ -496,6 +532,21 @@ function invalidCapability(): ConsoleHandlerResult {
       detail: 'Step-up requires a valid administrative console capability.',
     },
   };
+}
+
+function logConsoleAuthEvent(
+  type: 'OPERATION_COMPLETED' | 'OPERATION_FAILED',
+  severity: 'LOW' | 'MEDIUM',
+  details: string,
+  additionalData?: Record<string, unknown>,
+): void {
+  SecurityMonitor.logSecurityEvent({
+    type,
+    severity,
+    source: 'ConsoleBffAuthModule',
+    details,
+    additionalData,
+  });
 }
 
 function requireAuthentication(req: ConsoleRequest): ConsoleAuthenticatedContext {

--- a/src/web-console/auth/ConsoleBffAuthModule.ts
+++ b/src/web-console/auth/ConsoleBffAuthModule.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from 'node:crypto';
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 
 import { logger } from '../../utils/logger.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
@@ -557,5 +557,5 @@ function requireAuthentication(req: ConsoleRequest): ConsoleAuthenticatedContext
 }
 
 function buffersEqual(left: Buffer, right: Buffer): boolean {
-  return left.length === right.length && left.equals(right);
+  return left.length === right.length && timingSafeEqual(left, right);
 }

--- a/src/web-console/middleware/ConsoleIdempotency.ts
+++ b/src/web-console/middleware/ConsoleIdempotency.ts
@@ -1,8 +1,14 @@
 import { createHash } from 'node:crypto';
 
 import { requireConsoleAuthentication } from './ConsoleAuthentication.js';
+import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import type { ConsoleAdminAuditResult } from '../audit/IAdminAuditWriter.js';
-import type { ConsoleHandlerResult, ConsoleRequest, ConsoleRouteDefinition } from '../platform/ConsolePlatformTypes.js';
+import type {
+  ConsoleHandlerResult,
+  ConsolePathParamValueNormalization,
+  ConsoleRequest,
+  ConsoleRouteDefinition,
+} from '../platform/ConsolePlatformTypes.js';
 import type { ConsoleProblemInput } from '../platform/ProblemResponses.js';
 import type { IIdempotencyStore } from '../stores/IIdempotencyStore.js';
 import { ConsoleStoreValidationError, assertUuid } from '../stores/ConsoleStoreValidation.js';
@@ -57,7 +63,7 @@ export async function executeWithConsoleIdempotency(
     consoleSessionIdHash: requireConsoleAuthentication(req).sessionIdHash,
     idempotencyKey,
     httpMethod: route.method,
-    canonicalTarget: canonicalRequestTarget(req),
+    canonicalTarget: canonicalRequestTarget(req, route),
     requestFingerprint,
     createdAt: now,
     expiresAt: new Date(now.getTime() + RETENTION_MS),
@@ -108,13 +114,14 @@ export async function executeWithConsoleIdempotency(
   }
 }
 
-export function canonicalRequestTarget(req: ConsoleRequest): string {
+export function canonicalRequestTarget(req: ConsoleRequest, route?: ConsoleRouteDefinition): string {
   const parsed = new URL(req.originalUrl, 'https://console.invalid');
-  const sortedQuery = [...parsed.searchParams.entries()]
+  const sortedQuery = canonicalQueryEntries(parsed)
     .sort(([leftName, leftValue], [rightName, rightValue]) =>
       compareCodeUnits(leftName, rightName) || compareCodeUnits(leftValue, rightValue));
   const search = new URLSearchParams(sortedQuery).toString();
-  return search ? `${parsed.pathname}?${search}` : parsed.pathname;
+  const pathname = route ? canonicalPathname(req, route, parsed.pathname) : parsed.pathname;
+  return search ? `${pathname}?${search}` : pathname;
 }
 
 export function fingerprintBody(body: unknown): Buffer {
@@ -158,6 +165,47 @@ function validationProblem(detail: string): ConsoleIdempotentExecution {
 
 function singleHeader(value: string | string[] | undefined): string | undefined {
   return typeof value === 'string' ? value : undefined;
+}
+
+function canonicalPathname(req: ConsoleRequest, route: ConsoleRouteDefinition, fallbackPathname: string): string {
+  const routeSegments = route.path.split('/');
+  const fallbackSegments = fallbackPathname.split('/');
+  if (routeSegments.length !== fallbackSegments.length) return fallbackPathname;
+  return routeSegments.map((routeSegment, index) => {
+    if (!routeSegment.startsWith(':')) return fallbackSegments[index];
+    const paramName = routeParamName(routeSegment);
+    const value = typeof req.params[paramName] === 'string'
+      ? req.params[paramName]
+      : decodePathSegment(fallbackSegments[index]);
+    const mode = route.pathParamValueNormalization?.[paramName] ?? 'security';
+    return encodeURIComponent(normalizePathParamValue(value, mode));
+  }).join('/');
+}
+
+function routeParamName(routeSegment: string): string {
+  return routeSegment.slice(1).replace(/\?$/, '');
+}
+
+function decodePathSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+function normalizePathParamValue(value: string, mode: ConsolePathParamValueNormalization): string {
+  return mode === 'nfc'
+    ? value.normalize('NFC')
+    : UnicodeValidator.normalize(value).normalizedContent;
+}
+
+function canonicalQueryEntries(parsed: URL): [string, string][] {
+  return [...parsed.searchParams.entries()]
+    .map(([key, value]) => [
+      UnicodeValidator.normalize(key).normalizedContent,
+      UnicodeValidator.normalize(value).normalizedContent,
+    ]);
 }
 
 function compareCodeUnits(left: string, right: string): number {

--- a/src/web-console/middleware/ConsoleIdempotency.ts
+++ b/src/web-console/middleware/ConsoleIdempotency.ts
@@ -5,9 +5,8 @@ import { UnicodeValidator } from '../../security/validators/unicodeValidator.js'
 import type { ConsoleAdminAuditResult } from '../audit/IAdminAuditWriter.js';
 import type {
   ConsoleHandlerResult,
-  ConsolePathParamValueNormalization,
-  ConsoleQueryParamValueNormalization,
   ConsoleRequest,
+  ConsoleRequestTargetValueNormalization,
   ConsoleRouteDefinition,
 } from '../platform/ConsolePlatformTypes.js';
 import type { ConsoleProblemInput } from '../platform/ProblemResponses.js';
@@ -179,7 +178,7 @@ function canonicalPathname(req: ConsoleRequest, route: ConsoleRouteDefinition, f
       ? req.params[paramName]
       : decodePathSegment(fallbackSegments[index]);
     const mode = route.pathParamValueNormalization?.[paramName] ?? 'security';
-    return encodeURIComponent(normalizePathParamValue(value, mode));
+    return encodeURIComponent(normalizeRequestTargetValue(value, mode));
   }).join('/');
 }
 
@@ -195,7 +194,7 @@ function decodePathSegment(segment: string): string {
   }
 }
 
-function normalizePathParamValue(value: string, mode: ConsolePathParamValueNormalization): string {
+function normalizeRequestTargetValue(value: string, mode: ConsoleRequestTargetValueNormalization): string {
   return mode === 'nfc'
     ? value.normalize('NFC')
     : UnicodeValidator.normalize(value).normalizedContent;
@@ -207,7 +206,7 @@ function canonicalQueryEntries(parsed: URL, route?: ConsoleRouteDefinition): [st
       const normalizedKey = UnicodeValidator.normalize(key).normalizedContent;
       return [
         normalizedKey,
-        normalizeQueryParamValue(value, queryParamMode(route, key, normalizedKey)),
+        normalizeRequestTargetValue(value, queryParamMode(route, key, normalizedKey)),
       ];
     });
 }
@@ -216,16 +215,10 @@ function queryParamMode(
   route: ConsoleRouteDefinition | undefined,
   key: string,
   normalizedKey: string,
-): ConsoleQueryParamValueNormalization {
+): ConsoleRequestTargetValueNormalization {
   return route?.queryParamValueNormalization?.[key] ??
     route?.queryParamValueNormalization?.[normalizedKey] ??
     'security';
-}
-
-function normalizeQueryParamValue(value: string, mode: ConsoleQueryParamValueNormalization): string {
-  return mode === 'nfc'
-    ? value.normalize('NFC')
-    : UnicodeValidator.normalize(value).normalizedContent;
 }
 
 function compareCodeUnits(left: string, right: string): number {

--- a/src/web-console/middleware/ConsoleIdempotency.ts
+++ b/src/web-console/middleware/ConsoleIdempotency.ts
@@ -6,6 +6,7 @@ import type { ConsoleAdminAuditResult } from '../audit/IAdminAuditWriter.js';
 import type {
   ConsoleHandlerResult,
   ConsolePathParamValueNormalization,
+  ConsoleQueryParamValueNormalization,
   ConsoleRequest,
   ConsoleRouteDefinition,
 } from '../platform/ConsolePlatformTypes.js';
@@ -116,7 +117,7 @@ export async function executeWithConsoleIdempotency(
 
 export function canonicalRequestTarget(req: ConsoleRequest, route?: ConsoleRouteDefinition): string {
   const parsed = new URL(req.originalUrl, 'https://console.invalid');
-  const sortedQuery = canonicalQueryEntries(parsed)
+  const sortedQuery = canonicalQueryEntries(parsed, route)
     .sort(([leftName, leftValue], [rightName, rightValue]) =>
       compareCodeUnits(leftName, rightName) || compareCodeUnits(leftValue, rightValue));
   const search = new URLSearchParams(sortedQuery).toString();
@@ -200,12 +201,31 @@ function normalizePathParamValue(value: string, mode: ConsolePathParamValueNorma
     : UnicodeValidator.normalize(value).normalizedContent;
 }
 
-function canonicalQueryEntries(parsed: URL): [string, string][] {
+function canonicalQueryEntries(parsed: URL, route?: ConsoleRouteDefinition): [string, string][] {
   return [...parsed.searchParams.entries()]
-    .map(([key, value]) => [
-      UnicodeValidator.normalize(key).normalizedContent,
-      UnicodeValidator.normalize(value).normalizedContent,
-    ]);
+    .map(([key, value]) => {
+      const normalizedKey = UnicodeValidator.normalize(key).normalizedContent;
+      return [
+        normalizedKey,
+        normalizeQueryParamValue(value, queryParamMode(route, key, normalizedKey)),
+      ];
+    });
+}
+
+function queryParamMode(
+  route: ConsoleRouteDefinition | undefined,
+  key: string,
+  normalizedKey: string,
+): ConsoleQueryParamValueNormalization {
+  return route?.queryParamValueNormalization?.[key] ??
+    route?.queryParamValueNormalization?.[normalizedKey] ??
+    'security';
+}
+
+function normalizeQueryParamValue(value: string, mode: ConsoleQueryParamValueNormalization): string {
+  return mode === 'nfc'
+    ? value.normalize('NFC')
+    : UnicodeValidator.normalize(value).normalizedContent;
 }
 
 function compareCodeUnits(left: string, right: string): number {

--- a/src/web-console/modules/account-admin/AccountAdminAllowlistService.ts
+++ b/src/web-console/modules/account-admin/AccountAdminAllowlistService.ts
@@ -1,4 +1,5 @@
 import type { ConsoleAdminAuditResult } from '../../audit/IAdminAuditWriter.js';
+import { UnicodeValidator } from '../../../security/validators/unicodeValidator.js';
 import { buildConsoleAdminAuditEvent } from '../../middleware/ConsoleAdminAudit.js';
 import { requireConsoleAuthentication } from '../../middleware/ConsoleAuthentication.js';
 import type { ConsoleHandlerResult, ConsoleRequest, ConsoleRouteDefinition } from '../../platform/ConsolePlatformTypes.js';
@@ -11,7 +12,10 @@ import type {
   ConsoleAccountAllowlistKind,
   IConsoleAccountAllowlistStore,
 } from '../../stores/IConsoleAccountAllowlistStore.js';
-import { assertAllowlistKind , validateAllowlistValue } from '../../stores/IConsoleAccountAllowlistStore.js';
+import {
+  assertAllowlistKind,
+  validateAllowlistValue,
+} from '../../stores/IConsoleAccountAllowlistStore.js';
 import type { IAccountAdminMutationTransactionRunner } from './AccountAdminMutationTransaction.js';
 import {
   serializeAccountAllowlistEntry,
@@ -152,7 +156,8 @@ function parseAddBody(body: unknown): { readonly kind: 'valid'; readonly value: 
     if (typeof record.kind !== 'string') throw new ConsoleStoreValidationError('kind must be a string.');
     assertAllowlistKind(record.kind, 'kind');
     if (typeof record.value !== 'string') throw new ConsoleStoreValidationError('value must be a string.');
-    validateAllowlistValue(record.kind, record.value, 'value');
+    const value = UnicodeValidator.normalize(record.value).normalizedContent.trim();
+    validateAllowlistValue(record.kind, value, 'value');
     if (record.note !== undefined && record.note !== null && typeof record.note !== 'string') {
       throw new ConsoleStoreValidationError('note must be a string or null.');
     }
@@ -161,7 +166,7 @@ function parseAddBody(body: unknown): { readonly kind: 'valid'; readonly value: 
     }
     return {
       kind: 'valid',
-      value: { kind: record.kind, value: record.value, note: record.note },
+      value: { kind: record.kind, value, note: record.note },
     };
   } catch (error) {
     return {

--- a/src/web-console/modules/activations/ActivationModule.ts
+++ b/src/web-console/modules/activations/ActivationModule.ts
@@ -69,6 +69,7 @@ export function createActivationModule(options: ActivationModuleOptions): Consol
         privacyClass: 'self_private',
         idempotency: 'required',
         privacyProjector: projectSessionDeactivation,
+        pathParamValueNormalization: { name: 'nfc' },
         handler: req => withActivationParams(
           req,
           (sessionId, type, name) => service.deactivate(req, sessionId, type, name),

--- a/src/web-console/modules/integrations/IntegrationService.ts
+++ b/src/web-console/modules/integrations/IntegrationService.ts
@@ -259,10 +259,10 @@ export class IntegrationService {
     active: NonNullable<Awaited<ReturnType<IUserIntegrationStore['findByProvider']>>>,
   ): Promise<boolean> {
     const accessToken = active.accessTokenCiphertext
-      ? decryptNullable(deps.secretEncryption, active.accessTokenCiphertext, integrationSecretContext('access_token', auth.userId, 'github'))
+      ? decryptNullable(deps.secretEncryption, active.accessTokenCiphertext, integrationSecretContext('access_token', auth.userId, 'github'), auth.userId, 'github')
       : null;
     const refreshToken = active.refreshTokenCiphertext
-      ? decryptNullable(deps.secretEncryption, active.refreshTokenCiphertext, integrationSecretContext('refresh_token', auth.userId, 'github'))
+      ? decryptNullable(deps.secretEncryption, active.refreshTokenCiphertext, integrationSecretContext('refresh_token', auth.userId, 'github'), auth.userId, 'github')
       : null;
     try {
       await deps.githubProvider.revokeCredentials({
@@ -359,10 +359,17 @@ function decryptNullable(
   secretEncryption: ISecretEncryptionService,
   ciphertext: Buffer,
   context: IntegrationSecretContext,
+  userId: string,
+  provider: 'github',
 ): string | null {
   try {
     return secretEncryption.decrypt(ciphertext, context).toString('utf8');
   } catch {
+    logIntegrationSecurityEvent('OPERATION_FAILED', 'MEDIUM', 'GitHub integration credential decrypt failed', {
+      userId,
+      provider,
+      secretClass: context.secretClass,
+    });
     return null;
   }
 }

--- a/src/web-console/modules/integrations/IntegrationService.ts
+++ b/src/web-console/modules/integrations/IntegrationService.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from 'node:crypto';
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 
 import { SecurityMonitor } from '../../../security/securityMonitor.js';
 import {
@@ -427,5 +427,5 @@ function logIntegrationSecurityEvent(
 }
 
 function buffersEqual(left: Buffer, right: Buffer): boolean {
-  return left.length === right.length && left.equals(right);
+  return left.length === right.length && timingSafeEqual(left, right);
 }

--- a/src/web-console/modules/integrations/IntegrationService.ts
+++ b/src/web-console/modules/integrations/IntegrationService.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes } from 'node:crypto';
 
+import { SecurityMonitor } from '../../../security/securityMonitor.js';
 import {
   CONSOLE_INTEGRATION_STATE_COOKIE,
   readCookie,
@@ -93,6 +94,10 @@ export class IntegrationService {
       expiresAt: new Date(now.getTime() + INTEGRATION_TRANSACTION_TTL_MS),
       consumedAt: null,
     });
+    logIntegrationSecurityEvent('OPERATION_COMPLETED', 'LOW', 'GitHub integration link flow started', {
+      userId: auth.userId,
+      contentsPermission,
+    });
     return {
       // Return the authorization URL in the body (not a 302): the console is an
       // SPA driven by fetch, which can't follow a cross-origin redirect, and CSRF
@@ -173,6 +178,9 @@ export class IntegrationService {
         errorReason: 'token_exchange_failed',
         occurredAt: this.now(),
       });
+      logIntegrationSecurityEvent('OPERATION_FAILED', 'MEDIUM', 'GitHub integration token exchange failed', {
+        userId: auth.userId,
+      });
       return failedIntegrationCallback(transaction.returnTo ?? undefined);
     }
 
@@ -197,6 +205,11 @@ export class IntegrationService {
         )
         : null,
       connectedAt,
+    });
+    logIntegrationSecurityEvent('OPERATION_COMPLETED', 'LOW', 'GitHub integration connected', {
+      userId: auth.userId,
+      repositorySelection: exchanged.repositorySelection,
+      contentsPermission: exchanged.contentsPermission,
     });
 
     return {
@@ -229,6 +242,9 @@ export class IntegrationService {
         userId: auth.userId,
         provider: 'github',
         revokedAt: this.now(),
+      });
+      logIntegrationSecurityEvent('OPERATION_COMPLETED', 'LOW', 'GitHub integration disconnected', {
+        userId: auth.userId,
       });
     }
     return {
@@ -299,6 +315,10 @@ export class IntegrationService {
     userId: string | null,
     reason: IntegrationCallbackRejectedReason,
   ): Promise<void> {
+    logIntegrationSecurityEvent('OPERATION_FAILED', 'MEDIUM', 'GitHub integration callback rejected', {
+      userId,
+      reason,
+    });
     try {
       await this.options.securityEventSink?.recordIntegrationCallbackRejected({
         type: 'console.auth.integration_callback_rejected.v1',
@@ -389,6 +409,21 @@ function serviceUnavailable(detail: string): ConsoleHandlerResult {
       detail,
     },
   };
+}
+
+function logIntegrationSecurityEvent(
+  type: 'OPERATION_COMPLETED' | 'OPERATION_FAILED',
+  severity: 'LOW' | 'MEDIUM',
+  details: string,
+  additionalData?: Record<string, unknown>,
+): void {
+  SecurityMonitor.logSecurityEvent({
+    type,
+    severity,
+    source: 'IntegrationService',
+    details,
+    additionalData,
+  });
 }
 
 function buffersEqual(left: Buffer, right: Buffer): boolean {

--- a/src/web-console/modules/portfolio/PortfolioModule.ts
+++ b/src/web-console/modules/portfolio/PortfolioModule.ts
@@ -65,6 +65,7 @@ export function createPortfolioModule(options: PortfolioModuleOptions): ConsoleM
       privacyClass: 'self_private',
       idempotency: 'not_applicable',
       privacyProjector: projectPortfolioElementList,
+      queryParamValueNormalization: { tag: 'nfc' },
       handler: req => service.listElements(req),
     },
     {

--- a/src/web-console/modules/portfolio/PortfolioModule.ts
+++ b/src/web-console/modules/portfolio/PortfolioModule.ts
@@ -77,6 +77,7 @@ export function createPortfolioModule(options: PortfolioModuleOptions): ConsoleM
       privacyClass: 'self_private',
       idempotency: 'not_applicable',
       privacyProjector: projectPortfolioElementDetail,
+      pathParamValueNormalization: { name: 'nfc' },
       handler: req => withElementParams(req, (type, name) => service.getElement(req, type, name)),
     },
   ];
@@ -125,6 +126,7 @@ function writeRoutes(service: PortfolioService): ConsoleModuleDescriptor['routes
       privacyClass: 'self_private',
       idempotency: 'required',
       privacyProjector: projectPortfolioElementDetail,
+      pathParamValueNormalization: { name: 'nfc' },
       handler: req => withElementParams(req, (type, name) => service.updateElement(req, type, name)),
     },
     {
@@ -137,6 +139,7 @@ function writeRoutes(service: PortfolioService): ConsoleModuleDescriptor['routes
       privacyClass: 'self_private',
       idempotency: 'required',
       privacyProjector: projectPortfolioElementDelete,
+      pathParamValueNormalization: { name: 'nfc' },
       handler: req => withElementParams(req, (type, name) => service.deleteElement(req, type, name)),
     },
     {
@@ -150,6 +153,7 @@ function writeRoutes(service: PortfolioService): ConsoleModuleDescriptor['routes
       // The v1 checklist requires Idempotency-Key coverage for these side-effect-free POSTs.
       idempotency: 'required',
       privacyProjector: projectPortfolioElementValidation,
+      pathParamValueNormalization: { name: 'nfc' },
       handler: req => withElementParams(req, (type, name) => service.validateElement(req, type, name)),
     },
     {
@@ -163,6 +167,7 @@ function writeRoutes(service: PortfolioService): ConsoleModuleDescriptor['routes
       // The v1 checklist requires Idempotency-Key coverage for these side-effect-free POSTs.
       idempotency: 'required',
       privacyProjector: projectPortfolioElementRender,
+      pathParamValueNormalization: { name: 'nfc' },
       handler: req => withElementParams(req, (type, name) => service.renderElement(req, type, name)),
     },
   ];

--- a/src/web-console/platform/ConsolePlatformTypes.ts
+++ b/src/web-console/platform/ConsolePlatformTypes.ts
@@ -52,7 +52,9 @@ export type ConsoleOwnershipPolicy = 'none' | 'flow_transaction' | 'authenticate
 export type ConsoleIdempotencyPolicy = 'not_applicable' | 'required';
 export type ConsoleAuditExecutionPolicy = 'kernel' | 'handler_transaction';
 export type ConsoleResponseKind = 'json' | 'sse';
-export type ConsolePathParamValueNormalization = 'security' | 'nfc';
+export type ConsoleRequestTargetValueNormalization = 'security' | 'nfc';
+export type ConsolePathParamValueNormalization = ConsoleRequestTargetValueNormalization;
+export type ConsoleQueryParamValueNormalization = ConsoleRequestTargetValueNormalization;
 
 export interface ConsoleRequestContext {
   readonly correlationId: string;
@@ -167,6 +169,11 @@ export interface ConsoleRouteDefinition {
    * the stored identifier, such as portfolio element names.
    */
   readonly pathParamValueNormalization?: Readonly<Record<string, ConsolePathParamValueNormalization>>;
+  /**
+   * Query values are security-normalized by default. Mark query parameters as
+   * `nfc` when they are free-form filters compared against stored user text.
+   */
+  readonly queryParamValueNormalization?: Readonly<Record<string, ConsoleQueryParamValueNormalization>>;
   readonly handler: ConsoleHandler;
 }
 

--- a/src/web-console/platform/ConsolePlatformTypes.ts
+++ b/src/web-console/platform/ConsolePlatformTypes.ts
@@ -53,8 +53,6 @@ export type ConsoleIdempotencyPolicy = 'not_applicable' | 'required';
 export type ConsoleAuditExecutionPolicy = 'kernel' | 'handler_transaction';
 export type ConsoleResponseKind = 'json' | 'sse';
 export type ConsoleRequestTargetValueNormalization = 'security' | 'nfc';
-export type ConsolePathParamValueNormalization = ConsoleRequestTargetValueNormalization;
-export type ConsoleQueryParamValueNormalization = ConsoleRequestTargetValueNormalization;
 
 export interface ConsoleRequestContext {
   readonly correlationId: string;
@@ -168,12 +166,12 @@ export interface ConsoleRouteDefinition {
    * they are free-form resource names whose confusable characters are part of
    * the stored identifier, such as portfolio element names.
    */
-  readonly pathParamValueNormalization?: Readonly<Record<string, ConsolePathParamValueNormalization>>;
+  readonly pathParamValueNormalization?: Readonly<Record<string, ConsoleRequestTargetValueNormalization>>;
   /**
    * Query values are security-normalized by default. Mark query parameters as
    * `nfc` when they are free-form filters compared against stored user text.
    */
-  readonly queryParamValueNormalization?: Readonly<Record<string, ConsoleQueryParamValueNormalization>>;
+  readonly queryParamValueNormalization?: Readonly<Record<string, ConsoleRequestTargetValueNormalization>>;
   readonly handler: ConsoleHandler;
 }
 

--- a/src/web-console/platform/ConsolePlatformTypes.ts
+++ b/src/web-console/platform/ConsolePlatformTypes.ts
@@ -52,6 +52,7 @@ export type ConsoleOwnershipPolicy = 'none' | 'flow_transaction' | 'authenticate
 export type ConsoleIdempotencyPolicy = 'not_applicable' | 'required';
 export type ConsoleAuditExecutionPolicy = 'kernel' | 'handler_transaction';
 export type ConsoleResponseKind = 'json' | 'sse';
+export type ConsolePathParamValueNormalization = 'security' | 'nfc';
 
 export interface ConsoleRequestContext {
   readonly correlationId: string;
@@ -160,6 +161,12 @@ export interface ConsoleRouteDefinition {
   readonly streamPolicy?: ConsoleStreamPolicy;
   readonly streamEventProjectors?: ConsoleStreamEventProjectors;
   readonly privacyProjector?: ConsolePrivacyProjector;
+  /**
+   * Path params are security-normalized by default. Mark params as `nfc` when
+   * they are free-form resource names whose confusable characters are part of
+   * the stored identifier, such as portfolio element names.
+   */
+  readonly pathParamValueNormalization?: Readonly<Record<string, ConsolePathParamValueNormalization>>;
   readonly handler: ConsoleHandler;
 }
 

--- a/src/web-console/platform/ConsoleRequestContext.ts
+++ b/src/web-console/platform/ConsoleRequestContext.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import type { RequestHandler } from 'express';
 import type { ConsoleRequest, ConsoleRequestContext } from './ConsolePlatformTypes.js';
+import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 
 // The API contract accepts client UUIDs as opaque correlation values; only
 // server-generated values are constrained by randomUUID() to UUIDv4.
@@ -11,7 +12,8 @@ function incomingCorrelationId(value: string | string[] | undefined): string | u
   if (typeof value !== 'string') {
     return undefined;
   }
-  return UUID_PATTERN.test(value) ? value : undefined;
+  const normalized = UnicodeValidator.normalize(value).normalizedContent;
+  return UUID_PATTERN.test(normalized) ? normalized : undefined;
 }
 
 export function createConsoleRequestContextMiddleware(): RequestHandler {

--- a/src/web-console/platform/ConsoleRouterAssembler.ts
+++ b/src/web-console/platform/ConsoleRouterAssembler.ts
@@ -10,6 +10,7 @@ import { problemForConsoleError, sendProblemResponse } from './ProblemResponses.
 function registerRoute(router: Router, route: ConsoleRouteDefinition): void {
   const normalizeUnicode = createConsoleUnicodeNormalizationMiddleware({
     pathParamValueNormalization: route.pathParamValueNormalization,
+    queryParamValueNormalization: route.queryParamValueNormalization,
   });
   const handler: RequestHandler = (request, response, next): void => {
     const consoleRequest = request as ConsoleRequest;

--- a/src/web-console/platform/ConsoleRouterAssembler.ts
+++ b/src/web-console/platform/ConsoleRouterAssembler.ts
@@ -7,7 +7,10 @@ import type { ConsoleHttpMethod, ConsoleRequest, ConsoleRouteDefinition } from '
 import type { ConsoleModuleRegistry } from './ConsoleModuleRegistry.js';
 import { problemForConsoleError, sendProblemResponse } from './ProblemResponses.js';
 
-function registerRoute(router: Router, route: ConsoleRouteDefinition, normalizeUnicode: RequestHandler): void {
+function registerRoute(router: Router, route: ConsoleRouteDefinition): void {
+  const normalizeUnicode = createConsoleUnicodeNormalizationMiddleware({
+    pathParamValueNormalization: route.pathParamValueNormalization,
+  });
   const handler: RequestHandler = (request, response, next): void => {
     const consoleRequest = request as ConsoleRequest;
     void executeConsoleRoute(route, consoleRequest)
@@ -42,11 +45,10 @@ function registerRoute(router: Router, route: ConsoleRouteDefinition, normalizeU
 export function assembleConsoleRouter(registry: ConsoleModuleRegistry): Router {
   const router = Router();
   router.use(createConsoleRequestContextMiddleware());
-  const normalizeUnicode = createConsoleUnicodeNormalizationMiddleware();
 
   for (const module of registry.getModules()) {
     for (const route of module.routes) {
-      registerRoute(router, route, normalizeUnicode);
+      registerRoute(router, route);
     }
   }
   const sendKnownProblem: ErrorRequestHandler = (error, request, response, next): void => {

--- a/src/web-console/platform/ConsoleRouterAssembler.ts
+++ b/src/web-console/platform/ConsoleRouterAssembler.ts
@@ -2,11 +2,12 @@ import { Router } from 'express';
 import type { ErrorRequestHandler, RequestHandler } from 'express';
 import { createConsoleRequestContextMiddleware , requireConsoleRequestContext } from './ConsoleRequestContext.js';
 import { executeConsoleRoute, sendConsoleHandlerResult } from './ConsoleRouteExecution.js';
+import { createConsoleUnicodeNormalizationMiddleware } from './ConsoleUnicodeNormalization.js';
 import type { ConsoleHttpMethod, ConsoleRequest, ConsoleRouteDefinition } from './ConsolePlatformTypes.js';
 import type { ConsoleModuleRegistry } from './ConsoleModuleRegistry.js';
 import { problemForConsoleError, sendProblemResponse } from './ProblemResponses.js';
 
-function registerRoute(router: Router, route: ConsoleRouteDefinition): void {
+function registerRoute(router: Router, route: ConsoleRouteDefinition, normalizeUnicode: RequestHandler): void {
   const handler: RequestHandler = (request, response, next): void => {
     const consoleRequest = request as ConsoleRequest;
     void executeConsoleRoute(route, consoleRequest)
@@ -17,19 +18,19 @@ function registerRoute(router: Router, route: ConsoleRouteDefinition): void {
 
   switch (method) {
     case 'GET':
-      router.get(route.path, handler);
+      router.get(route.path, normalizeUnicode, handler);
       return;
     case 'POST':
-      router.post(route.path, handler);
+      router.post(route.path, normalizeUnicode, handler);
       return;
     case 'PUT':
-      router.put(route.path, handler);
+      router.put(route.path, normalizeUnicode, handler);
       return;
     case 'PATCH':
-      router.patch(route.path, handler);
+      router.patch(route.path, normalizeUnicode, handler);
       return;
     case 'DELETE':
-      router.delete(route.path, handler);
+      router.delete(route.path, normalizeUnicode, handler);
       return;
   }
 }
@@ -41,10 +42,11 @@ function registerRoute(router: Router, route: ConsoleRouteDefinition): void {
 export function assembleConsoleRouter(registry: ConsoleModuleRegistry): Router {
   const router = Router();
   router.use(createConsoleRequestContextMiddleware());
+  const normalizeUnicode = createConsoleUnicodeNormalizationMiddleware();
 
   for (const module of registry.getModules()) {
     for (const route of module.routes) {
-      registerRoute(router, route);
+      registerRoute(router, route, normalizeUnicode);
     }
   }
   const sendKnownProblem: ErrorRequestHandler = (error, request, response, next): void => {

--- a/src/web-console/platform/ConsoleSecuredRouterAssembler.ts
+++ b/src/web-console/platform/ConsoleSecuredRouterAssembler.ts
@@ -127,7 +127,10 @@ function middlewareForRoute(input: {
     queryParamValueNormalization: input.route.queryParamValueNormalization,
   });
   if (input.route.audience === 'public') {
-    return [normalizeRequestTarget, input.normalizeBody, createSecuredHandler(input.route, input.options)];
+    // Current public console routes are GET-only health/auth redirects and do
+    // not consume JSON bodies. Avoid recursive body walking before any auth
+    // boundary; future public body routes must validate their own payloads.
+    return [normalizeRequestTarget, createSecuredHandler(input.route, input.options)];
   }
   return [
     normalizeRequestTarget,

--- a/src/web-console/platform/ConsoleSecuredRouterAssembler.ts
+++ b/src/web-console/platform/ConsoleSecuredRouterAssembler.ts
@@ -124,6 +124,7 @@ function middlewareForRoute(input: {
   const normalizeRequestTarget = createConsoleUnicodeNormalizationMiddleware({
     body: 'off',
     pathParamValueNormalization: input.route.pathParamValueNormalization,
+    queryParamValueNormalization: input.route.queryParamValueNormalization,
   });
   if (input.route.audience === 'public') {
     return [normalizeRequestTarget, input.normalizeBody, createSecuredHandler(input.route, input.options)];

--- a/src/web-console/platform/ConsoleSecuredRouterAssembler.ts
+++ b/src/web-console/platform/ConsoleSecuredRouterAssembler.ts
@@ -59,7 +59,6 @@ export function assembleSecuredConsoleRouter(
   router.use(createConsoleSecurityHeadersMiddleware());
   const authenticate = createConsoleAuthenticationMiddleware(options);
   const csrf = createConsoleCsrfProtectionMiddleware(options);
-  const normalizeRequestTarget = createConsoleUnicodeNormalizationMiddleware({ body: 'off' });
   const normalizeBody = createConsoleUnicodeNormalizationMiddleware({ params: false, query: false, body: 'keys' });
   const userContext = options.userContext
     ? createConsoleUserContextMiddleware(options.userContext)
@@ -70,7 +69,6 @@ export function assembleSecuredConsoleRouter(
       registerSecuredRoute(router, route, middlewareForRoute({
         route,
         options,
-        normalizeRequestTarget,
         normalizeBody,
         authenticate,
         userContext,
@@ -118,17 +116,20 @@ export function assembleSecuredConsoleRouter(
 function middlewareForRoute(input: {
   readonly route: ConsoleRouteDefinition;
   readonly options: SecuredConsoleRouterOptions;
-  readonly normalizeRequestTarget: RequestHandler;
   readonly normalizeBody: RequestHandler;
   readonly authenticate: RequestHandler;
   readonly userContext: RequestHandler | null;
   readonly csrf: RequestHandler;
 }): readonly RequestHandler[] {
+  const normalizeRequestTarget = createConsoleUnicodeNormalizationMiddleware({
+    body: 'off',
+    pathParamValueNormalization: input.route.pathParamValueNormalization,
+  });
   if (input.route.audience === 'public') {
-    return [input.normalizeRequestTarget, input.normalizeBody, createSecuredHandler(input.route, input.options)];
+    return [normalizeRequestTarget, input.normalizeBody, createSecuredHandler(input.route, input.options)];
   }
   return [
-    input.normalizeRequestTarget,
+    normalizeRequestTarget,
     ...(input.route.responseKind === 'sse' ? [createConsoleStreamRequestProtectionMiddleware(input.route, input.options)] : []),
     input.authenticate,
     input.normalizeBody,

--- a/src/web-console/platform/ConsoleSecuredRouterAssembler.ts
+++ b/src/web-console/platform/ConsoleSecuredRouterAssembler.ts
@@ -59,7 +59,8 @@ export function assembleSecuredConsoleRouter(
   router.use(createConsoleSecurityHeadersMiddleware());
   const authenticate = createConsoleAuthenticationMiddleware(options);
   const csrf = createConsoleCsrfProtectionMiddleware(options);
-  const normalizeUnicode = createConsoleUnicodeNormalizationMiddleware();
+  const normalizeRequestTarget = createConsoleUnicodeNormalizationMiddleware({ body: 'off' });
+  const normalizeBody = createConsoleUnicodeNormalizationMiddleware({ params: false, query: false, body: 'keys' });
   const userContext = options.userContext
     ? createConsoleUserContextMiddleware(options.userContext)
     : null;
@@ -69,7 +70,8 @@ export function assembleSecuredConsoleRouter(
       registerSecuredRoute(router, route, middlewareForRoute({
         route,
         options,
-        normalizeUnicode,
+        normalizeRequestTarget,
+        normalizeBody,
         authenticate,
         userContext,
         csrf,
@@ -116,18 +118,20 @@ export function assembleSecuredConsoleRouter(
 function middlewareForRoute(input: {
   readonly route: ConsoleRouteDefinition;
   readonly options: SecuredConsoleRouterOptions;
-  readonly normalizeUnicode: RequestHandler;
+  readonly normalizeRequestTarget: RequestHandler;
+  readonly normalizeBody: RequestHandler;
   readonly authenticate: RequestHandler;
   readonly userContext: RequestHandler | null;
   readonly csrf: RequestHandler;
 }): readonly RequestHandler[] {
   if (input.route.audience === 'public') {
-    return [input.normalizeUnicode, createSecuredHandler(input.route, input.options)];
+    return [input.normalizeRequestTarget, input.normalizeBody, createSecuredHandler(input.route, input.options)];
   }
   return [
-    input.normalizeUnicode,
+    input.normalizeRequestTarget,
     ...(input.route.responseKind === 'sse' ? [createConsoleStreamRequestProtectionMiddleware(input.route, input.options)] : []),
     input.authenticate,
+    input.normalizeBody,
     ...(input.userContext ? [input.userContext] : []),
     input.csrf,
     createConsoleAuthorizationMiddleware(input.route, input.options),

--- a/src/web-console/platform/ConsoleSecuredRouterAssembler.ts
+++ b/src/web-console/platform/ConsoleSecuredRouterAssembler.ts
@@ -25,6 +25,7 @@ import type { ConsoleHttpMethod, ConsoleRouteDefinition , ConsoleRequest } from 
 import { isElevationValidForRoute } from './ConsolePlatformTypes.js';
 import type { ConsoleModuleRegistry } from './ConsoleModuleRegistry.js';
 import { createConsoleRequestContextMiddleware, requireConsoleRequestContext } from './ConsoleRequestContext.js';
+import { createConsoleUnicodeNormalizationMiddleware } from './ConsoleUnicodeNormalization.js';
 import { executeConsoleRoute, sendConsoleHandlerResult } from './ConsoleRouteExecution.js';
 import {
   createConsoleUserContextMiddleware,
@@ -58,6 +59,7 @@ export function assembleSecuredConsoleRouter(
   router.use(createConsoleSecurityHeadersMiddleware());
   const authenticate = createConsoleAuthenticationMiddleware(options);
   const csrf = createConsoleCsrfProtectionMiddleware(options);
+  const normalizeUnicode = createConsoleUnicodeNormalizationMiddleware();
   const userContext = options.userContext
     ? createConsoleUserContextMiddleware(options.userContext)
     : null;
@@ -67,6 +69,7 @@ export function assembleSecuredConsoleRouter(
       registerSecuredRoute(router, route, middlewareForRoute({
         route,
         options,
+        normalizeUnicode,
         authenticate,
         userContext,
         csrf,
@@ -113,14 +116,16 @@ export function assembleSecuredConsoleRouter(
 function middlewareForRoute(input: {
   readonly route: ConsoleRouteDefinition;
   readonly options: SecuredConsoleRouterOptions;
+  readonly normalizeUnicode: RequestHandler;
   readonly authenticate: RequestHandler;
   readonly userContext: RequestHandler | null;
   readonly csrf: RequestHandler;
 }): readonly RequestHandler[] {
   if (input.route.audience === 'public') {
-    return [createSecuredHandler(input.route, input.options)];
+    return [input.normalizeUnicode, createSecuredHandler(input.route, input.options)];
   }
   return [
+    input.normalizeUnicode,
     ...(input.route.responseKind === 'sse' ? [createConsoleStreamRequestProtectionMiddleware(input.route, input.options)] : []),
     input.authenticate,
     ...(input.userContext ? [input.userContext] : []),

--- a/src/web-console/platform/ConsoleUnicodeNormalization.ts
+++ b/src/web-console/platform/ConsoleUnicodeNormalization.ts
@@ -8,6 +8,7 @@ type StringNormalizationMode = ConsolePathParamValueNormalization | 'preserve';
 
 const MAX_BODY_NORMALIZATION_DEPTH = 64;
 const MAX_BODY_NORMALIZATION_NODES = 10_000;
+const PROTOTYPE_POLLUTING_KEYS = new Set(['__proto__', '__defineGetter__', '__defineSetter__']);
 
 interface ConsoleUnicodeNormalizationOptions {
   readonly params?: boolean;
@@ -136,6 +137,9 @@ function checkBodyTraversal(options: NormalizeValueOptions, depth: number): void
 }
 
 function assertNoNormalizedKeyCollision(seen: Set<string>, key: string): void {
+  if (PROTOTYPE_POLLUTING_KEYS.has(key)) {
+    throw new ConsoleStoreValidationError('Request contains a reserved Unicode-normalized field');
+  }
   if (seen.has(key)) {
     throw new ConsoleStoreValidationError('Request contains duplicate Unicode-equivalent fields');
   }

--- a/src/web-console/platform/ConsoleUnicodeNormalization.ts
+++ b/src/web-console/platform/ConsoleUnicodeNormalization.ts
@@ -1,0 +1,59 @@
+import type { RequestHandler } from 'express';
+import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
+
+type MutableRecord = Record<string, unknown>;
+
+export function createConsoleUnicodeNormalizationMiddleware(): RequestHandler {
+  return (request, _response, next): void => {
+    normalizeRecordInPlace(request.params as MutableRecord);
+    Object.defineProperty(request, 'query', {
+      value: normalizeValue(request.query),
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    });
+    request.body = normalizeValue(request.body);
+    next();
+  };
+}
+
+function normalizeRecordInPlace(value: MutableRecord): void {
+  for (const [key, item] of Object.entries(value)) {
+    const normalizedKey = UnicodeValidator.normalize(key).normalizedContent;
+    const normalizedValue = normalizeValue(item);
+    if (normalizedKey !== key) {
+      delete value[key];
+    }
+    value[normalizedKey] = normalizedValue;
+  }
+}
+
+function normalizeValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return UnicodeValidator.normalize(value).normalizedContent;
+  }
+  if (Array.isArray(value)) {
+    return value.map(item => normalizeValue(item));
+  }
+  if (isPlainObject(value)) {
+    return normalizePlainObject(value);
+  }
+  return value;
+}
+
+function normalizePlainObject(value: MutableRecord): MutableRecord {
+  const normalized: MutableRecord = {};
+  for (const [key, item] of Object.entries(value)) {
+    const normalizedKey = UnicodeValidator.normalize(key).normalizedContent;
+    normalized[normalizedKey] = normalizeValue(item);
+  }
+  return normalized;
+}
+
+function isPlainObject(value: unknown): value is MutableRecord {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}

--- a/src/web-console/platform/ConsoleUnicodeNormalization.ts
+++ b/src/web-console/platform/ConsoleUnicodeNormalization.ts
@@ -1,20 +1,24 @@
 import type { RequestHandler } from 'express';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { ConsoleStoreValidationError } from '../stores/ConsoleStoreValidation.js';
+import type { ConsolePathParamValueNormalization } from './ConsolePlatformTypes.js';
 
 type MutableRecord = Record<string, unknown>;
+type StringNormalizationMode = ConsolePathParamValueNormalization | 'preserve';
 
 const MAX_BODY_NORMALIZATION_DEPTH = 64;
 const MAX_BODY_NORMALIZATION_NODES = 10_000;
 
 interface ConsoleUnicodeNormalizationOptions {
   readonly params?: boolean;
+  readonly pathParamValueNormalization?: Readonly<Record<string, ConsolePathParamValueNormalization>>;
   readonly query?: boolean;
   readonly body?: 'keys' | 'off';
 }
 
 interface NormalizeValueOptions {
-  readonly strings: 'normalize' | 'preserve';
+  readonly strings: StringNormalizationMode;
+  readonly stringModesByKey?: Readonly<Record<string, StringNormalizationMode>>;
   readonly bodyState?: {
     nodes: number;
   };
@@ -28,15 +32,19 @@ export function createConsoleUnicodeNormalizationMiddleware(
   const normalizeParams = options.params ?? true;
   const normalizeQuery = options.query ?? true;
   const bodyMode = options.body ?? 'keys';
+  const pathParamValueNormalization = options.pathParamValueNormalization;
 
   return (request, _response, next): void => {
     try {
       if (normalizeParams) {
-        normalizeRecordInPlace(request.params as MutableRecord, { strings: 'normalize' });
+        normalizeRecordInPlace(request.params as MutableRecord, {
+          strings: 'security',
+          stringModesByKey: pathParamValueNormalization,
+        });
       }
       if (normalizeQuery) {
         Object.defineProperty(request, 'query', {
-          value: normalizeValue(request.query, { strings: 'normalize' }),
+          value: normalizeValue(request.query, { strings: 'security' }),
           configurable: true,
           enumerable: true,
           writable: true,
@@ -66,7 +74,7 @@ function normalizeRecordInPlace(value: MutableRecord, options: NormalizeValueOpt
   for (const [key, item] of entries) {
     const normalizedKey = UnicodeValidator.normalize(key).normalizedContent;
     assertNoNormalizedKeyCollision(seen, normalizedKey);
-    const normalizedValue = normalizeValue(item, options, 1);
+    const normalizedValue = normalizeValue(item, optionsForKey(options, key, normalizedKey), 1);
     defineDataProperty(value, normalizedKey, normalizedValue);
   }
 }
@@ -74,9 +82,7 @@ function normalizeRecordInPlace(value: MutableRecord, options: NormalizeValueOpt
 function normalizeValue(value: unknown, options: NormalizeValueOptions, depth = 0): unknown {
   checkBodyTraversal(options, depth);
   if (typeof value === 'string') {
-    return options.strings === 'normalize'
-      ? UnicodeValidator.normalize(value).normalizedContent
-      : value;
+    return normalizeString(value, options.strings);
   }
   if (Array.isArray(value)) {
     return value.map(item => normalizeValue(item, options, depth + 1));
@@ -85,6 +91,26 @@ function normalizeValue(value: unknown, options: NormalizeValueOptions, depth = 
     return normalizePlainObject(value, options, depth);
   }
   return value;
+}
+
+function optionsForKey(
+  options: NormalizeValueOptions,
+  key: string,
+  normalizedKey: string,
+): NormalizeValueOptions {
+  const mode = options.stringModesByKey?.[key] ?? options.stringModesByKey?.[normalizedKey];
+  return mode === undefined ? options : { ...options, strings: mode };
+}
+
+function normalizeString(value: string, mode: StringNormalizationMode): string {
+  switch (mode) {
+    case 'security':
+      return UnicodeValidator.normalize(value).normalizedContent;
+    case 'nfc':
+      return value.normalize('NFC');
+    case 'preserve':
+      return value;
+  }
 }
 
 function normalizePlainObject(value: MutableRecord, options: NormalizeValueOptions, depth: number): MutableRecord {

--- a/src/web-console/platform/ConsoleUnicodeNormalization.ts
+++ b/src/web-console/platform/ConsoleUnicodeNormalization.ts
@@ -1,7 +1,10 @@
 import type { RequestHandler } from 'express';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { ConsoleStoreValidationError } from '../stores/ConsoleStoreValidation.js';
-import type { ConsolePathParamValueNormalization } from './ConsolePlatformTypes.js';
+import type {
+  ConsolePathParamValueNormalization,
+  ConsoleQueryParamValueNormalization,
+} from './ConsolePlatformTypes.js';
 
 type MutableRecord = Record<string, unknown>;
 type StringNormalizationMode = ConsolePathParamValueNormalization | 'preserve';
@@ -31,6 +34,7 @@ interface ConsoleUnicodeNormalizationOptions {
   readonly params?: boolean;
   readonly pathParamValueNormalization?: Readonly<Record<string, ConsolePathParamValueNormalization>>;
   readonly query?: boolean;
+  readonly queryParamValueNormalization?: Readonly<Record<string, ConsoleQueryParamValueNormalization>>;
   readonly body?: 'keys' | 'off';
 }
 
@@ -51,6 +55,7 @@ export function createConsoleUnicodeNormalizationMiddleware(
   const normalizeQuery = options.query ?? true;
   const bodyMode = options.body ?? 'keys';
   const pathParamValueNormalization = options.pathParamValueNormalization;
+  const queryParamValueNormalization = options.queryParamValueNormalization;
 
   return (request, _response, next): void => {
     try {
@@ -67,7 +72,10 @@ export function createConsoleUnicodeNormalizationMiddleware(
       }
       if (normalizeQuery) {
         Object.defineProperty(request, 'query', {
-          value: normalizeValue(request.query, { strings: 'security' }),
+          value: normalizeValue(request.query, {
+            strings: 'security',
+            stringModesByKey: queryParamValueNormalization,
+          }),
           configurable: true,
           enumerable: true,
           writable: true,
@@ -141,7 +149,11 @@ function normalizePlainObject(value: MutableRecord, options: NormalizeValueOptio
   for (const [key, item] of Object.entries(value)) {
     const normalizedKey = UnicodeValidator.normalize(key).normalizedContent;
     assertNoNormalizedKeyCollision(seen, normalizedKey, JSON_OBJECT_RESERVED_KEYS);
-    defineDataProperty(normalized, normalizedKey, normalizeValue(item, options, depth + 1));
+    defineDataProperty(
+      normalized,
+      normalizedKey,
+      normalizeValue(item, optionsForKey(options, key, normalizedKey), depth + 1),
+    );
   }
   return normalized;
 }

--- a/src/web-console/platform/ConsoleUnicodeNormalization.ts
+++ b/src/web-console/platform/ConsoleUnicodeNormalization.ts
@@ -2,12 +2,11 @@ import type { RequestHandler } from 'express';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import { ConsoleStoreValidationError } from '../stores/ConsoleStoreValidation.js';
 import type {
-  ConsolePathParamValueNormalization,
-  ConsoleQueryParamValueNormalization,
+  ConsoleRequestTargetValueNormalization,
 } from './ConsolePlatformTypes.js';
 
 type MutableRecord = Record<string, unknown>;
-type StringNormalizationMode = ConsolePathParamValueNormalization | 'preserve';
+type StringNormalizationMode = ConsoleRequestTargetValueNormalization | 'preserve';
 
 const MAX_BODY_NORMALIZATION_DEPTH = 64;
 const MAX_BODY_NORMALIZATION_NODES = 10_000;
@@ -32,9 +31,9 @@ const ROUTE_PARAM_RESERVED_KEYS = new Set([
 
 interface ConsoleUnicodeNormalizationOptions {
   readonly params?: boolean;
-  readonly pathParamValueNormalization?: Readonly<Record<string, ConsolePathParamValueNormalization>>;
+  readonly pathParamValueNormalization?: Readonly<Record<string, ConsoleRequestTargetValueNormalization>>;
   readonly query?: boolean;
-  readonly queryParamValueNormalization?: Readonly<Record<string, ConsoleQueryParamValueNormalization>>;
+  readonly queryParamValueNormalization?: Readonly<Record<string, ConsoleRequestTargetValueNormalization>>;
   readonly body?: 'keys' | 'off';
 }
 

--- a/src/web-console/platform/ConsoleUnicodeNormalization.ts
+++ b/src/web-console/platform/ConsoleUnicodeNormalization.ts
@@ -8,7 +8,24 @@ type StringNormalizationMode = ConsolePathParamValueNormalization | 'preserve';
 
 const MAX_BODY_NORMALIZATION_DEPTH = 64;
 const MAX_BODY_NORMALIZATION_NODES = 10_000;
-const PROTOTYPE_POLLUTING_KEYS = new Set(['__proto__', '__defineGetter__', '__defineSetter__']);
+const JSON_OBJECT_RESERVED_KEYS = new Set([
+  '__proto__',
+  '__defineGetter__',
+  '__defineSetter__',
+  '__lookupGetter__',
+  '__lookupSetter__',
+]);
+const ROUTE_PARAM_RESERVED_KEYS = new Set([
+  ...JSON_OBJECT_RESERVED_KEYS,
+  'constructor',
+  'hasOwnProperty',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+  'prototype',
+  'toLocaleString',
+  'toString',
+  'valueOf',
+]);
 
 interface ConsoleUnicodeNormalizationOptions {
   readonly params?: boolean;
@@ -38,9 +55,14 @@ export function createConsoleUnicodeNormalizationMiddleware(
   return (request, _response, next): void => {
     try {
       if (normalizeParams) {
-        normalizeRecordInPlace(request.params as MutableRecord, {
-          strings: 'security',
-          stringModesByKey: pathParamValueNormalization,
+        Object.defineProperty(request, 'params', {
+          value: normalizeRecord(request.params as MutableRecord, {
+            strings: 'security',
+            stringModesByKey: pathParamValueNormalization,
+          }),
+          configurable: true,
+          enumerable: true,
+          writable: true,
         });
       }
       if (normalizeQuery) {
@@ -66,18 +88,17 @@ export function createConsoleUnicodeNormalizationMiddleware(
   };
 }
 
-function normalizeRecordInPlace(value: MutableRecord, options: NormalizeValueOptions): void {
+function normalizeRecord(value: MutableRecord, options: NormalizeValueOptions): MutableRecord {
+  const normalized = Object.create(null) as MutableRecord;
   const entries = Object.entries(value);
   const seen = new Set<string>();
-  for (const key of Object.keys(value)) {
-    delete value[key];
-  }
   for (const [key, item] of entries) {
     const normalizedKey = UnicodeValidator.normalize(key).normalizedContent;
-    assertNoNormalizedKeyCollision(seen, normalizedKey);
+    assertNoNormalizedKeyCollision(seen, normalizedKey, ROUTE_PARAM_RESERVED_KEYS);
     const normalizedValue = normalizeValue(item, optionsForKey(options, key, normalizedKey), 1);
-    defineDataProperty(value, normalizedKey, normalizedValue);
+    defineDataProperty(normalized, normalizedKey, normalizedValue);
   }
+  return normalized;
 }
 
 function normalizeValue(value: unknown, options: NormalizeValueOptions, depth = 0): unknown {
@@ -119,7 +140,7 @@ function normalizePlainObject(value: MutableRecord, options: NormalizeValueOptio
   const seen = new Set<string>();
   for (const [key, item] of Object.entries(value)) {
     const normalizedKey = UnicodeValidator.normalize(key).normalizedContent;
-    assertNoNormalizedKeyCollision(seen, normalizedKey);
+    assertNoNormalizedKeyCollision(seen, normalizedKey, JSON_OBJECT_RESERVED_KEYS);
     defineDataProperty(normalized, normalizedKey, normalizeValue(item, options, depth + 1));
   }
   return normalized;
@@ -136,8 +157,8 @@ function checkBodyTraversal(options: NormalizeValueOptions, depth: number): void
   }
 }
 
-function assertNoNormalizedKeyCollision(seen: Set<string>, key: string): void {
-  if (PROTOTYPE_POLLUTING_KEYS.has(key)) {
+function assertNoNormalizedKeyCollision(seen: Set<string>, key: string, reservedKeys: ReadonlySet<string>): void {
+  if (reservedKeys.has(key)) {
     throw new ConsoleStoreValidationError('Request contains a reserved Unicode-normalized field');
   }
   if (seen.has(key)) {

--- a/src/web-console/platform/ConsoleUnicodeNormalization.ts
+++ b/src/web-console/platform/ConsoleUnicodeNormalization.ts
@@ -24,7 +24,7 @@ function normalizeRecordInPlace(value: MutableRecord): void {
     if (normalizedKey !== key) {
       delete value[key];
     }
-    value[normalizedKey] = normalizedValue;
+    defineDataProperty(value, normalizedKey, normalizedValue);
   }
 }
 
@@ -42,12 +42,21 @@ function normalizeValue(value: unknown): unknown {
 }
 
 function normalizePlainObject(value: MutableRecord): MutableRecord {
-  const normalized: MutableRecord = {};
+  const normalized = Object.create(null) as MutableRecord;
   for (const [key, item] of Object.entries(value)) {
     const normalizedKey = UnicodeValidator.normalize(key).normalizedContent;
-    normalized[normalizedKey] = normalizeValue(item);
+    defineDataProperty(normalized, normalizedKey, normalizeValue(item));
   }
   return normalized;
+}
+
+function defineDataProperty(target: MutableRecord, key: string, value: unknown): void {
+  Object.defineProperty(target, key, {
+    value,
+    configurable: true,
+    enumerable: true,
+    writable: true,
+  });
 }
 
 function isPlainObject(value: unknown): value is MutableRecord {

--- a/src/web-console/platform/ConsoleUnicodeNormalization.ts
+++ b/src/web-console/platform/ConsoleUnicodeNormalization.ts
@@ -1,53 +1,119 @@
 import type { RequestHandler } from 'express';
 import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
+import { ConsoleStoreValidationError } from '../stores/ConsoleStoreValidation.js';
 
 type MutableRecord = Record<string, unknown>;
 
-export function createConsoleUnicodeNormalizationMiddleware(): RequestHandler {
+const MAX_BODY_NORMALIZATION_DEPTH = 64;
+const MAX_BODY_NORMALIZATION_NODES = 10_000;
+
+interface ConsoleUnicodeNormalizationOptions {
+  readonly params?: boolean;
+  readonly query?: boolean;
+  readonly body?: 'keys' | 'off';
+}
+
+interface NormalizeValueOptions {
+  readonly strings: 'normalize' | 'preserve';
+  readonly bodyState?: {
+    nodes: number;
+  };
+  readonly maxDepth?: number;
+  readonly maxNodes?: number;
+}
+
+export function createConsoleUnicodeNormalizationMiddleware(
+  options: ConsoleUnicodeNormalizationOptions = {},
+): RequestHandler {
+  const normalizeParams = options.params ?? true;
+  const normalizeQuery = options.query ?? true;
+  const bodyMode = options.body ?? 'keys';
+
   return (request, _response, next): void => {
-    normalizeRecordInPlace(request.params as MutableRecord);
-    Object.defineProperty(request, 'query', {
-      value: normalizeValue(request.query),
-      configurable: true,
-      enumerable: true,
-      writable: true,
-    });
-    request.body = normalizeValue(request.body);
-    next();
+    try {
+      if (normalizeParams) {
+        normalizeRecordInPlace(request.params as MutableRecord, { strings: 'normalize' });
+      }
+      if (normalizeQuery) {
+        Object.defineProperty(request, 'query', {
+          value: normalizeValue(request.query, { strings: 'normalize' }),
+          configurable: true,
+          enumerable: true,
+          writable: true,
+        });
+      }
+      if (bodyMode === 'keys') {
+        request.body = normalizeValue(request.body, {
+          strings: 'preserve',
+          bodyState: { nodes: 0 },
+          maxDepth: MAX_BODY_NORMALIZATION_DEPTH,
+          maxNodes: MAX_BODY_NORMALIZATION_NODES,
+        });
+      }
+      next();
+    } catch (error) {
+      next(error);
+    }
   };
 }
 
-function normalizeRecordInPlace(value: MutableRecord): void {
-  for (const [key, item] of Object.entries(value)) {
+function normalizeRecordInPlace(value: MutableRecord, options: NormalizeValueOptions): void {
+  const entries = Object.entries(value);
+  const seen = new Set<string>();
+  for (const key of Object.keys(value)) {
+    delete value[key];
+  }
+  for (const [key, item] of entries) {
     const normalizedKey = UnicodeValidator.normalize(key).normalizedContent;
-    const normalizedValue = normalizeValue(item);
-    if (normalizedKey !== key) {
-      delete value[key];
-    }
+    assertNoNormalizedKeyCollision(seen, normalizedKey);
+    const normalizedValue = normalizeValue(item, options, 1);
     defineDataProperty(value, normalizedKey, normalizedValue);
   }
 }
 
-function normalizeValue(value: unknown): unknown {
+function normalizeValue(value: unknown, options: NormalizeValueOptions, depth = 0): unknown {
+  checkBodyTraversal(options, depth);
   if (typeof value === 'string') {
-    return UnicodeValidator.normalize(value).normalizedContent;
+    return options.strings === 'normalize'
+      ? UnicodeValidator.normalize(value).normalizedContent
+      : value;
   }
   if (Array.isArray(value)) {
-    return value.map(item => normalizeValue(item));
+    return value.map(item => normalizeValue(item, options, depth + 1));
   }
   if (isPlainObject(value)) {
-    return normalizePlainObject(value);
+    return normalizePlainObject(value, options, depth);
   }
   return value;
 }
 
-function normalizePlainObject(value: MutableRecord): MutableRecord {
+function normalizePlainObject(value: MutableRecord, options: NormalizeValueOptions, depth: number): MutableRecord {
   const normalized = Object.create(null) as MutableRecord;
+  const seen = new Set<string>();
   for (const [key, item] of Object.entries(value)) {
     const normalizedKey = UnicodeValidator.normalize(key).normalizedContent;
-    defineDataProperty(normalized, normalizedKey, normalizeValue(item));
+    assertNoNormalizedKeyCollision(seen, normalizedKey);
+    defineDataProperty(normalized, normalizedKey, normalizeValue(item, options, depth + 1));
   }
   return normalized;
+}
+
+function checkBodyTraversal(options: NormalizeValueOptions, depth: number): void {
+  if (!options.bodyState) return;
+  if (depth > (options.maxDepth ?? MAX_BODY_NORMALIZATION_DEPTH)) {
+    throw new ConsoleStoreValidationError('Request body exceeds the Unicode normalization nesting limit');
+  }
+  options.bodyState.nodes += 1;
+  if (options.bodyState.nodes > (options.maxNodes ?? MAX_BODY_NORMALIZATION_NODES)) {
+    throw new ConsoleStoreValidationError('Request body exceeds the Unicode normalization size limit');
+  }
+}
+
+function assertNoNormalizedKeyCollision(seen: Set<string>, key: string): void {
+  if (seen.has(key)) {
+    throw new ConsoleStoreValidationError('Request contains duplicate Unicode-equivalent fields');
+  }
+  seen.add(key);
 }
 
 function defineDataProperty(target: MutableRecord, key: string, value: unknown): void {

--- a/src/web-console/platform/index.ts
+++ b/src/web-console/platform/index.ts
@@ -4,6 +4,7 @@ export * from './ConsoleProjectorHelpers.js';
 export * from './ConsoleRequestContext.js';
 export * from './ConsoleRouterAssembler.js';
 export * from './ConsoleRouteExecution.js';
+export * from './ConsoleUnicodeNormalization.js';
 export * from './ConsoleReturnPaths.js';
 export * from './ConsoleSecuredRouterAssembler.js';
 export * from './ConsoleSessionActivationBridgeState.js';

--- a/src/web-console/security/SecretEncryption.ts
+++ b/src/web-console/security/SecretEncryption.ts
@@ -3,6 +3,7 @@ import {
   createDecipheriv,
   randomBytes,
 } from 'node:crypto';
+import { SecurityMonitor } from '../../security/securityMonitor.js';
 
 const ALGORITHM = 'aes-256-gcm';
 const ALGORITHM_ID = 1;
@@ -46,38 +47,47 @@ export class AeadSecretEncryptionService implements ISecretEncryptionService {
 
   encrypt(plaintext: Buffer, context: SecretEncryptionContext): Buffer {
     validateContext(context);
-    const keyId = Buffer.from(this.activeKey.keyId, 'utf8');
-    if (keyId.length > 255) throw new Error('Secret encryption key ID exceeds 255 bytes');
-    const nonce = randomBytes(NONCE_BYTES);
-    const cipher = createCipheriv(ALGORITHM, this.activeKey.key, nonce);
-    cipher.setAAD(additionalAuthenticatedData(context));
-    const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
-    const tag = cipher.getAuthTag();
-    return Buffer.concat([
-      Buffer.from([FORMAT_VERSION, ALGORITHM_ID, keyId.length]),
-      keyId,
-      nonce,
-      tag,
-      ciphertext,
-    ]);
+    try {
+      const keyId = Buffer.from(this.activeKey.keyId, 'utf8');
+      if (keyId.length > 255) throw new Error('Secret encryption key ID exceeds 255 bytes');
+      const nonce = randomBytes(NONCE_BYTES);
+      const cipher = createCipheriv(ALGORITHM, this.activeKey.key, nonce);
+      cipher.setAAD(additionalAuthenticatedData(context));
+      const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+      const tag = cipher.getAuthTag();
+      return Buffer.concat([
+        Buffer.from([FORMAT_VERSION, ALGORITHM_ID, keyId.length]),
+        keyId,
+        nonce,
+        tag,
+        ciphertext,
+      ]);
+    } catch (error) {
+      logSecretCryptoFailure('encrypt', context, asError(error));
+      throw error;
+    }
   }
 
   decrypt(record: Buffer, context: SecretEncryptionContext): Buffer {
     validateContext(context);
     if (!Buffer.isBuffer(record) || record.length < 3 + NONCE_BYTES + TAG_BYTES) {
-      throw new Error('Invalid secret ciphertext record');
+      throw logSecretCryptoFailure('decrypt', context, new Error('Invalid secret ciphertext record'));
     }
     const version = record[0];
-    if (version !== FORMAT_VERSION) throw new Error('Unsupported secret ciphertext format version');
-    if (record[1] !== ALGORITHM_ID) throw new Error('Unsupported secret ciphertext algorithm');
+    if (version !== FORMAT_VERSION) {
+      throw logSecretCryptoFailure('decrypt', context, new Error('Unsupported secret ciphertext format version'));
+    }
+    if (record[1] !== ALGORITHM_ID) {
+      throw logSecretCryptoFailure('decrypt', context, new Error('Unsupported secret ciphertext algorithm'));
+    }
     const keyIdLength = record[2];
     const dataStart = 3 + keyIdLength;
     if (record.length < dataStart + NONCE_BYTES + TAG_BYTES) {
-      throw new Error('Invalid secret ciphertext record');
+      throw logSecretCryptoFailure('decrypt', context, new Error('Invalid secret ciphertext record'));
     }
     const keyId = record.subarray(3, dataStart).toString('utf8');
     const key = this.decryptKeys.get(keyId);
-    if (!key) throw new Error('Unknown secret encryption key ID');
+    if (!key) throw logSecretCryptoFailure('decrypt', context, new Error('Unknown secret encryption key ID'));
     const nonce = record.subarray(dataStart, dataStart + NONCE_BYTES);
     const tag = record.subarray(dataStart + NONCE_BYTES, dataStart + NONCE_BYTES + TAG_BYTES);
     const ciphertext = record.subarray(dataStart + NONCE_BYTES + TAG_BYTES);
@@ -87,7 +97,7 @@ export class AeadSecretEncryptionService implements ISecretEncryptionService {
       decipher.setAuthTag(tag);
       return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
     } catch {
-      throw new Error('Secret ciphertext authentication failed');
+      throw logSecretCryptoFailure('decrypt', context, new Error('Secret ciphertext authentication failed'));
     }
   }
 }
@@ -112,4 +122,27 @@ function validateKey(key: AeadSecretKey): void {
   if (key.keyId.trim() === '' || key.key.length !== 32) {
     throw new Error('Secret encryption keys require a key ID and exactly 32 bytes');
   }
+}
+
+function logSecretCryptoFailure(
+  operation: 'encrypt' | 'decrypt',
+  context: SecretEncryptionContext,
+  error: Error,
+): Error {
+  SecurityMonitor.logSecurityEvent({
+    type: 'OPERATION_FAILED',
+    severity: 'HIGH',
+    source: 'AeadSecretEncryptionService',
+    details: `Secret ${operation} operation failed`,
+    additionalData: {
+      operation,
+      secretClass: context.secretClass,
+      error: error.message,
+    },
+  });
+  return error;
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }

--- a/src/web-console/stores/IConsoleAccountAllowlistStore.ts
+++ b/src/web-console/stores/IConsoleAccountAllowlistStore.ts
@@ -1,5 +1,6 @@
 import type { AuthAllowlistKind } from '../../database/schema/index.js';
 import type { AllowlistMatchValues } from '../../auth/embedded-as/storage/IAuthStorageLayer.js';
+import { UnicodeValidator } from '../../security/validators/unicodeValidator.js';
 import {
   assertUuid,
   cloneDate,
@@ -78,22 +79,26 @@ export function assertAllowlistKind(value: string, name: string): asserts value 
 }
 
 export function normalizeAllowlistValue(kind: ConsoleAccountAllowlistKind, value: string): string {
-  const trimmed = value.trim();
-  return kind === 'github_id' ? trimmed : trimmed.toLowerCase();
+  const normalized = normalizeAllowlistDisplayValue(value);
+  return kind === 'github_id' ? normalized : normalized.toLowerCase();
+}
+
+export function normalizeAllowlistDisplayValue(value: string): string {
+  return UnicodeValidator.normalize(value).normalizedContent.trim();
 }
 
 export function validateAllowlistValue(kind: ConsoleAccountAllowlistKind, value: string, name: string): void {
-  const trimmed = value.trim();
-  if (trimmed === '' || trimmed.length > 320) {
+  const normalized = normalizeAllowlistDisplayValue(value);
+  if (normalized === '' || normalized.length > 320) {
     throw new ConsoleStoreValidationError(`${name} must be non-empty and at most 320 characters`);
   }
-  if (kind === 'email' && !isLiteEmailAddress(trimmed)) {
+  if (kind === 'email' && !isLiteEmailAddress(normalized)) {
     throw new ConsoleStoreValidationError(`${name} must be a valid email address`);
   }
-  if (kind === 'github_username' && !/^[A-Za-z0-9-]{1,39}$/.test(trimmed)) {
+  if (kind === 'github_username' && !/^[A-Za-z0-9-]{1,39}$/.test(normalized)) {
     throw new ConsoleStoreValidationError(`${name} must be a valid GitHub username`);
   }
-  if (kind === 'github_id' && !/^\d+$/.test(trimmed)) {
+  if (kind === 'github_id' && !/^\d+$/.test(normalized)) {
     throw new ConsoleStoreValidationError(`${name} must be a numeric GitHub id`);
   }
 }

--- a/src/web-console/stores/InMemoryConsoleAccountAllowlistStore.ts
+++ b/src/web-console/stores/InMemoryConsoleAccountAllowlistStore.ts
@@ -11,6 +11,7 @@ import type {
 } from './IConsoleAccountAllowlistStore.js';
 import {
   cloneAllowlistEntry,
+  normalizeAllowlistDisplayValue,
   normalizeAllowlistValue,
   validateAllowlistAddInput,
   validateAllowlistRemoveInput,
@@ -71,7 +72,7 @@ export class InMemoryConsoleAccountAllowlistStore implements IConsoleAccountAllo
       id: randomUUID(),
       kind: input.kind,
       normalizedValue,
-      displayValue: input.value.trim(),
+      displayValue: normalizeAllowlistDisplayValue(input.value),
       note: input.note ?? null,
       createdByUserId: input.createdByUserId,
       createdAt: new Date(input.createdAt),

--- a/src/web-console/stores/PostgresConsoleAccountAllowlistStore.ts
+++ b/src/web-console/stores/PostgresConsoleAccountAllowlistStore.ts
@@ -17,6 +17,7 @@ import type {
   IConsoleAccountAllowlistStore,
 } from './IConsoleAccountAllowlistStore.js';
 import {
+  normalizeAllowlistDisplayValue,
   normalizeAllowlistValue,
   validateAllowlistAddInput,
   validateAllowlistRemoveInput,
@@ -124,7 +125,7 @@ export async function addAccountAllowlistEntryWithTx(
     const rows = await tx.insert(accountAllowlistEntries).values({
       kind: input.kind,
       normalizedValue: normalizeAllowlistValue(input.kind, input.value),
-      displayValue: input.value.trim(),
+      displayValue: normalizeAllowlistDisplayValue(input.value),
       note: input.note ?? null,
       createdByUserId: input.createdByUserId,
       createdAt: input.createdAt,

--- a/src/web-console/ui/api.js
+++ b/src/web-console/ui/api.js
@@ -16,14 +16,28 @@
 
 const API_PREFIX = '/api/v1';
 const MUTATING = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const RESERVED_NORMALIZED_KEYS = new Set(['__proto__', '__defineGetter__', '__defineSetter__']);
+
+function assertCanWriteNormalizedKey(seen, key) {
+  if (RESERVED_NORMALIZED_KEYS.has(key)) {
+    throw new Error('Request contains a reserved Unicode-normalized field');
+  }
+  if (seen.has(key)) {
+    throw new Error('Request contains duplicate Unicode-equivalent fields');
+  }
+  seen.add(key);
+}
 
 function normalizeUnicode(value) {
   if (typeof value === 'string') return value.normalize('NFC');
   if (Array.isArray(value)) return value.map(item => normalizeUnicode(item));
   if (value && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
     const normalized = Object.create(null);
+    const seen = new Set();
     for (const [key, item] of Object.entries(value)) {
-      Object.defineProperty(normalized, key.normalize('NFC'), {
+      const normalizedKey = key.normalize('NFC');
+      assertCanWriteNormalizedKey(seen, normalizedKey);
+      Object.defineProperty(normalized, normalizedKey, {
         value: normalizeUnicode(item),
         configurable: true,
         enumerable: true,
@@ -40,8 +54,11 @@ function normalizeBodyKeys(value) {
   if (Array.isArray(value)) return value.map(item => normalizeBodyKeys(item));
   if (value && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
     const normalized = Object.create(null);
+    const seen = new Set();
     for (const [key, item] of Object.entries(value)) {
-      Object.defineProperty(normalized, key.normalize('NFC'), {
+      const normalizedKey = key.normalize('NFC');
+      assertCanWriteNormalizedKey(seen, normalizedKey);
+      Object.defineProperty(normalized, normalizedKey, {
         value: normalizeBodyKeys(item),
         configurable: true,
         enumerable: true,

--- a/src/web-console/ui/api.js
+++ b/src/web-console/ui/api.js
@@ -21,10 +21,16 @@ function normalizeUnicode(value) {
   if (typeof value === 'string') return value.normalize('NFC');
   if (Array.isArray(value)) return value.map(item => normalizeUnicode(item));
   if (value && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
-    return Object.fromEntries(Object.entries(value).map(([key, item]) => [
-      key.normalize('NFC'),
-      normalizeUnicode(item),
-    ]));
+    const normalized = Object.create(null);
+    for (const [key, item] of Object.entries(value)) {
+      Object.defineProperty(normalized, key.normalize('NFC'), {
+        value: normalizeUnicode(item),
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
+    }
+    return normalized;
   }
   return value;
 }

--- a/src/web-console/ui/api.js
+++ b/src/web-console/ui/api.js
@@ -17,6 +17,18 @@
 const API_PREFIX = '/api/v1';
 const MUTATING = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
+function normalizeUnicode(value) {
+  if (typeof value === 'string') return value.normalize('NFC');
+  if (Array.isArray(value)) return value.map(item => normalizeUnicode(item));
+  if (value && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [
+      key.normalize('NFC'),
+      normalizeUnicode(item),
+    ]));
+  }
+  return value;
+}
+
 /** Read a non-HttpOnly cookie (used for the dh_csrf double-submit token). */
 function readCookie(name) {
   const prefix = `${name}=`;
@@ -52,12 +64,13 @@ function parseProblemCode(body) {
  * required capability + step_up_url) before returning so the shell can react.
  */
 export async function request(method, path, options = {}) {
-  const res = await fetch(API_PREFIX + path, {
+  const normalizedBody = options.body === undefined ? undefined : normalizeUnicode(options.body);
+  const res = await fetch(API_PREFIX + normalizeUnicode(path), {
     method,
     credentials: 'same-origin',
     redirect: 'manual',
     headers: buildHeaders(method, options),
-    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+    body: normalizedBody === undefined ? undefined : JSON.stringify(normalizedBody),
     signal: options.signal,
   });
 

--- a/src/web-console/ui/api.js
+++ b/src/web-console/ui/api.js
@@ -35,6 +35,24 @@ function normalizeUnicode(value) {
   return value;
 }
 
+function normalizeBodyKeys(value) {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value.map(item => normalizeBodyKeys(item));
+  if (value && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
+    const normalized = Object.create(null);
+    for (const [key, item] of Object.entries(value)) {
+      Object.defineProperty(normalized, key.normalize('NFC'), {
+        value: normalizeBodyKeys(item),
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
+    }
+    return normalized;
+  }
+  return value;
+}
+
 /** Read a non-HttpOnly cookie (used for the dh_csrf double-submit token). */
 function readCookie(name) {
   const prefix = `${name}=`;
@@ -70,7 +88,7 @@ function parseProblemCode(body) {
  * required capability + step_up_url) before returning so the shell can react.
  */
 export async function request(method, path, options = {}) {
-  const normalizedBody = options.body === undefined ? undefined : normalizeUnicode(options.body);
+  const normalizedBody = options.body === undefined ? undefined : normalizeBodyKeys(options.body);
   const res = await fetch(API_PREFIX + normalizeUnicode(path), {
     method,
     credentials: 'same-origin',

--- a/src/web-console/ui/api.js
+++ b/src/web-console/ui/api.js
@@ -16,7 +16,13 @@
 
 const API_PREFIX = '/api/v1';
 const MUTATING = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
-const RESERVED_NORMALIZED_KEYS = new Set(['__proto__', '__defineGetter__', '__defineSetter__']);
+const RESERVED_NORMALIZED_KEYS = new Set([
+  '__proto__',
+  '__defineGetter__',
+  '__defineSetter__',
+  '__lookupGetter__',
+  '__lookupSetter__',
+]);
 
 function assertCanWriteNormalizedKey(seen, key) {
   if (RESERVED_NORMALIZED_KEYS.has(key)) {
@@ -28,6 +34,10 @@ function assertCanWriteNormalizedKey(seen, key) {
   seen.add(key);
 }
 
+/**
+ * Normalize API request targets. Paths and query fragments are identifiers, so
+ * string values are NFC-normalized along with object keys before fetch.
+ */
 function normalizeUnicode(value) {
   if (typeof value === 'string') return value.normalize('NFC');
   if (Array.isArray(value)) return value.map(item => normalizeUnicode(item));
@@ -49,6 +59,10 @@ function normalizeUnicode(value) {
   return value;
 }
 
+/**
+ * Normalize JSON body keys without rewriting string values. Element content and
+ * metadata can contain free-form user text that must round-trip exactly.
+ */
 function normalizeBodyKeys(value) {
   if (typeof value === 'string') return value;
   if (Array.isArray(value)) return value.map(item => normalizeBodyKeys(item));

--- a/tests/unit/auth/OidcAuthProvider.test.ts
+++ b/tests/unit/auth/OidcAuthProvider.test.ts
@@ -199,6 +199,30 @@ describe('OidcAuthProvider — typed error classification (Cycle-11 H11-1)', () 
     }
   });
 
+  it('includes reason and provider in validation failure details for audit deduplication', async () => {
+    const logSpy = jest.spyOn(SecurityMonitor, 'logSecurityEvent').mockImplementation(() => {});
+    try {
+      const missingScopeToken = await mintToken({ scope: 'openid profile' });
+      await provider.validate(missingScopeToken);
+
+      const wrongProvider = new OidcAuthProvider({
+        issuer: ISSUER,
+        audience: AUDIENCE,
+        jwksGetter: wrongJwks,
+      });
+      await wrongProvider.validate(await mintToken());
+
+      const details = logSpy.mock.calls.map(([event]) => event.details);
+      expect(details).toEqual([
+        'OIDC access token validation failed: token missing mcp scope [provider:oidc:tenant.example.com]',
+        'OIDC access token validation failed: invalid signature [provider:oidc:tenant.example.com]',
+      ]);
+      expect(new Set(details).size).toBe(details.length);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
   // Cycle-12 fix (M12-1): algorithms allowlist parity with EmbeddedAS
   // and LocalDev. The default allowlist excludes `none` and HS-family
   // algorithms; jose rejects them at verify-time even if a token were

--- a/tests/unit/auth/OidcAuthProvider.test.ts
+++ b/tests/unit/auth/OidcAuthProvider.test.ts
@@ -16,7 +16,7 @@
  * provider is mounted.
  */
 
-import { describe, it, expect, beforeAll } from '@jest/globals';
+import { describe, it, expect, beforeAll, jest } from '@jest/globals';
 import {
   SignJWT,
   exportJWK,
@@ -25,6 +25,7 @@ import {
   type JWTVerifyGetKey,
 } from 'jose';
 import { OidcAuthProvider } from '../../../src/auth/OidcAuthProvider.js';
+import { SecurityMonitor } from '../../../src/security/securityMonitor.js';
 
 const ISSUER = 'https://tenant.example.com/';
 const AUDIENCE = 'mcp-resource';
@@ -173,6 +174,28 @@ describe('OidcAuthProvider — typed error classification (Cycle-11 H11-1)', () 
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.reason).toMatch(/mcp scope/);
+    }
+  });
+
+  it('logs verified tokens rejected by provider authorization checks', async () => {
+    const logSpy = jest.spyOn(SecurityMonitor, 'logSecurityEvent').mockImplementation(() => {});
+    try {
+      const token = await mintToken({ scope: 'openid profile' });
+      const result = await provider.validate(token);
+
+      expect(result.ok).toBe(false);
+      expect(logSpy).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'TOKEN_VALIDATION_FAILURE',
+        severity: 'MEDIUM',
+        source: 'OidcAuthProvider.validate',
+        additionalData: expect.objectContaining({
+          provider: 'oidc:tenant.example.com',
+          issuer: ISSUER,
+          reason: 'token missing mcp scope',
+        }),
+      }));
+    } finally {
+      logSpy.mockRestore();
     }
   });
 

--- a/tests/unit/auth/embedded-as/EmbeddedAuthorizationServer.validate.test.ts
+++ b/tests/unit/auth/embedded-as/EmbeddedAuthorizationServer.validate.test.ts
@@ -14,7 +14,7 @@
  * Bearer-protected route.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { describe, it, expect, beforeAll, afterAll, jest } from '@jest/globals';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import os from 'node:os';
@@ -23,6 +23,7 @@ import { EmbeddedAuthorizationServer } from '../../../../src/auth/embedded-as/Em
 import { loadPublicSigningJwksFromStore } from '../../../../src/auth/embedded-as/EmbeddedASTokens.js';
 import { InMemoryAuthStorageLayer } from '../../../../src/auth/embedded-as/storage/InMemoryAuthStorageLayer.js';
 import { TrivialConsentMethod } from '../../../../src/auth/embedded-as/methods/TrivialConsentMethod.js';
+import { SecurityMonitor } from '../../../../src/security/securityMonitor.js';
 import {
   loadOrGenerateSigningJwks,
   rotateSigningKeyViaStore,
@@ -478,10 +479,33 @@ describe('EmbeddedAuthorizationServer store-backed live signing keys', () => {
     }
 
     await signingKeyStore.retire(firstKid);
-    await expect(server.validate(firstToken)).resolves.toEqual({
-      ok: false,
-      reason: UNKNOWN_KEY_ID_REASON,
-    });
+    const logSpy = jest.spyOn(SecurityMonitor, 'logSecurityEvent').mockImplementation(() => {});
+    try {
+      await expect(server.validate(firstToken)).resolves.toEqual({
+        ok: false,
+        reason: UNKNOWN_KEY_ID_REASON,
+      });
+      expect(logSpy).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'TOKEN_VALIDATION_FAILURE',
+        severity: 'MEDIUM',
+        source: 'EmbeddedASTokens.validateWithStore',
+        additionalData: { reason: UNKNOWN_KEY_ID_REASON },
+      }));
+
+      const tokenWithoutKid = removeTokenKid(secondToken);
+      await expect(server.validate(tokenWithoutKid)).resolves.toEqual({
+        ok: false,
+        reason: 'token missing kid header',
+      });
+      expect(logSpy).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'TOKEN_VALIDATION_FAILURE',
+        severity: 'MEDIUM',
+        source: 'EmbeddedASTokens.validateWithStore',
+        additionalData: { reason: 'token missing kid header' },
+      }));
+    } finally {
+      logSpy.mockRestore();
+    }
     await expect(server.validate(secondToken)).resolves.toMatchObject({ ok: true });
     await expect(loadPublicSigningJwksFromStore(signingKeyStore)).resolves.toEqual({
       keys: [expect.objectContaining({ kid: secondKid })],
@@ -508,4 +532,12 @@ function tokenKid(token: string): string {
   const header = JSON.parse(Buffer.from(headerB64, 'base64url').toString('utf8')) as { kid?: string };
   expect(header.kid).toEqual(expect.any(String));
   return header.kid ?? '';
+}
+
+function removeTokenKid(token: string): string {
+  const [headerB64, payloadB64, signatureB64] = token.split('.');
+  const header = JSON.parse(Buffer.from(headerB64, 'base64url').toString('utf8')) as Record<string, unknown>;
+  delete header.kid;
+  const rewrittenHeader = Buffer.from(JSON.stringify(header), 'utf8').toString('base64url');
+  return [rewrittenHeader, payloadB64, signatureB64].join('.');
 }

--- a/tests/unit/auth/embedded-as/totp/AdminTotpService.test.ts
+++ b/tests/unit/auth/embedded-as/totp/AdminTotpService.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import { Secret, TOTP } from 'otpauth';
 
 import {
@@ -6,6 +6,7 @@ import {
   AdminTotpError,
   AdminTotpService,
 } from '../../../../../src/auth/embedded-as/totp/AdminTotpService.js';
+import { SecurityMonitor } from '../../../../../src/security/securityMonitor.js';
 import { InMemoryAuthStorageLayer } from '../../../../../src/auth/embedded-as/storage/InMemoryAuthStorageLayer.js';
 import { AeadSecretEncryptionService } from '../../../../../src/web-console/security/SecretEncryption.js';
 import { InMemoryConsoleFactorStore } from '../../../../../src/web-console/stores/InMemoryConsoleFactorStore.js';
@@ -16,6 +17,10 @@ const TOTP_LABEL = 'Admin Console';
 const NOW = new Date('2026-05-27T12:00:00.000Z');
 const FIVE_MINUTES = new Date('2026-05-27T12:05:00.000Z');
 const ELEVEN_MINUTES = new Date('2026-05-27T12:11:00.000Z');
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
 function createService(now: () => Date = () => NOW): {
   service: AdminTotpService;
@@ -163,5 +168,29 @@ describe('AdminTotpService', () => {
 
     await expect(service.prove(USER_ID, '000000')).resolves.toEqual({ ok: false });
     await expect(service.disable(USER_ID, '000000')).resolves.toBe(false);
+  });
+
+  it('adds a principal fingerprint to TOTP audit details for deduplication', async () => {
+    const logSpy = jest.spyOn(SecurityMonitor, 'logSecurityEvent').mockImplementation(() => {});
+    const { service } = createService();
+    const { service: otherService } = createService();
+    const begin = await service.beginEnrollment(USER_ID, TOTP_LABEL);
+    const otherBegin = await otherService.beginEnrollment(OTHER_USER_ID, TOTP_LABEL);
+
+    await expect(service.confirmEnrollment(USER_ID, begin.pendingId, '000000'))
+      .rejects.toBeInstanceOf(AdminTotpError);
+    await expect(otherService.confirmEnrollment(OTHER_USER_ID, otherBegin.pendingId, '000000'))
+      .rejects.toBeInstanceOf(AdminTotpError);
+
+    const failureDetails = logSpy.mock.calls
+      .map(call => call[0])
+      .filter(event => event.type === 'TOTP_VERIFICATION_FAILED')
+      .map(event => event.details);
+    expect(failureDetails).toHaveLength(2);
+    expect(failureDetails[0]).toMatch(/Admin TOTP enrollment confirmation failed \[principal:[0-9a-f]{16}\]/);
+    expect(failureDetails[1]).toMatch(/Admin TOTP enrollment confirmation failed \[principal:[0-9a-f]{16}\]/);
+    expect(failureDetails[0]).not.toBe(failureDetails[1]);
+    expect(failureDetails.join('\n')).not.toContain(USER_ID);
+    expect(failureDetails.join('\n')).not.toContain(OTHER_USER_ID);
   });
 });

--- a/tests/unit/auth/instrumentAuthProvider.test.ts
+++ b/tests/unit/auth/instrumentAuthProvider.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { instrumentAuthProvider } from '../../../src/auth/instrumentAuthProvider.js';
+import type { AuthResult, IAuthProvider } from '../../../src/auth/IAuthProvider.js';
+import { SecurityMonitor } from '../../../src/security/securityMonitor.js';
+import type { PerformanceMonitor } from '../../../src/utils/PerformanceMonitor.js';
+
+describe('instrumentAuthProvider', () => {
+  it('times validation without duplicating concrete provider security events', async () => {
+    const providerEvent = {
+      type: 'TOKEN_VALIDATION_FAILURE',
+      severity: 'MEDIUM',
+      source: 'fixture-provider',
+      details: 'Fixture token validation failed',
+      additionalData: { reason: 'invalid signature' },
+    } as const;
+    const provider: IAuthProvider = {
+      name: 'fixture',
+      validate: jest.fn(async (): Promise<AuthResult> => {
+        SecurityMonitor.logSecurityEvent(providerEvent);
+        return { ok: false, reason: 'invalid signature' };
+      }),
+    };
+    const monitor = {
+      timeAuthOp: jest.fn(async <T>(_op: string, fn: () => Promise<T>): Promise<T> => fn()),
+    } as unknown as PerformanceMonitor;
+    const logSpy = jest.spyOn(SecurityMonitor, 'logSecurityEvent').mockImplementation(() => {});
+
+    try {
+      const instrumented = instrumentAuthProvider(provider, monitor);
+      const result = await instrumented.validate('bad-token');
+
+      expect(result).toEqual({ ok: false, reason: 'invalid signature' });
+      expect(monitor.timeAuthOp).toHaveBeenCalledWith('auth.validateToken', expect.any(Function), 'fixture');
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy).toHaveBeenCalledWith(providerEvent);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/tests/unit/security/CommandValidator.test.ts
+++ b/tests/unit/security/CommandValidator.test.ts
@@ -5,9 +5,15 @@
  * Issue #449: Direct unit tests for the CommandValidator class.
  */
 
-import { describe, it, expect, jest } from '@jest/globals';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { EventEmitter } from 'node:events';
 
 // ESM mocking: mock child_process and logger
+const mockSpawn = jest.fn();
+jest.unstable_mockModule('child_process', () => ({
+  spawn: mockSpawn,
+}));
+
 jest.unstable_mockModule('../../../src/utils/logger.js', () => ({
   logger: {
     debug: jest.fn(),
@@ -20,6 +26,10 @@ jest.unstable_mockModule('../../../src/utils/logger.js', () => ({
 const { CommandValidator } = await import('../../../src/security/commandValidator.js');
 
 describe('CommandValidator', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('sanitizeCommand()', () => {
     it('should allow git with permitted subcommands', () => {
       expect(() => CommandValidator.sanitizeCommand('git', ['status'])).not.toThrow();
@@ -74,19 +84,52 @@ describe('CommandValidator', () => {
     it('should reject disallowed commands before execution', async () => {
       await expect(CommandValidator.secureExec('rm', ['-rf', '/']))
         .rejects.toThrow('Command not allowed: rm');
+      expect(mockSpawn).not.toHaveBeenCalled();
     });
 
     it('should execute allowed command and return output', async () => {
-      // CommandValidator restricts PATH to Unix-only paths (/usr/bin:/bin:/usr/local/bin).
-      // On Windows, git is not on that restricted PATH, so skip this test.
-      if (process.platform === 'win32') return;
-      const result = await CommandValidator.secureExec('git', ['status']);
-      expect(typeof result).toBe('string');
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc);
+
+      const result = CommandValidator.secureExec('git', ['status']);
+      proc.stdout.emit('data', 'working tree clean\n');
+      proc.emit('exit', 0);
+
+      await expect(result).resolves.toBe('working tree clean');
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'git',
+        ['status'],
+        expect.objectContaining({
+          cwd: process.cwd(),
+          stdio: ['ignore', 'pipe', 'pipe'],
+          timeout: 30000,
+          env: expect.objectContaining({
+            PATH: '/usr/bin:/bin:/usr/local/bin',
+          }),
+        })
+      );
     });
 
     it('should reject shell metacharacters before execution', async () => {
       await expect(CommandValidator.secureExec('git', ['status; rm -rf /']))
         .rejects.toThrow('Argument not allowed');
+      expect(mockSpawn).not.toHaveBeenCalled();
     });
   });
 });
+
+function createMockProcess(): EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: jest.Mock;
+} {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: jest.Mock;
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = jest.fn();
+  return proc;
+}

--- a/tests/unit/security/audit/SecurityAuditor.test.ts
+++ b/tests/unit/security/audit/SecurityAuditor.test.ts
@@ -322,6 +322,29 @@ describe('SecurityAuditor', () => {
 
       expect(result.findings.some(f => f.ruleId === 'OWASP-A01-001')).toBe(false);
     });
+
+    test('should suppress findings with config glob patterns against absolute scanner paths', async () => {
+      const configWithSuppression: SecurityAuditConfig = {
+        ...await SecurityAuditor.getDefaultConfig(mockFileOperations),
+        suppressions: [{
+          rule: 'DMCP-SEC-004',
+          file: '**/src/feature/suppressed.ts',
+          reason: 'Test glob suppression for scanner absolute paths'
+        }]
+      };
+
+      const auditorWithSuppression = new SecurityAuditor(configWithSuppression, mockFileOperations);
+      const sourceDir = path.join(tempDir, 'src', 'feature');
+      await fs.mkdir(sourceDir, { recursive: true });
+      await fs.writeFile(
+        path.join(sourceDir, 'suppressed.ts'),
+        'export function handler(req: { body: string }) { return req.body; }',
+      );
+
+      const result = await auditorWithSuppression.audit(tempDir);
+
+      expect(result.findings.some(f => f.ruleId === 'DMCP-SEC-004')).toBe(false);
+    });
   });
 
   describe('Build Failure Logic', () => {

--- a/tests/unit/web-console/middleware/ConsoleIdempotency.test.ts
+++ b/tests/unit/web-console/middleware/ConsoleIdempotency.test.ts
@@ -6,16 +6,47 @@ import {
   canonicalRequestTarget,
   fingerprintBody,
 } from '../../../../src/web-console/middleware/ConsoleIdempotency.js';
-import type { ConsoleRequest } from '../../../../src/web-console/platform/ConsolePlatformTypes.js';
+import type {
+  ConsoleRequest,
+  ConsoleRouteDefinition,
+} from '../../../../src/web-console/platform/ConsolePlatformTypes.js';
 
-function requestForTarget(originalUrl: string): ConsoleRequest {
-  return { originalUrl } as ConsoleRequest;
+const PORTFOLIO_MUTATION_ROUTE = {
+  method: 'PATCH',
+  path: '/api/v1/me/portfolio/elements/:type/:name',
+  audience: 'self',
+  requiredCapability: 'console:self',
+  ownership: 'authenticated_user',
+  elevation: 'none',
+  privacyClass: 'self_private',
+  idempotency: 'required',
+  pathParamValueNormalization: { name: 'nfc' },
+  handler: () => ({ status: 200 }),
+} satisfies ConsoleRouteDefinition;
+
+function requestForTarget(
+  originalUrl: string,
+  overrides: Partial<Pick<ConsoleRequest, 'params' | 'query'>> = {},
+): ConsoleRequest {
+  return { originalUrl, params: {}, query: {}, ...overrides } as ConsoleRequest;
 }
 
 describe('console idempotency canonicalization', () => {
   it('orders query values using deterministic code-unit comparison', () => {
-    expect(canonicalRequestTarget(requestForTarget('/api/v1/me/change?value=%C3%A4&value=a&name=z')))
+    expect(canonicalRequestTarget(requestForTarget('/api/v1/me/change?value=%C3%A4&value=a&name=z', {
+      query: { value: ['ä', 'a'], name: 'z' },
+    })))
       .toBe('/api/v1/me/change?name=z&value=a&value=%C3%A4');
+  });
+
+  it('uses normalized params and query values for canonical idempotency targets', () => {
+    const request = requestForTarget('/api/v1/me/portfolio/elements/personas/%CE%B1-cafe%CC%81?tag=cafe%CC%81', {
+      params: { type: 'personas', name: 'α-café' },
+      query: { tag: 'café' },
+    });
+
+    expect(canonicalRequestTarget(request, PORTFOLIO_MUTATION_ROUTE))
+      .toBe('/api/v1/me/portfolio/elements/personas/%CE%B1-caf%C3%A9?tag=caf%C3%A9');
   });
 
   it('fingerprints object key order canonically', () => {

--- a/tests/unit/web-console/middleware/ConsoleIdempotency.test.ts
+++ b/tests/unit/web-console/middleware/ConsoleIdempotency.test.ts
@@ -21,6 +21,7 @@ const PORTFOLIO_MUTATION_ROUTE = {
   privacyClass: 'self_private',
   idempotency: 'required',
   pathParamValueNormalization: { name: 'nfc' },
+  queryParamValueNormalization: { tag: 'nfc' },
   handler: () => ({ status: 200 }),
 } satisfies ConsoleRouteDefinition;
 
@@ -40,13 +41,13 @@ describe('console idempotency canonicalization', () => {
   });
 
   it('uses normalized params and query values for canonical idempotency targets', () => {
-    const request = requestForTarget('/api/v1/me/portfolio/elements/personas/%CE%B1-cafe%CC%81?tag=cafe%CC%81', {
+    const request = requestForTarget('/api/v1/me/portfolio/elements/personas/%CE%B1-cafe%CC%81?tag=%CE%B1-cafe%CC%81&q=%CE%B1-cafe%CC%81', {
       params: { type: 'personas', name: 'α-café' },
-      query: { tag: 'café' },
+      query: { tag: 'α-café', q: 'a-café' },
     });
 
     expect(canonicalRequestTarget(request, PORTFOLIO_MUTATION_ROUTE))
-      .toBe('/api/v1/me/portfolio/elements/personas/%CE%B1-caf%C3%A9?tag=caf%C3%A9');
+      .toBe('/api/v1/me/portfolio/elements/personas/%CE%B1-caf%C3%A9?q=a-caf%C3%A9&tag=%CE%B1-caf%C3%A9');
   });
 
   it('fingerprints object key order canonically', () => {

--- a/tests/unit/web-console/middleware/ConsoleSecuredRouter.test.ts
+++ b/tests/unit/web-console/middleware/ConsoleSecuredRouter.test.ts
@@ -452,6 +452,10 @@ function adminTransactionMutationRequest(app: express.Express, key: string = IDE
     .set(IDEMPOTENCY_HEADER, key);
 }
 
+function nestedJson(depth: number): string {
+  return '{"child":'.repeat(depth) + 'null' + '}'.repeat(depth);
+}
+
 describe('secured console router authentication', () => {
   it('serves public readiness without browser authentication', async () => {
     const { app, sessionStore } = await buildApp(null);
@@ -552,6 +556,17 @@ describe('secured console router authentication', () => {
     expect(response.headers['x-content-type-options']).toBe('nosniff');
     expect(response.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
     expect(response.headers['permissions-policy']).toBe('geolocation=(), microphone=(), camera=()');
+  });
+
+  it('authenticates protected routes before walking JSON request bodies', async () => {
+    const { app } = await buildApp();
+
+    const response = await request(app).post(CHANGE_PATH)
+      .set('Content-Type', 'application/json')
+      .send(nestedJson(80));
+
+    expect(response.status).toBe(401);
+    expect(response.body.code).toBe('unauthenticated');
   });
 
   it('fails closed when the login subject maps to a disabled principal', async () => {

--- a/tests/unit/web-console/middleware/ConsoleSecuredRouter.test.ts
+++ b/tests/unit/web-console/middleware/ConsoleSecuredRouter.test.ts
@@ -488,6 +488,19 @@ describe('secured console router authentication', () => {
     expect(response.headers['content-security-policy']).toContain("frame-ancestors 'none'");
   });
 
+  it('does not recursively normalize JSON bodies for public readiness routes', async () => {
+    const { app, sessionStore } = await buildApp(null);
+    const lookup = jest.spyOn(sessionStore, 'findActiveByIdHash');
+
+    const response = await request(app).get(HEALTH_PATH)
+      .set('Content-Type', 'application/json')
+      .send(nestedJson(80));
+
+    expect(response.status).toBe(503);
+    expect(response.body.code).toBeUndefined();
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
   it('resolves an opaque session to canonical user context and sets security headers', async () => {
     const { app, sessionStore, adminAuditWriter } = await buildApp();
     const touch = jest.spyOn(sessionStore, 'touch');

--- a/tests/unit/web-console/middleware/ConsoleSecuredRouter.test.ts
+++ b/tests/unit/web-console/middleware/ConsoleSecuredRouter.test.ts
@@ -35,6 +35,7 @@ const SELF_CAPABILITY = 'console:self' as const;
 const AUDIT_CAPABILITY = 'console:admin:audit' as const;
 const CONTEXT_PATH = '/api/v1/me/context';
 const CHANGE_PATH = '/api/v1/me/change';
+const UNICODE_CHANGE_PREFIX = '/api/v1/me/unicode-change';
 const HEALTH_PATH = '/api/v1/health/ready';
 const OWNED_SESSION_ID = 'mcp-session-owned';
 const OTHER_SESSION_ID = 'mcp-session-other';
@@ -137,6 +138,20 @@ function fixtureModules(
       handler: () => {
         onChange?.();
         return { status: 200, body: { changed: true } };
+      },
+    }, {
+      method: 'POST',
+      path: `${UNICODE_CHANGE_PREFIX}/:name`,
+      audience: 'self',
+      requiredCapability: SELF_CAPABILITY,
+      ownership: 'authenticated_user',
+      elevation: 'none',
+      privacyClass: 'self_private',
+      idempotency: 'required',
+      pathParamValueNormalization: { name: 'nfc' },
+      handler: req => {
+        onChange?.();
+        return { status: 200, body: { changed: true, name: req.params.name, query: req.query.q } };
       },
     }],
   }, {
@@ -854,6 +869,30 @@ describe('secured console router browser protections', () => {
     expect(first.status).toBe(200);
     expect(replay.status).toBe(200);
     expect(replay.body).toEqual({ changed: true });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('replays Unicode-equivalent normalized targets without reporting idempotency mismatch', async () => {
+    const { app, onChange } = await buildApp();
+    const headers = {
+      Cookie: csrfCookies(),
+      [CSRF_HEADER]: CSRF_VALUE,
+      Origin: ORIGIN,
+      [CONSOLE_REQUEST_HEADER]: '1',
+      [IDEMPOTENCY_HEADER]: IDEMPOTENCY_KEY,
+    };
+    const decomposedName = 'α-cafe\u0301';
+    const composedName = 'α-café';
+    const target = (name: string) =>
+      `${UNICODE_CHANGE_PREFIX}/${encodeURIComponent(name)}?q=${encodeURIComponent(name)}`;
+
+    const first = await request(app).post(target(decomposedName)).set(headers).send({ value: 1 });
+    const replay = await request(app).post(target(composedName)).set(headers).send({ value: 1 });
+
+    expect(first.status).toBe(200);
+    expect(first.body).toEqual({ changed: true, name: composedName, query: 'a-café' });
+    expect(replay.status).toBe(200);
+    expect(replay.body).toEqual(first.body);
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/unit/web-console/middleware/ConsoleSecuredRouter.test.ts
+++ b/tests/unit/web-console/middleware/ConsoleSecuredRouter.test.ts
@@ -1349,6 +1349,23 @@ describe('secured console router rate limiting', () => {
     expect(onProtectedCorrelation).not.toHaveBeenCalled();
   });
 
+  it('authenticates protected routes before walking deeply nested JSON bodies', async () => {
+    const { app, onChange } = await buildApp(record());
+    const deepBody = `${'{"nested":'.repeat(80)}null${'}'.repeat(80)}`;
+
+    const response = await request(app)
+      .post(CHANGE_PATH)
+      .set('Content-Type', 'application/json')
+      .set(CSRF_HEADER, CSRF_VALUE)
+      .set(CONSOLE_REQUEST_HEADER, '1')
+      .set(IDEMPOTENCY_HEADER, IDEMPOTENCY_KEY)
+      .send(deepBody);
+
+    expect(response.status).toBe(401);
+    expect(response.body.code).toBe('unauthenticated');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('fails closed on protected rate-limit dependency errors', async () => {
     const limiter = protectedCorrelationLimiter();
     jest.spyOn(limiter, 'consume').mockRejectedValue(

--- a/tests/unit/web-console/modules/AccountAdminModule.test.ts
+++ b/tests/unit/web-console/modules/AccountAdminModule.test.ts
@@ -1077,6 +1077,27 @@ describe('AccountAdminModule', () => {
     ]);
   });
 
+  it('normalizes security-sensitive allowlist body values before storage', async () => {
+    const { module } = mutationFixture();
+    const add = findRoute(module.routes, ACCOUNT_ALLOWLIST_PATH, 'POST');
+
+    await expect(add.handler(consoleRequest({
+      body: { kind: 'github_username', value: 'ｍick' },
+    }))).resolves.toMatchObject({
+      status: 201,
+      body: {
+        kind: 'github_username',
+        value: 'mick',
+      },
+    });
+    await expect(add.handler(consoleRequest({
+      body: { kind: 'github_username', value: 'mick' },
+    }))).resolves.toMatchObject({
+      status: 409,
+      body: { code: 'conflict' },
+    });
+  });
+
   it('rejects malformed list query parameters before hitting the store', async () => {
     const { module } = mutationFixture();
     const route = findRoute(module.routes, '/api/v1/admin/accounts/users');

--- a/tests/unit/web-console/modules/IntegrationModule.test.ts
+++ b/tests/unit/web-console/modules/IntegrationModule.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 
 import {
   AeadSecretEncryptionService,
@@ -15,6 +15,7 @@ import {
   type IntegrationCallbackRejectedEvent,
   type UserIntegrationRecord,
 } from '../../../../src/web-console/index.js';
+import { SecurityMonitor } from '../../../../src/security/securityMonitor.js';
 
 const USER_ID = '018f3d47-73ae-7f10-a0de-0742618d4fb1';
 const OTHER_USER_ID = '118f3d47-73ae-7f10-a0de-0742618d4fb2';
@@ -601,6 +602,41 @@ describe('IntegrationModule', () => {
       accessTokenCiphertext: null,
       refreshTokenCiphertext: null,
     });
+  });
+
+  it('logs integration credential decrypt failures with caller context', async () => {
+    const { module } = writeModuleFixture({
+      records: [integrationFixture({
+        accessTokenCiphertext: Buffer.from('not-valid-ciphertext'),
+        refreshTokenCiphertext: null,
+      })],
+    });
+    const disconnect = findRoute(module.routes, GITHUB_PATH, 'DELETE');
+    const logSpy = jest.spyOn(SecurityMonitor, 'logSecurityEvent').mockImplementation(() => {});
+    try {
+      const result = await disconnect.handler(consoleRequest());
+
+      expect(result).toMatchObject({
+        status: 200,
+        body: {
+          provider: 'github',
+          status: 'disconnected',
+        },
+      });
+      expect(logSpy).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'OPERATION_FAILED',
+        severity: 'MEDIUM',
+        source: 'IntegrationService',
+        details: 'GitHub integration credential decrypt failed',
+        additionalData: {
+          userId: USER_ID,
+          provider: 'github',
+          secretClass: 'integration_access_token',
+        },
+      }));
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 
   it('binds encrypted integration credentials to the owning user AAD', async () => {

--- a/tests/unit/web-console/modules/PortfolioModule.test.ts
+++ b/tests/unit/web-console/modules/PortfolioModule.test.ts
@@ -190,6 +190,7 @@ describe('PortfolioModule', () => {
         path: ELEMENTS_PATH,
         ownership: 'authenticated_user',
         privacyClass: 'self_private',
+        queryParamValueNormalization: { tag: 'nfc' },
       }),
       expect.objectContaining({
         method: 'GET',

--- a/tests/unit/web-console/platform/ConsolePlatformHttp.test.ts
+++ b/tests/unit/web-console/platform/ConsolePlatformHttp.test.ts
@@ -197,7 +197,7 @@ describe('console platform HTTP foundations', () => {
     expect(registry.createRouteManifest().routes.map(route => route.moduleId)).toEqual(['profile', 'settings']);
   });
 
-  it('normalizes route params, query values, and JSON body strings before handlers run', async () => {
+  it('normalizes route params, query values, and JSON body keys while preserving body strings', async () => {
     const registry = new ConsoleModuleRegistry();
     registry.register({
       id: 'unicode',
@@ -217,7 +217,9 @@ describe('console platform HTTP foundations', () => {
           body: {
             param: req.params.name,
             query: req.query.q,
+            keyed: (req.body as Record<string, unknown>)['café'],
             nested: (req.body as { nested: { label: string } }).nested.label,
+            content: (req.body as { content: string }).content,
           },
         }),
       }],
@@ -227,15 +229,22 @@ describe('console platform HTTP foundations', () => {
     app.use(assembleConsoleRouter(registry));
 
     const decomposedCafe = 'cafe\u0301';
+    const familyEmoji = 'family: 👨‍👩‍👧‍👦';
     const response = await request(app)
       .post(`/api/v1/me/unicode/${encodeURIComponent(decomposedCafe)}?q=${encodeURIComponent(decomposedCafe)}`)
-      .send({ nested: { label: decomposedCafe } });
+      .send({
+        [decomposedCafe]: 'body-key-normalized',
+        nested: { label: decomposedCafe },
+        content: familyEmoji,
+      });
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
       param: 'café',
       query: 'café',
-      nested: 'café',
+      keyed: 'body-key-normalized',
+      nested: decomposedCafe,
+      content: familyEmoji,
     });
   });
 
@@ -295,7 +304,7 @@ describe('console platform HTTP foundations', () => {
       nestedPrototypeIsNull: true,
       nestedPrototypeRole: null,
       globalPrototypeRole: null,
-      label: 'café',
+      label: 'cafe\u0301',
     });
   });
 

--- a/tests/unit/web-console/platform/ConsolePlatformHttp.test.ts
+++ b/tests/unit/web-console/platform/ConsolePlatformHttp.test.ts
@@ -239,6 +239,66 @@ describe('console platform HTTP foundations', () => {
     });
   });
 
+  it('normalizes JSON bodies without invoking prototype setters', async () => {
+    const registry = new ConsoleModuleRegistry();
+    registry.register({
+      id: 'prototype-guard',
+      apiVersion: 'v1',
+      capabilities: [SELF_CAPABILITY],
+      routes: [{
+        method: 'POST',
+        path: '/api/v1/me/prototype-guard',
+        audience: 'self',
+        requiredCapability: SELF_CAPABILITY,
+        ownership: 'authenticated_user',
+        elevation: 'none',
+        privacyClass: 'self_private',
+        idempotency: 'not_applicable',
+        handler: req => {
+          const body = req.body as Record<string, unknown>;
+          const nested = body.nested as Record<string, unknown>;
+          const bodyPrototype = Object.getPrototypeOf(body) as { readonly role?: unknown } | null;
+          const nestedPrototype = Object.getPrototypeOf(nested) as { readonly role?: unknown } | null;
+          const cleanObject = {} as { readonly role?: unknown };
+
+          return {
+            status: 200,
+            body: {
+              bodyOwnProto: Object.prototype.hasOwnProperty.call(body, '__proto__'),
+              bodyPrototypeIsNull: bodyPrototype === null,
+              bodyPrototypeRole: typeof bodyPrototype?.role === 'string' ? bodyPrototype.role : null,
+              nestedOwnProto: Object.prototype.hasOwnProperty.call(nested, '__proto__'),
+              nestedPrototypeIsNull: nestedPrototype === null,
+              nestedPrototypeRole: typeof nestedPrototype?.role === 'string' ? nestedPrototype.role : null,
+              globalPrototypeRole: typeof cleanObject.role === 'string' ? cleanObject.role : null,
+              label: nested.label,
+            },
+          };
+        },
+      }],
+    });
+    const app = express();
+    app.use(express.json());
+    app.use(assembleConsoleRouter(registry));
+
+    const response = await request(app)
+      .post('/api/v1/me/prototype-guard')
+      .set('Content-Type', 'application/json')
+      .send('{"__proto__":{"role":"admin"},"nested":{"label":"cafe\\u0301","__proto__":{"role":"nested-admin"}}}');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      bodyOwnProto: true,
+      bodyPrototypeIsNull: true,
+      bodyPrototypeRole: null,
+      nestedOwnProto: true,
+      nestedPrototypeIsNull: true,
+      nestedPrototypeRole: null,
+      globalPrototypeRole: null,
+      label: 'café',
+    });
+  });
+
   it('sends allowlisted handler headers', async () => {
     const registry = new ConsoleModuleRegistry();
     registry.register({

--- a/tests/unit/web-console/platform/ConsolePlatformHttp.test.ts
+++ b/tests/unit/web-console/platform/ConsolePlatformHttp.test.ts
@@ -197,6 +197,48 @@ describe('console platform HTTP foundations', () => {
     expect(registry.createRouteManifest().routes.map(route => route.moduleId)).toEqual(['profile', 'settings']);
   });
 
+  it('normalizes route params, query values, and JSON body strings before handlers run', async () => {
+    const registry = new ConsoleModuleRegistry();
+    registry.register({
+      id: 'unicode',
+      apiVersion: 'v1',
+      capabilities: [SELF_CAPABILITY],
+      routes: [{
+        method: 'POST',
+        path: '/api/v1/me/unicode/:name',
+        audience: 'self',
+        requiredCapability: SELF_CAPABILITY,
+        ownership: 'authenticated_user',
+        elevation: 'none',
+        privacyClass: 'self_private',
+        idempotency: 'not_applicable',
+        handler: req => ({
+          status: 200,
+          body: {
+            param: req.params.name,
+            query: req.query.q,
+            nested: (req.body as { nested: { label: string } }).nested.label,
+          },
+        }),
+      }],
+    });
+    const app = express();
+    app.use(express.json());
+    app.use(assembleConsoleRouter(registry));
+
+    const decomposedCafe = 'cafe\u0301';
+    const response = await request(app)
+      .post(`/api/v1/me/unicode/${encodeURIComponent(decomposedCafe)}?q=${encodeURIComponent(decomposedCafe)}`)
+      .send({ nested: { label: decomposedCafe } });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      param: 'café',
+      query: 'café',
+      nested: 'café',
+    });
+  });
+
   it('sends allowlisted handler headers', async () => {
     const registry = new ConsoleModuleRegistry();
     registry.register({

--- a/tests/unit/web-console/platform/ConsolePlatformHttp.test.ts
+++ b/tests/unit/web-console/platform/ConsolePlatformHttp.test.ts
@@ -216,6 +216,7 @@ describe('console platform HTTP foundations', () => {
           status: 200,
           body: {
             param: req.params.name,
+            paramPrototype: Object.getPrototypeOf(req.params) === null,
             query: req.query.q,
             keyed: (req.body as Record<string, unknown>)['café'],
             nested: (req.body as { nested: { label: string } }).nested.label,
@@ -241,6 +242,7 @@ describe('console platform HTTP foundations', () => {
     expect(response.status).toBe(200);
     expect(response.body).toEqual({
       param: 'café',
+      paramPrototype: true,
       query: 'café',
       keyed: 'body-key-normalized',
       nested: decomposedCafe,
@@ -282,37 +284,40 @@ describe('console platform HTTP foundations', () => {
     expect(response.body).toEqual({ name: 'α-café' });
   });
 
-  it('rejects reserved route params before they can invoke prototype setters', async () => {
-    const registry = new ConsoleModuleRegistry();
-    const handler = jest.fn(() => ({ status: 200, body: {} }));
-    registry.register({
-      id: 'prototype-param',
-      apiVersion: 'v1',
-      capabilities: [SELF_CAPABILITY],
-      routes: [{
-        method: 'GET',
-        path: '/api/v1/me/prototype-param/:__proto__',
-        audience: 'self',
-        requiredCapability: SELF_CAPABILITY,
-        ownership: 'authenticated_user',
-        elevation: 'none',
-        privacyClass: 'self_private',
-        idempotency: 'not_applicable',
-        handler,
-      }],
-    });
-    const app = express();
-    app.use(assembleConsoleRouter(registry));
+  it.each(['__proto__', 'constructor'])(
+    'rejects reserved route param key %s before it can shadow object internals',
+    async paramName => {
+      const registry = new ConsoleModuleRegistry();
+      const handler = jest.fn(() => ({ status: 200, body: {} }));
+      registry.register({
+        id: 'prototype-param',
+        apiVersion: 'v1',
+        capabilities: [SELF_CAPABILITY],
+        routes: [{
+          method: 'GET',
+          path: `/api/v1/me/prototype-param/:${paramName}`,
+          audience: 'self',
+          requiredCapability: SELF_CAPABILITY,
+          ownership: 'authenticated_user',
+          elevation: 'none',
+          privacyClass: 'self_private',
+          idempotency: 'not_applicable',
+          handler,
+        }],
+      });
+      const app = express();
+      app.use(assembleConsoleRouter(registry));
 
-    const response = await request(app).get('/api/v1/me/prototype-param/not-admin');
+      const response = await request(app).get('/api/v1/me/prototype-param/not-admin');
 
-    expect(response.status).toBe(400);
-    expect(response.body).toMatchObject({
-      code: 'invalid_request',
-      detail: 'Request contains a reserved Unicode-normalized field',
-    });
-    expect(handler).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        code: 'invalid_request',
+        detail: 'Request contains a reserved Unicode-normalized field',
+      });
+      expect(handler).not.toHaveBeenCalled();
+    },
+  );
 
   it('rejects reserved JSON body keys before they can invoke prototype setters', async () => {
     const registry = new ConsoleModuleRegistry();

--- a/tests/unit/web-console/platform/ConsolePlatformHttp.test.ts
+++ b/tests/unit/web-console/platform/ConsolePlatformHttp.test.ts
@@ -282,8 +282,9 @@ describe('console platform HTTP foundations', () => {
     expect(response.body).toEqual({ name: 'α-café' });
   });
 
-  it('normalizes route params without invoking prototype setters', async () => {
+  it('rejects reserved route params before they can invoke prototype setters', async () => {
     const registry = new ConsoleModuleRegistry();
+    const handler = jest.fn(() => ({ status: 200, body: {} }));
     registry.register({
       id: 'prototype-param',
       apiVersion: 'v1',
@@ -297,20 +298,7 @@ describe('console platform HTTP foundations', () => {
         elevation: 'none',
         privacyClass: 'self_private',
         idempotency: 'not_applicable',
-        handler: req => {
-          const params = req.params as Record<string, unknown>;
-          const paramsPrototype = Object.getPrototypeOf(params) as { readonly role?: unknown } | null;
-          const cleanObject = {} as { readonly role?: unknown };
-          return {
-            status: 200,
-            body: {
-              ownProto: Object.prototype.hasOwnProperty.call(params, '__proto__'),
-              protoValue: params.__proto__,
-              prototypeRole: typeof paramsPrototype?.role === 'string' ? paramsPrototype.role : null,
-              globalPrototypeRole: typeof cleanObject.role === 'string' ? cleanObject.role : null,
-            },
-          };
-        },
+        handler,
       }],
     });
     const app = express();
@@ -318,17 +306,17 @@ describe('console platform HTTP foundations', () => {
 
     const response = await request(app).get('/api/v1/me/prototype-param/not-admin');
 
-    expect(response.status).toBe(200);
-    expect(response.body).toEqual({
-      ownProto: true,
-      protoValue: 'not-admin',
-      prototypeRole: null,
-      globalPrototypeRole: null,
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      code: 'invalid_request',
+      detail: 'Request contains a reserved Unicode-normalized field',
     });
+    expect(handler).not.toHaveBeenCalled();
   });
 
-  it('normalizes JSON bodies without invoking prototype setters', async () => {
+  it('rejects reserved JSON body keys before they can invoke prototype setters', async () => {
     const registry = new ConsoleModuleRegistry();
+    const handler = jest.fn(() => ({ status: 200, body: {} }));
     registry.register({
       id: 'prototype-guard',
       apiVersion: 'v1',
@@ -342,27 +330,7 @@ describe('console platform HTTP foundations', () => {
         elevation: 'none',
         privacyClass: 'self_private',
         idempotency: 'not_applicable',
-        handler: req => {
-          const body = req.body as Record<string, unknown>;
-          const nested = body.nested as Record<string, unknown>;
-          const bodyPrototype = Object.getPrototypeOf(body) as { readonly role?: unknown } | null;
-          const nestedPrototype = Object.getPrototypeOf(nested) as { readonly role?: unknown } | null;
-          const cleanObject = {} as { readonly role?: unknown };
-
-          return {
-            status: 200,
-            body: {
-              bodyOwnProto: Object.prototype.hasOwnProperty.call(body, '__proto__'),
-              bodyPrototypeIsNull: bodyPrototype === null,
-              bodyPrototypeRole: typeof bodyPrototype?.role === 'string' ? bodyPrototype.role : null,
-              nestedOwnProto: Object.prototype.hasOwnProperty.call(nested, '__proto__'),
-              nestedPrototypeIsNull: nestedPrototype === null,
-              nestedPrototypeRole: typeof nestedPrototype?.role === 'string' ? nestedPrototype.role : null,
-              globalPrototypeRole: typeof cleanObject.role === 'string' ? cleanObject.role : null,
-              label: nested.label,
-            },
-          };
-        },
+        handler,
       }],
     });
     const app = express();
@@ -374,17 +342,12 @@ describe('console platform HTTP foundations', () => {
       .set('Content-Type', 'application/json')
       .send('{"__proto__":{"role":"admin"},"nested":{"label":"cafe\\u0301","__proto__":{"role":"nested-admin"}}}');
 
-    expect(response.status).toBe(200);
-    expect(response.body).toEqual({
-      bodyOwnProto: true,
-      bodyPrototypeIsNull: true,
-      bodyPrototypeRole: null,
-      nestedOwnProto: true,
-      nestedPrototypeIsNull: true,
-      nestedPrototypeRole: null,
-      globalPrototypeRole: null,
-      label: 'cafe\u0301',
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      code: 'invalid_request',
+      detail: 'Request contains a reserved Unicode-normalized field',
     });
+    expect(handler).not.toHaveBeenCalled();
   });
 
   it('sends allowlisted handler headers', async () => {

--- a/tests/unit/web-console/platform/ConsolePlatformHttp.test.ts
+++ b/tests/unit/web-console/platform/ConsolePlatformHttp.test.ts
@@ -248,6 +248,85 @@ describe('console platform HTTP foundations', () => {
     });
   });
 
+  it('preserves free-form route param confusables while applying canonical NFC', async () => {
+    const registry = new ConsoleModuleRegistry();
+    registry.register({
+      id: 'freeform-param',
+      apiVersion: 'v1',
+      capabilities: [SELF_CAPABILITY],
+      routes: [{
+        method: 'GET',
+        path: '/api/v1/me/freeform/:name',
+        audience: 'self',
+        requiredCapability: SELF_CAPABILITY,
+        ownership: 'authenticated_user',
+        elevation: 'none',
+        privacyClass: 'self_private',
+        idempotency: 'not_applicable',
+        pathParamValueNormalization: { name: 'nfc' },
+        handler: req => ({
+          status: 200,
+          body: {
+            name: req.params.name,
+          },
+        }),
+      }],
+    });
+    const app = express();
+    app.use(assembleConsoleRouter(registry));
+
+    const response = await request(app)
+      .get(`/api/v1/me/freeform/${encodeURIComponent('α-cafe\u0301')}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ name: 'α-café' });
+  });
+
+  it('normalizes route params without invoking prototype setters', async () => {
+    const registry = new ConsoleModuleRegistry();
+    registry.register({
+      id: 'prototype-param',
+      apiVersion: 'v1',
+      capabilities: [SELF_CAPABILITY],
+      routes: [{
+        method: 'GET',
+        path: '/api/v1/me/prototype-param/:__proto__',
+        audience: 'self',
+        requiredCapability: SELF_CAPABILITY,
+        ownership: 'authenticated_user',
+        elevation: 'none',
+        privacyClass: 'self_private',
+        idempotency: 'not_applicable',
+        handler: req => {
+          const params = req.params as Record<string, unknown>;
+          const paramsPrototype = Object.getPrototypeOf(params) as { readonly role?: unknown } | null;
+          const cleanObject = {} as { readonly role?: unknown };
+          return {
+            status: 200,
+            body: {
+              ownProto: Object.prototype.hasOwnProperty.call(params, '__proto__'),
+              protoValue: params.__proto__,
+              prototypeRole: typeof paramsPrototype?.role === 'string' ? paramsPrototype.role : null,
+              globalPrototypeRole: typeof cleanObject.role === 'string' ? cleanObject.role : null,
+            },
+          };
+        },
+      }],
+    });
+    const app = express();
+    app.use(assembleConsoleRouter(registry));
+
+    const response = await request(app).get('/api/v1/me/prototype-param/not-admin');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      ownProto: true,
+      protoValue: 'not-admin',
+      prototypeRole: null,
+      globalPrototypeRole: null,
+    });
+  });
+
   it('normalizes JSON bodies without invoking prototype setters', async () => {
     const registry = new ConsoleModuleRegistry();
     registry.register({

--- a/tests/unit/web-console/platform/ConsolePlatformHttp.test.ts
+++ b/tests/unit/web-console/platform/ConsolePlatformHttp.test.ts
@@ -284,6 +284,45 @@ describe('console platform HTTP foundations', () => {
     expect(response.body).toEqual({ name: 'α-café' });
   });
 
+  it('preserves free-form query value confusables while applying canonical NFC', async () => {
+    const registry = new ConsoleModuleRegistry();
+    registry.register({
+      id: 'freeform-query',
+      apiVersion: 'v1',
+      capabilities: [SELF_CAPABILITY],
+      routes: [{
+        method: 'GET',
+        path: '/api/v1/me/freeform-query',
+        audience: 'self',
+        requiredCapability: SELF_CAPABILITY,
+        ownership: 'authenticated_user',
+        elevation: 'none',
+        privacyClass: 'self_private',
+        idempotency: 'not_applicable',
+        queryParamValueNormalization: { tag: 'nfc' },
+        handler: req => ({
+          status: 200,
+          body: {
+            tag: req.query.tag,
+            q: req.query.q,
+          },
+        }),
+      }],
+    });
+    const app = express();
+    app.use(assembleConsoleRouter(registry));
+
+    const freeformTag = 'α-cafe\u0301';
+    const response = await request(app)
+      .get(`/api/v1/me/freeform-query?tag=${encodeURIComponent(freeformTag)}&q=${encodeURIComponent(freeformTag)}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      tag: 'α-café',
+      q: 'a-café',
+    });
+  });
+
   it.each(['__proto__', 'constructor'])(
     'rejects reserved route param key %s before it can shadow object internals',
     async paramName => {

--- a/tests/unit/web-console/stores/ConsoleSecurityStores.test.ts
+++ b/tests/unit/web-console/stores/ConsoleSecurityStores.test.ts
@@ -807,6 +807,27 @@ describe('InMemoryConsoleAccountAllowlistStore', () => {
       revokedAt: FIVE_MINUTES,
     })).rejects.toThrow('revokedByUserId must be a UUID');
   });
+
+  it('security-normalizes account allowlist values before storage and matching', async () => {
+    const store = new InMemoryConsoleAccountAllowlistStore();
+
+    const entry = await store.add({
+      kind: 'github_username',
+      value: 'ｍick',
+      createdByUserId: USER_ID,
+      createdAt: FIVE_MINUTES,
+    });
+
+    expect(entry.displayValue).toBe('mick');
+    expect(entry.normalizedValue).toBe('mick');
+    await expect(store.matchesIdentity({ githubUsername: 'mick' })).resolves.toBe(true);
+    await expect(store.add({
+      kind: 'github_username',
+      value: 'mick',
+      createdByUserId: USER_ID,
+      createdAt: FIVE_MINUTES,
+    })).rejects.toThrow('active allowlist entry already exists');
+  });
 });
 
 describe('InMemoryConsoleSecurityInvalidationStore', () => {


### PR DESCRIPTION
## Summary
- add web-console Unicode normalization at route boundaries and browser API request normalization
- add security audit logging for hosted auth, integration, token-validation, TOTP, and secret crypto failure paths
- fix JSON suppression glob matching and document architecture-level suppressions for downstream/non-ingress layers
- keep local security audit suppression loading aligned with CI

## Verification
- npm run build
- npm run lint
- NODE_OPTIONS="--experimental-vm-modules --no-warnings" npx jest --config tests/jest.config.cjs tests/unit/web-console/platform/ConsolePlatformHttp.test.ts tests/unit/security/audit/SecurityAuditor.test.ts --runInBand
- npm run security:audit:json -- --fail-on-high
- dist-based CI-shaped SecurityAuditor run: 0 findings
- git diff --check