### PR TITLE
Fix MCP Registry publisher OIDC workflow

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -71,28 +71,30 @@ jobs:
       - name: Build package
         run: npm run build
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac
+        with:
+          cosign-release: 'v3.0.6'
+
       - name: Download mcp-publisher CLI
         shell: bash
         run: |
           set -euo pipefail
 
-          # Pinned to v1.3.3 for reproducibility
-          VERSION="v1.3.3"
+          # Pinned for reproducibility. v1.3.3 used the retired shared OIDC
+          # audience ("mcp-registry"); current registry auth expects the
+          # registry URL as the audience.
+          VERSION="v1.7.9"
           ARCHIVE="mcp-publisher_linux_amd64.tar.gz"
-          EXPECTED_SHA256="1113b9d6bf59b000966c4f17752cf87b51db03dcc5482721421fd843ce3bf048"
-          CERT_B64="/tmp/mcp-publisher.cert.b64"
-          CERT_PEM="/tmp/mcp-publisher.cert.pem"
-          PUBKEY_FILE="/tmp/mcp-publisher.pub"
-          SIG_B64="/tmp/mcp-publisher.tar.gz.sig.b64"
-          SIG_FILE="/tmp/mcp-publisher.tar.gz.sig"
+          EXPECTED_SHA256="ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac"
           ARCHIVE_FILE="/tmp/mcp-publisher.tar.gz"
-          EXPECTED_ISSUER="sigstore-intermediate"
-          EXPECTED_SAN_URI="https://github.com/modelcontextprotocol/registry/.github/workflows/release.yml@refs/tags/${VERSION}"
+          BUNDLE_FILE="/tmp/mcp-publisher.tar.gz.sigstore.json"
+          EXPECTED_IDENTITY="https://github.com/modelcontextprotocol/registry/.github/workflows/release.yml@refs/tags/${VERSION}"
+          EXPECTED_ISSUER="https://token.actions.githubusercontent.com"
 
           # Download archive and signature material.
           curl --retry 3 --retry-delay 5 -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/${ARCHIVE}" -o "$ARCHIVE_FILE"
-          curl --retry 3 --retry-delay 5 -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/${ARCHIVE}.sig" -o "$SIG_B64"
-          curl --retry 3 --retry-delay 5 -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/mcp-publisher_linux_amd64.pem" -o "$CERT_B64"
+          curl --retry 3 --retry-delay 5 -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${VERSION}/${ARCHIVE}.sigstore.json" -o "$BUNDLE_FILE"
 
           # Verify the pinned archive digest first for deterministic release inputs.
           if ! echo "${EXPECTED_SHA256}  ${ARCHIVE_FILE}" | sha256sum --check --status; then
@@ -100,48 +102,18 @@ jobs:
             exit 1
           fi
 
-          # The upstream release assets (.pem and .sig) are base64-encoded; decode them for OpenSSL verification.
-          if ! base64 -d "$CERT_B64" > "$CERT_PEM"; then
-            echo "::error::Failed to decode upstream certificate asset"
-            exit 1
-          fi
-          if ! base64 -d "$SIG_B64" > "$SIG_FILE"; then
-            echo "::error::Failed to decode upstream signature asset"
-            exit 1
-          fi
-
-          # Confirm the signing certificate parses cleanly and is tied to the expected upstream workflow.
-          if ! openssl x509 -in "$CERT_PEM" -noout >/dev/null; then
-            echo "::error::Upstream signing certificate could not be parsed"
-            exit 1
-          fi
-          if ! openssl x509 -in "$CERT_PEM" -noout -issuer | grep -F "$EXPECTED_ISSUER" >/dev/null; then
-            echo "::error::Upstream signing certificate issuer did not contain ${EXPECTED_ISSUER}"
-            exit 1
-          fi
-          if ! openssl x509 -in "$CERT_PEM" -noout -ext subjectAltName | grep -F "$EXPECTED_SAN_URI" >/dev/null; then
-            echo "::error::Upstream signing certificate SAN does not match ${EXPECTED_SAN_URI}"
-            exit 1
-          fi
-
-          # Verify the archive signature using the public key embedded in the release certificate.
-          if ! openssl x509 -in "$CERT_PEM" -pubkey -noout > "$PUBKEY_FILE"; then
-            echo "::error::Failed to extract public key from upstream signing certificate"
-            exit 1
-          fi
-          if ! openssl dgst -sha256 \
-            -verify "$PUBKEY_FILE" \
-            -signature "$SIG_FILE" \
-            "$ARCHIVE_FILE"; then
-            echo "::error::Signature verification failed for ${ARCHIVE}"
-            exit 1
-          fi
+          # Verify the upstream Sigstore bundle is tied to the MCP Registry
+          # release workflow for the pinned tag.
+          cosign verify-blob \
+            --bundle "$BUNDLE_FILE" \
+            --certificate-identity "$EXPECTED_IDENTITY" \
+            --certificate-oidc-issuer "$EXPECTED_ISSUER" \
+            "$ARCHIVE_FILE"
 
           # Extract and install
-          cd /tmp
-          tar -xzf mcp-publisher.tar.gz
-          chmod +x mcp-publisher
-          sudo mv mcp-publisher /usr/local/bin/mcp-publisher
+          tar -xzf "$ARCHIVE_FILE" -C /tmp mcp-publisher
+          chmod +x /tmp/mcp-publisher
+          sudo mv /tmp/mcp-publisher /usr/local/bin/mcp-publisher
 
       - name: Verify mcp-publisher installation
         run: mcp-publisher --version

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -184,16 +184,24 @@ describe('GitHub Workflow Validation', () => {
       expect(checkoutStep?.with?.ref).toBe('${{ steps.source-ref.outputs.ref }}');
     });
 
-    it('should verify publisher downloads with explicit certificate and signature checks', () => {
+    it('should verify publisher downloads with pinned Sigstore bundle checks', () => {
       const publishJob = workflow.jobs.publish;
+      const cosignStep = publishJob.steps.find(step => step.name === 'Install cosign');
       const downloadStep = publishJob.steps.find(step => step.name === 'Download mcp-publisher CLI');
 
+      expect(cosignStep?.uses).toMatch(/^sigstore\/cosign-installer@[a-f0-9]{40}$/);
+      expect(cosignStep?.with?.['cosign-release']).toBe('v3.0.6');
       expect(downloadStep?.run).toContain('set -euo pipefail');
+      expect(downloadStep?.run).toContain('VERSION="v1.7.9"');
+      expect(downloadStep?.run).toContain('EXPECTED_SHA256="ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac"');
+      expect(downloadStep?.run).toContain('.sigstore.json');
       expect(downloadStep?.run).toContain('SHA256 verification failed');
-      expect(downloadStep?.run).toContain('openssl x509 -in "$CERT_PEM" -noout >/dev/null');
+      expect(downloadStep?.run).toContain('cosign verify-blob');
+      expect(downloadStep?.run).toContain('--bundle "$BUNDLE_FILE"');
+      expect(downloadStep?.run).toContain('--certificate-identity "$EXPECTED_IDENTITY"');
+      expect(downloadStep?.run).toContain('--certificate-oidc-issuer "$EXPECTED_ISSUER"');
       expect(downloadStep?.run).toContain('EXPECTED_ISSUER');
-      expect(downloadStep?.run).toContain('subjectAltName');
-      expect(downloadStep?.run).toContain('Signature verification failed');
+      expect(downloadStep?.run).toContain('https://token.actions.githubusercontent.com');
     });
   });
 });


### PR DESCRIPTION
## Summary
- update the pinned mcp-publisher CLI from v1.3.3 to v1.7.9
- switch current release asset verification to the upstream Sigstore bundle plus pinned SHA-256
- preserve the existing release_ref/dry_run workflow behavior so v2.0.34 can be republished to the MCP Registry after npm publication

## Why
The v2.0.34 release successfully published to npm, GitHub Packages, and the MCP bundle, but the MCP Registry workflow failed during OIDC login because mcp-publisher v1.3.3 requested the retired audience `mcp-registry`. The registry now expects `https://registry.modelcontextprotocol.io`.

## Validation
- parsed .github/workflows/publish-mcp-registry.yml with js-yaml
- verified v1.7.9 linux amd64 checksum from the official modelcontextprotocol/registry release