### PR TITLE
Fix main Sonar quality gate findings

### DIFF
--- a/scripts/qa-element-test.js
+++ b/scripts/qa-element-test.js
@@ -262,6 +262,8 @@ class ElementTestRunner {
     const maxDuration = total > 0 ? 
       Math.max(...this.results.map(r => r.duration)) : 0;
     
+    const firstResult = this.results[0];
+
     const report = {
       timestamp: endTime.toISOString(),
       agent: 'SONNET-1',
@@ -283,10 +285,10 @@ class ElementTestRunner {
           (r.params.type === 'invalid_type' || r.params.name === 'NonExistentElement')).length
       },
       performance_analysis: {
-        fastest_operation: this.results.length > 0 ? 
-          this.results.reduce((min, r) => r.duration < min.duration ? r : min).tool : null,
-        slowest_operation: this.results.length > 0 ? 
-          this.results.reduce((max, r) => r.duration > max.duration ? r : max).tool : null,
+        fastest_operation: firstResult ?
+          this.results.reduce((min, r) => r.duration < min.duration ? r : min, firstResult).tool : null,
+        slowest_operation: firstResult ?
+          this.results.reduce((max, r) => r.duration > max.duration ? r : max, firstResult).tool : null,
         timeout_rate: `${((this.results.filter(r => r.error && r.error.includes('Timeout')).length / total) * 100).toFixed(1)}%`
       },
       detailed_results: this.results.map(r => ({

--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -43,6 +43,7 @@ import {
 } from '../converters/index.js';
 import { SecurityMonitor } from '../security/securityMonitor.js';
 import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
+import { resolvePathWithinBase } from '../utils/pathSecurity.js';
 
 const program = new Command();
 
@@ -344,7 +345,7 @@ async function convertToAnthropic(input: string, options: ConvertOptions): Promi
         logConversionSteps(structure, operationsLog, options.verbose);
 
         // Determine output directory
-        const outputDir = path.join(options.output || './anthropic-skills', skillName);
+        const outputDir = resolvePathWithinBase(options.output || './anthropic-skills', skillName);
 
         if (options.dryRun) {
             console.log(chalk.yellow('\n[DRY RUN] Would create:'));
@@ -374,7 +375,7 @@ async function convertToAnthropic(input: string, options: ConvertOptions): Promi
                 success: true
             });
 
-            const reportPath = path.join(outputDir, '.conversion-report.md');
+            const reportPath = resolvePathWithinBase(outputDir, '.conversion-report.md');
             fs.writeFileSync(reportPath, report);
 
             if (options.verbose) {
@@ -459,8 +460,8 @@ async function convertFromAnthropic(input: string, options: ConvertOptions): Pro
         logReverseConversionSteps(actualInput, operationsLog, options.verbose);
 
         // Determine output file
-        const outputDir = options.output || getDefaultSkillsDirectory();
-        const outputFile = path.join(outputDir, `${skillName}.md`);
+        const outputDir = path.resolve(options.output || getDefaultSkillsDirectory());
+        const outputFile = resolvePathWithinBase(outputDir, `${skillName}.md`);
 
         if (options.dryRun) {
             console.log(chalk.yellow('\n[DRY RUN] Would create:'));
@@ -492,7 +493,7 @@ async function convertFromAnthropic(input: string, options: ConvertOptions): Pro
                 success: true
             });
 
-            const reportPath = path.join(outputDir, `${skillName}-conversion-report.md`);
+            const reportPath = resolvePathWithinBase(outputDir, `${skillName}-conversion-report.md`);
             fs.writeFileSync(reportPath, report);
 
             if (options.verbose) {
@@ -741,8 +742,8 @@ function getCreatedFiles(structure: AnthropicSkillStructure, outputDir: string):
     const files: string[] = [];
     iterateStructureFiles(structure, (dirName, filename) => {
         const filePath = dirName
-            ? path.join(outputDir, dirName, filename)
-            : path.join(outputDir, filename);
+            ? resolvePathWithinBase(outputDir, dirName, filename)
+            : resolvePathWithinBase(outputDir, filename);
         files.push(filePath);
     });
     return files;

--- a/src/converters/DollhouseToAnthropicConverter.ts
+++ b/src/converters/DollhouseToAnthropicConverter.ts
@@ -16,10 +16,10 @@
  */
 
 import * as fs from 'node:fs';
-import * as path from 'node:path';
 import * as yaml from 'js-yaml';
 import { SchemaMapper, type DollhouseMCPSkillMetadata, type AnthropicSkillMetadata } from './SchemaMapper.js';
 import { ContentExtractor, type ExtractedSection } from './ContentExtractor.js';
+import { resolvePathWithinBase } from '../utils/pathSecurity.js';
 
 export interface AnthropicSkillStructure {
     'SKILL.md': string;
@@ -150,7 +150,7 @@ export class DollhouseToAnthropicConverter {
         this.ensureDirectoryExists(outputDir);
 
         // Write SKILL.md
-        fs.writeFileSync(path.join(outputDir, 'SKILL.md'), structure['SKILL.md']);
+        fs.writeFileSync(resolvePathWithinBase(outputDir, 'SKILL.md'), structure['SKILL.md']);
 
         // Write all component directories
         this.writeScriptsDirectory(structure, outputDir);
@@ -161,7 +161,7 @@ export class DollhouseToAnthropicConverter {
 
         // Write license file
         if (structure['LICENSE.txt']) {
-            fs.writeFileSync(path.join(outputDir, 'LICENSE.txt'), structure['LICENSE.txt']);
+            fs.writeFileSync(resolvePathWithinBase(outputDir, 'LICENSE.txt'), structure['LICENSE.txt']);
         }
     }
 
@@ -182,11 +182,11 @@ export class DollhouseToAnthropicConverter {
     private writeScriptsDirectory(structure: AnthropicSkillStructure, outputDir: string): void {
         if (!structure['scripts/']) return;
 
-        const scriptsDir = path.join(outputDir, 'scripts');
+        const scriptsDir = resolvePathWithinBase(outputDir, 'scripts');
         fs.mkdirSync(scriptsDir, { recursive: true });
 
         for (const [filename, content] of Object.entries(structure['scripts/'])) {
-            fs.writeFileSync(path.join(scriptsDir, filename), content);
+            fs.writeFileSync(resolvePathWithinBase(scriptsDir, filename), content);
             // SECURITY (SonarCloud S2612): Do NOT auto-chmod scripts executable
             // - Scripts from DollhouseMCP are markdown code blocks, not executable files
             // - Format transformer shouldn't make security decisions (chmod = security decision)
@@ -206,11 +206,11 @@ export class DollhouseToAnthropicConverter {
     ): void {
         if (!files) return;
 
-        const targetDir = path.join(outputDir, dirName);
+        const targetDir = resolvePathWithinBase(outputDir, dirName);
         fs.mkdirSync(targetDir, { recursive: true });
 
         for (const [filename, content] of Object.entries(files)) {
-            fs.writeFileSync(path.join(targetDir, filename), content);
+            fs.writeFileSync(resolvePathWithinBase(targetDir, filename), content);
         }
     }
 

--- a/src/utils/pathSecurity.ts
+++ b/src/utils/pathSecurity.ts
@@ -1,0 +1,31 @@
+import * as path from 'node:path';
+
+/**
+ * Resolve a target path and verify that it remains inside the intended base
+ * directory. This is separator-aware, so sibling paths such as `/tmp/base2`
+ * are not treated as children of `/tmp/base`.
+ */
+export function resolvePathWithinBase(baseDir: string, ...segments: string[]): string {
+  if (!baseDir || typeof baseDir !== 'string') {
+    throw new Error('Base directory must be a non-empty string');
+  }
+
+  for (const segment of segments) {
+    if (typeof segment !== 'string') {
+      throw new Error('Path segments must be strings');
+    }
+    if (segment.includes('\0')) {
+      throw new Error('Path segment contains a null byte');
+    }
+  }
+
+  const resolvedBase = path.resolve(baseDir);
+  const resolvedTarget = path.resolve(resolvedBase, ...segments);
+  const relativePath = path.relative(resolvedBase, resolvedTarget);
+
+  if (relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))) {
+    return resolvedTarget;
+  }
+
+  throw new Error('Resolved path escapes the base directory');
+}

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -100,7 +100,7 @@
 
       <fieldset class="setup-channel-toggle" id="setup-channel-toggle">
         <legend class="setup-channel-legend">Release channel</legend>
-        <select id="setup-channel-select" class="setup-channel-select" aria-describedby="setup-channel-hint">
+        <select id="setup-channel-select" class="setup-channel-select" aria-label="Release channel" aria-describedby="setup-channel-hint">
           <option value="latest" selected>Stable</option>
           <option value="rc">Release Candidate</option>
           <option value="beta">Beta</option>

--- a/tests/unit/utils/pathSecurity.test.ts
+++ b/tests/unit/utils/pathSecurity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from '@jest/globals';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolvePathWithinBase } from '../../../src/utils/pathSecurity.js';
+
+describe('resolvePathWithinBase', () => {
+  const baseDir = path.join(tmpdir(), 'dollhouse-path-security-base');
+
+  it('resolves nested paths inside the base directory', () => {
+    expect(resolvePathWithinBase(baseDir, 'nested', 'file.md')).toBe(
+      path.resolve(baseDir, 'nested', 'file.md')
+    );
+  });
+
+  it('allows resolving the base directory itself', () => {
+    expect(resolvePathWithinBase(baseDir)).toBe(path.resolve(baseDir));
+  });
+
+  it('rejects traversal outside the base directory', () => {
+    expect(() => resolvePathWithinBase(baseDir, '..', 'outside.md')).toThrow(
+      'Resolved path escapes the base directory'
+    );
+  });
+
+  it('rejects absolute target paths outside the base directory', () => {
+    expect(() => resolvePathWithinBase(baseDir, path.join(tmpdir(), 'outside.md'))).toThrow(
+      'Resolved path escapes the base directory'
+    );
+  });
+
+  it('rejects sibling paths that only share a string prefix', () => {
+    const sibling = `${path.resolve(baseDir)}-sibling`;
+    expect(() => resolvePathWithinBase(baseDir, sibling, 'file.md')).toThrow(
+      'Resolved path escapes the base directory'
+    );
+  });
+
+  it('rejects null bytes in path segments', () => {
+    expect(() => resolvePathWithinBase(baseDir, 'bad\0file.md')).toThrow(
+      'Path segment contains a null byte'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add a separator-aware path guard for conversion output paths and report writes
- Use the guard when writing Anthropic skill directories so generated filenames cannot escape their output directory
- Add an accessible name to the setup release-channel selector
- Add explicit `reduce()` initial values in the QA element report helper

## Verification
- `npm test -- tests/unit/utils/pathSecurity.test.ts --runInBand`
- `npm test -- tests/unit/converter.test.ts tests/unit/utils/pathSecurity.test.ts --runInBand`
- `npm run build`
- `npx eslint --max-warnings=0 src/utils/pathSecurity.ts src/cli/convert.ts src/converters/DollhouseToAnthropicConverter.ts tests/unit/utils/pathSecurity.test.ts`
- `npm run security:audit`
- `git diff --cached --check`

## Notes
- Full `npm run lint` still fails on pre-existing unrelated lint issues in `src/utils/git.ts`, `src/web/routes.ts`, and several unit tests. The changed TypeScript files pass a focused lint check.
- This targets the main-branch SonarCloud reliability/security quality gate failures; merge should wait for the PR checks and your explicit approval.
