### PR TITLE
Fix main Sonar quality gate findings

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # v0.0.63
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ github.token }}  # Use workflow token directly when this workflow changes in a PR

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,8 +39,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Pin to a current Claude API alias instead of relying on the action default.
+          model: "claude-sonnet-4-6"
           
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
@@ -79,4 +79,3 @@ jobs:
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
-

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
     
@@ -38,9 +38,10 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ github.token }}  # Use workflow token directly when this workflow changes in a PR
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Pin to a current Claude API alias instead of relying on the action default.
+          model: "claude-sonnet-4-6"
           
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
@@ -79,4 +80,3 @@ jobs:
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # v0.0.63
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,8 @@ jobs:
           additional_permissions: |
             actions: read
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Pin to a current Claude API alias instead of relying on the action default.
+          model: "claude-sonnet-4-6"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
@@ -61,4 +61,3 @@ jobs:
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-

--- a/.github/workflows/doc-validation.yml
+++ b/.github/workflows/doc-validation.yml
@@ -39,6 +39,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ github.token }}  # Use workflow token directly, skip OIDC (no id-token:write needed)
           use_sticky_comment: true
+          model: "claude-sonnet-4-6"
 
           direct_prompt: |
             You are a documentation validation agent. Your job is to check whether code changes in this PR would invalidate any claims made in the user-facing documentation.

--- a/.github/workflows/doc-validation.yml
+++ b/.github/workflows/doc-validation.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Documentation Validation
-        uses: anthropics/claude-code-action@de8e0b9c42c6cb58e904c857f164aa072244c1ac # beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # v0.0.63
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ github.token }}  # Use workflow token directly, skip OIDC (no id-token:write needed)

--- a/scripts/qa-element-test.js
+++ b/scripts/qa-element-test.js
@@ -262,6 +262,8 @@ class ElementTestRunner {
     const maxDuration = total > 0 ? 
       Math.max(...this.results.map(r => r.duration)) : 0;
     
+    const firstResult = this.results[0];
+
     const report = {
       timestamp: endTime.toISOString(),
       agent: 'SONNET-1',
@@ -283,10 +285,10 @@ class ElementTestRunner {
           (r.params.type === 'invalid_type' || r.params.name === 'NonExistentElement')).length
       },
       performance_analysis: {
-        fastest_operation: this.results.length > 0 ? 
-          this.results.reduce((min, r) => r.duration < min.duration ? r : min).tool : null,
-        slowest_operation: this.results.length > 0 ? 
-          this.results.reduce((max, r) => r.duration > max.duration ? r : max).tool : null,
+        fastest_operation: firstResult ?
+          this.results.reduce((min, r) => r.duration < min.duration ? r : min, firstResult).tool : null,
+        slowest_operation: firstResult ?
+          this.results.reduce((max, r) => r.duration > max.duration ? r : max, firstResult).tool : null,
         timeout_rate: `${((this.results.filter(r => r.error && r.error.includes('Timeout')).length / total) * 100).toFixed(1)}%`
       },
       detailed_results: this.results.map(r => ({

--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -43,6 +43,7 @@ import {
 } from '../converters/index.js';
 import { SecurityMonitor } from '../security/securityMonitor.js';
 import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
+import { resolvePathWithinBase } from '../utils/pathSecurity.js';
 
 const program = new Command();
 
@@ -344,7 +345,7 @@ async function convertToAnthropic(input: string, options: ConvertOptions): Promi
         logConversionSteps(structure, operationsLog, options.verbose);
 
         // Determine output directory
-        const outputDir = path.join(options.output || './anthropic-skills', skillName);
+        const outputDir = resolvePathWithinBase(options.output || './anthropic-skills', skillName);
 
         if (options.dryRun) {
             console.log(chalk.yellow('\n[DRY RUN] Would create:'));
@@ -374,7 +375,7 @@ async function convertToAnthropic(input: string, options: ConvertOptions): Promi
                 success: true
             });
 
-            const reportPath = path.join(outputDir, '.conversion-report.md');
+            const reportPath = resolvePathWithinBase(outputDir, '.conversion-report.md');
             fs.writeFileSync(reportPath, report);
 
             if (options.verbose) {
@@ -459,8 +460,8 @@ async function convertFromAnthropic(input: string, options: ConvertOptions): Pro
         logReverseConversionSteps(actualInput, operationsLog, options.verbose);
 
         // Determine output file
-        const outputDir = options.output || getDefaultSkillsDirectory();
-        const outputFile = path.join(outputDir, `${skillName}.md`);
+        const outputDir = path.resolve(options.output || getDefaultSkillsDirectory());
+        const outputFile = resolvePathWithinBase(outputDir, `${skillName}.md`);
 
         if (options.dryRun) {
             console.log(chalk.yellow('\n[DRY RUN] Would create:'));
@@ -492,7 +493,7 @@ async function convertFromAnthropic(input: string, options: ConvertOptions): Pro
                 success: true
             });
 
-            const reportPath = path.join(outputDir, `${skillName}-conversion-report.md`);
+            const reportPath = resolvePathWithinBase(outputDir, `${skillName}-conversion-report.md`);
             fs.writeFileSync(reportPath, report);
 
             if (options.verbose) {
@@ -741,8 +742,8 @@ function getCreatedFiles(structure: AnthropicSkillStructure, outputDir: string):
     const files: string[] = [];
     iterateStructureFiles(structure, (dirName, filename) => {
         const filePath = dirName
-            ? path.join(outputDir, dirName, filename)
-            : path.join(outputDir, filename);
+            ? resolvePathWithinBase(outputDir, dirName, filename)
+            : resolvePathWithinBase(outputDir, filename);
         files.push(filePath);
     });
     return files;

--- a/src/converters/DollhouseToAnthropicConverter.ts
+++ b/src/converters/DollhouseToAnthropicConverter.ts
@@ -16,10 +16,10 @@
  */
 
 import * as fs from 'node:fs';
-import * as path from 'node:path';
 import * as yaml from 'js-yaml';
 import { SchemaMapper, type DollhouseMCPSkillMetadata, type AnthropicSkillMetadata } from './SchemaMapper.js';
 import { ContentExtractor, type ExtractedSection } from './ContentExtractor.js';
+import { resolvePathWithinBase } from '../utils/pathSecurity.js';
 
 export interface AnthropicSkillStructure {
     'SKILL.md': string;
@@ -150,7 +150,7 @@ export class DollhouseToAnthropicConverter {
         this.ensureDirectoryExists(outputDir);
 
         // Write SKILL.md
-        fs.writeFileSync(path.join(outputDir, 'SKILL.md'), structure['SKILL.md']);
+        fs.writeFileSync(resolvePathWithinBase(outputDir, 'SKILL.md'), structure['SKILL.md']);
 
         // Write all component directories
         this.writeScriptsDirectory(structure, outputDir);
@@ -161,7 +161,7 @@ export class DollhouseToAnthropicConverter {
 
         // Write license file
         if (structure['LICENSE.txt']) {
-            fs.writeFileSync(path.join(outputDir, 'LICENSE.txt'), structure['LICENSE.txt']);
+            fs.writeFileSync(resolvePathWithinBase(outputDir, 'LICENSE.txt'), structure['LICENSE.txt']);
         }
     }
 
@@ -182,11 +182,11 @@ export class DollhouseToAnthropicConverter {
     private writeScriptsDirectory(structure: AnthropicSkillStructure, outputDir: string): void {
         if (!structure['scripts/']) return;
 
-        const scriptsDir = path.join(outputDir, 'scripts');
+        const scriptsDir = resolvePathWithinBase(outputDir, 'scripts');
         fs.mkdirSync(scriptsDir, { recursive: true });
 
         for (const [filename, content] of Object.entries(structure['scripts/'])) {
-            fs.writeFileSync(path.join(scriptsDir, filename), content);
+            fs.writeFileSync(resolvePathWithinBase(scriptsDir, filename), content);
             // SECURITY (SonarCloud S2612): Do NOT auto-chmod scripts executable
             // - Scripts from DollhouseMCP are markdown code blocks, not executable files
             // - Format transformer shouldn't make security decisions (chmod = security decision)
@@ -206,11 +206,11 @@ export class DollhouseToAnthropicConverter {
     ): void {
         if (!files) return;
 
-        const targetDir = path.join(outputDir, dirName);
+        const targetDir = resolvePathWithinBase(outputDir, dirName);
         fs.mkdirSync(targetDir, { recursive: true });
 
         for (const [filename, content] of Object.entries(files)) {
-            fs.writeFileSync(path.join(targetDir, filename), content);
+            fs.writeFileSync(resolvePathWithinBase(targetDir, filename), content);
         }
     }
 

--- a/src/utils/pathSecurity.ts
+++ b/src/utils/pathSecurity.ts
@@ -22,8 +22,11 @@ export function resolvePathWithinBase(baseDir: string, ...segments: string[]): s
   const resolvedBase = path.resolve(baseDir);
   const resolvedTarget = path.resolve(resolvedBase, ...segments);
   const relativePath = path.relative(resolvedBase, resolvedTarget);
+  const isTraversal = relativePath === '..'
+    || relativePath.startsWith('..' + path.sep)
+    || path.isAbsolute(relativePath);
 
-  if (relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))) {
+  if (!isTraversal) {
     return resolvedTarget;
   }
 

--- a/src/utils/pathSecurity.ts
+++ b/src/utils/pathSecurity.ts
@@ -7,12 +7,12 @@ import * as path from 'node:path';
  */
 export function resolvePathWithinBase(baseDir: string, ...segments: string[]): string {
   if (!baseDir || typeof baseDir !== 'string') {
-    throw new Error('Base directory must be a non-empty string');
+    throw new TypeError('Base directory must be a non-empty string');
   }
 
   for (const segment of segments) {
     if (typeof segment !== 'string') {
-      throw new Error('Path segments must be strings');
+      throw new TypeError('Path segments must be strings');
     }
     if (segment.includes('\0')) {
       throw new Error('Path segment contains a null byte');

--- a/src/utils/pathSecurity.ts
+++ b/src/utils/pathSecurity.ts
@@ -1,0 +1,31 @@
+import * as path from 'node:path';
+
+/**
+ * Resolve a target path and verify that it remains inside the intended base
+ * directory. This is separator-aware, so sibling paths such as `/tmp/base2`
+ * are not treated as children of `/tmp/base`.
+ */
+export function resolvePathWithinBase(baseDir: string, ...segments: string[]): string {
+  if (!baseDir || typeof baseDir !== 'string') {
+    throw new Error('Base directory must be a non-empty string');
+  }
+
+  for (const segment of segments) {
+    if (typeof segment !== 'string') {
+      throw new Error('Path segments must be strings');
+    }
+    if (segment.includes('\0')) {
+      throw new Error('Path segment contains a null byte');
+    }
+  }
+
+  const resolvedBase = path.resolve(baseDir);
+  const resolvedTarget = path.resolve(resolvedBase, ...segments);
+  const relativePath = path.relative(resolvedBase, resolvedTarget);
+
+  if (relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))) {
+    return resolvedTarget;
+  }
+
+  throw new Error('Resolved path escapes the base directory');
+}

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -100,7 +100,7 @@
 
       <fieldset class="setup-channel-toggle" id="setup-channel-toggle">
         <legend class="setup-channel-legend">Release channel</legend>
-        <select id="setup-channel-select" class="setup-channel-select" aria-describedby="setup-channel-hint">
+        <select id="setup-channel-select" class="setup-channel-select" aria-label="Release channel" aria-describedby="setup-channel-hint">
           <option value="latest" selected>Stable</option>
           <option value="rc">Release Candidate</option>
           <option value="beta">Beta</option>

--- a/tests/unit/utils/pathSecurity.test.ts
+++ b/tests/unit/utils/pathSecurity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from '@jest/globals';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolvePathWithinBase } from '../../../src/utils/pathSecurity.js';
+
+describe('resolvePathWithinBase', () => {
+  const baseDir = path.join(tmpdir(), 'dollhouse-path-security-base');
+
+  it('resolves nested paths inside the base directory', () => {
+    expect(resolvePathWithinBase(baseDir, 'nested', 'file.md')).toBe(
+      path.resolve(baseDir, 'nested', 'file.md')
+    );
+  });
+
+  it('allows resolving the base directory itself', () => {
+    expect(resolvePathWithinBase(baseDir)).toBe(path.resolve(baseDir));
+  });
+
+  it('rejects traversal outside the base directory', () => {
+    expect(() => resolvePathWithinBase(baseDir, '..', 'outside.md')).toThrow(
+      'Resolved path escapes the base directory'
+    );
+  });
+
+  it('rejects absolute target paths outside the base directory', () => {
+    expect(() => resolvePathWithinBase(baseDir, path.join(tmpdir(), 'outside.md'))).toThrow(
+      'Resolved path escapes the base directory'
+    );
+  });
+
+  it('rejects sibling paths that only share a string prefix', () => {
+    const sibling = `${path.resolve(baseDir)}-sibling`;
+    expect(() => resolvePathWithinBase(baseDir, sibling, 'file.md')).toThrow(
+      'Resolved path escapes the base directory'
+    );
+  });
+
+  it('rejects null bytes in path segments', () => {
+    expect(() => resolvePathWithinBase(baseDir, 'bad\0file.md')).toThrow(
+      'Path segment contains a null byte'
+    );
+  });
+});

--- a/tests/unit/utils/pathSecurity.test.ts
+++ b/tests/unit/utils/pathSecurity.test.ts
@@ -16,6 +16,12 @@ describe('resolvePathWithinBase', () => {
     expect(resolvePathWithinBase(baseDir)).toBe(path.resolve(baseDir));
   });
 
+  it('allows in-base filenames that start with two dots', () => {
+    expect(resolvePathWithinBase(baseDir, '..backup.md')).toBe(
+      path.resolve(baseDir, '..backup.md')
+    );
+  });
+
   it('rejects traversal outside the base directory', () => {
     expect(() => resolvePathWithinBase(baseDir, '..', 'outside.md')).toThrow(
       'Resolved path escapes the base directory'


### PR DESCRIPTION
## Summary
- Add a separator-aware path guard for conversion output paths and report writes
- Use the guard when writing Anthropic skill directories so generated filenames cannot escape their output directory
- Add an accessible name to the setup release-channel selector
- Add explicit `reduce()` initial values in the QA element report helper
- Pin Claude action workflows to the current `claude-sonnet-4-6` API alias so review/doc validation jobs do not fail on the retired action default

## Verification
- `npm test -- tests/unit/utils/pathSecurity.test.ts --runInBand`
- `npm test -- tests/unit/converter.test.ts tests/unit/utils/pathSecurity.test.ts --runInBand`
- `npm run build`
- `npx eslint --max-warnings=0 src/utils/pathSecurity.ts src/cli/convert.ts src/converters/DollhouseToAnthropicConverter.ts tests/unit/utils/pathSecurity.test.ts`
- `npm run security:audit`
- `ruby -ryaml -e "ARGV.each { |f| YAML.load_file(f) }; puts 'workflow yaml ok'" .github/workflows/claude-code-review.yml .github/workflows/claude.yml .github/workflows/doc-validation.yml`
- `git diff --check`

## Notes
- Full `npm run lint` still fails on pre-existing unrelated lint issues in `src/utils/git.ts`, `src/web/routes.ts`, and several unit tests. The changed TypeScript files pass a focused lint check.
- This targets the main-branch SonarCloud reliability/security quality gate failures; merge should wait for the PR checks and explicit approval.
