### PR TITLE
chore: release 2.0.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.35] - 2026-06-23
+
+- Harden converter and CLI output path handling to keep generated files inside their intended output directories.
+- Restore SonarCloud main quality gate health with path traversal coverage, accessibility, and reliability fixes.
+- Update MCP registry publisher workflow verification for the current publisher release and OIDC audience.
+
 ## [2.0.32] - 2026-04-23
 
 - Restore the management console's stronger responsive header behavior, including cleaner tab overflow handling and keyboard-accessible menu navigation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 - Restore SonarCloud main quality gate health with path traversal coverage, accessibility, and reliability fixes.
 - Update MCP registry publisher workflow verification for the current publisher release and OIDC audience.
 
+## [2.0.34] - 2026-06-23
+
+- Preserve dependency and security hardening while rolling back the accidental 2.0.33 main merge state.
+- Fix nested documentation description handling so agent goal parameters, template variables, and template examples can keep substantive descriptions beyond the top-level element summary limit.
+- Restore permission audit metadata and Codex permission allow-response handling from the develop hardening work.
+- Keep release metadata aligned across package, lockfile, manifest, MCP server metadata, and generated version surfaces.
+
 ## [2.0.32] - 2026-04-23
 
 - Restore the management console's stronger responsive header behavior, including cleaner tab overflow handling and keyboard-accessible menu navigation.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dollhousemcp",
   "display_name": "DollhouseMCP",
-  "version": "2.0.34",
+  "version": "2.0.35",
   "description": "Open-source AI customization through modular Dollhouse elements — personas, skills, templates, agents, memories, and ensembles.",
   "long_description": "DollhouseMCP is an MCP server that lets you customize your AI with modular Dollhouse elements. Create personas that shape behavior and permissions, skills that add capabilities, templates for consistent outputs, agents for autonomous multi-step goals, memories for persistent context, and ensembles that bundle elements together. Includes MCP-AQL query language with 5 semantic CRUDE endpoints, Gatekeeper permission system, community collection, and a built-in portfolio browser.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.34",
+  "version": "2.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.34",
+      "version": "2.0.35",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.34",
+  "version": "2.0.35",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.34",
+  "version": "2.0.35",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.34",
+      "version": "2.0.35",
       "transport": {
         "type": "stdio"
       }

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.34';
-export const BUILD_TIMESTAMP = '2026-06-23T19:18:00.338Z';
+export const PACKAGE_VERSION = '2.0.35';
+export const BUILD_TIMESTAMP = '2026-06-23T22:05:55.087Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';


### PR DESCRIPTION
## Summary

Patch release 2.0.35 for the current stable 2.0.x line.

Includes the main-branch hotfixes already merged after v2.0.34:
- Harden converter and CLI output path handling so generated files stay inside intended output directories.
- Restore SonarCloud main quality gate health with path traversal coverage, accessibility, and reliability fixes.
- Update MCP registry publisher workflow verification for the current publisher release and OIDC audience.

## Version Updates

- package.json / package-lock.json: 2.0.35
- server.json package metadata: 2.0.35
- manifest.json: 2.0.35
- generated version constant: 2.0.35
- CHANGELOG.md entry added for 2026-06-23

## Local Validation

- npm run build
- npm test -- --maxWorkers=4
  - 396 suites passed, 1 skipped
  - 10,366 tests passed, 9 skipped
- npm run verify:package-assets
- npm run security:audit
  - 0 findings
