### PR TITLE
ci: fix MCP registry cosign installer version

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -74,7 +74,10 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac
         with:
-          cosign-release: 'v3.0.6'
+          # The pinned installer verifies cosign with detached .sig assets.
+          # Cosign v3 releases publish sigstore bundles instead, so keep the
+          # installer on the latest detached-signature release it supports.
+          cosign-release: 'v2.5.2'
 
       - name: Download mcp-publisher CLI
         shell: bash

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -72,12 +72,12 @@ jobs:
         run: npm run build
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
         with:
-          # The pinned installer verifies cosign with detached .sig assets.
-          # Cosign v3 releases publish sigstore bundles instead, so keep the
-          # installer on the latest detached-signature release it supports.
-          cosign-release: 'v2.5.2'
+          # Pinned to cosign-installer v4.1.2 so Cosign v3 releases are verified
+          # with Sigstore bundles instead of deprecated detached .sig assets.
+          # See https://github.com/sigstore/cosign-installer/issues/202.
+          cosign-release: 'v3.0.6'
 
       - name: Download mcp-publisher CLI
         shell: bash

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -190,7 +190,8 @@ describe('GitHub Workflow Validation', () => {
       const downloadStep = publishJob.steps.find(step => step.name === 'Download mcp-publisher CLI');
 
       expect(cosignStep?.uses).toMatch(/^sigstore\/cosign-installer@[a-f0-9]{40}$/);
-      expect(cosignStep?.with?.['cosign-release']).toBe('v3.0.6');
+      expect(cosignStep?.with?.['cosign-release']).toBe('v2.5.2');
+      expect(workflowContent).toContain('Cosign v3 releases publish sigstore bundles instead');
       expect(downloadStep?.run).toContain('set -euo pipefail');
       expect(downloadStep?.run).toContain('VERSION="v1.7.9"');
       expect(downloadStep?.run).toContain('EXPECTED_SHA256="ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac"');

--- a/tests/unit/github-workflow-validation.test.ts
+++ b/tests/unit/github-workflow-validation.test.ts
@@ -190,8 +190,9 @@ describe('GitHub Workflow Validation', () => {
       const downloadStep = publishJob.steps.find(step => step.name === 'Download mcp-publisher CLI');
 
       expect(cosignStep?.uses).toMatch(/^sigstore\/cosign-installer@[a-f0-9]{40}$/);
-      expect(cosignStep?.with?.['cosign-release']).toBe('v2.5.2');
-      expect(workflowContent).toContain('Cosign v3 releases publish sigstore bundles instead');
+      expect(cosignStep?.with?.['cosign-release']).toBe('v3.0.6');
+      expect(workflowContent).toContain('Pinned to cosign-installer v4.1.2');
+      expect(workflowContent).toContain('https://github.com/sigstore/cosign-installer/issues/202');
       expect(downloadStep?.run).toContain('set -euo pipefail');
       expect(downloadStep?.run).toContain('VERSION="v1.7.9"');
       expect(downloadStep?.run).toContain('EXPECTED_SHA256="ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac"');


### PR DESCRIPTION
## Summary

Fix the MCP Registry publish workflow after the v2.0.35 release exposed a cosign installer incompatibility.

The original workflow pinned `sigstore/cosign-installer` to an older action commit while requesting `cosign-release: v3.0.6`. That older installer expected detached `.sig` assets, but Cosign v3 releases publish Sigstore bundle assets instead, so the release-triggered workflow failed while trying to download `cosign-linux-amd64.sig`.

This updates the workflow to the `cosign-installer` v4.1.2 commit, which supports Cosign v3 Sigstore bundle verification, and keeps `cosign-release: v3.0.6`.

## Release Recovery

Used this branch via workflow dispatch to successfully publish `refs/tags/v2.0.35` to the MCP Registry after the release-triggered workflow failed at cosign install.

Successful recovery run: https://github.com/DollhouseMCP/mcp-server/actions/runs/28062281709

## Validation

- `git diff --check`
- `npm test -- --runTestsByPath tests/unit/github-workflow-validation.test.ts --runInBand`
- Workflow dispatch dry-run reached the publish step with the updated v4 installer path: `Install cosign`, `Download mcp-publisher CLI`, `Verify mcp-publisher installation`, and `Login to MCP Registry (OIDC)` all passed. The final dry-run publish was rejected by the registry because `2.0.35` is already published as a duplicate version, which is separate from the cosign installer fix.
