### PR TITLE
[codex] Fix production CLI commander dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@modelcontextprotocol/sdk": "^1.25.1",
         "argon2": "^0.44.0",
         "chalk": "^5.6.2",
+        "commander": "^13.1.0",
         "dompurify": "^3.4.11",
         "dotenv": "^17.2.3",
         "drizzle-orm": "^0.45.2",
@@ -6176,7 +6177,6 @@
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
       "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
     "@modelcontextprotocol/sdk": "^1.25.1",
     "argon2": "^0.44.0",
     "chalk": "^5.6.2",
+    "commander": "^13.1.0",
     "dompurify": "^3.4.11",
     "dotenv": "^17.2.3",
     "drizzle-orm": "^0.45.2",

--- a/tests/unit/cli/package-bin-dependencies.test.ts
+++ b/tests/unit/cli/package-bin-dependencies.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  bin?: Record<string, string>;
+}
+
+const COMMANDER_IMPORT_PATTERN = /\bfrom\s+['"]commander['"]|\brequire\(\s*['"]commander['"]\s*\)/u;
+
+function readPackageJson(): PackageJson {
+  return JSON.parse(readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')) as PackageJson;
+}
+
+function sourcePathForBin(binPath: string): string | null {
+  if (!binPath.startsWith('dist/') || !binPath.endsWith('.js')) return null;
+  return path.join(process.cwd(), binPath.replace(/^dist\//u, 'src/').replace(/\.js$/u, '.ts'));
+}
+
+describe('published CLI bin dependencies', () => {
+  it('declares commander as a production dependency for packaged bins that import it', () => {
+    const packageJson = readPackageJson();
+    const binEntries = Object.entries(packageJson.bin ?? {});
+    const binsImportingCommander = binEntries
+      .map(([name, binPath]) => ({ name, sourcePath: sourcePathForBin(binPath) }))
+      .filter((entry): entry is { name: string; sourcePath: string } =>
+        entry.sourcePath !== null && existsSync(entry.sourcePath))
+      .filter(entry => COMMANDER_IMPORT_PATTERN.test(readFileSync(entry.sourcePath, 'utf8')))
+      .map(entry => entry.name)
+      .sort();
+
+    expect(binsImportingCommander).toContain('dollhouse-allowlist');
+    expect(binsImportingCommander.length).toBeGreaterThan(0);
+    expect(packageJson.dependencies?.commander).toBeDefined();
+  });
+});

--- a/tests/unit/cli/package-bin-dependencies.test.ts
+++ b/tests/unit/cli/package-bin-dependencies.test.ts
@@ -8,29 +8,37 @@ interface PackageJson {
 }
 
 const COMMANDER_IMPORT_PATTERN = /\bfrom\s+['"]commander['"]|\brequire\(\s*['"]commander['"]\s*\)/u;
+const PROJECT_ROOT = process.cwd();
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts'] as const;
 
 function readPackageJson(): PackageJson {
-  return JSON.parse(readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')) as PackageJson;
+  return JSON.parse(readFileSync(path.join(PROJECT_ROOT, 'package.json'), 'utf8')) as PackageJson;
 }
 
 function sourcePathForBin(binPath: string): string | null {
   if (!binPath.startsWith('dist/') || !binPath.endsWith('.js')) return null;
-  return path.join(process.cwd(), binPath.replace(/^dist\//u, 'src/').replace(/\.js$/u, '.ts'));
+  const sourceBase = path.join(PROJECT_ROOT, binPath.replace(/^dist\//u, 'src/').replace(/\.js$/u, ''));
+  return SOURCE_EXTENSIONS
+    .map(extension => `${sourceBase}${extension}`)
+    .find(existsSync) ?? null;
 }
 
 describe('published CLI bin dependencies', () => {
   it('declares commander as a production dependency for packaged bins that import it', () => {
     const packageJson = readPackageJson();
     const binEntries = Object.entries(packageJson.bin ?? {});
-    const binsImportingCommander = binEntries
-      .map(([name, binPath]) => ({ name, sourcePath: sourcePathForBin(binPath) }))
-      .filter((entry): entry is { name: string; sourcePath: string } =>
-        entry.sourcePath !== null && existsSync(entry.sourcePath))
+    const binSources = binEntries
+      .map(([name, binPath]) => ({ name, binPath, sourcePath: sourcePathForBin(binPath) }));
+    const missingSources = binSources.filter(entry => entry.binPath.startsWith('dist/') && entry.sourcePath === null);
+    const binsImportingCommander = binSources
+      .filter((entry): entry is { name: string; binPath: string; sourcePath: string } => entry.sourcePath !== null)
       .filter(entry => COMMANDER_IMPORT_PATTERN.test(readFileSync(entry.sourcePath, 'utf8')))
       .map(entry => entry.name)
       .sort();
 
-    expect(binsImportingCommander).toContain('dollhouse-allowlist');
+    // This is intentionally Commander-specific: add similar checks when a
+    // packaged bin imports another package that is easy to strand in dev deps.
+    expect(missingSources).toEqual([]);
     expect(binsImportingCommander.length).toBeGreaterThan(0);
     expect(packageJson.dependencies?.commander).toBeDefined();
   });


### PR DESCRIPTION
## Summary

- promote `commander` to a direct production dependency
- keep the lockfile's `node_modules/commander` entry in the production dependency set
- add a package-boundary regression test for published CLI bins that import `commander`

## Why

Alpha showed that `dollhouse-allowlist` exists in the hosted production container but fails at startup:

```text
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'commander' imported from /app/dist/cli/allowlist.js
```

The root cause is that multiple published CLI bins import `commander`, but `commander` was only present transitively in the lockfile and not declared as a production dependency. The hosted Docker image runs `npm ci --omit=dev`, so transitive/dev-only availability is not reliable.

Fixes #2309.

## Validation

- `npm test -- --runTestsByPath tests/unit/cli/package-bin-dependencies.test.ts`
- `npm run build`
- `./node_modules/.bin/eslint --max-warnings=0 tests/unit/cli/package-bin-dependencies.test.ts`
