### PR TITLE
Fix CLI Postgres admin connection

### DIFF
--- a/src/cli/cliAuthStorage.ts
+++ b/src/cli/cliAuthStorage.ts
@@ -52,7 +52,8 @@ export interface CliAuthStorageHandle {
 
 function normalizePostgresUrlCandidate(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
+  if (!trimmed) return undefined;
+  return trimmed;
 }
 
 function detectBackend(): AuthStorageBackend {

--- a/src/cli/cliAuthStorage.ts
+++ b/src/cli/cliAuthStorage.ts
@@ -50,6 +50,11 @@ export interface CliAuthStorageHandle {
   close: () => Promise<void>;
 }
 
+function normalizePostgresUrlCandidate(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 function detectBackend(): AuthStorageBackend {
   // Mirror the resolution order in `createAuthStorage.pickBackend` —
   // explicit env wins, otherwise filesystem default. We do this
@@ -63,7 +68,8 @@ function detectBackend(): AuthStorageBackend {
 }
 
 export function resolveCliAuthStoragePostgresUrl(sourceEnv: CliAuthStoragePostgresUrlEnv = env): string {
-  const url = sourceEnv.DOLLHOUSE_DATABASE_ADMIN_URL ?? sourceEnv.DOLLHOUSE_DATABASE_URL;
+  const url = normalizePostgresUrlCandidate(sourceEnv.DOLLHOUSE_DATABASE_ADMIN_URL) ??
+    normalizePostgresUrlCandidate(sourceEnv.DOLLHOUSE_DATABASE_URL);
   if (!url) {
     throw new Error(
       'DOLLHOUSE_AUTH_STORAGE_BACKEND=postgres requires DOLLHOUSE_DATABASE_ADMIN_URL or ' +

--- a/src/cli/cliAuthStorage.ts
+++ b/src/cli/cliAuthStorage.ts
@@ -14,11 +14,11 @@
  * the documented `dollhouse-admin-bootstrap` CLI (Round 5 review
  * fixup, post-triage HIGH-1).
  *
- * This helper opens a short-lived Drizzle connection from
- * `DOLLHOUSE_DATABASE_URL` when the auth storage backend is postgres,
- * passes it through to `createAuthStorage`, and exposes a `close()`
- * to drain the pool when the CLI exits. Filesystem and memory
- * backends skip the database wiring entirely.
+ * This helper opens a short-lived Drizzle connection from the admin
+ * database URL when available (falling back to `DOLLHOUSE_DATABASE_URL`
+ * for simple installs), passes it through to `createAuthStorage`, and
+ * exposes a `close()` to drain the pool when the CLI exits. Filesystem
+ * and memory backends skip the database wiring entirely.
  *
  * @module cli/cliAuthStorage
  */
@@ -32,6 +32,11 @@ import {
 } from '../auth/embedded-as/storage/createAuthStorage.js';
 import type { IAuthStorageLayer } from '../auth/embedded-as/storage/IAuthStorageLayer.js';
 import type { DatabaseInstance } from '../database/connection.js';
+
+export interface CliAuthStoragePostgresUrlEnv {
+  readonly DOLLHOUSE_DATABASE_ADMIN_URL?: string;
+  readonly DOLLHOUSE_DATABASE_URL?: string;
+}
 
 export interface CliAuthStorageHandle {
   storage: IAuthStorageLayer;
@@ -57,6 +62,18 @@ function detectBackend(): AuthStorageBackend {
   return 'filesystem';
 }
 
+export function resolveCliAuthStoragePostgresUrl(sourceEnv: CliAuthStoragePostgresUrlEnv = env): string {
+  const url = sourceEnv.DOLLHOUSE_DATABASE_ADMIN_URL ?? sourceEnv.DOLLHOUSE_DATABASE_URL;
+  if (!url) {
+    throw new Error(
+      'DOLLHOUSE_AUTH_STORAGE_BACKEND=postgres requires DOLLHOUSE_DATABASE_ADMIN_URL or ' +
+      'DOLLHOUSE_DATABASE_URL to be set so the bootstrap CLI can open a connection. ' +
+      'Either set one URL or use DOLLHOUSE_AUTH_STORAGE_BACKEND=filesystem for non-DB deployments.',
+    );
+  }
+  return url;
+}
+
 /**
  * Build the storage handle for a CLI. Pass the same `methods` you'd
  * pass to `createAuthStorage` directly so the durable-method safety
@@ -74,18 +91,10 @@ export async function openCliAuthStorage(
     return { storage, close: async () => {} };
   }
 
-  // Postgres backend — open a connection from the same env the AS
-  // uses. The CLI shares the storage backend with the running AS;
-  // a separate connection pool is fine because (a) auth ops are
-  // low-volume, (b) the CLI is short-lived.
-  const url = env.DOLLHOUSE_DATABASE_URL;
-  if (!url) {
-    throw new Error(
-      'DOLLHOUSE_AUTH_STORAGE_BACKEND=postgres requires DOLLHOUSE_DATABASE_URL ' +
-      'to be set so the bootstrap CLI can open a connection. Either set the URL ' +
-      'or use DOLLHOUSE_AUTH_STORAGE_BACKEND=filesystem for non-DB deployments.',
-    );
-  }
+  // Postgres backend — open a short-lived operator connection. Hosted
+  // deployments expose DOLLHOUSE_DATABASE_URL as the RLS app role, while
+  // auth-admin CLIs need the admin role for withSystemContext operations.
+  const url = resolveCliAuthStoragePostgresUrl();
 
   // Lazy import: only callers on the postgres branch pull in the
   // database / drizzle dependencies.

--- a/tests/unit/cli/cliAuthStorage.test.ts
+++ b/tests/unit/cli/cliAuthStorage.test.ts
@@ -8,7 +8,8 @@
  * Tests cover the three branches:
  *   - filesystem backend → no DB pool opened (close() is a no-op)
  *   - memory backend → no DB pool opened
- *   - postgres backend without DOLLHOUSE_DATABASE_URL → clear error
+ *   - postgres URL resolution prefers DOLLHOUSE_DATABASE_ADMIN_URL
+ *   - postgres backend without a database URL → clear error
  *
  * The postgres-with-valid-DB-URL happy path is intentionally NOT unit
  * tested here. Mocking the postgres.js + Drizzle stack at unit level
@@ -22,7 +23,7 @@
  *   1. Integration coverage via storage-parity (gated, runs in CI).
  *   2. Manual smoke verification at deploy time:
  *      `DOLLHOUSE_AUTH_STORAGE_BACKEND=postgres
- *       DOLLHOUSE_DATABASE_URL=<...>
+ *       DOLLHOUSE_DATABASE_ADMIN_URL=<...>
  *       node dist/cli/admin-bootstrap.js --method github --github-id 1`
  *      which was confirmed end-to-end in cycle 5 review.
  */
@@ -31,7 +32,10 @@ import { describe, it, expect, afterEach } from '@jest/globals';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import os from 'node:os';
-import { openCliAuthStorage } from '../../../src/cli/cliAuthStorage.js';
+import {
+  openCliAuthStorage,
+  resolveCliAuthStoragePostgresUrl,
+} from '../../../src/cli/cliAuthStorage.js';
 import { InMemoryAuthStorageLayer } from '../../../src/auth/embedded-as/storage/InMemoryAuthStorageLayer.js';
 import { FilesystemAuthStorageLayer } from '../../../src/auth/embedded-as/storage/FilesystemAuthStorageLayer.js';
 
@@ -78,13 +82,32 @@ describe('openCliAuthStorage', () => {
     await expect(handle.close()).resolves.toBeUndefined();
   });
 
-  it('postgres backend: throws a clear error when DOLLHOUSE_DATABASE_URL is unset', async () => {
+  it('postgres URL resolution: prefers admin URL over app URL', () => {
+    expect(resolveCliAuthStoragePostgresUrl({
+      DOLLHOUSE_DATABASE_ADMIN_URL: 'postgres://admin@example/db',
+      DOLLHOUSE_DATABASE_URL: 'postgres://app@example/db',
+    })).toBe('postgres://admin@example/db');
+  });
+
+  it('postgres URL resolution: falls back to app URL for simple installs', () => {
+    expect(resolveCliAuthStoragePostgresUrl({
+      DOLLHOUSE_DATABASE_URL: 'postgres://app@example/db',
+    })).toBe('postgres://app@example/db');
+  });
+
+  it('postgres URL resolution: throws a clear error when no database URL is set', () => {
+    expect(() => resolveCliAuthStoragePostgresUrl({})).toThrow(
+      /DOLLHOUSE_DATABASE_ADMIN_URL.*DOLLHOUSE_DATABASE_URL/u,
+    );
+  });
+
+  it('postgres backend: throws a clear error when no database URL is set', async () => {
     // Cycle 19 / B2: same env-routing pattern. Test the explicit
     // backend selection; the env-driven path is covered by integration
     // tests where the env is set in the test runner.
     delete process.env.DOLLHOUSE_DATABASE_URL;
     await expect(openCliAuthStorage({ backend: 'postgres', methods: ['github'] })).rejects.toThrow(
-      /DOLLHOUSE_DATABASE_URL/,
+      /DOLLHOUSE_DATABASE_ADMIN_URL.*DOLLHOUSE_DATABASE_URL/u,
     );
   });
 

--- a/tests/unit/cli/cliAuthStorage.test.ts
+++ b/tests/unit/cli/cliAuthStorage.test.ts
@@ -41,12 +41,15 @@ import { FilesystemAuthStorageLayer } from '../../../src/auth/embedded-as/storag
 
 describe('openCliAuthStorage', () => {
   const savedBackend = process.env.DOLLHOUSE_AUTH_STORAGE_BACKEND;
+  const savedAdminDbUrl = process.env.DOLLHOUSE_DATABASE_ADMIN_URL;
   const savedDbUrl = process.env.DOLLHOUSE_DATABASE_URL;
   const tmpDirs: string[] = [];
 
   afterEach(async () => {
     if (savedBackend === undefined) delete process.env.DOLLHOUSE_AUTH_STORAGE_BACKEND;
     else process.env.DOLLHOUSE_AUTH_STORAGE_BACKEND = savedBackend;
+    if (savedAdminDbUrl === undefined) delete process.env.DOLLHOUSE_DATABASE_ADMIN_URL;
+    else process.env.DOLLHOUSE_DATABASE_ADMIN_URL = savedAdminDbUrl;
     if (savedDbUrl === undefined) delete process.env.DOLLHOUSE_DATABASE_URL;
     else process.env.DOLLHOUSE_DATABASE_URL = savedDbUrl;
     for (const dir of tmpDirs) {
@@ -91,6 +94,13 @@ describe('openCliAuthStorage', () => {
 
   it('postgres URL resolution: falls back to app URL for simple installs', () => {
     expect(resolveCliAuthStoragePostgresUrl({
+      DOLLHOUSE_DATABASE_URL: 'postgres://app@example/db',
+    })).toBe('postgres://app@example/db');
+  });
+
+  it('postgres URL resolution: treats a blank admin URL as unavailable', () => {
+    expect(resolveCliAuthStoragePostgresUrl({
+      DOLLHOUSE_DATABASE_ADMIN_URL: '   ',
       DOLLHOUSE_DATABASE_URL: 'postgres://app@example/db',
     })).toBe('postgres://app@example/db');
   });


### PR DESCRIPTION
## Summary
- make CLI auth storage prefer `DOLLHOUSE_DATABASE_ADMIN_URL` for Postgres-backed admin operations
- keep `DOLLHOUSE_DATABASE_URL` as a fallback for simple/local installs
- add focused unit coverage for URL selection and missing-URL errors

## Why
After PR #2310 deployed to alpha, the packaged allowlist CLI started correctly but failed live because it connected with the hosted app role (`dollhouse_app`). That role is intentionally constrained by RLS, so admin allowlist operations failed inside `withSystemContext`.

The hosted container already provides `DOLLHOUSE_DATABASE_ADMIN_URL`; the CLI should use that admin connection for bootstrap/admin commands while preserving the existing fallback behavior for non-hosted installs.

## Validation
- `npm test -- --runTestsByPath tests/unit/cli/cliAuthStorage.test.ts tests/unit/cli/package-bin-dependencies.test.ts`
- `./node_modules/.bin/eslint --max-warnings=0 src/cli/cliAuthStorage.ts tests/unit/cli/cliAuthStorage.test.ts tests/unit/cli/package-bin-dependencies.test.ts`
- `npm run build`
