### PR TITLE
Fix OAuth helper token handoff

### DIFF
--- a/docs/guides/configuration-basics.md
+++ b/docs/guides/configuration-basics.md
@@ -10,7 +10,7 @@
 |----------|---------|
 | `~/.dollhouse/config.yml` | Primary configuration file created by `ConfigManager` the first time you run the server or the setup wizard. |
 | `~/.dollhouse/config.yml.backup` | Automatic backup taken before each write so you can recover from a bad edit. |
-| `~/.dollhouse/` (directory) | Also stores OAuth helper state and logs (`.auth/`, `oauth-helper.log`). |
+| `~/.dollhouse/` (directory) | Also stores OAuth helper state under `.auth/`; helper logs are written to `oauth-helper.log` only when `DOLLHOUSE_OAUTH_DEBUG=true`. |
 
 Configuration is YAML-based. Manual edits are allowed, but using the `dollhouse_config` MCP tool keeps validation and backups automatic.
 

--- a/docs/guides/environment-variables.md
+++ b/docs/guides/environment-variables.md
@@ -558,6 +558,8 @@ These variables configure the runtime identity and filesystem paths used by the 
 | `DOLLHOUSE_HOME_DIR` | `~` (os.homedir) | Override the home directory for telemetry and auth file storage. |
 | `DOLLHOUSE_CACHE_DIR` | _(auto)_ | Override the collection cache directory path. |
 | `DOLLHOUSE_OAUTH_HELPER` | _(none)_ | Override the OAuth helper binary path for GitHub authentication. |
+| `DOLLHOUSE_OAUTH_DEBUG` | `false` | Enable OAuth helper debug logging to `~/.dollhouse/oauth-helper.log`. |
+| `DOLLHOUSE_OAUTH_TOKEN_URL` | GitHub token endpoint | Override the OAuth device-flow token endpoint. Intended for local tests and diagnostics. |
 | `DOLLHOUSE_DEBUG` | _(none)_ | Enable extra debug output at server startup. When set, additional diagnostic info is logged. |
 
 ### Feature Flags

--- a/docs/guides/oauth-setup.md
+++ b/docs/guides/oauth-setup.md
@@ -173,7 +173,8 @@ If you're setting up your own instance, follow the administrator instructions ab
 **Problem**: The helper process might not be running
 **Solution**:
 - Check if the helper is running: `ps aux | grep oauth-helper`
-- Look at logs: `cat ~/.dollhouse/oauth-helper.log`
+- Check helper state: `oauth_helper_status verbose=true`
+- If you started the flow with `DOLLHOUSE_OAUTH_DEBUG=true`, look at logs: `cat ~/.dollhouse/oauth-helper.log`
 - Try restarting the authentication process
  - Ensure your client ID is valid (re-run `dollhouse_config action="get" setting="github.auth.client_id"`)
 

--- a/docs/security/security-checklist.md
+++ b/docs/security/security-checklist.md
@@ -17,7 +17,7 @@ Use this checklist before merging PRs or cutting a release. It complements the d
 - [ ] Manually test `setup_github_auth` / `check_github_auth` to confirm the OAuth device flow still works.
 - [ ] Test a portfolio upload/download roundtrip (`portfolio_element_manager`) and a collection submission (`submit_collection_content`).
 - [ ] Rebuild the enhanced index (e.g., call `get_relationship_stats`) and watch for warnings or performance regressions.
-- [ ] Review `~/.dollhouse/oauth-helper.log` for errors if authentication was exercised.
+- [ ] Review `oauth_helper_status verbose=true` after exercising authentication; inspect `~/.dollhouse/oauth-helper.log` only when `DOLLHOUSE_OAUTH_DEBUG=true`.
 - [ ] Update release notes with notable security changes or mitigations.
 
 ## 3. Ongoing Practices

--- a/oauth-helper.mjs
+++ b/oauth-helper.mjs
@@ -27,6 +27,27 @@ const __dirname = dirname(__filename);
 const DEFAULT_POLL_INTERVAL = 5;
 const DEFAULT_EXPIRES_IN = 900; // 15 minutes
 const MAX_TOKEN_SIZE = 10000; // Maximum reasonable token size
+const DOLLHOUSE_HOME_DIR = process.env.DOLLHOUSE_HOME_DIR || homedir();
+const AUTH_DIR = join(DOLLHOUSE_HOME_DIR, '.dollhouse', '.auth');
+const PID_FILE = join(AUTH_DIR, 'oauth-helper.pid');
+const STATE_FILE = join(AUTH_DIR, 'oauth-helper-state.json');
+const RESULT_FILE = join(AUTH_DIR, 'oauth-helper-result.json');
+const LOG_FILE = join(DOLLHOUSE_HOME_DIR, '.dollhouse', 'oauth-helper.log');
+const TOKEN_URL = process.env.DOLLHOUSE_OAUTH_TOKEN_URL || 'https://github.com/login/oauth/access_token';
+const LOG_ENABLED = process.env.DOLLHOUSE_OAUTH_DEBUG === 'true';
+
+const RESULT_MESSAGES = {
+  success: 'OAuth helper completed successfully.',
+  expired_token: 'Device code expired before authorization completed.',
+  access_denied: 'User denied the GitHub authorization request.',
+  timeout: 'Authorization timed out before the user completed GitHub authorization.',
+  token_storage_failed: 'OAuth token could not be stored securely.',
+  network_failure: 'Too many network errors while contacting the OAuth token endpoint.',
+  fatal_error: 'OAuth helper stopped after an unrecoverable error.',
+  unknown_response: 'OAuth token endpoint returned an unrecognized response.',
+};
+
+const ALLOWED_RESULT_ERROR_CODES = new Set(Object.keys(RESULT_MESSAGES));
 
 // Parse command line arguments
 const args = process.argv.slice(2);
@@ -49,10 +70,6 @@ if (!clientId || clientId === 'undefined') {
   await log('OAUTH_HELPER_43: Process exiting - missing client ID');
   process.exit(1);
 }
-
-// Log file for debugging (optional, can be disabled in production)
-const LOG_FILE = join(homedir(), '.dollhouse', 'oauth-helper.log');
-const LOG_ENABLED = process.env.DOLLHOUSE_OAUTH_DEBUG === 'true';
 
 async function log(message) {
   if (!LOG_ENABLED) return;
@@ -86,13 +103,18 @@ async function log(message) {
   }
 }
 
+function sanitizeDiagnostic(value) {
+  return String(value ?? '')
+    .replace(/\bgithub_pat_[A-Za-z0-9_]+\b/g, '[REDACTED_GITHUB_TOKEN]')
+    .replace(/\bgh[a-z]_[A-Za-z0-9_]+\b/gi, '[REDACTED_GITHUB_TOKEN]')
+    .replaceAll(deviceCode, '[REDACTED_DEVICE_CODE]');
+}
+
 async function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 async function pollGitHub(deviceCode, clientId) {
-  const TOKEN_URL = 'https://github.com/login/oauth/access_token';
-  
   try {
     const response = await fetch(TOKEN_URL, {
       method: 'POST',
@@ -127,71 +149,110 @@ async function storeToken(token) {
     const { TokenManager } = await import('./dist/security/tokenManager.js');
     
     // Store the token using the secure storage mechanism
-    await TokenManager.storeGitHubToken(token);
+    const tokenManager = new TokenManager(createHelperFileOperations());
+    await tokenManager.storeGitHubToken(token);
     await log('Token stored successfully using TokenManager');
     return true;
-  } catch {
-    await log('Failed to store token using TokenManager');
-    
-    // Fallback: Write to a temporary file for the MCP server to pick up
-    try {
-      const tempTokenFile = join(homedir(), '.dollhouse', '.auth', 'pending_token.txt');
-      const tempDir = dirname(tempTokenFile);
-      
-      // Create directory with secure permissions
-      await fs.mkdir(tempDir, { recursive: true, mode: 0o700 });
-      
-      // Verify directory permissions
-      const dirStats = await fs.stat(tempDir);
-      const dirMode = dirStats.mode & parseInt('777', 8);
-      if (dirMode !== parseInt('700', 8)) {
-        await fs.chmod(tempDir, 0o700);
-      }
-      
-      // Write token with secure permissions
-      await fs.writeFile(tempTokenFile, token, { mode: 0o600 });
-      
-      // Verify file permissions
-      await fs.chmod(tempTokenFile, 0o600);
-      
-      await log('Token written to fallback file with secure permissions');
-      return true;
-    } catch (fallbackError) {
-      await log('Fallback storage also failed');
-      throw fallbackError;
-    }
+  } catch (error) {
+    await log(`Failed to store token using TokenManager: ${sanitizeDiagnostic(error instanceof Error ? error.message : 'Unknown error')}`);
+    throw error;
   }
+}
+
+function createHelperFileOperations() {
+  return {
+    async createDirectory(directoryPath) {
+      await fs.mkdir(directoryPath, { recursive: true });
+    },
+    async readFile(filePath) {
+      return fs.readFile(filePath, 'utf8');
+    },
+    async writeFile(filePath, content) {
+      await fs.writeFile(filePath, content, { encoding: 'utf8' });
+    },
+    async deleteFile(filePath) {
+      await fs.unlink(filePath);
+    },
+    async chmod(filePath, mode) {
+      await fs.chmod(filePath, mode);
+    },
+    async exists(filePath) {
+      try {
+        await fs.access(filePath);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  };
 }
 
 function cleanupPidFileSync() {
   try {
-    const pidFile = join(homedir(), '.dollhouse', '.auth', 'oauth-helper.pid');
-    if (fsSync.existsSync(pidFile)) {
-      fsSync.unlinkSync(pidFile);
+    if (fsSync.existsSync(PID_FILE)) {
+      fsSync.unlinkSync(PID_FILE);
     }
-  } catch (error) {
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+function cleanupStateFileSync() {
+  try {
+    if (fsSync.existsSync(STATE_FILE)) {
+      fsSync.unlinkSync(STATE_FILE);
+    }
+  } catch {
     // Ignore cleanup errors
   }
 }
 
 async function cleanupPidFile() {
   try {
-    const pidFile = join(homedir(), '.dollhouse', '.auth', 'oauth-helper.pid');
-    await fs.unlink(pidFile).catch(() => {});
+    await fs.unlink(PID_FILE).catch(() => {});
     await log('PID file cleaned up');
-  } catch (error) {
+  } catch {
     // Ignore cleanup errors
+  }
+}
+
+async function cleanupStateFile() {
+  try {
+    await fs.unlink(STATE_FILE).catch(() => {});
+    await log('OAuth helper state file cleaned up');
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+async function writeTerminalResult(status, attempts, errorCode = '') {
+  try {
+    await fs.mkdir(AUTH_DIR, { recursive: true, mode: 0o700 });
+    const safeErrorCode = ALLOWED_RESULT_ERROR_CODES.has(errorCode) ? errorCode : 'fatal_error';
+    const result = {
+      status,
+      attempts,
+      completedAt: new Date().toISOString()
+    };
+
+    if (status !== 'success') {
+      result.errorCode = safeErrorCode;
+      result.message = RESULT_MESSAGES[safeErrorCode];
+    }
+
+    await fs.writeFile(RESULT_FILE, JSON.stringify(result, null, 2), { mode: 0o600 });
+    await fs.chmod(RESULT_FILE, 0o600).catch(() => {});
+    await log(`Terminal result written: ${status}${status === 'success' ? '' : `/${safeErrorCode}`}`);
+  } catch {
+    await log('Failed to write terminal result');
   }
 }
 
 async function writePidFile() {
   try {
-    const pidFile = join(homedir(), '.dollhouse', '.auth', 'oauth-helper.pid');
-    const pidDir = dirname(pidFile);
-    
-    await fs.mkdir(pidDir, { recursive: true, mode: 0o700 });
-    await fs.writeFile(pidFile, process.pid.toString(), { mode: 0o600 });
-    await log(`PID file written: ${pidFile}`);
+    await fs.mkdir(AUTH_DIR, { recursive: true, mode: 0o700 });
+    await fs.writeFile(PID_FILE, process.pid.toString(), { mode: 0o600 });
+    await log(`PID file written: ${PID_FILE}`);
   } catch {
     await log('Failed to write PID file');
   }
@@ -233,14 +294,24 @@ async function main() {
   });
   
   process.on('SIGINT', () => {
+    cleanupStateFileSync();
     cleanupPidFileSync();
     process.exit(0);
   });
   
   process.on('SIGTERM', () => {
+    cleanupStateFileSync();
     cleanupPidFileSync();
     process.exit(0);
   });
+
+  async function finish(status, errorCode, exitCode) {
+    clearInterval(heartbeatInterval);
+    await writeTerminalResult(status, attempts, errorCode);
+    await cleanupStateFile();
+    await cleanupPidFile();
+    process.exit(exitCode);
+  }
   
   while (Date.now() < timeout) {
     attempts++;
@@ -266,43 +337,41 @@ async function main() {
           case 'expired_token':
             await log('OAUTH_HELPER_264: Device code expired - authentication window closed');
             console.error('OAUTH_EXPIRED: Device code expired at line 264 - authentication window closed');
-            clearInterval(heartbeatInterval);
-            await cleanupPidFile();
-            process.exit(1);
+            return finish('expired', 'expired_token', 1);
             
           case 'access_denied':
             await log('OAUTH_HELPER_270: User denied authorization request');
             console.error('OAUTH_ACCESS_DENIED: User denied authorization at line 270');
-            clearInterval(heartbeatInterval);
-            await cleanupPidFile();
-            process.exit(1);
+            return finish('denied', 'access_denied', 1);
             
           default:
             await log('OAUTH_HELPER_276: Unknown error from GitHub during device flow polling');
             await log('[ERROR] GitHub returned an unrecognized OAuth polling response');
             console.error('OAUTH_UNKNOWN_RESPONSE: Unknown GitHub OAuth response at line 276');
+            return finish('failed', 'unknown_response', 1);
         }
       } else if (response.access_token) {
         // Success! We got the token
         await log('[SUCCESS] ✅ Token received from GitHub!');
         consecutiveErrors = 0; // Reset error counter
         
-        // Store the token
-        const stored = await storeToken(response.access_token);
+        let stored = false;
+        try {
+          stored = await storeToken(response.access_token);
+        } catch {
+          console.error('OAUTH_TOKEN_STORAGE_FAILED: Failed to store authentication token securely');
+          return finish('failed', 'token_storage_failed', 1);
+        }
         
         if (stored) {
           await log('[SUCCESS] ✅ OAuth authentication completed successfully');
           await log(`[STATS] Total attempts: ${attempts}, Time elapsed: ${Math.round((Date.now() - startTime) / 1000)}s`);
           console.log('✅ GitHub authentication successful! Token has been stored.');
-          clearInterval(heartbeatInterval);
-          await cleanupPidFile();
-          process.exit(0);
+          return finish('success', 'success', 0);
         } else {
           await log('[ERROR] ❌ Failed to store token');
           console.error('❌ Failed to store authentication token');
-          clearInterval(heartbeatInterval);
-          await cleanupPidFile();
-          process.exit(1);
+          return finish('failed', 'token_storage_failed', 1);
         }
       } else {
         // Reset error counter on successful communication
@@ -327,17 +396,13 @@ async function main() {
         if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
           await log('OAUTH_HELPER_323: Too many consecutive network errors, exiting');
           console.error(`OAUTH_NETWORK_FAILURE: Too many network errors (${MAX_CONSECUTIVE_ERRORS}) at line 323 - check internet connection`);
-          clearInterval(heartbeatInterval);
-          await cleanupPidFile();
-          process.exit(1);
+          return finish('failed', 'network_failure', 1);
         }
       } else {
         // Non-network error, likely fatal
-        await log('OAUTH_HELPER_330: Non-recoverable error');
+        await log(`OAUTH_HELPER_330: Non-recoverable error: ${sanitizeDiagnostic(error instanceof Error ? error.message : 'Unknown error')}`);
         console.error('OAUTH_FATAL_ERROR: Non-recoverable error at line 330');
-        clearInterval(heartbeatInterval);
-        await cleanupPidFile();
-        process.exit(1);
+        return finish('failed', 'fatal_error', 1);
       }
     }
     
@@ -349,15 +414,15 @@ async function main() {
   await log('OAUTH_HELPER_342: OAuth authorization timed out');
   await log(`[STATS] Total attempts: ${attempts}, Time elapsed: ${Math.round((Date.now() - startTime) / 1000)}s`);
   console.error(`OAUTH_TIMEOUT: Authorization timed out at line 342 after ${Math.round((Date.now() - startTime) / 1000)}s - user did not authorize in time`);
-  clearInterval(heartbeatInterval);
-  await cleanupPidFile();
-  process.exit(1);
+  return finish('timeout', 'timeout', 1);
 }
 
 // Run the main function
 main().catch(async () => {
   await log('Fatal error');
   console.error('Fatal error in OAuth helper');
+  await writeTerminalResult('failed', 0, 'fatal_error');
+  await cleanupStateFile();
   await cleanupPidFile();
   process.exit(1);
 });

--- a/src/handlers/GitHubAuthHandler.ts
+++ b/src/handlers/GitHubAuthHandler.ts
@@ -18,6 +18,16 @@ import { PersonaIndicatorService } from '../services/PersonaIndicatorService.js'
 import { SecurityMonitor } from '../security/securityMonitor.js';
 import { FileOperationsService } from '../services/FileOperationsService.js';
 
+type OAuthHelperTerminalStatus = 'success' | 'failed' | 'expired' | 'denied' | 'timeout';
+
+interface OAuthHelperTerminalResult {
+    status: OAuthHelperTerminalStatus;
+    attempts?: number;
+    completedAt?: string;
+    errorCode?: string;
+    message?: string;
+}
+
 export class GitHubAuthHandler {
     constructor(
         private readonly githubAuthManager: GitHubAuthManager,
@@ -38,6 +48,8 @@ export class GitHubAuthHandler {
     async setupGitHubAuth() {
         await this.ensureInitialized();
         try {
+          await this.cleanupLegacyPendingToken('setupGitHubAuth');
+
           // Check current auth status first
           const currentStatus = await this.githubAuthManager.getAuthStatus();
           
@@ -155,8 +167,10 @@ export class GitHubAuthHandler {
             });
             
             const stateFile = path.join(this.getDollhouseHomeDir(), '.dollhouse', '.auth', 'oauth-helper-state.json');
+            const resultFile = path.join(this.getDollhouseHomeDir(), '.dollhouse', '.auth', 'oauth-helper-result.json');
             const stateDir = path.dirname(stateFile);
             await this.fileOperations.createDirectory(stateDir);
+            await this.fileOperations.deleteFile(resultFile).catch(() => {});
             
             const state = {
               pid: helper.pid,
@@ -243,14 +257,17 @@ export class GitHubAuthHandler {
     async checkGitHubAuth() {
         await this.ensureInitialized();
         try {
+          const removedLegacyPendingToken = await this.cleanupLegacyPendingToken('checkGitHubAuth');
           const helperHealth = await this.checkOAuthHelperHealth();
           const status = await this.githubAuthManager.getAuthStatus();
           
           if (status.isAuthenticated) {
             if (helperHealth.exists) {
               const stateFile = path.join(this.getDollhouseHomeDir(), '.dollhouse', '.auth', 'oauth-helper-state.json');
+              const resultFile = path.join(this.getDollhouseHomeDir(), '.dollhouse', '.auth', 'oauth-helper-result.json');
               // FileOperationsService.deleteFile already handles ENOENT gracefully
               await this.fileOperations.deleteFile(stateFile).catch(() => {}); // Preserve error swallowing pattern
+              await this.fileOperations.deleteFile(resultFile).catch(() => {});
             }
             
             return {
@@ -266,6 +283,48 @@ export class GitHubAuthHandler {
                   `✅ Submit content\n\n` +
                   `Everything is working properly!`
                 )
+              }]
+            };
+          } else if (helperHealth.resultStatus === 'success') {
+            const legacyNotice = removedLegacyPendingToken
+              ? `\n\nA stale plaintext OAuth fallback file from an earlier failed flow was removed.`
+              : '';
+            return {
+              content: [{
+                type: "text",
+                text: this.prefix(
+                  `✅ **GitHub Authentication Completed**\n\n` +
+                  `The OAuth helper finished successfully, but the GitHub token is not available to this server process.${legacyNotice}\n\n` +
+                  `**To fix this:**\n` +
+                  `1. Run \`check_github_auth\` again after the server refreshes\n` +
+                  `2. If it still fails, run \`setup_github_auth\` to authenticate again`
+                )
+              }]
+            };
+          } else if (helperHealth.resultStatus) {
+            const statusLabel = this.formatOAuthHelperTerminalStatus(helperHealth.resultStatus);
+            const lines = [
+              `${statusLabel.icon} **GitHub Authentication ${statusLabel.title}**`,
+              '',
+              helperHealth.resultMessage || statusLabel.defaultMessage,
+              '',
+              '**To try again:**',
+              'Run: `setup_github_auth` to get a new code',
+              ''
+            ];
+
+            if (removedLegacyPendingToken) {
+              lines.push('A stale plaintext OAuth fallback file from an earlier failed flow was removed.', '');
+            }
+
+            if (helperHealth.errorLog) {
+              lines.push('**Error Log:**', '```', helperHealth.errorLog, '```', '');
+            }
+
+            return {
+              content: [{
+                type: "text",
+                text: this.prefix(lines.join('\n'))
               }]
             };
           } else if (helperHealth.isActive) {
@@ -322,6 +381,9 @@ export class GitHubAuthHandler {
               }]
             };
           } else {
+            const legacyNotice = removedLegacyPendingToken
+              ? `\n\nA stale plaintext OAuth fallback file from an earlier failed flow was removed. Please run \`setup_github_auth\` again to reconnect.`
+              : '';
             return {
               content: [{
                 type: "text",
@@ -331,7 +393,7 @@ export class GitHubAuthHandler {
                       `✅ Browse the public collection\n` +
                       `✅ Install community content\n` +
                       `❌ Submit your own content (requires auth)\n\n` +
-                      `To connect, just say "set up GitHub" or "connect to GitHub"`
+                      `To connect, just say "set up GitHub" or "connect to GitHub"${legacyNotice}`
               }]
             };
           }
@@ -355,6 +417,7 @@ export class GitHubAuthHandler {
           const stateFile = path.join(homeDir, '.dollhouse', '.auth', 'oauth-helper-state.json');
           const logFile = path.join(homeDir, '.dollhouse', 'oauth-helper.log');
           const pidFile = path.join(homeDir, '.dollhouse', '.auth', 'oauth-helper.pid');
+          const resultFile = path.join(homeDir, '.dollhouse', '.auth', 'oauth-helper-result.json');
           
           let statusText = `📊 **OAuth Helper Process Diagnostics**\n\n`;
           
@@ -362,6 +425,25 @@ export class GitHubAuthHandler {
             statusText += `**Status:** No OAuth process detected\n`
             statusText += `**State File:** Not found\n\n`
             statusText += `No active authentication process. Run \`setup_github_auth\` to start one.\n`;
+          } else if (health.resultStatus) {
+            const statusLabel = this.formatOAuthHelperTerminalStatus(health.resultStatus);
+            statusText += `**Status:** ${statusLabel.icon} ${statusLabel.title.toUpperCase()}\n`
+            if (health.userCode) {
+              statusText += `**User Code:** ${health.userCode}\n`
+            }
+            if (health.pid) {
+              statusText += `**Process ID:** ${health.pid}\n`
+            }
+            if (health.completedAt) {
+              statusText += `**Completed:** ${health.completedAt.toLocaleString()}\n`
+            }
+            if (health.resultAttempts !== undefined) {
+              statusText += `**Attempts:** ${health.resultAttempts}\n`
+            }
+            if (health.resultMessage) {
+              statusText += `**Result:** ${health.resultMessage}\n`
+            }
+            statusText += '\n';
           } else if (health.isActive) {
             statusText += `**Status:** 🟢 ACTIVE - Authentication in progress\n`
             statusText += `**User Code:** ${health.userCode}\n`
@@ -391,6 +473,7 @@ setup_github_auth
           
           statusText += `**📁 File Locations:**\n`
           statusText += `• State: ${stateFile}\n`
+          statusText += `• Result: ${resultFile} ${health.hasResult ? '(exists)' : '(not found)'}\n`
           statusText += `• Log: ${logFile} ${health.hasLog ? '(exists)' : '(not found)'}\n`
           statusText += `• PID: ${pidFile}\n\n`
           
@@ -414,21 +497,26 @@ setup_github_auth
             }
           }
           
-          if (health.exists && !health.processAlive && !health.expired) {
+          if (health.exists && !health.processAlive && !health.expired && !health.resultStatus) {
             statusText += `**🔧 Troubleshooting Tips:**\n`
             statusText += `1. The helper process may have crashed\n`
-            statusText += `2. Check the log file for errors: ${logFile}\n`
-            statusText += `3. Try running 
-setup_github_auth
- again\n`
-            statusText += `4. Ensure DOLLHOUSE_GITHUB_CLIENT_ID is set\n`
-            statusText += `5. Check your internet connection\n`
+            if (health.hasLog) {
+              statusText += `2. Check the log file for errors: ${logFile}\n`
+              statusText += `3. Try running \`setup_github_auth\` again\n`
+              statusText += `4. Ensure DOLLHOUSE_GITHUB_CLIENT_ID is set\n`
+              statusText += `5. Check your internet connection\n`
+            } else {
+              statusText += `2. Try running \`setup_github_auth\` again\n`
+              statusText += `3. Ensure DOLLHOUSE_GITHUB_CLIENT_ID is set\n`
+              statusText += `4. Check your internet connection\n`
+            }
           }
           
           if (health.exists && (health.expired || !health.processAlive)) {
             statusText += `\n**🧹 Manual Cleanup (if needed):**\n`
             statusText += '```bash'
             statusText += `rm "${stateFile}"\n`
+            statusText += `rm "${resultFile}"\n`
             statusText += `rm "${logFile}"\n`
             statusText += `rm "${pidFile}"\n`
             statusText += '```';
@@ -457,20 +545,45 @@ setup_github_auth
         const homeDir = this.getDollhouseHomeDir();
         const stateFile = path.join(homeDir, '.dollhouse', '.auth', 'oauth-helper-state.json');
         const logFile = path.join(homeDir, '.dollhouse', 'oauth-helper.log');
+        const resultFile = path.join(homeDir, '.dollhouse', '.auth', 'oauth-helper-result.json');
         
         const health = {
           exists: false,
           isActive: false,
           expired: false,
           processAlive: false,
+          hasResult: false,
           hasLog: false,
           userCode: '',
           timeRemaining: 0,
           pid: 0,
           startTime: null as Date | null,
           expiresAt: null as Date | null,
+          completedAt: null as Date | null,
+          resultStatus: null as OAuthHelperTerminalStatus | null,
+          resultMessage: '',
+          resultAttempts: undefined as number | undefined,
           errorLog: ''
         };
+
+        try {
+          const resultData = await this.fileOperations.readFile(resultFile, {
+            source: 'GitHubAuthHandler.checkOAuthHelperHealth'
+          });
+          const result = JSON.parse(resultData) as Partial<OAuthHelperTerminalResult>;
+          if (this.isOAuthHelperTerminalStatus(result.status)) {
+            health.exists = true;
+            health.hasResult = true;
+            health.resultStatus = result.status;
+            health.resultMessage = typeof result.message === 'string' ? result.message : '';
+            health.resultAttempts = typeof result.attempts === 'number' ? result.attempts : undefined;
+            health.completedAt = typeof result.completedAt === 'string' ? new Date(result.completedAt) : null;
+          }
+        } catch (error) {
+          if (!(error instanceof Error && error.message.includes('ENOENT'))) {
+            logger.debug('Error reading OAuth helper result', { error });
+          }
+        }
         
         try {
           const stateData = await this.fileOperations.readFile(stateFile, {
@@ -484,7 +597,9 @@ setup_github_auth
           health.expiresAt = new Date(state.expiresAt);
 
           const now = new Date();
-          if (health.expiresAt > now) {
+          if (health.resultStatus) {
+            health.isActive = false;
+          } else if (health.expiresAt > now) {
             health.isActive = true;
             health.timeRemaining = Math.ceil((health.expiresAt.getTime() - now.getTime()) / 1000);
 
@@ -506,31 +621,6 @@ setup_github_auth
             health.expired = true;
           }
 
-          // Check if log file exists
-          health.hasLog = await this.fileOperations.exists(logFile);
-
-          // Read error log if process is dead or expired, or if verbose mode is on
-          if (health.hasLog && (!health.processAlive || health.expired)) {
-            try {
-              const logContent = await this.fileOperations.readFile(logFile, {
-                source: 'GitHubAuthHandler.checkOAuthHelperHealth'
-              });
-              const lines = logContent.split('\n');
-              const importantLines = lines.filter(line =>
-                line.toLowerCase().includes('error') ||
-                line.toLowerCase().includes('fail') ||
-                line.includes('❌') ||
-                line.includes('⚠️')
-              ).slice(-10); // Get last 10 relevant lines
-
-              if (importantLines.length > 0) {
-                health.errorLog = importantLines.join('\n');
-              }
-            } catch {
-              // Intentionally empty - ignore if log file read fails
-            }
-          }
-
         } catch (error) {
           // If state file is not found (ENOENT), it's expected, so don't log as debug
           if (error instanceof Error && error.message.includes('ENOENT')) {
@@ -539,8 +629,100 @@ setup_github_auth
             logger.debug('Error reading OAuth helper state', { error });
           }
         }
+
+        health.hasLog = await this.fileOperations.exists(logFile);
+
+        if (health.hasLog && (!health.processAlive || health.expired || health.resultStatus)) {
+          try {
+            const logContent = await this.fileOperations.readFile(logFile, {
+              source: 'GitHubAuthHandler.checkOAuthHelperHealth'
+            });
+            const lines = logContent.split('\n');
+            const importantLines = lines.filter(line =>
+              line.toLowerCase().includes('error') ||
+              line.toLowerCase().includes('fail') ||
+              line.includes('❌') ||
+              line.includes('⚠️')
+            ).slice(-10);
+
+            if (importantLines.length > 0) {
+              health.errorLog = importantLines.join('\n');
+            }
+          } catch {
+            // Intentionally empty - ignore if log file read fails
+          }
+        }
         
         return health;
+    }
+
+    private async cleanupLegacyPendingToken(source: string): Promise<boolean> {
+        const pendingTokenFile = path.join(this.getDollhouseHomeDir(), '.dollhouse', '.auth', 'pending_token.txt');
+        try {
+          if (!(await this.fileOperations.exists(pendingTokenFile))) {
+            return false;
+          }
+
+          await this.fileOperations.deleteFile(pendingTokenFile, undefined, {
+            source: `GitHubAuthHandler.${source}`
+          });
+
+          SecurityMonitor.logSecurityEvent({
+            type: 'TOKEN_CACHE_CLEARED',
+            severity: 'MEDIUM',
+            source: `GitHubAuthHandler.${source}`,
+            details: 'Removed stale plaintext OAuth pending token fallback file'
+          });
+          logger.warn('Removed stale plaintext OAuth pending token fallback file');
+          return true;
+        } catch (error) {
+          logger.warn('Failed to remove stale OAuth pending token fallback file', { error });
+          return false;
+        }
+    }
+
+    private isOAuthHelperTerminalStatus(status: unknown): status is OAuthHelperTerminalStatus {
+        return status === 'success' ||
+               status === 'failed' ||
+               status === 'expired' ||
+               status === 'denied' ||
+               status === 'timeout';
+    }
+
+    private formatOAuthHelperTerminalStatus(status: OAuthHelperTerminalStatus) {
+        switch (status) {
+          case 'success':
+            return {
+              icon: '✅',
+              title: 'Completed',
+              defaultMessage: 'The OAuth helper completed successfully.'
+            };
+          case 'expired':
+            return {
+              icon: '⏱️',
+              title: 'Expired',
+              defaultMessage: 'The GitHub authentication request expired.'
+            };
+          case 'denied':
+            return {
+              icon: '🚫',
+              title: 'Denied',
+              defaultMessage: 'The GitHub authentication request was denied.'
+            };
+          case 'timeout':
+            return {
+              icon: '⏱️',
+              title: 'Timed Out',
+              defaultMessage: 'The GitHub authentication request timed out.'
+            };
+          case 'failed':
+          default:
+            return {
+              icon: '❌',
+              title: 'Failed',
+              defaultMessage: 'The OAuth helper failed before authentication completed.'
+            };
+        }
     }
 
     async clearGitHubAuth() {

--- a/src/security/tokenManager.ts
+++ b/src/security/tokenManager.ts
@@ -53,7 +53,6 @@ export class TokenManager {
   };
 
   // Secure storage configuration
-  private static readonly TOKEN_DIR = path.join(homedir(), '.dollhouse', '.auth');
   private static readonly TOKEN_FILE = 'github_token.enc';
   private static readonly ALGORITHM = 'aes-256-gcm';
   private static readonly KEY_LENGTH = 32;
@@ -70,6 +69,10 @@ export class TokenManager {
 
   constructor(fileOperations: IFileOperationsService) {
     this.fileOperations = fileOperations;
+  }
+
+  static getTokenDir(): string {
+    return path.join(process.env.DOLLHOUSE_HOME_DIR || homedir(), '.dollhouse', '.auth');
   }
 
   /**
@@ -513,8 +516,9 @@ export class TokenManager {
       }
 
       // Ensure directory exists
-      await this.fileOperations.createDirectory(TokenManager.TOKEN_DIR);
-      await this.fileOperations.chmod(TokenManager.TOKEN_DIR, 0o700, {
+      const tokenDir = TokenManager.getTokenDir();
+      await this.fileOperations.createDirectory(tokenDir);
+      await this.fileOperations.chmod(tokenDir, 0o700, {
         source: 'TokenManager.storeGitHubToken'
       });
 
@@ -536,7 +540,7 @@ export class TokenManager {
       const stored = Buffer.concat([salt, iv, tag, encrypted]);
 
       // Write to file with restricted permissions
-      const tokenPath = path.join(TokenManager.TOKEN_DIR, TokenManager.TOKEN_FILE);
+      const tokenPath = path.join(tokenDir, TokenManager.TOKEN_FILE);
       // Write the binary content to the file (need to convert Buffer to string for FileOperationsService)
       // Since we're writing binary data, we'll write as base64 for safe storage
       await this.fileOperations.writeFile(tokenPath, stored.toString('base64'), {
@@ -576,7 +580,7 @@ export class TokenManager {
    */
   async retrieveGitHubToken(): Promise<string | null> {
     try {
-      const tokenPath = path.join(TokenManager.TOKEN_DIR, TokenManager.TOKEN_FILE);
+      const tokenPath = path.join(TokenManager.getTokenDir(), TokenManager.TOKEN_FILE);
 
       // Check if file exists
       const exists = await this.fileOperations.exists(tokenPath);
@@ -642,7 +646,7 @@ export class TokenManager {
    */
   async removeStoredToken(): Promise<void> {
     try {
-      const tokenPath = path.join(TokenManager.TOKEN_DIR, TokenManager.TOKEN_FILE);
+      const tokenPath = path.join(TokenManager.getTokenDir(), TokenManager.TOKEN_FILE);
 
       // Check if file exists before attempting deletion
       const exists = await this.fileOperations.exists(tokenPath);

--- a/tests/qa/oauth-auth-test.mjs
+++ b/tests/qa/oauth-auth-test.mjs
@@ -102,17 +102,17 @@ async function testTokenStorage() {
       path: '~/.dollhouse/.auth/github_token.enc'
     },
     {
-      name: 'Pending OAuth Token',
+      name: 'OAuth Helper Result',
       check: async () => {
-        const pendingPath = path.join(homedir(), '.dollhouse', '.auth', 'pending_token.txt');
+        const resultPath = path.join(homedir(), '.dollhouse', '.auth', 'oauth-helper-result.json');
         try {
-          await fs.access(pendingPath);
+          await fs.access(resultPath);
           return true;
         } catch {
           return false;
         }
       },
-      path: '~/.dollhouse/.auth/pending_token.txt'
+      path: '~/.dollhouse/.auth/oauth-helper-result.json'
     }
   ];
   

--- a/tests/unit/auth/oauth-helper.test.ts
+++ b/tests/unit/auth/oauth-helper.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from '@jest/globals';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { pathToFileURL } from 'node:url';
+import type { IFileOperationsService } from '../../../src/services/FileOperationsService.js';
+
+function realFileOperations(): IFileOperationsService {
+  return {
+    async createDirectory(directoryPath: string) {
+      await fs.mkdir(directoryPath, { recursive: true });
+    },
+    async readElementFile(filePath: string) {
+      return fs.readFile(filePath, 'utf-8');
+    },
+    async readFile(filePath: string) {
+      return fs.readFile(filePath, 'utf-8');
+    },
+    async writeFile(filePath: string, content: string) {
+      await fs.writeFile(filePath, content, 'utf-8');
+    },
+    async deleteFile(filePath: string) {
+      await fs.unlink(filePath);
+    },
+    async chmod(filePath: string, mode: number) {
+      await fs.chmod(filePath, mode);
+    },
+    async exists(filePath: string) {
+      try {
+        await fs.access(filePath);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    async listDirectory(directoryPath: string) {
+      return fs.readdir(directoryPath);
+    },
+    async listDirectoryWithTypes(directoryPath: string) {
+      const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+      return entries.map(entry => ({
+        name: entry.name,
+        isDirectory: entry.isDirectory(),
+        isFile: entry.isFile()
+      }));
+    },
+    async renameFile(oldPath: string, newPath: string) {
+      await fs.rename(oldPath, newPath);
+    },
+    async stat(filePath: string) {
+      return fs.stat(filePath);
+    },
+    resolvePath(relativePath: string, baseDirectory: string) {
+      return path.resolve(baseDirectory, relativePath);
+    },
+    validatePath(filePath: string, baseDirectory: string) {
+      const resolvedFile = path.resolve(filePath);
+      const resolvedBase = path.resolve(baseDirectory);
+      return resolvedFile === resolvedBase || resolvedFile.startsWith(`${resolvedBase}${path.sep}`);
+    },
+    async createFileExclusive(filePath: string, content: string) {
+      try {
+        await fs.writeFile(filePath, content, { flag: 'wx' });
+        return true;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+          return false;
+        }
+        throw error;
+      }
+    },
+    async copyFile(sourcePath: string, destPath: string) {
+      await fs.copyFile(sourcePath, destPath);
+    },
+    async appendFile(filePath: string, content: string) {
+      await fs.appendFile(filePath, content, 'utf-8');
+    }
+  };
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+function json(res: ServerResponse, statusCode: number, body: unknown): void {
+  res.writeHead(statusCode, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+async function closeServer(server: ReturnType<typeof createServer>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close(error => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function runHelper(helperPath: string, tokenUrl: string, homeDir: string) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const child = spawn(process.execPath, [
+    helperPath,
+    'device-code-for-test',
+    '1',
+    '20',
+    'Ov23liTestClientId'
+  ], {
+    env: {
+      ...process.env,
+      DOLLHOUSE_HOME_DIR: homeDir,
+      DOLLHOUSE_OAUTH_TOKEN_URL: tokenUrl,
+      DOLLHOUSE_OAUTH_DEBUG: 'true',
+      DOLLHOUSE_TOKEN_SECRET: 'oauth-helper-test-secret',
+      GITHUB_TOKEN: '',
+      TEST_GITHUB_TOKEN: '',
+      GITHUB_TEST_TOKEN: ''
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  child.stdout?.on('data', chunk => stdout.push(String(chunk)));
+  child.stderr?.on('data', chunk => stderr.push(String(chunk)));
+
+  return new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', code => {
+      resolve({
+        code,
+        stdout: stdout.join(''),
+        stderr: stderr.join('')
+      });
+    });
+  });
+}
+
+describe('oauth-helper.mjs', () => {
+  it('uses the TokenManager instance API and does not keep a plaintext pending-token fallback', async () => {
+    const helperSource = await fs.readFile(path.join(process.cwd(), 'oauth-helper.mjs'), 'utf-8');
+    const distTokenManagerPath = path.join(process.cwd(), 'dist', 'security', 'tokenManager.js');
+
+    await expect(fs.access(distTokenManagerPath)).resolves.toBeUndefined();
+
+    const { TokenManager } = await import(pathToFileURL(distTokenManagerPath).href);
+
+    expect(helperSource).toContain('new TokenManager(');
+    expect(helperSource).toContain('tokenManager.storeGitHubToken(');
+    expect(helperSource).not.toMatch(/\bTokenManager\.storeGitHubToken\s*\(/);
+    expect(helperSource).not.toContain('pending_token.txt');
+    expect(typeof TokenManager.prototype.storeGitHubToken).toBe('function');
+  });
+
+  it('stores a device-flow token where TokenManager can read it and writes a terminal result', async () => {
+    const helperPath = path.join(process.cwd(), 'oauth-helper.mjs');
+    const distTokenManagerPath = path.join(process.cwd(), 'dist', 'security', 'tokenManager.js');
+    const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'oauth-helper-e2e-'));
+    const originalHomeDir = process.env.DOLLHOUSE_HOME_DIR;
+    const originalTokenSecret = process.env.DOLLHOUSE_TOKEN_SECRET;
+    const originalGithubToken = process.env.GITHUB_TOKEN;
+    const originalTestGithubToken = process.env.TEST_GITHUB_TOKEN;
+    const originalGithubTestToken = process.env.GITHUB_TEST_TOKEN;
+    const expectedToken = 'gho_test_device_flow_token_1234567890';
+    let polls = 0;
+
+    await expect(fs.access(distTokenManagerPath)).resolves.toBeUndefined();
+
+    const server = createServer(async (req, res) => {
+      try {
+        const body = JSON.parse(await readRequestBody(req)) as Record<string, unknown>;
+        polls += 1;
+
+        expect(req.method).toBe('POST');
+        expect(body.client_id).toBe('Ov23liTestClientId');
+        expect(body.device_code).toBe('device-code-for-test');
+        expect(body.grant_type).toBe('urn:ietf:params:oauth:grant-type:device_code');
+
+        json(res, 200, {
+          access_token: expectedToken,
+          token_type: 'bearer',
+          scope: 'read:user'
+        });
+      } catch (error) {
+        json(res, 500, { error: error instanceof Error ? error.message : 'stub failure' });
+      }
+    });
+
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('OAuth helper test server did not bind to a TCP port');
+    }
+
+    const authDir = path.join(tempHome, '.dollhouse', '.auth');
+    await fs.mkdir(authDir, { recursive: true });
+    await fs.writeFile(path.join(authDir, 'oauth-helper-state.json'), JSON.stringify({ stale: true }), 'utf-8');
+
+    try {
+      process.env.DOLLHOUSE_HOME_DIR = tempHome;
+      process.env.DOLLHOUSE_TOKEN_SECRET = 'oauth-helper-test-secret';
+      delete process.env.GITHUB_TOKEN;
+      delete process.env.TEST_GITHUB_TOKEN;
+      delete process.env.GITHUB_TEST_TOKEN;
+
+      const result = await runHelper(helperPath, `http://127.0.0.1:${address.port}/token`, tempHome);
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('GitHub authentication successful');
+      expect(result.stderr).toBe('');
+      expect(polls).toBe(1);
+
+      const { TokenManager } = await import('../../../src/security/tokenManager.js');
+      const tokenManager = new TokenManager(realFileOperations());
+      await expect(tokenManager.retrieveGitHubToken()).resolves.toBe(expectedToken);
+
+      const terminalResult = JSON.parse(
+        await fs.readFile(path.join(authDir, 'oauth-helper-result.json'), 'utf-8')
+      ) as Record<string, unknown>;
+      expect(terminalResult.status).toBe('success');
+      expect(terminalResult.attempts).toBe(1);
+      expect(terminalResult.errorCode).toBeUndefined();
+
+      await expect(fs.access(path.join(authDir, 'github_token.enc'))).resolves.toBeUndefined();
+      await expect(fs.access(path.join(authDir, 'pending_token.txt'))).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.access(path.join(authDir, 'oauth-helper-state.json'))).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.access(path.join(authDir, 'oauth-helper.pid'))).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await closeServer(server);
+      await fs.rm(tempHome, { recursive: true, force: true });
+
+      if (originalHomeDir === undefined) delete process.env.DOLLHOUSE_HOME_DIR;
+      else process.env.DOLLHOUSE_HOME_DIR = originalHomeDir;
+      if (originalTokenSecret === undefined) delete process.env.DOLLHOUSE_TOKEN_SECRET;
+      else process.env.DOLLHOUSE_TOKEN_SECRET = originalTokenSecret;
+      if (originalGithubToken === undefined) delete process.env.GITHUB_TOKEN;
+      else process.env.GITHUB_TOKEN = originalGithubToken;
+      if (originalTestGithubToken === undefined) delete process.env.TEST_GITHUB_TOKEN;
+      else process.env.TEST_GITHUB_TOKEN = originalTestGithubToken;
+      if (originalGithubTestToken === undefined) delete process.env.GITHUB_TEST_TOKEN;
+      else process.env.GITHUB_TEST_TOKEN = originalGithubTestToken;
+    }
+  }, 15_000);
+});

--- a/tests/unit/handlers/GitHubAuthHandler.test.ts
+++ b/tests/unit/handlers/GitHubAuthHandler.test.ts
@@ -221,6 +221,9 @@ describe('GitHubAuthHandler (DI)', () => {
       const helperPath = path.join(tempHome, 'oauth-helper.mjs');
       await fs.writeFile(helperPath, 'console.log(\"helper\");', 'utf-8');
       process.env.DOLLHOUSE_OAUTH_HELPER = helperPath;
+      const staleResultFile = path.join(tempHome, '.dollhouse', '.auth', 'oauth-helper-result.json');
+      await fs.mkdir(path.dirname(staleResultFile), { recursive: true });
+      await fs.writeFile(staleResultFile, JSON.stringify({ status: 'failed' }), 'utf-8');
 
       const unref = jest.fn();
       const spawnSpy = jest.spyOn(handler as any, 'spawnHelperProcess').mockReturnValue({
@@ -249,6 +252,7 @@ describe('GitHubAuthHandler (DI)', () => {
       const state = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
       expect(state.deviceCode).toBe('device-code');
       expect(state.userCode).toBe('CODE-1234');
+      await expect(fs.access(staleResultFile)).rejects.toMatchObject({ code: 'ENOENT' });
 
       await fs.rm(tempHome, { recursive: true, force: true });
       delete process.env.DOLLHOUSE_OAUTH_HELPER;
@@ -343,6 +347,71 @@ describe('GitHubAuthHandler (DI)', () => {
         expect(response.content[0].text).toContain('Authentication Expired');
         expect(response.content[0].text).toContain('EXPIRED-1234');
         expect(response.content[0].text).toContain('ERROR polling failed');
+      });
+    });
+
+    it('reports terminal helper failure from result file without calling it active or crashed', async () => {
+      await withTempHome(async (homeDir) => {
+        const stateDir = path.join(homeDir, '.dollhouse', '.auth');
+        await fs.mkdir(stateDir, { recursive: true });
+        await fs.writeFile(
+          path.join(stateDir, 'oauth-helper-state.json'),
+          JSON.stringify({
+            pid: 7777,
+            deviceCode: 'device',
+            userCode: 'FAILED-7777',
+            startTime: new Date(Date.now() - 10_000).toISOString(),
+            expiresAt: new Date(Date.now() + 120_000).toISOString()
+          }, null, 2),
+          'utf-8'
+        );
+        await fs.writeFile(
+          path.join(stateDir, 'oauth-helper-result.json'),
+          JSON.stringify({
+            status: 'failed',
+            attempts: 2,
+            completedAt: new Date().toISOString(),
+            errorCode: 'token_storage_failed',
+            message: 'OAuth token could not be stored securely.'
+          }, null, 2),
+          'utf-8'
+        );
+
+        authManager.getAuthStatus.mockResolvedValue({ isAuthenticated: false, hasToken: false } as any);
+
+        const response = await handler.checkGitHubAuth();
+        const text = response.content[0].text;
+
+        expect(text).toContain('GitHub Authentication Failed');
+        expect(text).toContain('OAuth token could not be stored securely.');
+        expect(text).not.toContain('Authentication In Progress');
+        expect(text).not.toContain('may have crashed');
+
+        const diagnostics = await handler.getOAuthHelperStatus();
+        const diagnosticsText = diagnostics.content[0].text;
+
+        expect(diagnosticsText).toContain('FAILED');
+        expect(diagnosticsText).toContain('Attempts:** 2');
+        expect(diagnosticsText).not.toContain('ACTIVE - Authentication in progress');
+        expect(diagnosticsText).not.toContain('may have crashed');
+      });
+    });
+
+    it('removes stale plaintext pending-token fallback files before reporting disconnected status', async () => {
+      await withTempHome(async (homeDir) => {
+        const stateDir = path.join(homeDir, '.dollhouse', '.auth');
+        const pendingToken = path.join(stateDir, 'pending_token.txt');
+        await fs.mkdir(stateDir, { recursive: true });
+        await fs.writeFile(pendingToken, 'gho_stale_plaintext_token_from_old_flow', { mode: 0o600 });
+
+        authManager.getAuthStatus.mockResolvedValue({ isAuthenticated: false, hasToken: false } as any);
+
+        const response = await handler.checkGitHubAuth();
+        const text = response.content[0].text;
+
+        expect(text).toContain('Not Connected to GitHub');
+        expect(text).toContain('stale plaintext OAuth fallback file from an earlier failed flow was removed');
+        await expect(fs.access(pendingToken)).rejects.toMatchObject({ code: 'ENOENT' });
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes #2262.

Repairs the local GitHub device-flow OAuth helper so successful authorization stores the token through the current `TokenManager` instance API instead of falling into the old unconsumed plaintext fallback path.

## Changes

- Instantiate `TokenManager` inside `oauth-helper.mjs` with a helper-local file-operations adapter.
- Remove the helper's plaintext `pending_token.txt` fallback path.
- Add `oauth-helper-result.json` terminal status reporting for success, failed, expired, denied, and timeout outcomes.
- Clean up stale helper state/result files when flows complete or restart.
- Remove stale legacy `pending_token.txt` files during auth setup/check and report that cleanup to the user.
- Respect `DOLLHOUSE_HOME_DIR` consistently for helper/token storage.
- Add `DOLLHOUSE_OAUTH_TOKEN_URL` so the helper can be tested against a local token endpoint stub.
- Update QA/docs so `pending_token.txt` is no longer presented as a valid storage location and helper logs are described as opt-in via `DOLLHOUSE_OAUTH_DEBUG=true`.

## Tests

- `npm run build`
- `npx eslint tests/unit/auth/oauth-helper.test.ts tests/unit/handlers/GitHubAuthHandler.test.ts oauth-helper.mjs src/handlers/GitHubAuthHandler.ts src/security/tokenManager.ts`
- `npm test -- tests/unit/auth/oauth-helper.test.ts tests/unit/handlers/GitHubAuthHandler.test.ts tests/unit/auth/GitHubAuthManager.test.ts tests/unit/security/tokenManager.storage.test.ts --runInBand`
- `npm run security:rapid`
- `npm run verify:package-assets`

## Issue Coverage

- Fixes #2262.
- Adds coverage toward #2263 by pinning helper usage to the `TokenManager` instance API against built `dist/`.
- Adds coverage toward #2264 by spawning the real helper against a local OAuth token endpoint stub.
- Adds coverage toward #2265 by testing terminal helper result states and stale plaintext fallback cleanup.

## Prior Work / Thanks

Thanks to @jstar0 for PR #2275 and the root-cause report. Because this touches OAuth token handling, this PR lands the fix through an internally maintained branch with broader diagnostics, cleanup, and regression coverage.
