### PR TITLE
Port OAuth helper token handoff fix to beta

### DIFF
--- a/docs/guides/configuration-basics.md
+++ b/docs/guides/configuration-basics.md
@@ -10,7 +10,7 @@
 |----------|---------|
 | `~/.dollhouse/config.yml` | Primary configuration file created by `ConfigManager` the first time you run the server or the setup wizard. |
 | `~/.dollhouse/config.yml.backup` | Automatic backup taken before each write so you can recover from a bad edit. |
-| `~/.dollhouse/` (directory) | Also stores OAuth helper state and logs (`.auth/`, `oauth-helper.log`). |
+| `~/.dollhouse/` (directory) | Also stores OAuth helper state under `.auth/`; helper logs are written to `oauth-helper.log` only when `DOLLHOUSE_OAUTH_DEBUG=true`. |
 
 Configuration is YAML-based. Manual edits are allowed, but using the `dollhouse_config` MCP tool keeps validation and backups automatic.
 

--- a/docs/guides/environment-variables.md
+++ b/docs/guides/environment-variables.md
@@ -558,6 +558,8 @@ These variables configure the runtime identity and filesystem paths used by the 
 | `DOLLHOUSE_HOME_DIR` | `~` (os.homedir) | Override the home directory for telemetry and auth file storage. |
 | `DOLLHOUSE_CACHE_DIR` | _(auto)_ | Override the collection cache directory path. |
 | `DOLLHOUSE_OAUTH_HELPER` | _(none)_ | Override the OAuth helper binary path for GitHub authentication. |
+| `DOLLHOUSE_OAUTH_DEBUG` | `false` | Enable OAuth helper debug logging to `~/.dollhouse/oauth-helper.log`. |
+| `DOLLHOUSE_OAUTH_TOKEN_URL` | GitHub token endpoint | Override the OAuth device-flow token endpoint. Intended for local tests and diagnostics. |
 | `DOLLHOUSE_DEBUG` | _(none)_ | Enable extra debug output at server startup. When set, additional diagnostic info is logged. |
 
 ### Feature Flags

--- a/docs/guides/oauth-setup.md
+++ b/docs/guides/oauth-setup.md
@@ -180,7 +180,8 @@ If you're setting up your own instance, follow the administrator instructions ab
 **Problem**: The helper process might not be running
 **Solution**:
 - Check if the helper is running: `ps aux | grep oauth-helper`
-- Look at logs: `cat ~/.dollhouse/oauth-helper.log`
+- Check helper state: `oauth_helper_status verbose=true`
+- If you started the flow with `DOLLHOUSE_OAUTH_DEBUG=true`, look at logs: `cat ~/.dollhouse/oauth-helper.log`
 - Try restarting the authentication process
  - Ensure your client ID is valid (re-run `dollhouse_config action="get" setting="github.auth.client_id"`)
 

--- a/docs/security/security-checklist.md
+++ b/docs/security/security-checklist.md
@@ -17,7 +17,7 @@ Use this checklist before merging PRs or cutting a release. It complements the d
 - [ ] Manually test `setup_github_auth` / `check_github_auth` to confirm the OAuth device flow still works.
 - [ ] Test a portfolio upload/download roundtrip (`portfolio_element_manager`) and a collection submission (`submit_collection_content`).
 - [ ] Rebuild the enhanced index (e.g., call `get_relationship_stats`) and watch for warnings or performance regressions.
-- [ ] Review `~/.dollhouse/oauth-helper.log` for errors if authentication was exercised.
+- [ ] Review `oauth_helper_status verbose=true` after exercising authentication; inspect `~/.dollhouse/oauth-helper.log` only when `DOLLHOUSE_OAUTH_DEBUG=true`.
 - [ ] Update release notes with notable security changes or mitigations.
 
 ## 3. Ongoing Practices

--- a/oauth-helper.mjs
+++ b/oauth-helper.mjs
@@ -57,8 +57,8 @@ if (args.length < 4) {
 }
 
 const [deviceCode, intervalStr, expiresInStr, clientId] = args;
-const pollIntervalSeconds = parseInt(intervalStr, 10) || DEFAULT_POLL_INTERVAL;
-const expiresIn = parseInt(expiresInStr, 10) || DEFAULT_EXPIRES_IN;
+const pollIntervalSeconds = Number.parseInt(intervalStr, 10) || DEFAULT_POLL_INTERVAL;
+const expiresIn = Number.parseInt(expiresInStr, 10) || DEFAULT_EXPIRES_IN;
 
 // Validate client ID is provided (no hardcoded fallback)
 if (!clientId || clientId === 'undefined') {
@@ -160,6 +160,8 @@ async function storeToken(token) {
 }
 
 function createHelperFileOperations() {
+  // Paths are fixed by AUTH_DIR constants/env, so this standalone helper only
+  // needs the small FileOperations surface TokenManager uses for secure storage.
   return {
     async createDirectory(directoryPath) {
       await fs.mkdir(directoryPath, { recursive: true });
@@ -353,7 +355,8 @@ async function main() {
             break;
             
           case 'slow_down':
-            // GitHub is asking us to slow down
+            // GitHub asks clients to add 5s to the polling interval, then wait
+            // the updated interval before the next request.
             currentPollIntervalMs += 5000;
             await log(`[RATE_LIMIT] GitHub requested slower polling - increasing interval to ${currentPollIntervalMs / 1000}s`);
             await sleep(currentPollIntervalMs);

--- a/oauth-helper.mjs
+++ b/oauth-helper.mjs
@@ -28,6 +28,31 @@ const DEFAULT_POLL_INTERVAL = 5;
 const DEFAULT_EXPIRES_IN = 900; // 15 minutes
 const MAX_TOKEN_SIZE = 10000; // Maximum reasonable token size
 
+// User-scoped runtime files. The parent process passes these when the helper
+// is launched from a per-user session; standalone legacy launches keep the
+// historical operator-home locations.
+const DOLLHOUSE_HOME_DIR = process.env.DOLLHOUSE_HOME_DIR || homedir();
+const AUTH_DIR = process.env.DOLLHOUSE_OAUTH_HELPER_AUTH_DIR || join(DOLLHOUSE_HOME_DIR, '.dollhouse', '.auth');
+const PID_FILE = join(AUTH_DIR, 'oauth-helper.pid');
+const STATE_FILE = join(AUTH_DIR, 'oauth-helper-state.json');
+const RESULT_FILE = join(AUTH_DIR, 'oauth-helper-result.json');
+const LOG_FILE = process.env.DOLLHOUSE_OAUTH_HELPER_LOG_FILE || join(DOLLHOUSE_HOME_DIR, '.dollhouse', 'oauth-helper.log');
+const TOKEN_URL = process.env.DOLLHOUSE_OAUTH_TOKEN_URL || 'https://github.com/login/oauth/access_token';
+const LOG_ENABLED = process.env.DOLLHOUSE_OAUTH_DEBUG === 'true';
+
+const RESULT_MESSAGES = {
+  success: 'OAuth helper completed successfully.',
+  expired_token: 'Device code expired before authorization completed.',
+  access_denied: 'User denied the GitHub authorization request.',
+  timeout: 'Authorization timed out before the user completed GitHub authorization.',
+  token_storage_failed: 'OAuth token could not be stored securely.',
+  network_failure: 'Too many network errors while contacting the OAuth token endpoint.',
+  fatal_error: 'OAuth helper stopped after an unrecoverable error.',
+  unknown_response: 'OAuth token endpoint returned an unrecognized response.',
+};
+
+const ALLOWED_RESULT_ERROR_CODES = new Set(Object.keys(RESULT_MESSAGES));
+
 // Parse command line arguments
 const args = process.argv.slice(2);
 if (args.length < 4) {
@@ -49,13 +74,6 @@ if (!clientId || clientId === 'undefined') {
   await log('OAUTH_HELPER_43: Process exiting - missing client ID');
   process.exit(1);
 }
-
-// User-scoped runtime files. The parent process passes these when the helper
-// is launched from a per-user session; standalone legacy launches keep the
-// historical operator-home locations.
-const AUTH_DIR = process.env.DOLLHOUSE_OAUTH_HELPER_AUTH_DIR || join(homedir(), '.dollhouse', '.auth');
-const LOG_FILE = process.env.DOLLHOUSE_OAUTH_HELPER_LOG_FILE || join(homedir(), '.dollhouse', 'oauth-helper.log');
-const LOG_ENABLED = process.env.DOLLHOUSE_OAUTH_DEBUG === 'true';
 
 async function log(message) {
   if (!LOG_ENABLED) return;
@@ -89,13 +107,18 @@ async function log(message) {
   }
 }
 
+function sanitizeDiagnostic(value) {
+  return String(value ?? '')
+    .replace(/\bgithub_pat_[A-Za-z0-9_]+\b/g, '[REDACTED_GITHUB_TOKEN]')
+    .replace(/\bgh[a-z]_[A-Za-z0-9_]+\b/gi, '[REDACTED_GITHUB_TOKEN]')
+    .replaceAll(deviceCode, '[REDACTED_DEVICE_CODE]');
+}
+
 async function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 async function pollGitHub(deviceCode, clientId) {
-  const TOKEN_URL = 'https://github.com/login/oauth/access_token';
-  
   try {
     const response = await fetch(TOKEN_URL, {
       method: 'POST',
@@ -130,71 +153,110 @@ async function storeToken(token) {
     const { TokenManager } = await import('./dist/security/tokenManager.js');
     
     // Store the token using the secure storage mechanism
-    await TokenManager.storeGitHubToken(token);
+    const tokenManager = new TokenManager(createHelperFileOperations(), AUTH_DIR);
+    await tokenManager.storeGitHubToken(token);
     await log('Token stored successfully using TokenManager');
     return true;
-  } catch {
-    await log('Failed to store token using TokenManager');
-    
-    // Fallback: Write to a temporary file for the MCP server to pick up
-    try {
-      const tempTokenFile = join(AUTH_DIR, 'pending_token.txt');
-      const tempDir = dirname(tempTokenFile);
-      
-      // Create directory with secure permissions
-      await fs.mkdir(tempDir, { recursive: true, mode: 0o700 });
-      
-      // Verify directory permissions
-      const dirStats = await fs.stat(tempDir);
-      const dirMode = dirStats.mode & parseInt('777', 8);
-      if (dirMode !== parseInt('700', 8)) {
-        await fs.chmod(tempDir, 0o700);
-      }
-      
-      // Write token with secure permissions
-      await fs.writeFile(tempTokenFile, token, { mode: 0o600 });
-      
-      // Verify file permissions
-      await fs.chmod(tempTokenFile, 0o600);
-      
-      await log('Token written to fallback file with secure permissions');
-      return true;
-    } catch (fallbackError) {
-      await log('Fallback storage also failed');
-      throw fallbackError;
-    }
+  } catch (error) {
+    await log(`Failed to store token using TokenManager: ${sanitizeDiagnostic(error instanceof Error ? error.message : 'Unknown error')}`);
+    throw error;
   }
+}
+
+function createHelperFileOperations() {
+  return {
+    async createDirectory(directoryPath) {
+      await fs.mkdir(directoryPath, { recursive: true });
+    },
+    async readFile(filePath) {
+      return fs.readFile(filePath, 'utf8');
+    },
+    async writeFile(filePath, content) {
+      await fs.writeFile(filePath, content, { encoding: 'utf8' });
+    },
+    async deleteFile(filePath) {
+      await fs.unlink(filePath);
+    },
+    async chmod(filePath, mode) {
+      await fs.chmod(filePath, mode);
+    },
+    async exists(filePath) {
+      try {
+        await fs.access(filePath);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  };
 }
 
 function cleanupPidFileSync() {
   try {
-    const pidFile = join(AUTH_DIR, 'oauth-helper.pid');
-    if (fsSync.existsSync(pidFile)) {
-      fsSync.unlinkSync(pidFile);
+    if (fsSync.existsSync(PID_FILE)) {
+      fsSync.unlinkSync(PID_FILE);
     }
-  } catch (error) {
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+function cleanupStateFileSync() {
+  try {
+    if (fsSync.existsSync(STATE_FILE)) {
+      fsSync.unlinkSync(STATE_FILE);
+    }
+  } catch {
     // Ignore cleanup errors
   }
 }
 
 async function cleanupPidFile() {
   try {
-    const pidFile = join(AUTH_DIR, 'oauth-helper.pid');
-    await fs.unlink(pidFile).catch(() => {});
+    await fs.unlink(PID_FILE).catch(() => {});
     await log('PID file cleaned up');
-  } catch (error) {
+  } catch {
     // Ignore cleanup errors
+  }
+}
+
+async function cleanupStateFile() {
+  try {
+    await fs.unlink(STATE_FILE).catch(() => {});
+    await log('OAuth helper state file cleaned up');
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+async function writeTerminalResult(status, attempts, errorCode = '') {
+  try {
+    await fs.mkdir(AUTH_DIR, { recursive: true, mode: 0o700 });
+    const safeErrorCode = ALLOWED_RESULT_ERROR_CODES.has(errorCode) ? errorCode : 'fatal_error';
+    const result = {
+      status,
+      attempts,
+      completedAt: new Date().toISOString()
+    };
+
+    if (status !== 'success') {
+      result.errorCode = safeErrorCode;
+      result.message = RESULT_MESSAGES[safeErrorCode];
+    }
+
+    await fs.writeFile(RESULT_FILE, JSON.stringify(result, null, 2), { mode: 0o600 });
+    await fs.chmod(RESULT_FILE, 0o600).catch(() => {});
+    await log(`Terminal result written: ${status}${status === 'success' ? '' : `/${safeErrorCode}`}`);
+  } catch {
+    await log('Failed to write terminal result');
   }
 }
 
 async function writePidFile() {
   try {
-    const pidFile = join(AUTH_DIR, 'oauth-helper.pid');
-    const pidDir = dirname(pidFile);
-    
-    await fs.mkdir(pidDir, { recursive: true, mode: 0o700 });
-    await fs.writeFile(pidFile, process.pid.toString(), { mode: 0o600 });
-    await log(`PID file written: ${pidFile}`);
+    await fs.mkdir(AUTH_DIR, { recursive: true, mode: 0o700 });
+    await fs.writeFile(PID_FILE, process.pid.toString(), { mode: 0o600 });
+    await log(`PID file written: ${PID_FILE}`);
   } catch {
     await log('Failed to write PID file');
   }
@@ -236,14 +298,24 @@ async function main() {
   });
   
   process.on('SIGINT', () => {
+    cleanupStateFileSync();
     cleanupPidFileSync();
     process.exit(0);
   });
   
   process.on('SIGTERM', () => {
+    cleanupStateFileSync();
     cleanupPidFileSync();
     process.exit(0);
   });
+
+  async function finish(status, errorCode, exitCode) {
+    clearInterval(heartbeatInterval);
+    await writeTerminalResult(status, attempts, errorCode);
+    await cleanupStateFile();
+    await cleanupPidFile();
+    process.exit(exitCode);
+  }
   
   while (Date.now() < timeout) {
     attempts++;
@@ -269,43 +341,41 @@ async function main() {
           case 'expired_token':
             await log('OAUTH_HELPER_264: Device code expired - authentication window closed');
             console.error('OAUTH_EXPIRED: Device code expired at line 264 - authentication window closed');
-            clearInterval(heartbeatInterval);
-            await cleanupPidFile();
-            process.exit(1);
+            return finish('expired', 'expired_token', 1);
             
           case 'access_denied':
             await log('OAUTH_HELPER_270: User denied authorization request');
             console.error('OAUTH_ACCESS_DENIED: User denied authorization at line 270');
-            clearInterval(heartbeatInterval);
-            await cleanupPidFile();
-            process.exit(1);
+            return finish('denied', 'access_denied', 1);
             
           default:
             await log('OAUTH_HELPER_276: Unknown error from GitHub during device flow polling');
             await log('[ERROR] GitHub returned an unrecognized OAuth polling response');
             console.error('OAUTH_UNKNOWN_RESPONSE: Unknown GitHub OAuth response at line 276');
+            return finish('failed', 'unknown_response', 1);
         }
       } else if (response.access_token) {
         // Success! We got the token
         await log('[SUCCESS] ✅ Token received from GitHub!');
         consecutiveErrors = 0; // Reset error counter
         
-        // Store the token
-        const stored = await storeToken(response.access_token);
+        let stored = false;
+        try {
+          stored = await storeToken(response.access_token);
+        } catch {
+          console.error('OAUTH_TOKEN_STORAGE_FAILED: Failed to store authentication token securely');
+          return finish('failed', 'token_storage_failed', 1);
+        }
         
         if (stored) {
           await log('[SUCCESS] ✅ OAuth authentication completed successfully');
           await log(`[STATS] Total attempts: ${attempts}, Time elapsed: ${Math.round((Date.now() - startTime) / 1000)}s`);
           console.log('✅ GitHub authentication successful! Token has been stored.');
-          clearInterval(heartbeatInterval);
-          await cleanupPidFile();
-          process.exit(0);
+          return finish('success', 'success', 0);
         } else {
           await log('[ERROR] ❌ Failed to store token');
           console.error('❌ Failed to store authentication token');
-          clearInterval(heartbeatInterval);
-          await cleanupPidFile();
-          process.exit(1);
+          return finish('failed', 'token_storage_failed', 1);
         }
       } else {
         // Reset error counter on successful communication
@@ -330,17 +400,13 @@ async function main() {
         if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
           await log('OAUTH_HELPER_323: Too many consecutive network errors, exiting');
           console.error(`OAUTH_NETWORK_FAILURE: Too many network errors (${MAX_CONSECUTIVE_ERRORS}) at line 323 - check internet connection`);
-          clearInterval(heartbeatInterval);
-          await cleanupPidFile();
-          process.exit(1);
+          return finish('failed', 'network_failure', 1);
         }
       } else {
         // Non-network error, likely fatal
-        await log('OAUTH_HELPER_330: Non-recoverable error');
+        await log(`OAUTH_HELPER_330: Non-recoverable error: ${sanitizeDiagnostic(error instanceof Error ? error.message : 'Unknown error')}`);
         console.error('OAUTH_FATAL_ERROR: Non-recoverable error at line 330');
-        clearInterval(heartbeatInterval);
-        await cleanupPidFile();
-        process.exit(1);
+        return finish('failed', 'fatal_error', 1);
       }
     }
     
@@ -352,15 +418,15 @@ async function main() {
   await log('OAUTH_HELPER_342: OAuth authorization timed out');
   await log(`[STATS] Total attempts: ${attempts}, Time elapsed: ${Math.round((Date.now() - startTime) / 1000)}s`);
   console.error(`OAUTH_TIMEOUT: Authorization timed out at line 342 after ${Math.round((Date.now() - startTime) / 1000)}s - user did not authorize in time`);
-  clearInterval(heartbeatInterval);
-  await cleanupPidFile();
-  process.exit(1);
+  return finish('timeout', 'timeout', 1);
 }
 
 // Run the main function
 main().catch(async () => {
   await log('Fatal error');
   console.error('Fatal error in OAuth helper');
+  await writeTerminalResult('failed', 0, 'fatal_error');
+  await cleanupStateFile();
   await cleanupPidFile();
   process.exit(1);
 });

--- a/oauth-helper.mjs
+++ b/oauth-helper.mjs
@@ -13,15 +13,10 @@
  * between tool calls, breaking background OAuth polling.
  */
 
-import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import fs from 'fs/promises';
 import fsSync from 'fs';
 import { homedir } from 'os';
-
-// Get the directory of this script
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
 
 // Constants
 const DEFAULT_POLL_INTERVAL = 5;
@@ -48,6 +43,7 @@ const RESULT_MESSAGES = {
   token_storage_failed: 'OAuth token could not be stored securely.',
   network_failure: 'Too many network errors while contacting the OAuth token endpoint.',
   fatal_error: 'OAuth helper stopped after an unrecoverable error.',
+  interrupted: 'OAuth helper was interrupted before authentication completed.',
   unknown_response: 'OAuth token endpoint returned an unrecognized response.',
 };
 
@@ -61,7 +57,7 @@ if (args.length < 4) {
 }
 
 const [deviceCode, intervalStr, expiresInStr, clientId] = args;
-const pollInterval = parseInt(intervalStr, 10) || DEFAULT_POLL_INTERVAL;
+const pollIntervalSeconds = parseInt(intervalStr, 10) || DEFAULT_POLL_INTERVAL;
 const expiresIn = parseInt(expiresInStr, 10) || DEFAULT_EXPIRES_IN;
 
 // Validate client ID is provided (no hardcoded fallback)
@@ -109,8 +105,8 @@ async function log(message) {
 
 function sanitizeDiagnostic(value) {
   return String(value ?? '')
-    .replace(/\bgithub_pat_[A-Za-z0-9_]+\b/g, '[REDACTED_GITHUB_TOKEN]')
-    .replace(/\bgh[a-z]_[A-Za-z0-9_]+\b/gi, '[REDACTED_GITHUB_TOKEN]')
+    .replace(/\bgithub_pat_\w+\b/g, '[REDACTED_GITHUB_TOKEN]')
+    .replace(/\bgh[a-z]_\w+\b/gi, '[REDACTED_GITHUB_TOKEN]')
     .replaceAll(deviceCode, '[REDACTED_DEVICE_CODE]');
 }
 
@@ -150,9 +146,9 @@ async function storeToken(token) {
   
   try {
     // Import the compiled TokenManager
-    const { TokenManager } = await import('./dist/security/tokenManager.js');
+    const { TokenManager } = await import(new URL('./dist/security/tokenManager.js', import.meta.url).href);
     
-    // Store the token using the secure storage mechanism
+    // Passing file operations selects TokenManager's file-backed secure storage overload.
     const tokenManager = new TokenManager(createHelperFileOperations(), AUTH_DIR);
     await tokenManager.storeGitHubToken(token);
     await log('Token stored successfully using TokenManager');
@@ -245,10 +241,31 @@ async function writeTerminalResult(status, attempts, errorCode = '') {
     }
 
     await fs.writeFile(RESULT_FILE, JSON.stringify(result, null, 2), { mode: 0o600 });
-    await fs.chmod(RESULT_FILE, 0o600).catch(() => {});
-    await log(`Terminal result written: ${status}${status === 'success' ? '' : `/${safeErrorCode}`}`);
+    const resultSuffix = status === 'success' ? '' : `/${safeErrorCode}`;
+    await log(`Terminal result written: ${status}${resultSuffix}`);
   } catch {
     await log('Failed to write terminal result');
+  }
+}
+
+function writeTerminalResultSync(status, attempts, errorCode = '') {
+  try {
+    fsSync.mkdirSync(AUTH_DIR, { recursive: true, mode: 0o700 });
+    const safeErrorCode = ALLOWED_RESULT_ERROR_CODES.has(errorCode) ? errorCode : 'fatal_error';
+    const result = {
+      status,
+      attempts,
+      completedAt: new Date().toISOString()
+    };
+
+    if (status !== 'success') {
+      result.errorCode = safeErrorCode;
+      result.message = RESULT_MESSAGES[safeErrorCode];
+    }
+
+    fsSync.writeFileSync(RESULT_FILE, JSON.stringify(result, null, 2), { mode: 0o600 });
+  } catch {
+    // Ignore cleanup/status errors during process termination
   }
 }
 
@@ -265,7 +282,7 @@ async function writePidFile() {
 async function main() {
   await log(`[START] OAuth helper started - PID: ${process.pid}`);
   await log('[CONFIG] Device code received');
-  await log(`[CONFIG] Poll interval: ${pollInterval}s, Expires in: ${expiresIn}s`);
+  await log(`[CONFIG] Poll interval: ${pollIntervalSeconds}s, Expires in: ${expiresIn}s`);
   await log(`[CONFIG] Node version: ${process.version}`);
   await log(`[CONFIG] Platform: ${process.platform}`);
   // Never log client ID
@@ -284,6 +301,7 @@ async function main() {
   const timeout = startTime + (expiresIn * 1000);
   let attempts = 0;
   let consecutiveErrors = 0;
+  let currentPollIntervalMs = pollIntervalSeconds * 1000;
   const MAX_CONSECUTIVE_ERRORS = 5;
   
   // Set up cleanup on exit - use synchronous cleanup for exit event
@@ -298,15 +316,17 @@ async function main() {
   });
   
   process.on('SIGINT', () => {
+    writeTerminalResultSync('failed', attempts, 'interrupted');
     cleanupStateFileSync();
     cleanupPidFileSync();
-    process.exit(0);
+    process.exit(1);
   });
   
   process.on('SIGTERM', () => {
+    writeTerminalResultSync('failed', attempts, 'interrupted');
     cleanupStateFileSync();
     cleanupPidFileSync();
-    process.exit(0);
+    process.exit(1);
   });
 
   async function finish(status, errorCode, exitCode) {
@@ -334,8 +354,9 @@ async function main() {
             
           case 'slow_down':
             // GitHub is asking us to slow down
-            await log(`[RATE_LIMIT] GitHub requested slower polling - increasing interval to ${pollInterval * 1.5}s`);
-            await sleep(pollInterval * 1500);
+            currentPollIntervalMs += 5000;
+            await log(`[RATE_LIMIT] GitHub requested slower polling - increasing interval to ${currentPollIntervalMs / 1000}s`);
+            await sleep(currentPollIntervalMs);
             continue;
             
           case 'expired_token':
@@ -411,7 +432,7 @@ async function main() {
     }
     
     // Wait before next poll
-    await sleep(pollInterval * 1000);
+    await sleep(currentPollIntervalMs);
   }
   
   // Timeout reached
@@ -422,8 +443,8 @@ async function main() {
 }
 
 // Run the main function
-main().catch(async () => {
-  await log('Fatal error');
+main().catch(async (error) => {
+  await log(`Fatal error: ${sanitizeDiagnostic(error instanceof Error ? error.message : 'Unknown error')}`);
   console.error('Fatal error in OAuth helper');
   await writeTerminalResult('failed', 0, 'fatal_error');
   await cleanupStateFile();

--- a/oauth-helper.mjs
+++ b/oauth-helper.mjs
@@ -32,6 +32,7 @@ const PID_FILE = join(AUTH_DIR, 'oauth-helper.pid');
 const STATE_FILE = join(AUTH_DIR, 'oauth-helper-state.json');
 const RESULT_FILE = join(AUTH_DIR, 'oauth-helper-result.json');
 const LOG_FILE = process.env.DOLLHOUSE_OAUTH_HELPER_LOG_FILE || join(DOLLHOUSE_HOME_DIR, '.dollhouse', 'oauth-helper.log');
+const FLOW_ID = process.env.DOLLHOUSE_OAUTH_HELPER_FLOW_ID || '';
 const TOKEN_URL = process.env.DOLLHOUSE_OAUTH_TOKEN_URL || 'https://github.com/login/oauth/access_token';
 const LOG_ENABLED = process.env.DOLLHOUSE_OAUTH_DEBUG === 'true';
 
@@ -191,7 +192,7 @@ function createHelperFileOperations() {
 
 function cleanupPidFileSync() {
   try {
-    if (fsSync.existsSync(PID_FILE)) {
+    if (pidFileBelongsToThisHelperSync()) {
       fsSync.unlinkSync(PID_FILE);
     }
   } catch {
@@ -201,7 +202,7 @@ function cleanupPidFileSync() {
 
 function cleanupStateFileSync() {
   try {
-    if (fsSync.existsSync(STATE_FILE)) {
+    if (stateFileBelongsToThisHelperSync()) {
       fsSync.unlinkSync(STATE_FILE);
     }
   } catch {
@@ -211,8 +212,12 @@ function cleanupStateFileSync() {
 
 async function cleanupPidFile() {
   try {
-    await fs.unlink(PID_FILE).catch(() => {});
-    await log('PID file cleaned up');
+    if (await pidFileBelongsToThisHelper()) {
+      await fs.unlink(PID_FILE).catch(() => {});
+      await log('PID file cleaned up');
+    } else {
+      await log('PID file belongs to another helper flow; leaving it in place');
+    }
   } catch {
     // Ignore cleanup errors
   }
@@ -220,27 +225,42 @@ async function cleanupPidFile() {
 
 async function cleanupStateFile() {
   try {
-    await fs.unlink(STATE_FILE).catch(() => {});
-    await log('OAuth helper state file cleaned up');
+    if (await stateFileBelongsToThisHelper()) {
+      await fs.unlink(STATE_FILE).catch(() => {});
+      await log('OAuth helper state file cleaned up');
+    } else {
+      await log('OAuth helper state belongs to another flow; leaving it in place');
+    }
   } catch {
     // Ignore cleanup errors
   }
 }
 
+function buildTerminalResult(status, attempts, errorCode = '') {
+  const safeErrorCode = ALLOWED_RESULT_ERROR_CODES.has(errorCode) ? errorCode : 'fatal_error';
+  const result = {
+    status,
+    attempts,
+    completedAt: new Date().toISOString(),
+    pid: process.pid
+  };
+
+  if (FLOW_ID) {
+    result.flowId = FLOW_ID;
+  }
+
+  if (status !== 'success') {
+    result.errorCode = safeErrorCode;
+    result.message = RESULT_MESSAGES[safeErrorCode];
+  }
+
+  return { result, safeErrorCode };
+}
+
 async function writeTerminalResult(status, attempts, errorCode = '') {
   try {
     await fs.mkdir(AUTH_DIR, { recursive: true, mode: 0o700 });
-    const safeErrorCode = ALLOWED_RESULT_ERROR_CODES.has(errorCode) ? errorCode : 'fatal_error';
-    const result = {
-      status,
-      attempts,
-      completedAt: new Date().toISOString()
-    };
-
-    if (status !== 'success') {
-      result.errorCode = safeErrorCode;
-      result.message = RESULT_MESSAGES[safeErrorCode];
-    }
+    const { result, safeErrorCode } = buildTerminalResult(status, attempts, errorCode);
 
     await fs.writeFile(RESULT_FILE, JSON.stringify(result, null, 2), { mode: 0o600 });
     const resultSuffix = status === 'success' ? '' : `/${safeErrorCode}`;
@@ -253,21 +273,53 @@ async function writeTerminalResult(status, attempts, errorCode = '') {
 function writeTerminalResultSync(status, attempts, errorCode = '') {
   try {
     fsSync.mkdirSync(AUTH_DIR, { recursive: true, mode: 0o700 });
-    const safeErrorCode = ALLOWED_RESULT_ERROR_CODES.has(errorCode) ? errorCode : 'fatal_error';
-    const result = {
-      status,
-      attempts,
-      completedAt: new Date().toISOString()
-    };
-
-    if (status !== 'success') {
-      result.errorCode = safeErrorCode;
-      result.message = RESULT_MESSAGES[safeErrorCode];
-    }
+    const { result } = buildTerminalResult(status, attempts, errorCode);
 
     fsSync.writeFileSync(RESULT_FILE, JSON.stringify(result, null, 2), { mode: 0o600 });
   } catch {
     // Ignore cleanup/status errors during process termination
+  }
+}
+
+async function pidFileBelongsToThisHelper() {
+  if (!FLOW_ID) return true;
+  try {
+    const pid = (await fs.readFile(PID_FILE, 'utf8')).trim();
+    return pid === String(process.pid);
+  } catch {
+    return false;
+  }
+}
+
+function pidFileBelongsToThisHelperSync() {
+  if (!FLOW_ID) return fsSync.existsSync(PID_FILE);
+  try {
+    const pid = fsSync.readFileSync(PID_FILE, 'utf8').trim();
+    return pid === String(process.pid);
+  } catch {
+    return false;
+  }
+}
+
+async function stateFileBelongsToThisHelper() {
+  if (!FLOW_ID) return true;
+  try {
+    const state = JSON.parse(await fs.readFile(STATE_FILE, 'utf8'));
+    return state?.flowId === FLOW_ID &&
+      (typeof state.pid !== 'number' || state.pid === process.pid);
+  } catch {
+    return false;
+  }
+}
+
+function stateFileBelongsToThisHelperSync() {
+  if (!FLOW_ID) return fsSync.existsSync(STATE_FILE);
+  try {
+    const state = JSON.parse(fsSync.readFileSync(STATE_FILE, 'utf8'));
+    return state?.flowId === FLOW_ID &&
+      (typeof state.pid !== 'number' || state.pid === process.pid);
+  } catch {
+    return false;
   }
 }
 

--- a/src/handlers/GitHubAuthHandler.ts
+++ b/src/handlers/GitHubAuthHandler.ts
@@ -31,6 +31,13 @@ interface OAuthHelperTerminalResult {
     message?: string;
 }
 
+interface OAuthHelperState {
+    pid: number;
+    userCode: string;
+    startTime: string;
+    expiresAt: string;
+}
+
 export class GitHubAuthHandler {
     constructor(
         private readonly githubAuthManager: GitHubAuthManager,
@@ -232,7 +239,6 @@ export class GitHubAuthHandler {
 
         const state = {
           pid,
-          deviceCode: deviceResponse.device_code,
           userCode: deviceResponse.user_code,
           startTime: new Date().toISOString(),
           expiresAt: new Date(Date.now() + deviceResponse.expires_in * 1000).toISOString()
@@ -244,12 +250,13 @@ export class GitHubAuthHandler {
     }
 
     private oauthHelperLaunchFailedResponse(spawnError: unknown, helperPath: string | null, clientId: string) {
+        const spawnErr = spawnError as NodeJS.ErrnoException;
         logger.error('OAUTH_INDEX_2774: Failed to spawn OAuth helper process', {
           error: spawnError,
           helperPath,
           clientId: clientId?.substring(0, 8) + '...',
-          errorCode: (spawnError as any)?.code,
-          syscall: (spawnError as any)?.syscall
+          errorCode: spawnErr.code,
+          syscall: spawnErr.syscall
         });
 
         const errorDetail = this.formatOAuthHelperSpawnError(spawnError, helperPath);
@@ -370,7 +377,7 @@ export class GitHubAuthHandler {
         const lines = [
           `${statusLabel.icon} **GitHub Authentication ${statusLabel.title}**`,
           '',
-          helperHealth.resultMessage || statusLabel.defaultMessage,
+          this.sanitizeOAuthHelperResultMessage(helperHealth.resultMessage) || statusLabel.defaultMessage,
           '',
           '**To try again:**',
           'Run: `setup_github_auth` to get a new code',
@@ -553,7 +560,8 @@ export class GitHubAuthHandler {
         if (health.pid) statusText += `**Process ID:** ${health.pid}\n`;
         if (health.completedAt) statusText += `**Completed:** ${health.completedAt.toLocaleString()}\n`;
         if (health.resultAttempts !== undefined) statusText += `**Attempts:** ${health.resultAttempts}\n`;
-        if (health.resultMessage) statusText += `**Result:** ${health.resultMessage}\n`;
+        const resultMessage = this.sanitizeOAuthHelperResultMessage(health.resultMessage);
+        if (resultMessage) statusText += `**Result:** ${resultMessage}\n`;
         return `${statusText}\n`;
     }
 
@@ -619,12 +627,12 @@ export class GitHubAuthHandler {
     ): string {
         if (!health.exists || (!health.expired && health.processAlive && !health.resultStatus)) return '';
         return `\n**🧹 Manual Cleanup (if needed):**\n` +
-          '```bash' +
+          '```bash\n' +
           `rm "${stateFile}"\n` +
           `rm "${resultFile}"\n` +
           `rm "${logFile}"\n` +
           `rm "${pidFile}"\n` +
-          '```';
+          '```\n';
     }
 
     private async checkOAuthHelperHealth() {
@@ -633,11 +641,10 @@ export class GitHubAuthHandler {
 
         await this.populateOAuthHelperResult(health);
 
-        try {
-          this.populateOAuthHelperHealth(health, await this.readOAuthHelperState());
+        const state = await this.readOAuthHelperState();
+        if (state) {
+          this.populateOAuthHelperHealth(health, state);
           this.updateOAuthHelperActivity(health);
-        } catch (error) {
-          this.logOAuthHelperHealthReadError(error);
         }
 
         health.hasLog = await this.fileOperations.exists(logFile);
@@ -669,42 +676,51 @@ export class GitHubAuthHandler {
 
     private async populateOAuthHelperResult(health: ReturnType<GitHubAuthHandler['emptyOAuthHelperHealth']>): Promise<void> {
         const result = await this.readOAuthHelperResult();
-        if (!result || !this.isOAuthHelperTerminalStatus(result.status)) return;
+        if (!result) return;
 
         health.exists = true;
         health.hasResult = true;
         health.resultStatus = result.status;
-        health.resultMessage = typeof result.message === 'string' ? result.message : '';
-        health.resultAttempts = typeof result.attempts === 'number' ? result.attempts : undefined;
-        health.completedAt = typeof result.completedAt === 'string' ? new Date(result.completedAt) : null;
+        health.resultMessage = result.message ?? '';
+        health.resultAttempts = result.attempts;
+        health.completedAt = result.completedAt ? new Date(result.completedAt) : null;
     }
 
-    private async readOAuthHelperResult(): Promise<Partial<OAuthHelperTerminalResult> | null> {
+    private async readOAuthHelperResult(): Promise<OAuthHelperTerminalResult | null> {
         const resultFile = this.getOAuthHelperResultFile();
         try {
           const resultData = await this.fileOperations.readFile(resultFile, {
             source: 'GitHubAuthHandler.checkOAuthHelperHealth'
           });
-          return JSON.parse(resultData) as Partial<OAuthHelperTerminalResult>;
+          return this.normalizeOAuthHelperResult(JSON.parse(resultData));
         } catch (error) {
-          if (!(error instanceof Error && error.message.includes('ENOENT'))) {
+          if (!this.isFileNotFoundError(error)) {
             logger.debug('Error reading OAuth helper result', { error });
           }
           return null;
         }
     }
 
-    private async readOAuthHelperState() {
+    private async readOAuthHelperState(): Promise<OAuthHelperState | null> {
         const stateFile = this.getOAuthHelperStateFile();
-        const stateData = await this.fileOperations.readFile(stateFile, {
-          source: 'GitHubAuthHandler.checkOAuthHelperHealth'
-        });
-        return JSON.parse(stateData);
+        try {
+          const stateData = await this.fileOperations.readFile(stateFile, {
+            source: 'GitHubAuthHandler.checkOAuthHelperHealth'
+          });
+          const parsed = JSON.parse(stateData);
+          if (this.isOAuthHelperState(parsed)) return parsed;
+          logger.debug('OAuth helper state file had invalid shape');
+        } catch (error) {
+          if (!this.isFileNotFoundError(error)) {
+            logger.debug('Error reading OAuth helper state', { error });
+          }
+        }
+        return null;
     }
 
     private populateOAuthHelperHealth(
         health: ReturnType<GitHubAuthHandler['emptyOAuthHelperHealth']>,
-        state: any,
+        state: OAuthHelperState,
     ): void {
         health.exists = true;
         health.pid = state.pid;
@@ -765,11 +781,6 @@ export class GitHubAuthHandler {
         return importantLines.length > 0 ? importantLines.join('\n') : '';
     }
 
-    private logOAuthHelperHealthReadError(error: unknown): void {
-        if (error instanceof Error && error.message.includes('ENOENT')) return;
-        logger.debug('Error reading OAuth helper state', { error });
-    }
-
     private async cleanupLegacyPendingToken(source: string): Promise<boolean> {
         const pendingTokenFile = path.join(this.getOAuthHelperAuthDir(), 'pending_token.txt');
         try {
@@ -801,6 +812,49 @@ export class GitHubAuthHandler {
                status === 'expired' ||
                status === 'denied' ||
                status === 'timeout';
+    }
+
+    private normalizeOAuthHelperResult(value: unknown): OAuthHelperTerminalResult | null {
+        if (!this.isRecord(value) || !this.isOAuthHelperTerminalStatus(value.status)) return null;
+        return {
+          status: value.status,
+          attempts: typeof value.attempts === 'number' ? value.attempts : undefined,
+          completedAt: typeof value.completedAt === 'string' ? value.completedAt : undefined,
+          errorCode: typeof value.errorCode === 'string' ? value.errorCode : undefined,
+          message: typeof value.message === 'string'
+            ? this.sanitizeOAuthHelperResultMessage(value.message)
+            : undefined
+        };
+    }
+
+    private isOAuthHelperState(value: unknown): value is OAuthHelperState {
+        if (!this.isRecord(value)) return false;
+        return typeof value.pid === 'number' &&
+          typeof value.userCode === 'string' &&
+          typeof value.startTime === 'string' &&
+          typeof value.expiresAt === 'string' &&
+          !Number.isNaN(new Date(value.startTime).getTime()) &&
+          !Number.isNaN(new Date(value.expiresAt).getTime());
+    }
+
+    private sanitizeOAuthHelperResultMessage(message: string): string {
+        const withoutControlCharacters = Array.from(message, character => {
+          const codePoint = character.charCodeAt(0);
+          return codePoint <= 31 || codePoint === 127 ? ' ' : character;
+        }).join('');
+
+        return withoutControlCharacters
+          .replace(/\s+/g, ' ')
+          .trim()
+          .slice(0, 500);
+    }
+
+    private isRecord(value: unknown): value is Record<string, unknown> {
+        return typeof value === 'object' && value !== null && !Array.isArray(value);
+    }
+
+    private isFileNotFoundError(error: unknown): boolean {
+        return this.isRecord(error) && error.code === 'ENOENT';
     }
 
     private formatOAuthHelperTerminalStatus(status: OAuthHelperTerminalStatus) {

--- a/src/handlers/GitHubAuthHandler.ts
+++ b/src/handlers/GitHubAuthHandler.ts
@@ -12,6 +12,7 @@ import { logger } from '../utils/logger.js';
 import { PackageResourceLocator } from '../paths/PackageResourceLocator.js';
 import * as path from 'path';
 import { homedir } from 'os';
+import { randomUUID } from 'node:crypto';
 import * as child_process from 'child_process';
 import { InitializationService } from '../services/InitializationService.js';
 import { PersonaIndicatorService } from '../services/PersonaIndicatorService.js';
@@ -29,10 +30,13 @@ interface OAuthHelperTerminalResult {
     completedAt?: string;
     errorCode?: string;
     message?: string;
+    flowId?: string;
+    pid?: number;
 }
 
 interface OAuthHelperState {
     pid: number;
+    flowId?: string;
     userCode: string;
     startTime: string;
     expiresAt: string;
@@ -176,10 +180,11 @@ export class GitHubAuthHandler {
         try {
           helperPath = await this.findOAuthHelperPath();
           this.logSpawningOAuthHelper(helperPath, clientId, deviceResponse);
-          const helper = this.spawnHelperProcess(helperPath, deviceResponse, clientId);
+          const flowId = randomUUID();
+          const helper = this.spawnHelperProcess(helperPath, deviceResponse, clientId, flowId);
           helper.unref();
           this.logOAuthHelperSpawned(helper.pid, deviceResponse);
-          await this.writeOAuthHelperState(helper.pid, deviceResponse);
+          await this.writeOAuthHelperState(helper.pid, deviceResponse, flowId);
           return null;
         } catch (spawnError) {
           return this.oauthHelperLaunchFailedResponse(spawnError, helperPath, clientId);
@@ -230,7 +235,7 @@ export class GitHubAuthHandler {
         });
     }
 
-    private async writeOAuthHelperState(pid: number | undefined, deviceResponse: DeviceCodeResponse): Promise<void> {
+    private async writeOAuthHelperState(pid: number | undefined, deviceResponse: DeviceCodeResponse, flowId: string): Promise<void> {
         const stateFile = this.getOAuthHelperStateFile();
         const resultFile = this.getOAuthHelperResultFile();
         const stateDir = path.dirname(stateFile);
@@ -239,6 +244,7 @@ export class GitHubAuthHandler {
 
         const state = {
           pid,
+          flowId,
           userCode: deviceResponse.user_code,
           startTime: new Date().toISOString(),
           expiresAt: new Date(Date.now() + deviceResponse.expires_in * 1000).toISOString()
@@ -647,11 +653,17 @@ export class GitHubAuthHandler {
         const logFile = this.getOAuthHelperLogFile();
         const health = this.emptyOAuthHelperHealth();
 
-        await this.populateOAuthHelperResult(health);
-
         const state = await this.readOAuthHelperState();
         if (state) {
           this.populateOAuthHelperHealth(health, state);
+        }
+
+        const result = await this.readOAuthHelperResult();
+        if (result && (!state || this.oauthHelperResultMatchesState(result, state))) {
+          this.populateOAuthHelperResult(health, result);
+        }
+
+        if (state) {
           this.updateOAuthHelperActivity(health);
         }
 
@@ -682,10 +694,10 @@ export class GitHubAuthHandler {
         };
     }
 
-    private async populateOAuthHelperResult(health: ReturnType<GitHubAuthHandler['emptyOAuthHelperHealth']>): Promise<void> {
-        const result = await this.readOAuthHelperResult();
-        if (!result) return;
-
+    private populateOAuthHelperResult(
+        health: ReturnType<GitHubAuthHandler['emptyOAuthHelperHealth']>,
+        result: OAuthHelperTerminalResult,
+    ): void {
         health.exists = true;
         health.hasResult = true;
         health.resultStatus = result.status;
@@ -837,13 +849,16 @@ export class GitHubAuthHandler {
           errorCode: typeof value.errorCode === 'string' ? value.errorCode : undefined,
           message: typeof value.message === 'string'
             ? this.sanitizeOAuthHelperResultMessage(value.message)
-            : undefined
+            : undefined,
+          flowId: typeof value.flowId === 'string' ? value.flowId : undefined,
+          pid: this.isValidOAuthHelperPid(value.pid) ? value.pid : undefined
         };
     }
 
     private isOAuthHelperState(value: unknown): value is OAuthHelperState {
         if (!this.isRecord(value)) return false;
         return this.isValidOAuthHelperPid(value.pid) &&
+          (value.flowId === undefined || typeof value.flowId === 'string') &&
           typeof value.userCode === 'string' &&
           typeof value.startTime === 'string' &&
           typeof value.expiresAt === 'string' &&
@@ -875,6 +890,12 @@ export class GitHubAuthHandler {
         return typeof value === 'number' &&
           Number.isSafeInteger(value) &&
           value > 0;
+    }
+
+    private oauthHelperResultMatchesState(result: OAuthHelperTerminalResult, state: OAuthHelperState): boolean {
+        if (!state.flowId) return true;
+        if (result.flowId !== state.flowId) return false;
+        return typeof result.pid !== 'number' || result.pid === state.pid;
     }
 
     private isFileNotFoundError(error: unknown): boolean {
@@ -1066,7 +1087,7 @@ export class GitHubAuthHandler {
         };
     }
 
-    private spawnHelperProcess(helperPath: string, deviceResponse: DeviceCodeResponse, clientId: string) {
+    private spawnHelperProcess(helperPath: string, deviceResponse: DeviceCodeResponse, clientId: string, flowId: string) {
         return child_process.spawn('node', [
             helperPath,
             deviceResponse.device_code,
@@ -1080,7 +1101,8 @@ export class GitHubAuthHandler {
             env: {
                 ...process.env,
                 DOLLHOUSE_OAUTH_HELPER_AUTH_DIR: this.getOAuthHelperAuthDir(),
-                DOLLHOUSE_OAUTH_HELPER_LOG_FILE: this.getOAuthHelperLogFile()
+                DOLLHOUSE_OAUTH_HELPER_LOG_FILE: this.getOAuthHelperLogFile(),
+                DOLLHOUSE_OAUTH_HELPER_FLOW_ID: flowId
             }
         });
     }

--- a/src/handlers/GitHubAuthHandler.ts
+++ b/src/handlers/GitHubAuthHandler.ts
@@ -21,6 +21,16 @@ import type { PathService } from '../paths/PathService.js';
 
 const UNKNOWN_ERROR = 'Unknown error';
 
+type OAuthHelperTerminalStatus = 'success' | 'failed' | 'expired' | 'denied' | 'timeout';
+
+interface OAuthHelperTerminalResult {
+    status: OAuthHelperTerminalStatus;
+    attempts?: number;
+    completedAt?: string;
+    errorCode?: string;
+    message?: string;
+}
+
 export class GitHubAuthHandler {
     constructor(
         private readonly githubAuthManager: GitHubAuthManager,
@@ -42,6 +52,7 @@ export class GitHubAuthHandler {
     async setupGitHubAuth() {
         await this.ensureInitialized();
         try {
+          await this.cleanupLegacyPendingToken('setupGitHubAuth');
           const currentStatus = await this.githubAuthManager.getAuthStatus();
           if (currentStatus.isAuthenticated) {
             return this.alreadyConnectedResponse(currentStatus);
@@ -214,8 +225,10 @@ export class GitHubAuthHandler {
 
     private async writeOAuthHelperState(pid: number | undefined, deviceResponse: DeviceCodeResponse): Promise<void> {
         const stateFile = this.getOAuthHelperStateFile();
+        const resultFile = this.getOAuthHelperResultFile();
         const stateDir = path.dirname(stateFile);
         await this.fileOperations.createDirectory(stateDir);
+        await this.fileOperations.deleteFile(resultFile).catch(() => {});
 
         const state = {
           pid,
@@ -274,6 +287,7 @@ export class GitHubAuthHandler {
     async checkGitHubAuth() {
         await this.ensureInitialized();
         try {
+          const removedLegacyPendingToken = await this.cleanupLegacyPendingToken('checkGitHubAuth');
           const helperHealth = await this.checkOAuthHelperHealth();
           const status = await this.githubAuthManager.getAuthStatus();
 
@@ -281,10 +295,16 @@ export class GitHubAuthHandler {
             await this.cleanupOAuthHelperStateIfPresent(helperHealth.exists);
             return this.githubConnectedResponse(status);
           }
+          if (helperHealth.resultStatus === 'success') {
+            return this.githubAuthCompletedButTokenUnavailableResponse(removedLegacyPendingToken);
+          }
+          if (helperHealth.resultStatus) {
+            return this.githubAuthTerminalResultResponse(helperHealth, removedLegacyPendingToken);
+          }
           if (helperHealth.isActive) return this.githubAuthInProgressResponse(helperHealth);
           if (helperHealth.exists && helperHealth.expired) return this.githubAuthExpiredResponse(helperHealth);
           if (status.hasToken) return this.invalidTokenResponse();
-          return this.notConnectedResponse();
+          return this.notConnectedResponse(removedLegacyPendingToken);
         } catch (error) {
           logger.error('Failed to check GitHub auth', { error });
           return {
@@ -300,7 +320,9 @@ export class GitHubAuthHandler {
     private async cleanupOAuthHelperStateIfPresent(exists: boolean): Promise<void> {
         if (!exists) return;
         const stateFile = this.getOAuthHelperStateFile();
+        const resultFile = this.getOAuthHelperResultFile();
         await this.fileOperations.deleteFile(stateFile).catch(() => {}); // Preserve error swallowing pattern
+        await this.fileOperations.deleteFile(resultFile).catch(() => {});
     }
 
     private githubConnectedResponse(status: Awaited<ReturnType<GitHubAuthManager['getAuthStatus']>>) {
@@ -317,6 +339,56 @@ export class GitHubAuthHandler {
               `✅ Submit content\n\n` +
               `Everything is working properly!`
             )
+          }]
+        };
+    }
+
+    private githubAuthCompletedButTokenUnavailableResponse(removedLegacyPendingToken: boolean) {
+        const legacyNotice = removedLegacyPendingToken
+          ? `\n\nA stale plaintext OAuth fallback file from an earlier failed flow was removed.`
+          : '';
+
+        return {
+          content: [{
+            type: "text",
+            text: this.prefix(
+              `✅ **GitHub Authentication Completed**\n\n` +
+              `The OAuth helper finished successfully, but the GitHub token is not available to this server process.${legacyNotice}\n\n` +
+              `**To fix this:**\n` +
+              `1. Run \`check_github_auth\` again after the server refreshes\n` +
+              `2. If it still fails, run \`setup_github_auth\` to authenticate again`
+            )
+          }]
+        };
+    }
+
+    private githubAuthTerminalResultResponse(
+        helperHealth: Awaited<ReturnType<GitHubAuthHandler['checkOAuthHelperHealth']>>,
+        removedLegacyPendingToken: boolean,
+    ) {
+        const statusLabel = this.formatOAuthHelperTerminalStatus(helperHealth.resultStatus ?? 'failed');
+        const lines = [
+          `${statusLabel.icon} **GitHub Authentication ${statusLabel.title}**`,
+          '',
+          helperHealth.resultMessage || statusLabel.defaultMessage,
+          '',
+          '**To try again:**',
+          'Run: `setup_github_auth` to get a new code',
+          ''
+        ];
+
+        if (removedLegacyPendingToken) {
+          lines.push('A stale plaintext OAuth fallback file from an earlier failed flow was removed.', '');
+        }
+
+        if (helperHealth.errorLog) {
+          lines.push('**Error Log:**', '```', helperHealth.errorLog, '```', '');
+        }
+
+        return {
+          content: [{
+            type: "text",
+            text: this.prefix(lines.join('\n'))
           }]
         };
     }
@@ -380,7 +452,11 @@ export class GitHubAuthHandler {
         };
     }
 
-    private notConnectedResponse() {
+    private notConnectedResponse(removedLegacyPendingToken: boolean = false) {
+        const legacyNotice = removedLegacyPendingToken
+          ? `\n\nA stale plaintext OAuth fallback file from an earlier failed flow was removed. Please run \`setup_github_auth\` again to reconnect.`
+          : '';
+
         return {
           content: [{
             type: "text",
@@ -390,7 +466,7 @@ export class GitHubAuthHandler {
                   `✅ Browse the public collection\n` +
                   `✅ Install community content\n` +
                   `❌ Submit your own content (requires auth)\n\n` +
-                  `To connect, just say "set up GitHub" or "connect to GitHub"`
+                  `To connect, just say "set up GitHub" or "connect to GitHub"${legacyNotice}`
           }]
         };
     }
@@ -400,14 +476,15 @@ export class GitHubAuthHandler {
         try {
           const health = await this.checkOAuthHelperHealth();
           const stateFile = this.getOAuthHelperStateFile();
+          const resultFile = this.getOAuthHelperResultFile();
           const logFile = this.getOAuthHelperLogFile();
           const pidFile = this.getOAuthHelperPidFile();
 
           let statusText = this.formatOAuthHelperStatus(health);
-          statusText += this.formatOAuthHelperFileLocations(health, stateFile, logFile, pidFile);
+          statusText += this.formatOAuthHelperFileLocations(health, stateFile, resultFile, logFile, pidFile);
           statusText += await this.formatVerboseOAuthHelperLog(verbose, health.hasLog, logFile);
           statusText += this.formatOAuthHelperTroubleshooting(health, logFile);
-          statusText += this.formatOAuthHelperCleanup(health, stateFile, logFile, pidFile);
+          statusText += this.formatOAuthHelperCleanup(health, stateFile, resultFile, logFile, pidFile);
 
           return {
             content: [{
@@ -431,6 +508,7 @@ export class GitHubAuthHandler {
     private formatOAuthHelperStatus(health: Awaited<ReturnType<GitHubAuthHandler['checkOAuthHelperHealth']>>): string {
         let statusText = `📊 **OAuth Helper Process Diagnostics**\n\n`;
         if (!health.exists) return statusText + this.formatNoOAuthHelperStatus();
+        if (health.resultStatus) return statusText + this.formatTerminalOAuthHelperStatus(health);
         if (health.isActive) return statusText + this.formatActiveOAuthHelperStatus(health);
         if (health.expired) return statusText + this.formatExpiredOAuthHelperStatus(health);
         return statusText;
@@ -454,9 +532,7 @@ export class GitHubAuthHandler {
         if (!health.processAlive) {
           statusText += `⚠️ **WARNING:** Process appears to have stopped!\n` +
             `The helper process (PID ${health.pid}) is not responding.\n` +
-            `You may need to run
-setup_github_auth
- again.\n\n`;
+            `You may need to run \`setup_github_auth\` again.\n\n`;
         }
         return statusText;
     }
@@ -467,19 +543,30 @@ setup_github_auth
           `**Process ID:** ${health.pid}\n` +
           `**Started:** ${health.startTime?.toLocaleString()}\n` +
           `**Expired:** ${health.expiresAt?.toLocaleString()}\n\n` +
-          `The authentication request has expired. Run
-setup_github_auth
- to try again.\n\n`;
+          `The authentication request has expired. Run \`setup_github_auth\` to try again.\n\n`;
+    }
+
+    private formatTerminalOAuthHelperStatus(health: Awaited<ReturnType<GitHubAuthHandler['checkOAuthHelperHealth']>>): string {
+        const statusLabel = this.formatOAuthHelperTerminalStatus(health.resultStatus ?? 'failed');
+        let statusText = `**Status:** ${statusLabel.icon} ${statusLabel.title.toUpperCase()}\n`;
+        if (health.userCode) statusText += `**User Code:** ${health.userCode}\n`;
+        if (health.pid) statusText += `**Process ID:** ${health.pid}\n`;
+        if (health.completedAt) statusText += `**Completed:** ${health.completedAt.toLocaleString()}\n`;
+        if (health.resultAttempts !== undefined) statusText += `**Attempts:** ${health.resultAttempts}\n`;
+        if (health.resultMessage) statusText += `**Result:** ${health.resultMessage}\n`;
+        return `${statusText}\n`;
     }
 
     private formatOAuthHelperFileLocations(
         health: Awaited<ReturnType<GitHubAuthHandler['checkOAuthHelperHealth']>>,
         stateFile: string,
+        resultFile: string,
         logFile: string,
         pidFile: string,
     ): string {
         let statusText = `**📁 File Locations:**\n` +
           `• State: ${stateFile}\n` +
+          `• Result: ${resultFile} ${health.hasResult ? '(exists)' : '(not found)'}\n` +
           `• Log: ${logFile} ${health.hasLog ? '(exists)' : '(not found)'}\n` +
           `• PID: ${pidFile}\n\n`;
 
@@ -510,27 +597,31 @@ setup_github_auth
         health: Awaited<ReturnType<GitHubAuthHandler['checkOAuthHelperHealth']>>,
         logFile: string,
     ): string {
-        if (!health.exists || health.processAlive || health.expired) return '';
+        if (!health.exists || health.processAlive || health.expired || health.resultStatus) return '';
+        const retryStep = health.hasLog ? 3 : 2;
+        const clientIdStep = health.hasLog ? 4 : 3;
+        const networkStep = health.hasLog ? 5 : 4;
+
         return `**🔧 Troubleshooting Tips:**\n` +
           `1. The helper process may have crashed\n` +
-          `2. Check the log file for errors: ${logFile}\n` +
-          `3. Try running
-setup_github_auth
- again\n` +
-          `4. Ensure DOLLHOUSE_GITHUB_CLIENT_ID is set\n` +
-          `5. Check your internet connection\n`;
+          (health.hasLog ? `2. Check the log file for errors: ${logFile}\n` : '') +
+          `${retryStep}. Try running \`setup_github_auth\` again\n` +
+          `${clientIdStep}. Ensure DOLLHOUSE_GITHUB_CLIENT_ID is set\n` +
+          `${networkStep}. Check your internet connection\n`;
     }
 
     private formatOAuthHelperCleanup(
         health: Awaited<ReturnType<GitHubAuthHandler['checkOAuthHelperHealth']>>,
         stateFile: string,
+        resultFile: string,
         logFile: string,
         pidFile: string,
     ): string {
-        if (!health.exists || (!health.expired && health.processAlive)) return '';
+        if (!health.exists || (!health.expired && health.processAlive && !health.resultStatus)) return '';
         return `\n**🧹 Manual Cleanup (if needed):**\n` +
           '```bash' +
           `rm "${stateFile}"\n` +
+          `rm "${resultFile}"\n` +
           `rm "${logFile}"\n` +
           `rm "${pidFile}"\n` +
           '```';
@@ -540,14 +631,17 @@ setup_github_auth
         const logFile = this.getOAuthHelperLogFile();
         const health = this.emptyOAuthHelperHealth();
 
+        await this.populateOAuthHelperResult(health);
+
         try {
           this.populateOAuthHelperHealth(health, await this.readOAuthHelperState());
           this.updateOAuthHelperActivity(health);
-          health.hasLog = await this.fileOperations.exists(logFile);
-          health.errorLog = await this.readOAuthHelperErrorLogIfNeeded(health, logFile);
         } catch (error) {
           this.logOAuthHelperHealthReadError(error);
         }
+
+        health.hasLog = await this.fileOperations.exists(logFile);
+        health.errorLog = await this.readOAuthHelperErrorLogIfNeeded(health, logFile);
 
         return health;
     }
@@ -558,14 +652,46 @@ setup_github_auth
           isActive: false,
           expired: false,
           processAlive: false,
+          hasResult: false,
           hasLog: false,
           userCode: '',
           timeRemaining: 0,
           pid: 0,
           startTime: null as Date | null,
           expiresAt: null as Date | null,
+          completedAt: null as Date | null,
+          resultStatus: null as OAuthHelperTerminalStatus | null,
+          resultMessage: '',
+          resultAttempts: undefined as number | undefined,
           errorLog: ''
         };
+    }
+
+    private async populateOAuthHelperResult(health: ReturnType<GitHubAuthHandler['emptyOAuthHelperHealth']>): Promise<void> {
+        const result = await this.readOAuthHelperResult();
+        if (!result || !this.isOAuthHelperTerminalStatus(result.status)) return;
+
+        health.exists = true;
+        health.hasResult = true;
+        health.resultStatus = result.status;
+        health.resultMessage = typeof result.message === 'string' ? result.message : '';
+        health.resultAttempts = typeof result.attempts === 'number' ? result.attempts : undefined;
+        health.completedAt = typeof result.completedAt === 'string' ? new Date(result.completedAt) : null;
+    }
+
+    private async readOAuthHelperResult(): Promise<Partial<OAuthHelperTerminalResult> | null> {
+        const resultFile = this.getOAuthHelperResultFile();
+        try {
+          const resultData = await this.fileOperations.readFile(resultFile, {
+            source: 'GitHubAuthHandler.checkOAuthHelperHealth'
+          });
+          return JSON.parse(resultData) as Partial<OAuthHelperTerminalResult>;
+        } catch (error) {
+          if (!(error instanceof Error && error.message.includes('ENOENT'))) {
+            logger.debug('Error reading OAuth helper result', { error });
+          }
+          return null;
+        }
     }
 
     private async readOAuthHelperState() {
@@ -588,6 +714,11 @@ setup_github_auth
     }
 
     private updateOAuthHelperActivity(health: ReturnType<GitHubAuthHandler['emptyOAuthHelperHealth']>): void {
+        if (health.resultStatus) {
+          health.isActive = false;
+          return;
+        }
+
         const now = new Date();
         if (health.expiresAt && health.expiresAt > now) {
           health.isActive = true;
@@ -612,7 +743,7 @@ setup_github_auth
         health: ReturnType<GitHubAuthHandler['emptyOAuthHelperHealth']>,
         logFile: string,
     ): Promise<string> {
-        if (!health.hasLog || (health.processAlive && !health.expired)) return '';
+        if (!health.hasLog || (health.processAlive && !health.expired && !health.resultStatus)) return '';
         try {
           const logContent = await this.fileOperations.readFile(logFile, {
             source: 'GitHubAuthHandler.checkOAuthHelperHealth'
@@ -637,6 +768,75 @@ setup_github_auth
     private logOAuthHelperHealthReadError(error: unknown): void {
         if (error instanceof Error && error.message.includes('ENOENT')) return;
         logger.debug('Error reading OAuth helper state', { error });
+    }
+
+    private async cleanupLegacyPendingToken(source: string): Promise<boolean> {
+        const pendingTokenFile = path.join(this.getOAuthHelperAuthDir(), 'pending_token.txt');
+        try {
+          if (!(await this.fileOperations.exists(pendingTokenFile))) {
+            return false;
+          }
+
+          await this.fileOperations.deleteFile(pendingTokenFile, undefined, {
+            source: `GitHubAuthHandler.${source}`
+          });
+
+          SecurityMonitor.logSecurityEvent({
+            type: 'TOKEN_CACHE_CLEARED',
+            severity: 'MEDIUM',
+            source: `GitHubAuthHandler.${source}`,
+            details: 'Removed stale plaintext OAuth pending token fallback file'
+          });
+          logger.warn('Removed stale plaintext OAuth pending token fallback file');
+          return true;
+        } catch (error) {
+          logger.warn('Failed to remove stale OAuth pending token fallback file', { error });
+          return false;
+        }
+    }
+
+    private isOAuthHelperTerminalStatus(status: unknown): status is OAuthHelperTerminalStatus {
+        return status === 'success' ||
+               status === 'failed' ||
+               status === 'expired' ||
+               status === 'denied' ||
+               status === 'timeout';
+    }
+
+    private formatOAuthHelperTerminalStatus(status: OAuthHelperTerminalStatus) {
+        switch (status) {
+          case 'success':
+            return {
+              icon: '✅',
+              title: 'Completed',
+              defaultMessage: 'The OAuth helper completed successfully.'
+            };
+          case 'expired':
+            return {
+              icon: '⏱️',
+              title: 'Expired',
+              defaultMessage: 'The GitHub authentication request expired.'
+            };
+          case 'denied':
+            return {
+              icon: '🚫',
+              title: 'Denied',
+              defaultMessage: 'The GitHub authentication request was denied.'
+            };
+          case 'timeout':
+            return {
+              icon: '⏱️',
+              title: 'Timed Out',
+              defaultMessage: 'The GitHub authentication request timed out.'
+            };
+          case 'failed':
+          default:
+            return {
+              icon: '❌',
+              title: 'Failed',
+              defaultMessage: 'The OAuth helper failed before authentication completed.'
+            };
+        }
     }
 
     async clearGitHubAuth() {
@@ -816,6 +1016,10 @@ setup_github_auth
 
     private getOAuthHelperStateFile(): string {
         return path.join(this.getOAuthHelperAuthDir(), 'oauth-helper-state.json');
+    }
+
+    private getOAuthHelperResultFile(): string {
+        return path.join(this.getOAuthHelperAuthDir(), 'oauth-helper-result.json');
     }
 
     private getOAuthHelperLogFile(): string {

--- a/src/handlers/GitHubAuthHandler.ts
+++ b/src/handlers/GitHubAuthHandler.ts
@@ -317,8 +317,10 @@ export class GitHubAuthHandler {
           return {
             content: [{
               type: "text",
-              text: this.prefix(`❌ **Unable to Check Authentication**\n\n`) +
-                    `Error: ${error instanceof Error ? error.message : UNKNOWN_ERROR}`
+              text: this.prefix(
+                `❌ **Unable to Check Authentication**\n\n` +
+                `Error: ${error instanceof Error ? error.message : UNKNOWN_ERROR}`
+              )
             }]
           };
         }
@@ -449,12 +451,14 @@ export class GitHubAuthHandler {
         return {
           content: [{
             type: "text",
-            text: this.prefix(`⚠️ **GitHub Token Invalid**\n\n`) +
-                  `A GitHub token was found but it appears to be invalid or expired.\n\n` +
-                  `**To fix this:**\n` +
-                  `1. Say "set up GitHub" to authenticate again\n` +
-                  `2. Or check your GITHUB_TOKEN environment variable\n\n` +
-                  `Note: Browse and install still work without authentication!`
+            text: this.prefix(
+              `⚠️ **GitHub Token Invalid**\n\n` +
+              `A GitHub token was found but it appears to be invalid or expired.\n\n` +
+              `**To fix this:**\n` +
+              `1. Say "set up GitHub" to authenticate again\n` +
+              `2. Or check your GITHUB_TOKEN environment variable\n\n` +
+              `Note: Browse and install still work without authentication!`
+            )
           }]
         };
     }
@@ -467,13 +471,15 @@ export class GitHubAuthHandler {
         return {
           content: [{
             type: "text",
-            text: this.prefix(`🔒 **Not Connected to GitHub**\n\n`) +
-                  `You're not currently authenticated with GitHub.\n\n` +
-                  `**What works without auth:**\n` +
-                  `✅ Browse the public collection\n` +
-                  `✅ Install community content\n` +
-                  `❌ Submit your own content (requires auth)\n\n` +
-                  `To connect, just say "set up GitHub" or "connect to GitHub"${legacyNotice}`
+            text: this.prefix(
+              `🔒 **Not Connected to GitHub**\n\n` +
+              `You're not currently authenticated with GitHub.\n\n` +
+              `**What works without auth:**\n` +
+              `✅ Browse the public collection\n` +
+              `✅ Install community content\n` +
+              `❌ Submit your own content (requires auth)\n\n` +
+              `To connect, just say "set up GitHub" or "connect to GitHub"${legacyNotice}`
+            )
           }]
         };
     }
@@ -505,8 +511,10 @@ export class GitHubAuthHandler {
           return {
             content: [{
               type: "text",
-              text: this.prefix(`❌ **Failed to Get OAuth Helper Status**\n\n`) +
-                    `Error: ${error instanceof Error ? error.message : UNKNOWN_ERROR}`
+              text: this.prefix(
+                `❌ **Failed to Get OAuth Helper Status**\n\n` +
+                `Error: ${error instanceof Error ? error.message : UNKNOWN_ERROR}`
+              )
             }]
           };
         }
@@ -750,9 +758,15 @@ export class GitHubAuthHandler {
         try {
           process.kill(pid, 0);
           return true;
-        } catch {
-          return false;
+        } catch (error) {
+          return this.isProcessPermissionError(error);
         }
+    }
+
+    private isProcessPermissionError(error: unknown): boolean {
+        return error instanceof Error &&
+          'code' in error &&
+          (error as NodeJS.ErrnoException).code === 'EPERM';
     }
 
     private async readOAuthHelperErrorLogIfNeeded(
@@ -829,7 +843,7 @@ export class GitHubAuthHandler {
 
     private isOAuthHelperState(value: unknown): value is OAuthHelperState {
         if (!this.isRecord(value)) return false;
-        return typeof value.pid === 'number' &&
+        return this.isValidOAuthHelperPid(value.pid) &&
           typeof value.userCode === 'string' &&
           typeof value.startTime === 'string' &&
           typeof value.expiresAt === 'string' &&
@@ -839,8 +853,12 @@ export class GitHubAuthHandler {
 
     private sanitizeOAuthHelperResultMessage(message: string): string {
         const withoutControlCharacters = Array.from(message, character => {
-          const codePoint = character.charCodeAt(0);
-          return codePoint <= 31 || codePoint === 127 ? ' ' : character;
+          const codePoint = character.codePointAt(0) ?? 0;
+          return codePoint <= 31 ||
+            codePoint === 127 ||
+            (codePoint >= 0xD800 && codePoint <= 0xDFFF)
+            ? ' '
+            : character;
         }).join('');
 
         return withoutControlCharacters
@@ -851,6 +869,12 @@ export class GitHubAuthHandler {
 
     private isRecord(value: unknown): value is Record<string, unknown> {
         return typeof value === 'object' && value !== null && !Array.isArray(value);
+    }
+
+    private isValidOAuthHelperPid(value: unknown): value is number {
+        return typeof value === 'number' &&
+          Number.isSafeInteger(value) &&
+          value > 0;
     }
 
     private isFileNotFoundError(error: unknown): boolean {
@@ -1080,6 +1104,8 @@ export class GitHubAuthHandler {
         if (this.pathService) {
             return path.join(this.getOAuthHelperAuthDir(), 'oauth-helper.log');
         }
+        // Preserve the legacy standalone helper log path; PathService deployments
+        // pass a per-session log path to the helper through its environment.
         return path.join(this.getDollhouseHomeDir(), '.dollhouse', 'oauth-helper.log');
     }
 

--- a/src/security/tokenManager.ts
+++ b/src/security/tokenManager.ts
@@ -54,8 +54,9 @@ export class TokenManager {
     GENERIC_GITHUB_TOKEN: /^gh[a-z]_.+$/i   // Catch-all for any gh*_ pattern
   };
 
-  // Secure storage configuration
-  private static readonly DEFAULT_TOKEN_DIR = path.join(homedir(), '.dollhouse', '.auth');
+  private static getDefaultTokenDir(): string {
+    return path.join(process.env.DOLLHOUSE_HOME_DIR || homedir(), '.dollhouse', '.auth');
+  }
 
   // Rate limiter for token validation operations - prevents brute force attacks
   private tokenValidationLimiter: RateLimiter | null = null;
@@ -92,7 +93,7 @@ export class TokenManager {
 
     const authDir = typeof userIdResolverOrAuthDir === 'string'
       ? userIdResolverOrAuthDir
-      : TokenManager.DEFAULT_TOKEN_DIR;
+      : TokenManager.getDefaultTokenDir();
     const tokenStore = new FileTokenStore(
       tokenStoreOrFileOperationsOrResolver,
       { getUserAuthDir: () => authDir },
@@ -588,7 +589,6 @@ export class TokenManager {
     // Fall back to secure storage
     return this.retrieveGitHubToken();
   }
-
   private resolveUserId(): string {
     return this.userIdResolver();
   }

--- a/tests/qa/oauth-auth-test.mjs
+++ b/tests/qa/oauth-auth-test.mjs
@@ -102,17 +102,17 @@ async function testTokenStorage() {
       path: '~/.dollhouse/.auth/github_token.enc'
     },
     {
-      name: 'Pending OAuth Token',
+      name: 'OAuth Helper Result',
       check: async () => {
-        const pendingPath = path.join(homedir(), '.dollhouse', '.auth', 'pending_token.txt');
+        const resultPath = path.join(homedir(), '.dollhouse', '.auth', 'oauth-helper-result.json');
         try {
-          await fs.access(pendingPath);
+          await fs.access(resultPath);
           return true;
         } catch {
           return false;
         }
       },
-      path: '~/.dollhouse/.auth/pending_token.txt'
+      path: '~/.dollhouse/.auth/oauth-helper-result.json'
     }
   ];
   

--- a/tests/qa/oauth-auth-test.mjs
+++ b/tests/qa/oauth-auth-test.mjs
@@ -11,6 +11,45 @@ import fs from 'fs/promises';
 import path from 'path';
 import { homedir } from 'os';
 
+function createFileOperations() {
+  return {
+    async createDirectory(directoryPath) {
+      await fs.mkdir(directoryPath, { recursive: true });
+    },
+    async readFile(filePath) {
+      return fs.readFile(filePath, 'utf-8');
+    },
+    async writeFile(filePath, content) {
+      await fs.writeFile(filePath, content, 'utf-8');
+    },
+    async deleteFile(filePath) {
+      await fs.unlink(filePath);
+    },
+    async chmod(filePath, mode) {
+      await fs.chmod(filePath, mode);
+    },
+    async exists(filePath) {
+      try {
+        await fs.access(filePath);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    async createFileExclusive(filePath, content) {
+      try {
+        await fs.writeFile(filePath, content, { flag: 'wx' });
+        return true;
+      } catch (error) {
+        if (error?.code === 'EEXIST') return false;
+        throw error;
+      }
+    }
+  };
+}
+
+const tokenManager = new TokenManager(createFileOperations());
+
 async function testTokenValidation() {
   console.log('🔍 Testing Token Validation Patterns...\n');
   
@@ -31,8 +70,8 @@ async function testTokenValidation() {
   let failed = 0;
   
   for (const testCase of testCases) {
-    const isValid = TokenManager.validateTokenFormat(testCase.token);
-    const tokenType = TokenManager.getTokenType(testCase.token);
+    const isValid = tokenManager.validateTokenFormat(testCase.token);
+    const tokenType = tokenManager.getTokenType(testCase.token);
     
     if (isValid === testCase.expected) {
       console.log(`✅ ${testCase.name}: ${isValid ? 'Valid' : 'Invalid'} (Type: ${tokenType})`);
@@ -182,18 +221,18 @@ async function testTokenRetrieval() {
   
   try {
     // Test synchronous retrieval (env var)
-    const syncToken = TokenManager.getGitHubToken();
+    const syncToken = tokenManager.getGitHubToken();
     if (syncToken) {
-      const tokenType = TokenManager.getTokenType(syncToken);
+      const tokenType = tokenManager.getTokenType(syncToken);
       console.log(`✅ Sync retrieval: Found ${tokenType} from environment`);
     } else {
       console.log('⚠️  Sync retrieval: No token in environment');
     }
     
     // Test async retrieval (all sources)
-    const asyncToken = await TokenManager.getGitHubTokenAsync();
+    const asyncToken = await tokenManager.getGitHubTokenAsync();
     if (asyncToken) {
-      const tokenType = TokenManager.getTokenType(asyncToken);
+      const tokenType = tokenManager.getTokenType(asyncToken);
       console.log(`✅ Async retrieval: Found ${tokenType}`);
     } else {
       console.log('⚠️  Async retrieval: No token found in any source');

--- a/tests/unit/auth/oauth-helper.test.ts
+++ b/tests/unit/auth/oauth-helper.test.ts
@@ -7,6 +7,8 @@ import * as os from 'node:os';
 import { pathToFileURL } from 'node:url';
 import type { IFileOperationsService } from '../../../src/services/FileOperationsService.js';
 
+const TEST_CLIENT_ID = 'Ov23liABCDEFGHIJKLMNOP';
+
 function realFileOperations(): IFileOperationsService {
   return {
     async createDirectory(directoryPath: string) {
@@ -103,6 +105,11 @@ async function closeServer(server: ReturnType<typeof createServer>): Promise<voi
 }
 
 function runHelper(helperPath: string, tokenUrl: string, homeDir: string) {
+  const child = spawnHelper(helperPath, tokenUrl, homeDir);
+  return waitForClose(child);
+}
+
+function spawnHelper(helperPath: string, tokenUrl: string, homeDir: string) {
   const stdout: string[] = [];
   const stderr: string[] = [];
   const child = spawn(process.execPath, [
@@ -110,7 +117,7 @@ function runHelper(helperPath: string, tokenUrl: string, homeDir: string) {
     'device-code-for-test',
     '1',
     '20',
-    'Ov23liTestClientId'
+    TEST_CLIENT_ID
   ], {
     env: {
       ...process.env,
@@ -128,16 +135,40 @@ function runHelper(helperPath: string, tokenUrl: string, homeDir: string) {
   child.stdout?.on('data', chunk => stdout.push(String(chunk)));
   child.stderr?.on('data', chunk => stderr.push(String(chunk)));
 
-  return new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+  return Object.assign(child, {
+    readOutput: () => ({
+      stdout: stdout.join(''),
+      stderr: stderr.join('')
+    })
+  });
+}
+
+function waitForClose(child: ReturnType<typeof spawnHelper>) {
+  return new Promise<{ code: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string }>((resolve, reject) => {
     child.on('error', reject);
-    child.on('close', code => {
+    child.on('close', (code, signal) => {
+      const output = child.readOutput();
       resolve({
         code,
-        stdout: stdout.join(''),
-        stderr: stderr.join('')
+        signal,
+        stdout: output.stdout,
+        stderr: output.stderr
       });
     });
   });
+}
+
+async function waitForFile(filePath: string, timeoutMs = 5_000): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      await fs.access(filePath);
+      return;
+    } catch {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+  }
+  throw new Error(`Timed out waiting for ${filePath}`);
 }
 
 describe('oauth-helper.mjs', () => {
@@ -176,7 +207,7 @@ describe('oauth-helper.mjs', () => {
         polls += 1;
 
         expect(req.method).toBe('POST');
-        expect(body.client_id).toBe('Ov23liTestClientId');
+        expect(body.client_id).toBe(TEST_CLIENT_ID);
         expect(body.device_code).toBe('device-code-for-test');
         expect(body.grant_type).toBe('urn:ietf:params:oauth:grant-type:device_code');
 
@@ -243,6 +274,90 @@ describe('oauth-helper.mjs', () => {
       else process.env.TEST_GITHUB_TOKEN = originalTestGithubToken;
       if (originalGithubTestToken === undefined) delete process.env.GITHUB_TEST_TOKEN;
       else process.env.GITHUB_TEST_TOKEN = originalGithubTestToken;
+    }
+  }, 15_000);
+
+  it('persists GitHub slow_down backoff across polling attempts', async () => {
+    const helperPath = path.join(process.cwd(), 'oauth-helper.mjs');
+    const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'oauth-helper-slow-down-'));
+    const expectedToken = 'gho_test_slow_down_token_1234567890';
+    let polls = 0;
+
+    const server = createServer(async (_req, res) => {
+      polls += 1;
+      if (polls === 1) {
+        json(res, 200, { error: 'slow_down' });
+        return;
+      }
+      json(res, 200, {
+        access_token: expectedToken,
+        token_type: 'bearer',
+        scope: 'read:user'
+      });
+    });
+
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('OAuth helper test server did not bind to a TCP port');
+    }
+
+    try {
+      const result = await runHelper(helperPath, `http://127.0.0.1:${address.port}/token`, tempHome);
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('GitHub authentication successful');
+      expect(result.stderr).toBe('');
+      expect(polls).toBe(2);
+
+      const logPath = path.join(tempHome, '.dollhouse', 'oauth-helper.log');
+      await expect(fs.readFile(logPath, 'utf-8')).resolves.toContain('increasing interval to 6s');
+    } finally {
+      await closeServer(server);
+      await fs.rm(tempHome, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it('writes a terminal result when interrupted by SIGTERM', async () => {
+    const helperPath = path.join(process.cwd(), 'oauth-helper.mjs');
+    const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'oauth-helper-interrupt-'));
+
+    const server = createServer((_req, res) => {
+      json(res, 200, { error: 'authorization_pending' });
+    });
+
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('OAuth helper test server did not bind to a TCP port');
+    }
+
+    const authDir = path.join(tempHome, '.dollhouse', '.auth');
+    await fs.mkdir(authDir, { recursive: true });
+    await fs.writeFile(path.join(authDir, 'oauth-helper-state.json'), JSON.stringify({ stale: true }), 'utf-8');
+
+    try {
+      const child = spawnHelper(helperPath, `http://127.0.0.1:${address.port}/token`, tempHome);
+      await waitForFile(path.join(authDir, 'oauth-helper.pid'));
+
+      child.kill('SIGTERM');
+      const result = await waitForClose(child);
+
+      expect(result.code).toBe(1);
+      expect(result.signal).toBeNull();
+
+      const terminalResult = JSON.parse(
+        await fs.readFile(path.join(authDir, 'oauth-helper-result.json'), 'utf-8')
+      ) as Record<string, unknown>;
+      expect(terminalResult.status).toBe('failed');
+      expect(terminalResult.errorCode).toBe('interrupted');
+      expect(terminalResult.message).toBe('OAuth helper was interrupted before authentication completed.');
+
+      await expect(fs.access(path.join(authDir, 'oauth-helper-state.json'))).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.access(path.join(authDir, 'oauth-helper.pid'))).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await closeServer(server);
+      await fs.rm(tempHome, { recursive: true, force: true });
     }
   }, 15_000);
 });

--- a/tests/unit/auth/oauth-helper.test.ts
+++ b/tests/unit/auth/oauth-helper.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from '@jest/globals';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { spawn } from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { pathToFileURL } from 'node:url';
+import type { IFileOperationsService } from '../../../src/services/FileOperationsService.js';
+
+function realFileOperations(): IFileOperationsService {
+  return {
+    async createDirectory(directoryPath: string) {
+      await fs.mkdir(directoryPath, { recursive: true });
+    },
+    async readElementFile(filePath: string) {
+      return fs.readFile(filePath, 'utf-8');
+    },
+    async readFile(filePath: string) {
+      return fs.readFile(filePath, 'utf-8');
+    },
+    async writeFile(filePath: string, content: string) {
+      await fs.writeFile(filePath, content, 'utf-8');
+    },
+    async deleteFile(filePath: string) {
+      await fs.unlink(filePath);
+    },
+    async chmod(filePath: string, mode: number) {
+      await fs.chmod(filePath, mode);
+    },
+    async exists(filePath: string) {
+      try {
+        await fs.access(filePath);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    async listDirectory(directoryPath: string) {
+      return fs.readdir(directoryPath);
+    },
+    async listDirectoryWithTypes(directoryPath: string) {
+      const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+      return entries.map(entry => ({
+        name: entry.name,
+        isDirectory: entry.isDirectory(),
+        isFile: entry.isFile()
+      }));
+    },
+    async renameFile(oldPath: string, newPath: string) {
+      await fs.rename(oldPath, newPath);
+    },
+    async stat(filePath: string) {
+      return fs.stat(filePath);
+    },
+    resolvePath(relativePath: string, baseDirectory: string) {
+      return path.resolve(baseDirectory, relativePath);
+    },
+    validatePath(filePath: string, baseDirectory: string) {
+      const resolvedFile = path.resolve(filePath);
+      const resolvedBase = path.resolve(baseDirectory);
+      return resolvedFile === resolvedBase || resolvedFile.startsWith(`${resolvedBase}${path.sep}`);
+    },
+    async createFileExclusive(filePath: string, content: string) {
+      try {
+        await fs.writeFile(filePath, content, { flag: 'wx' });
+        return true;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+          return false;
+        }
+        throw error;
+      }
+    },
+    async copyFile(sourcePath: string, destPath: string) {
+      await fs.copyFile(sourcePath, destPath);
+    },
+    async appendFile(filePath: string, content: string) {
+      await fs.appendFile(filePath, content, 'utf-8');
+    }
+  };
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+function json(res: ServerResponse, statusCode: number, body: unknown): void {
+  res.writeHead(statusCode, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+async function closeServer(server: ReturnType<typeof createServer>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close(error => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function runHelper(helperPath: string, tokenUrl: string, homeDir: string) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const child = spawn(process.execPath, [
+    helperPath,
+    'device-code-for-test',
+    '1',
+    '20',
+    'Ov23liTestClientId'
+  ], {
+    env: {
+      ...process.env,
+      DOLLHOUSE_HOME_DIR: homeDir,
+      DOLLHOUSE_OAUTH_TOKEN_URL: tokenUrl,
+      DOLLHOUSE_OAUTH_DEBUG: 'true',
+      DOLLHOUSE_TOKEN_SECRET: 'oauth-helper-test-secret',
+      GITHUB_TOKEN: '',
+      TEST_GITHUB_TOKEN: '',
+      GITHUB_TEST_TOKEN: ''
+    },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  child.stdout?.on('data', chunk => stdout.push(String(chunk)));
+  child.stderr?.on('data', chunk => stderr.push(String(chunk)));
+
+  return new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', code => {
+      resolve({
+        code,
+        stdout: stdout.join(''),
+        stderr: stderr.join('')
+      });
+    });
+  });
+}
+
+describe('oauth-helper.mjs', () => {
+  it('uses the TokenManager instance API and does not keep a plaintext pending-token fallback', async () => {
+    const helperSource = await fs.readFile(path.join(process.cwd(), 'oauth-helper.mjs'), 'utf-8');
+    const distTokenManagerPath = path.join(process.cwd(), 'dist', 'security', 'tokenManager.js');
+
+    await expect(fs.access(distTokenManagerPath)).resolves.toBeUndefined();
+
+    const { TokenManager } = await import(pathToFileURL(distTokenManagerPath).href);
+
+    expect(helperSource).toContain('new TokenManager(');
+    expect(helperSource).toContain('tokenManager.storeGitHubToken(');
+    expect(helperSource).not.toMatch(/\bTokenManager\.storeGitHubToken\s*\(/);
+    expect(helperSource).not.toContain('pending_token.txt');
+    expect(typeof TokenManager.prototype.storeGitHubToken).toBe('function');
+  });
+
+  it('stores a device-flow token where TokenManager can read it and writes a terminal result', async () => {
+    const helperPath = path.join(process.cwd(), 'oauth-helper.mjs');
+    const distTokenManagerPath = path.join(process.cwd(), 'dist', 'security', 'tokenManager.js');
+    const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'oauth-helper-e2e-'));
+    const originalHomeDir = process.env.DOLLHOUSE_HOME_DIR;
+    const originalTokenSecret = process.env.DOLLHOUSE_TOKEN_SECRET;
+    const originalGithubToken = process.env.GITHUB_TOKEN;
+    const originalTestGithubToken = process.env.TEST_GITHUB_TOKEN;
+    const originalGithubTestToken = process.env.GITHUB_TEST_TOKEN;
+    const expectedToken = 'gho_test_device_flow_token_1234567890';
+    let polls = 0;
+
+    await expect(fs.access(distTokenManagerPath)).resolves.toBeUndefined();
+
+    const server = createServer(async (req, res) => {
+      try {
+        const body = JSON.parse(await readRequestBody(req)) as Record<string, unknown>;
+        polls += 1;
+
+        expect(req.method).toBe('POST');
+        expect(body.client_id).toBe('Ov23liTestClientId');
+        expect(body.device_code).toBe('device-code-for-test');
+        expect(body.grant_type).toBe('urn:ietf:params:oauth:grant-type:device_code');
+
+        json(res, 200, {
+          access_token: expectedToken,
+          token_type: 'bearer',
+          scope: 'read:user'
+        });
+      } catch (error) {
+        json(res, 500, { error: error instanceof Error ? error.message : 'stub failure' });
+      }
+    });
+
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('OAuth helper test server did not bind to a TCP port');
+    }
+
+    const authDir = path.join(tempHome, '.dollhouse', '.auth');
+    await fs.mkdir(authDir, { recursive: true });
+    await fs.writeFile(path.join(authDir, 'oauth-helper-state.json'), JSON.stringify({ stale: true }), 'utf-8');
+
+    try {
+      process.env.DOLLHOUSE_HOME_DIR = tempHome;
+      process.env.DOLLHOUSE_TOKEN_SECRET = 'oauth-helper-test-secret';
+      delete process.env.GITHUB_TOKEN;
+      delete process.env.TEST_GITHUB_TOKEN;
+      delete process.env.GITHUB_TEST_TOKEN;
+
+      const result = await runHelper(helperPath, `http://127.0.0.1:${address.port}/token`, tempHome);
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('GitHub authentication successful');
+      expect(result.stderr).toBe('');
+      expect(polls).toBe(1);
+
+      const { TokenManager } = await import('../../../src/security/tokenManager.js');
+      const tokenManager = new TokenManager(realFileOperations());
+      await expect(tokenManager.retrieveGitHubToken()).resolves.toBe(expectedToken);
+
+      const terminalResult = JSON.parse(
+        await fs.readFile(path.join(authDir, 'oauth-helper-result.json'), 'utf-8')
+      ) as Record<string, unknown>;
+      expect(terminalResult.status).toBe('success');
+      expect(terminalResult.attempts).toBe(1);
+      expect(terminalResult.errorCode).toBeUndefined();
+
+      await expect(fs.access(path.join(authDir, 'github_token.enc'))).resolves.toBeUndefined();
+      await expect(fs.access(path.join(authDir, 'pending_token.txt'))).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.access(path.join(authDir, 'oauth-helper-state.json'))).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.access(path.join(authDir, 'oauth-helper.pid'))).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await closeServer(server);
+      await fs.rm(tempHome, { recursive: true, force: true });
+
+      if (originalHomeDir === undefined) delete process.env.DOLLHOUSE_HOME_DIR;
+      else process.env.DOLLHOUSE_HOME_DIR = originalHomeDir;
+      if (originalTokenSecret === undefined) delete process.env.DOLLHOUSE_TOKEN_SECRET;
+      else process.env.DOLLHOUSE_TOKEN_SECRET = originalTokenSecret;
+      if (originalGithubToken === undefined) delete process.env.GITHUB_TOKEN;
+      else process.env.GITHUB_TOKEN = originalGithubToken;
+      if (originalTestGithubToken === undefined) delete process.env.TEST_GITHUB_TOKEN;
+      else process.env.TEST_GITHUB_TOKEN = originalTestGithubToken;
+      if (originalGithubTestToken === undefined) delete process.env.GITHUB_TEST_TOKEN;
+      else process.env.GITHUB_TEST_TOKEN = originalGithubTestToken;
+    }
+  }, 15_000);
+});

--- a/tests/unit/auth/oauth-helper.test.ts
+++ b/tests/unit/auth/oauth-helper.test.ts
@@ -319,6 +319,10 @@ describe('oauth-helper.mjs', () => {
   }, 15_000);
 
   it('writes a terminal result when interrupted by SIGTERM', async () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
     const helperPath = path.join(process.cwd(), 'oauth-helper.mjs');
     const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'oauth-helper-interrupt-'));
 

--- a/tests/unit/auth/oauth-helper.test.ts
+++ b/tests/unit/auth/oauth-helper.test.ts
@@ -104,12 +104,12 @@ async function closeServer(server: ReturnType<typeof createServer>): Promise<voi
   });
 }
 
-function runHelper(helperPath: string, tokenUrl: string, homeDir: string) {
-  const child = spawnHelper(helperPath, tokenUrl, homeDir);
+function runHelper(helperPath: string, tokenUrl: string, homeDir: string, extraEnv: NodeJS.ProcessEnv = {}) {
+  const child = spawnHelper(helperPath, tokenUrl, homeDir, extraEnv);
   return waitForClose(child);
 }
 
-function spawnHelper(helperPath: string, tokenUrl: string, homeDir: string) {
+function spawnHelper(helperPath: string, tokenUrl: string, homeDir: string, extraEnv: NodeJS.ProcessEnv = {}) {
   const stdout: string[] = [];
   const stderr: string[] = [];
   const child = spawn(process.execPath, [
@@ -127,7 +127,8 @@ function spawnHelper(helperPath: string, tokenUrl: string, homeDir: string) {
       DOLLHOUSE_TOKEN_SECRET: 'oauth-helper-test-secret',
       GITHUB_TOKEN: '',
       TEST_GITHUB_TOKEN: '',
-      GITHUB_TEST_TOKEN: ''
+      GITHUB_TEST_TOKEN: '',
+      ...extraEnv
     },
     stdio: ['ignore', 'pipe', 'pipe']
   });
@@ -359,6 +360,66 @@ describe('oauth-helper.mjs', () => {
 
       await expect(fs.access(path.join(authDir, 'oauth-helper-state.json'))).rejects.toMatchObject({ code: 'ENOENT' });
       await expect(fs.access(path.join(authDir, 'oauth-helper.pid'))).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await closeServer(server);
+      await fs.rm(tempHome, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it('does not remove state or pid files owned by a newer helper flow', async () => {
+    const helperPath = path.join(process.cwd(), 'oauth-helper.mjs');
+    const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'oauth-helper-flow-race-'));
+    let releaseOldFlow = false;
+
+    const server = createServer((_req, res) => {
+      json(res, 200, releaseOldFlow ? { error: 'expired_token' } : { error: 'authorization_pending' });
+    });
+
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('OAuth helper test server did not bind to a TCP port');
+    }
+
+    const authDir = path.join(tempHome, '.dollhouse', '.auth');
+    const pidFile = path.join(authDir, 'oauth-helper.pid');
+    const stateFile = path.join(authDir, 'oauth-helper-state.json');
+    const resultFile = path.join(authDir, 'oauth-helper-result.json');
+
+    try {
+      const child = spawnHelper(
+        helperPath,
+        `http://127.0.0.1:${address.port}/token`,
+        tempHome,
+        { DOLLHOUSE_OAUTH_HELPER_FLOW_ID: 'old-flow' }
+      );
+      await waitForFile(pidFile);
+
+      await fs.writeFile(pidFile, '999999', 'utf-8');
+      await fs.writeFile(
+        stateFile,
+        JSON.stringify({
+          pid: 999999,
+          flowId: 'new-flow',
+          userCode: 'NEW-FLOW',
+          startTime: new Date().toISOString(),
+          expiresAt: new Date(Date.now() + 120_000).toISOString()
+        }, null, 2),
+        'utf-8'
+      );
+
+      releaseOldFlow = true;
+      const result = await waitForClose(child);
+
+      expect(result.code).toBe(1);
+      await expect(fs.readFile(pidFile, 'utf-8')).resolves.toBe('999999');
+      const state = JSON.parse(await fs.readFile(stateFile, 'utf-8')) as Record<string, unknown>;
+      expect(state.flowId).toBe('new-flow');
+      expect(state.pid).toBe(999999);
+
+      const terminalResult = JSON.parse(await fs.readFile(resultFile, 'utf-8')) as Record<string, unknown>;
+      expect(terminalResult.status).toBe('expired');
+      expect(terminalResult.flowId).toBe('old-flow');
     } finally {
       await closeServer(server);
       await fs.rm(tempHome, { recursive: true, force: true });

--- a/tests/unit/handlers/GitHubAuthHandler.test.ts
+++ b/tests/unit/handlers/GitHubAuthHandler.test.ts
@@ -493,6 +493,64 @@ describe('GitHubAuthHandler (DI)', () => {
       });
     });
 
+    it('ignores malformed helper state JSON without checking an invalid process id', async () => {
+      await withTempHome(async (homeDir) => {
+        const stateDir = path.join(homeDir, '.dollhouse', '.auth');
+        await fs.mkdir(stateDir, { recursive: true });
+        await fs.writeFile(
+          path.join(stateDir, 'oauth-helper-state.json'),
+          JSON.stringify({
+            pid: -1,
+            userCode: 'BAD-PID',
+            startTime: new Date().toISOString(),
+            expiresAt: new Date(Date.now() + 120_000).toISOString()
+          }),
+          'utf-8'
+        );
+
+        const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => undefined as any);
+        authManager.getAuthStatus.mockResolvedValue({ isAuthenticated: false, hasToken: false } as any);
+
+        const response = await handler.checkGitHubAuth();
+        const text = response.content[0].text;
+
+        expect(text).toContain('Not Connected to GitHub');
+        expect(text).not.toContain('BAD-PID');
+        expect(killSpy).not.toHaveBeenCalled();
+
+        killSpy.mockRestore();
+      });
+    });
+
+    it('treats EPERM during helper process checks as alive', async () => {
+      await withTempHome(async (homeDir) => {
+        const stateDir = path.join(homeDir, '.dollhouse', '.auth');
+        await fs.mkdir(stateDir, { recursive: true });
+        await fs.writeFile(
+          path.join(stateDir, 'oauth-helper-state.json'),
+          JSON.stringify({
+            pid: 9999,
+            userCode: 'EPERM-9999',
+            startTime: new Date().toISOString(),
+            expiresAt: new Date(Date.now() + 120_000).toISOString()
+          }, null, 2),
+          'utf-8'
+        );
+
+        const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => {
+          throw Object.assign(new Error('permission denied'), { code: 'EPERM' });
+        });
+
+        authManager.getAuthStatus.mockResolvedValue({ isAuthenticated: false } as any);
+        const response = await handler.checkGitHubAuth();
+
+        expect(response.content[0].text).toContain('Authentication In Progress');
+        expect(response.content[0].text).toContain('Process Status:** ✅ Running');
+
+        killSpy.mockRestore();
+      });
+    });
+
     it('sanitizes helper result messages before rendering them', async () => {
       await withTempHome(async (homeDir) => {
         const stateDir = path.join(homeDir, '.dollhouse', '.auth');

--- a/tests/unit/handlers/GitHubAuthHandler.test.ts
+++ b/tests/unit/handlers/GitHubAuthHandler.test.ts
@@ -269,6 +269,7 @@ describe('GitHubAuthHandler (DI)', () => {
       const stateFile = path.join(tempHome, '.dollhouse', '.auth', 'oauth-helper-state.json');
       const state = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
       expect(state.deviceCode).toBeUndefined();
+      expect(typeof state.flowId).toBe('string');
       expect(state.userCode).toBe('CODE-1234');
       await expect(fs.access(staleResultFile)).rejects.toMatchObject({ code: 'ENOENT' });
 
@@ -334,8 +335,11 @@ describe('GitHubAuthHandler (DI)', () => {
         );
 
         expect(aliceState.deviceCode).toBeUndefined();
+        expect(typeof aliceState.flowId).toBe('string');
         expect(aliceState.userCode).toBe('ALICE-CODE');
         expect(bobState.deviceCode).toBeUndefined();
+        expect(typeof bobState.flowId).toBe('string');
+        expect(bobState.flowId).not.toBe(aliceState.flowId);
         expect(bobState.userCode).toBe('BOB-CODE');
         expect(aliceSpawn).toHaveBeenCalledTimes(1);
         expect(bobSpawn).toHaveBeenCalledTimes(1);
@@ -474,6 +478,50 @@ describe('GitHubAuthHandler (DI)', () => {
         expect(diagnosticsText).toContain('Attempts:** 2');
         expect(diagnosticsText).not.toContain('ACTIVE - Authentication in progress');
         expect(diagnosticsText).not.toContain('may have crashed');
+      });
+    });
+
+    it('ignores a stale helper result from an older OAuth flow while a newer flow is active', async () => {
+      await withTempHome(async (homeDir) => {
+        const stateDir = path.join(homeDir, '.dollhouse', '.auth');
+        await fs.mkdir(stateDir, { recursive: true });
+        await fs.writeFile(
+          path.join(stateDir, 'oauth-helper-state.json'),
+          JSON.stringify({
+            pid: 7777,
+            flowId: 'new-flow',
+            userCode: 'ACTIVE-7777',
+            startTime: new Date(Date.now() - 10_000).toISOString(),
+            expiresAt: new Date(Date.now() + 120_000).toISOString()
+          }, null, 2),
+          'utf-8'
+        );
+        await fs.writeFile(
+          path.join(stateDir, 'oauth-helper-result.json'),
+          JSON.stringify({
+            status: 'failed',
+            flowId: 'old-flow',
+            pid: 1111,
+            attempts: 3,
+            completedAt: new Date().toISOString(),
+            errorCode: 'expired_token',
+            message: 'The previous GitHub authentication request expired.'
+          }, null, 2),
+          'utf-8'
+        );
+
+        const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => undefined as any);
+        authManager.getAuthStatus.mockResolvedValue({ isAuthenticated: false, hasToken: false } as any);
+
+        const response = await handler.checkGitHubAuth();
+        const text = response.content[0].text;
+
+        expect(text).toContain('Authentication In Progress');
+        expect(text).toContain('ACTIVE-7777');
+        expect(text).not.toContain('GitHub Authentication Failed');
+        expect(text).not.toContain('previous GitHub authentication request expired');
+
+        killSpy.mockRestore();
       });
     });
 

--- a/tests/unit/handlers/GitHubAuthHandler.test.ts
+++ b/tests/unit/handlers/GitHubAuthHandler.test.ts
@@ -236,6 +236,9 @@ describe('GitHubAuthHandler (DI)', () => {
       const helperPath = path.join(tempHome, 'oauth-helper.mjs');
       await fs.writeFile(helperPath, 'console.log("helper");', 'utf-8');
       process.env.DOLLHOUSE_OAUTH_HELPER = helperPath;
+      const staleResultFile = path.join(tempHome, '.dollhouse', '.auth', 'oauth-helper-result.json');
+      await fs.mkdir(path.dirname(staleResultFile), { recursive: true });
+      await fs.writeFile(staleResultFile, JSON.stringify({ status: 'failed' }), 'utf-8');
 
       const unref = jest.fn();
       const spawnSpy = jest.spyOn(handler as any, 'spawnHelperProcess').mockReturnValue({
@@ -264,6 +267,7 @@ describe('GitHubAuthHandler (DI)', () => {
       const state = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
       expect(state.deviceCode).toBe('device-code');
       expect(state.userCode).toBe('CODE-1234');
+      await expect(fs.access(staleResultFile)).rejects.toMatchObject({ code: 'ENOENT' });
 
       await fs.rm(tempHome, { recursive: true, force: true });
       delete process.env.DOLLHOUSE_OAUTH_HELPER;
@@ -423,6 +427,71 @@ describe('GitHubAuthHandler (DI)', () => {
         expect(response.content[0].text).toContain('Authentication Expired');
         expect(response.content[0].text).toContain('EXPIRED-1234');
         expect(response.content[0].text).toContain('ERROR polling failed');
+      });
+    });
+
+    it('reports terminal helper failure from result file without calling it active or crashed', async () => {
+      await withTempHome(async (homeDir) => {
+        const stateDir = path.join(homeDir, '.dollhouse', '.auth');
+        await fs.mkdir(stateDir, { recursive: true });
+        await fs.writeFile(
+          path.join(stateDir, 'oauth-helper-state.json'),
+          JSON.stringify({
+            pid: 7777,
+            deviceCode: 'device',
+            userCode: 'FAILED-7777',
+            startTime: new Date(Date.now() - 10_000).toISOString(),
+            expiresAt: new Date(Date.now() + 120_000).toISOString()
+          }, null, 2),
+          'utf-8'
+        );
+        await fs.writeFile(
+          path.join(stateDir, 'oauth-helper-result.json'),
+          JSON.stringify({
+            status: 'failed',
+            attempts: 2,
+            completedAt: new Date().toISOString(),
+            errorCode: 'token_storage_failed',
+            message: 'OAuth token could not be stored securely.'
+          }, null, 2),
+          'utf-8'
+        );
+
+        authManager.getAuthStatus.mockResolvedValue({ isAuthenticated: false, hasToken: false } as any);
+
+        const response = await handler.checkGitHubAuth();
+        const text = response.content[0].text;
+
+        expect(text).toContain('GitHub Authentication Failed');
+        expect(text).toContain('OAuth token could not be stored securely.');
+        expect(text).not.toContain('Authentication In Progress');
+        expect(text).not.toContain('may have crashed');
+
+        const diagnostics = await handler.getOAuthHelperStatus();
+        const diagnosticsText = diagnostics.content[0].text;
+
+        expect(diagnosticsText).toContain('FAILED');
+        expect(diagnosticsText).toContain('Attempts:** 2');
+        expect(diagnosticsText).not.toContain('ACTIVE - Authentication in progress');
+        expect(diagnosticsText).not.toContain('may have crashed');
+      });
+    });
+
+    it('removes stale plaintext pending-token fallback files before reporting disconnected status', async () => {
+      await withTempHome(async (homeDir) => {
+        const stateDir = path.join(homeDir, '.dollhouse', '.auth');
+        const pendingToken = path.join(stateDir, 'pending_token.txt');
+        await fs.mkdir(stateDir, { recursive: true });
+        await fs.writeFile(pendingToken, 'gho_stale_plaintext_token_from_old_flow', { mode: 0o600 });
+
+        authManager.getAuthStatus.mockResolvedValue({ isAuthenticated: false, hasToken: false } as any);
+
+        const response = await handler.checkGitHubAuth();
+        const text = response.content[0].text;
+
+        expect(text).toContain('Not Connected to GitHub');
+        expect(text).toContain('stale plaintext OAuth fallback file from an earlier failed flow was removed');
+        await expect(fs.access(pendingToken)).rejects.toMatchObject({ code: 'ENOENT' });
       });
     });
   });

--- a/tests/unit/handlers/GitHubAuthHandler.test.ts
+++ b/tests/unit/handlers/GitHubAuthHandler.test.ts
@@ -38,8 +38,11 @@ function createFileOperationsMock(): jest.Mocked<FileOperationsService> {
     deleteFile: jest.fn().mockImplementation(async (filePath: string) => {
       try {
         await fs.unlink(filePath);
-      } catch (error: any) {
-        if (error.code !== 'ENOENT') throw error;
+      } catch (error: unknown) {
+        const code = error instanceof Error && 'code' in error
+          ? (error as NodeJS.ErrnoException).code
+          : undefined;
+        if (code !== 'ENOENT') throw error;
       }
     }),
     // Add other methods that might be needed (returning defaults)
@@ -225,7 +228,7 @@ describe('GitHubAuthHandler (DI)', () => {
   });
 
   describe('setupGitHubAuth helper orchestration', () => {
-    it('spawns helper and writes state file with device code details', async () => {
+    it('spawns helper and writes state file without persisting the device code', async () => {
       const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'oauth-home-'));
       const originalHome = process.env.HOME;
       const originalUserProfile = process.env.USERPROFILE;
@@ -265,7 +268,7 @@ describe('GitHubAuthHandler (DI)', () => {
 
       const stateFile = path.join(tempHome, '.dollhouse', '.auth', 'oauth-helper-state.json');
       const state = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
-      expect(state.deviceCode).toBe('device-code');
+      expect(state.deviceCode).toBeUndefined();
       expect(state.userCode).toBe('CODE-1234');
       await expect(fs.access(staleResultFile)).rejects.toMatchObject({ code: 'ENOENT' });
 
@@ -330,9 +333,9 @@ describe('GitHubAuthHandler (DI)', () => {
           await fs.readFile(path.join(bobAuthDir, 'oauth-helper-state.json'), 'utf-8')
         );
 
-        expect(aliceState.deviceCode).toBe('alice-device');
+        expect(aliceState.deviceCode).toBeUndefined();
         expect(aliceState.userCode).toBe('ALICE-CODE');
-        expect(bobState.deviceCode).toBe('bob-device');
+        expect(bobState.deviceCode).toBeUndefined();
         expect(bobState.userCode).toBe('BOB-CODE');
         expect(aliceSpawn).toHaveBeenCalledTimes(1);
         expect(bobSpawn).toHaveBeenCalledTimes(1);
@@ -379,7 +382,6 @@ describe('GitHubAuthHandler (DI)', () => {
           path.join(stateDir, 'oauth-helper-state.json'),
           JSON.stringify({
             pid: 9999,
-            deviceCode: 'device',
             userCode: 'STATE-9999',
             startTime: new Date().toISOString(),
             expiresAt
@@ -410,7 +412,6 @@ describe('GitHubAuthHandler (DI)', () => {
           path.join(stateDir, 'oauth-helper-state.json'),
           JSON.stringify({
             pid: 5555,
-            deviceCode: 'device',
             userCode: 'EXPIRED-1234',
             startTime: new Date(Date.now() - 3600_000).toISOString(),
             expiresAt: new Date(Date.now() - 60_000).toISOString()
@@ -438,7 +439,6 @@ describe('GitHubAuthHandler (DI)', () => {
           path.join(stateDir, 'oauth-helper-state.json'),
           JSON.stringify({
             pid: 7777,
-            deviceCode: 'device',
             userCode: 'FAILED-7777',
             startTime: new Date(Date.now() - 10_000).toISOString(),
             expiresAt: new Date(Date.now() + 120_000).toISOString()
@@ -474,6 +474,59 @@ describe('GitHubAuthHandler (DI)', () => {
         expect(diagnosticsText).toContain('Attempts:** 2');
         expect(diagnosticsText).not.toContain('ACTIVE - Authentication in progress');
         expect(diagnosticsText).not.toContain('may have crashed');
+      });
+    });
+
+    it('ignores malformed helper result JSON without throwing or leaking raw content', async () => {
+      await withTempHome(async (homeDir) => {
+        const stateDir = path.join(homeDir, '.dollhouse', '.auth');
+        await fs.mkdir(stateDir, { recursive: true });
+        await fs.writeFile(path.join(stateDir, 'oauth-helper-result.json'), '{not-json', 'utf-8');
+
+        authManager.getAuthStatus.mockResolvedValue({ isAuthenticated: false, hasToken: false } as any);
+
+        const response = await handler.checkGitHubAuth();
+        const text = response.content[0].text;
+
+        expect(text).toContain('Not Connected to GitHub');
+        expect(text).not.toContain('{not-json');
+      });
+    });
+
+    it('sanitizes helper result messages before rendering them', async () => {
+      await withTempHome(async (homeDir) => {
+        const stateDir = path.join(homeDir, '.dollhouse', '.auth');
+        await fs.mkdir(stateDir, { recursive: true });
+        await fs.writeFile(
+          path.join(stateDir, 'oauth-helper-state.json'),
+          JSON.stringify({
+            pid: 8888,
+            userCode: 'FAILED-8888',
+            startTime: new Date(Date.now() - 10_000).toISOString(),
+            expiresAt: new Date(Date.now() + 120_000).toISOString()
+          }, null, 2),
+          'utf-8'
+        );
+        await fs.writeFile(
+          path.join(stateDir, 'oauth-helper-result.json'),
+          JSON.stringify({
+            status: 'failed',
+            attempts: 1,
+            completedAt: new Date().toISOString(),
+            errorCode: 'fatal_error',
+            message: `Bad\u0000message ${'x'.repeat(700)}`
+          }, null, 2),
+          'utf-8'
+        );
+
+        authManager.getAuthStatus.mockResolvedValue({ isAuthenticated: false, hasToken: false } as any);
+
+        const response = await handler.checkGitHubAuth();
+        const text = response.content[0].text;
+
+        expect(text).toContain('Bad message');
+        expect(text).not.toContain('\u0000');
+        expect(text).not.toContain('x'.repeat(600));
       });
     });
 


### PR DESCRIPTION
## Summary

Ports the OAuth helper token handoff repair from the 2.0 hotfix path into `beta` while preserving the beta branch's newer per-user auth directory and `TokenStore` architecture.

## What changed

- Uses the `TokenManager` instance API from `oauth-helper.mjs` instead of the removed/static token write path.
- Removes the plaintext `pending_token.txt` fallback and cleans up stale fallback files from older failed flows.
- Adds terminal helper result reporting via `oauth-helper-result.json` so completed/failed/expired/denied/timeout helper exits are visible to `check_github_auth` and diagnostics.
- Keeps beta-specific `DOLLHOUSE_OAUTH_HELPER_AUTH_DIR` and `DOLLHOUSE_OAUTH_HELPER_LOG_FILE` handoff for per-user/session-scoped helper storage.
- Updates docs/QA references so operators check helper status first and only inspect logs when `DOLLHOUSE_OAUTH_DEBUG=true`.
- Adds focused helper and handler tests for secure token storage, terminal results, stale result cleanup, and stale plaintext fallback cleanup.

## Validation

Passed:

- `npm run build` after building the local safety workspace
- `npx eslint tests/unit/auth/oauth-helper.test.ts tests/unit/handlers/GitHubAuthHandler.test.ts oauth-helper.mjs src/handlers/GitHubAuthHandler.ts src/security/tokenManager.ts`
- `npm test -- tests/unit/auth/oauth-helper.test.ts tests/unit/handlers/GitHubAuthHandler.test.ts tests/unit/auth/GitHubAuthManager.test.ts tests/unit/security/tokenManager.storage.test.ts --runInBand`
- `npm run security:rapid` after building the local safety workspace
- `npm run postbuild && npm run verify:package-assets`

Notes:

- Fresh `npm ci` creates the workspace symlink for `@dollhousemcp/safety`, but the safety workspace needs its `dist` built before the full beta build/security checks can resolve it locally. I used `npm run build --workspace @dollhousemcp/safety` before rerunning the broader checks.
- `npm run verify:package-assets` requires the postbuild asset-copy step; I ran `npm run postbuild && npm run verify:package-assets` to verify the package contents.

## Related

- Ports the internal 2.0 hotfix PR #2323 to beta.
- Supersedes the token handoff behavior discussed in #2262, #2263, #2264, and #2265.
