### PR TITLE
chore: release 2.0.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.0.36] - 2026-07-03
+
+- Fix silent memory data loss: `addEntry` reported success while entries were never persisted when a memory's serialized YAML exceeded 64KB. Saves now persist correctly and surface errors instead of failing silently. (#2329, #2330, #2332)
+- Fix GitHub OAuth helper token handoff so the helper stores tokens through TokenManager instead of plaintext fallback files, with hardened result/state handling, slow_down backoff, and sanitized diagnostics. (#2325)
+
 ## [2.0.35] - 2026-06-23
 
 - Harden converter and CLI output path handling to keep generated files inside their intended output directories.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dollhousemcp",
   "display_name": "DollhouseMCP",
-  "version": "2.0.35",
+  "version": "2.0.36",
   "description": "Open-source AI customization through modular Dollhouse elements — personas, skills, templates, agents, memories, and ensembles.",
   "long_description": "DollhouseMCP is an MCP server that lets you customize your AI with modular Dollhouse elements. Create personas that shape behavior and permissions, skills that add capabilities, templates for consistent outputs, agents for autonomous multi-step goals, memories for persistent context, and ensembles that bundle elements together. Includes MCP-AQL query language with 5 semantic CRUDE endpoints, Gatekeeper permission system, community collection, and a built-in portfolio browser.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.35",
+  "version": "2.0.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.35",
+      "version": "2.0.36",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.35",
+  "version": "2.0.36",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.35",
+  "version": "2.0.36",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.35",
+      "version": "2.0.36",
       "transport": {
         "type": "stdio"
       }

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.35';
-export const BUILD_TIMESTAMP = '2026-06-23T22:05:55.087Z';
+export const PACKAGE_VERSION = '2.0.36';
+export const BUILD_TIMESTAMP = '2026-07-03T19:08:52.386Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';


### PR DESCRIPTION
## Summary

Patch release 2.0.36 for the current stable 2.0.x line.

Includes the main-branch hotfixes already merged after v2.0.35:
- **Fix silent memory data loss** (#2329, #2330, #2332): `addEntry` reported success while entries were never persisted when a memory's serialized YAML exceeded 64KB. Saves now persist correctly and surface errors instead of failing silently. Users should upgrade.
- **Fix GitHub OAuth helper token handoff** (#2325): the helper now stores tokens through TokenManager instead of plaintext fallback files, with hardened result/state handling, slow_down backoff, and sanitized diagnostics.

## Version Updates

- package.json / package-lock.json: 2.0.36
- server.json package metadata: 2.0.36
- manifest.json: 2.0.36
- generated version constant: 2.0.36
- CHANGELOG.md entry added for 2026-07-03

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5NVm7Bn9QCmshrLK84X9t