### PR TITLE
Port memory silent-save-loss fix (#2329) to beta

### DIFF
--- a/src/elements/memories/Memory.ts
+++ b/src/elements/memories/Memory.ts
@@ -1186,7 +1186,14 @@ export class Memory extends BaseElement implements IElement {
    * @returns true if entry was removed, false if not found
    */
   public removeEntry(entryId: string): boolean {
-    return this.entries.delete(entryId);
+    const removed = this.entries.delete(entryId);
+    if (removed) {
+      // Issue #2329: keep the search index consistent with the entries map —
+      // previously removed entries stayed searchable until a full index rebuild.
+      this.searchIndex.removeEntry(entryId);
+      this._isDirty = true;
+    }
+    return removed;
   }
 
   /**

--- a/src/elements/memories/MemoryManager.ts
+++ b/src/elements/memories/MemoryManager.ts
@@ -31,7 +31,6 @@ import { LRUCache } from '../../cache/LRUCache.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
 import { logger } from '../../utils/logger.js';
 import { sanitizeInput } from '../../security/InputValidator.js';
-import { ContentValidator } from '../../security/contentValidator.js';
 import { SecureYamlParser } from '../../security/secureYamlParser.js';
 import { SECURITY_LIMITS } from '../../security/constants.js';
 import { MEMORY_CONSTANTS, MEMORY_SECURITY_EVENTS } from './constants.js';
@@ -674,43 +673,50 @@ export class MemoryManager extends BaseElementManager<Memory> {
   }
 
   /**
+   * Issue #2329: Serialize and run the full save-path validation without writing to disk.
+   * Lets callers reject a mutation immediately (e.g. addEntry) when the memory can no
+   * longer be persisted, instead of the failure surfacing only in a deferred save
+   * where it cannot be reported back to the caller.
+   */
+  async assertPersistable(element: Memory): Promise<void> {
+    const yamlContent = await this.serializeElement(element);
+    this.validateSerializedContent(yamlContent);
+  }
+
+  /**
    * Memory-specific content validation.
    * Memories are pure YAML (no frontmatter delimiters), so they need different
    * validation than frontmatter-based elements. The base class validateSerializedContent
    * handles frontmatter elements; this override handles pure YAML memories.
-   *
-   * Checks: size enforcement (Fix #916/#918), YAML bomb detection (Fix #908/#918),
-   * and gatekeeper policy validation.
+   * Shared by save() (via super.save) and assertPersistable() so the pre-flight
+   * check and the actual write can never disagree.
    */
   protected override validateSerializedContent(content: string): void {
-    // Size enforcement (Fix #916/#918)
-    if (content.length > SECURITY_LIMITS.MAX_PERSONA_SIZE_BYTES) {
+    // Fix #916/#918, tightened for #2329: cap at MAX_YAML_SIZE (256KB) — the same
+    // limit parseContent() enforces on load. The previous 2MB cap allowed writing
+    // files the loader would then reject.
+    if (content.length > MEMORY_CONSTANTS.MAX_YAML_SIZE) {
       SecurityMonitor.logSecurityEvent({
         type: MEMORY_SECURITY_EVENTS.MEMORY_SAVE_FAILED,
         severity: 'HIGH',
         source: 'MemoryManager.validateSerializedContent',
-        details: `Memory exceeds maximum file size (${content.length} > ${SECURITY_LIMITS.MAX_PERSONA_SIZE_BYTES})`,
+        details: `Memory exceeds maximum serialized size (${content.length} > ${MEMORY_CONSTANTS.MAX_YAML_SIZE})`,
       });
       throw new Error(
-        `Memory exceeds maximum file size (${content.length} > ${SECURITY_LIMITS.MAX_PERSONA_SIZE_BYTES})`
+        `Memory exceeds maximum serialized size (${content.length} > ${MEMORY_CONSTANTS.MAX_YAML_SIZE} bytes). ` +
+        `This memory is full — start a new memory for additional entries.`
       );
     }
 
-    // YAML bomb detection (Fix #908/#918)
-    if (content.length <= SECURITY_LIMITS.MAX_YAML_LENGTH) {
-      if (!ContentValidator.validateYamlContent(content)) {
-        SecurityMonitor.logSecurityEvent({
-          type: 'YAML_INJECTION_ATTEMPT',
-          severity: 'CRITICAL',
-          source: 'MemoryManager.validateSerializedContent',
-          details: 'Serialized memory contains malicious YAML patterns — write blocked',
-        });
-        throw new Error('Serialized memory contains malicious YAML patterns — write blocked');
-      }
-    }
-
-    // Gatekeeper policy validation (pure YAML structure — root + nested metadata)
-    const parsedYaml = SecureYamlParser.parseRawYaml(content, SECURITY_LIMITS.MAX_YAML_LENGTH);
+    // Bomb/injection detection + gatekeeper policy validation. Issue #2329 root
+    // cause: this parse previously capped at MAX_YAML_LENGTH (64KB — a frontmatter
+    // limit), so every save of a memory whose serialized YAML exceeded 64KB threw
+    // here, and the deferred save path swallowed the error while addEntry kept
+    // reporting success. The cap now matches the memory size limit enforced above
+    // and on load. parseRawYaml runs ContentValidator.validateYamlContent with the
+    // same cap internally (Fix #908/#918), covering every size — the previous
+    // `<= MAX_YAML_LENGTH` guard skipped bomb detection for content over 64KB.
+    const parsedYaml = SecureYamlParser.parseRawYaml(content, MEMORY_CONSTANTS.MAX_YAML_SIZE);
     const gatekeeperErrors = [
       ...getGatekeeperAuthoringErrors(parsedYaml),
       ...getGatekeeperAuthoringErrors(

--- a/src/elements/memories/constants.ts
+++ b/src/elements/memories/constants.ts
@@ -56,7 +56,7 @@ export const MEMORY_CONSTANTS = {
    * - 1MB: Parse time ~50-100ms (acceptable but not ideal)
    * - >5MB: Parse time >500ms (unacceptable, blocks UI)
    */
-  MAX_YAML_SIZE: 256 * 1024,           // 256KB max YAML size for import
+  MAX_YAML_SIZE: 256 * 1024,           // 256KB max serialized memory YAML — enforced on save, load, import, and index extraction (#2329)
 
   /**
    * Privacy Level Hierarchy:

--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -90,6 +90,7 @@ import type { PerformanceMonitor } from '../../utils/PerformanceMonitor.js';
 import type { OperationMetricsTracker } from '../../metrics/OperationMetricsTracker.js';
 import type { GatekeeperMetricsTracker } from '../../metrics/GatekeeperMetricsTracker.js';
 import { ElementType, type PortfolioManager } from '../../portfolio/PortfolioManager.js';
+import { normalizeElementType } from '../../utils/elementTypeNormalization.js';
 import { getAutonomyMetrics } from '../../elements/agents/autonomyEvaluator.js';
 import type { AutonomyMetricsSnapshot } from '../../elements/agents/autonomyEvaluator.js';
 
@@ -867,6 +868,7 @@ export class MCPAQLHandler {
         elementType,
         params: mergedParams,
       });
+      this.cleanupDeletedMemoryBookkeeping(operation, elementType, mergedParams);
 
       // Step 5: Apply field selection (Issue #202)
       // Transform name → element_name for LLM consistency
@@ -1255,6 +1257,27 @@ export class MCPAQLHandler {
 
   async flushPendingSaves(): Promise<void> {
     await this.memorySaveHandler.flushPendingSaves();
+  }
+
+  /**
+   * Issue #2329 (Codex review): a successfully deleted memory must drop its
+   * save bookkeeping — a retained failure-ledger instance or pending debounce
+   * timer would otherwise re-save the in-RAM state and resurrect the deleted
+   * file. Called after dispatch in executeOperation so the schema-dispatch,
+   * legacy, and batch paths are all covered.
+   */
+  private cleanupDeletedMemoryBookkeeping(
+    operation: string,
+    elementType: string | undefined,
+    params: Record<string, unknown> | undefined,
+  ): void {
+    if (operation !== 'delete_element') return;
+    const p = params ?? {};
+    const type = (elementType ?? p.element_type ?? p.type) as string | undefined;
+    const name = (p.element_name ?? p.name) as string | undefined;
+    if (name && normalizeElementType(type) === ElementType.MEMORY) {
+      this.memorySaveHandler.clearMemorySaveBookkeeping(name);
+    }
   }
 
   private get saveFrequencyCounters(): Map<string, unknown> {

--- a/src/handlers/mcp-aql/MemorySaveHandler.ts
+++ b/src/handlers/mcp-aql/MemorySaveHandler.ts
@@ -12,6 +12,19 @@ interface PendingSave {
   manager: MemoryManager;
 }
 
+/**
+ * Issue #2329: record of a memory whose most recent save attempt failed.
+ * Holds the failing Memory instance and its manager — the unpersisted entries
+ * exist only in that instance, so recovery must retry it (a freshly loaded
+ * instance would lack them), and holding the reference keeps it alive across
+ * cache eviction.
+ */
+interface FailedSave {
+  error: Error;
+  memory: Memory;
+  manager: MemoryManager;
+}
+
 interface SaveFrequencyCounter {
   timestamps: number[];
   warned: boolean;
@@ -22,6 +35,21 @@ export class MemorySaveHandler {
   private readonly pendingSaves = new Map<string, PendingSave>();
   private readonly debounceMetrics = { coalesced: 0, written: 0 };
   private readonly saveFrequencyCounters = new Map<string, SaveFrequencyCounter>();
+  /**
+   * Issue #2329: memories whose most recent save failed. The next addEntry on
+   * that memory retries the save synchronously and reports the error to the
+   * caller instead of silently accepting more entries; flush/cleanup paths
+   * retry these as a last resort.
+   */
+  private readonly failedMemorySaves = new Map<string, FailedSave>();
+  /**
+   * Issue #2329: monotonically increasing save-attempt counter per memory key.
+   * Guards the failure ledger against reordering: an older in-flight save that
+   * resolves after a newer one started must not overwrite the newer attempt's
+   * outcome. Pruned on latest-success so the map stays bounded by
+   * currently-failing memories.
+   */
+  private readonly memorySaveAttempts = new Map<string, number>();
 
   constructor(
     private readonly handlers: HandlerRegistry,
@@ -45,41 +73,101 @@ export class MemorySaveHandler {
       case 'addEntry':
         return this.addEntry(memoryName, memory, manager, params);
       case 'clear':
-        return this.clear(memory, manager);
+        return this.clear(memoryName, memory, manager);
       default:
         throw new Error(`Unknown Memory method: ${method}`);
     }
   }
 
+  /**
+   * Issue #2329: flush a session's pending and failed saves instead of dropping
+   * them — cancelling timers without saving silently discarded entries added
+   * within the debounce window (the fresh-memory loss case in the incident).
+   * Fire-and-forget: cleanup is synchronous, but the process is still alive.
+   */
   cleanupSession(sessionId: string): void {
     const prefix = `${sessionId}:`;
     for (const [key, entry] of this.pendingSaves) {
       if (key.startsWith(prefix)) {
         clearTimeout(entry.timer);
         this.pendingSaves.delete(key);
+        this.saveMemoryTracked(key, entry.memory, entry.manager).catch((err) => {
+          logger.error(`[MCPAQLHandler] Session-cleanup save failed for memory '${key}': ${err}`);
+        });
+      }
+    }
+    for (const [key, entry] of this.failedMemorySaves) {
+      if (key.startsWith(prefix) && !this.pendingSaves.has(key)) {
+        this.saveMemoryTracked(key, entry.memory, entry.manager).catch((err) => {
+          logger.error(`[MCPAQLHandler] Session-cleanup retry failed for memory '${key}' — unpersisted entries will be lost: ${err}`);
+        }).finally(() => {
+          // Session is gone either way — release the retained instance.
+          this.failedMemorySaves.delete(key);
+          this.memorySaveAttempts.delete(key);
+        });
       }
     }
     this.deleteByPrefix(this.saveFrequencyCounters, prefix);
+  }
+
+  /**
+   * Issue #2329 (Codex review): drop all save bookkeeping for a deleted memory.
+   * Without this, the failure ledger keeps the deleted memory's in-RAM instance
+   * and the flush/retry paths re-save it, resurrecting the deleted file. A save
+   * already in flight when the delete lands can still race the file back — that
+   * narrow window is inherent to fire-and-forget writes and unchanged here.
+   */
+  clearMemorySaveBookkeeping(memoryName: string): void {
+    const key = this.saveKey(memoryName);
+    const pending = this.pendingSaves.get(key);
+    if (pending) {
+      clearTimeout(pending.timer);
+      this.pendingSaves.delete(key);
+    }
+    this.failedMemorySaves.delete(key);
+    this.memorySaveAttempts.delete(key);
+    this.saveFrequencyCounters.delete(key);
   }
 
   async dispose(): Promise<void> {
     await this.flushPendingSaves();
   }
 
+  /**
+   * Issue #656: Flush all pending debounced saves immediately.
+   * Issue #2329: also retries memories whose earlier deferred save failed and
+   * that have no pending timer — their dirty state exists only in RAM and this
+   * is the last chance to persist it before shutdown.
+   */
   async flushPendingSaves(): Promise<void> {
     const pending = [...this.pendingSaves.entries()];
     this.pendingSaves.clear();
     if (pending.length > 0) {
       logger.info(`[MCPAQLHandler] Flushing ${pending.length} pending memory save(s) on shutdown (total coalesced: ${this.debounceMetrics.coalesced}, total written: ${this.debounceMetrics.written})`);
     }
+    const flushedKeys = new Set<string>();
     for (const [key, { timer, memory, manager }] of pending) {
       clearTimeout(timer);
+      flushedKeys.add(key);
       try {
-        await manager.save(memory);
+        await this.saveMemoryTracked(key, memory, manager);
         this.debounceMetrics.written++;
       } catch (err) {
         const entryCount = typeof memory.getEntries === 'function' ? memory.getEntries().size : 'unknown';
         logger.error(`[MCPAQLHandler] Flush save failed for memory '${key}' (entries: ${entryCount}, pending remaining: ${pending.length}): ${err}`);
+      }
+    }
+    // Direct Map iteration is safe here: saveMemoryTracked only deletes the
+    // current key on success, which the iteration protocol tolerates.
+    for (const [key, { memory, manager }] of this.failedMemorySaves) {
+      if (flushedKeys.has(key)) continue; // just attempted above
+      try {
+        await this.saveMemoryTracked(key, memory, manager);
+        this.debounceMetrics.written++;
+        logger.info(`[MCPAQLHandler] Recovered previously failed save for memory '${key}' during flush`);
+      } catch (err) {
+        const entryCount = typeof memory.getEntries === 'function' ? memory.getEntries().size : 'unknown';
+        logger.error(`[MCPAQLHandler] Final flush retry failed for memory '${key}' (entries: ${entryCount}) — unpersisted entries will be lost if the process exits: ${err}`);
       }
     }
   }
@@ -92,24 +180,118 @@ export class MemorySaveHandler {
     this.trackSaveFrequency(memoryName);
   }
 
-  private addEntry(
+  /**
+   * Normalized key shared by pendingSaves, failedMemorySaves, memorySaveAttempts,
+   * and saveFrequencyCounters. All memory-save bookkeeping must use this — a
+   * mismatched key silently disconnects the failure ledger from recovery (#2329).
+   */
+  private saveKey(memoryName: string): string {
+    return this.sessionKey(memoryName.toLowerCase());
+  }
+
+  /**
+   * Issue #2329: save a memory with failure-ledger bookkeeping. On failure the
+   * ledger records the error AND the failing instance (its unpersisted entries
+   * exist nowhere else); on success the record clears. The attempt counter makes
+   * the newest-started save win: an older in-flight save resolving late cannot
+   * erase a newer failure. Rethrows the save error.
+   */
+  private async saveMemoryTracked(
+    key: string,
+    memory: Memory,
+    manager: MemoryManager,
+  ): Promise<void> {
+    const attempt = (this.memorySaveAttempts.get(key) ?? 0) + 1;
+    this.memorySaveAttempts.set(key, attempt);
+    try {
+      await manager.save(memory);
+      if (this.memorySaveAttempts.get(key) === attempt) {
+        this.failedMemorySaves.delete(key);
+        // Prune the counter on latest-success so the map stays bounded by
+        // currently-failing memories. A stale in-flight save then sees
+        // undefined !== its attempt and correctly skips ledger updates.
+        this.memorySaveAttempts.delete(key);
+      }
+    } catch (err) {
+      if (this.memorySaveAttempts.get(key) === attempt) {
+        this.failedMemorySaves.set(key, {
+          error: err instanceof Error ? err : new Error(String(err)),
+          memory,
+          manager,
+        });
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * addEntry with the #2329 persistence guarantees: recover from a prior failed
+   * save, mutate the authoritative instance, verify persistability before
+   * reporting success (rolling back on failure), then schedule the debounced save.
+   */
+  private async addEntry(
     memoryName: string,
     memory: Memory,
     manager: MemoryManager,
     params: Record<string, unknown>
-  ): unknown {
+  ): Promise<unknown> {
     if (params.entry !== undefined && params.content === undefined) {
       params.content = params.entry;
     }
     this.validateContent(memoryName, params);
 
-    const pendingKey = this.sessionKey(memoryName.toLowerCase());
-    const targetMemory = this.pendingSaves.get(pendingKey)?.memory ?? memory;
-    const entryResult = targetMemory.addEntry(
+    // Issue #2329: operate on the authoritative instance. Unpersisted entries
+    // live only in the instance held by the failure ledger or a pending
+    // debounced save; after cache eviction find() reloads a fresh copy from
+    // disk that lacks them, and writing through that copy would clobber the
+    // recovered state.
+    const pendingKey = this.saveKey(memoryName);
+    const priorFailure = this.failedMemorySaves.get(pendingKey);
+    const targetMemory = priorFailure?.memory ?? this.pendingSaves.get(pendingKey)?.memory ?? memory;
+
+    // Issue #2329: if a previous save of this memory failed (e.g. disk error),
+    // recover before accepting more entries — otherwise they pile up in RAM
+    // behind the same failure and are lost on restart.
+    if (priorFailure) {
+      try {
+        await this.saveMemoryTracked(pendingKey, targetMemory, priorFailure.manager);
+      } catch (retryErr) {
+        throw new Error(
+          `Entry NOT saved: memory '${memoryName}' has unpersisted entries from an earlier save failure ` +
+          `(${priorFailure.error.message}) and the retry also failed: ` +
+          `${retryErr instanceof Error ? retryErr.message : retryErr}`
+        );
+      }
+    }
+
+    const entriesBefore = targetMemory.getEntries().size;
+    const entryResult = await targetMemory.addEntry(
       params.content as string,
       params.tags as string[] | undefined,
       params.metadata as Record<string, unknown> | undefined,
     );
+
+    // Issue #2329: verify the memory can still be persisted BEFORE reporting
+    // success. The disk write below is deferred (debounced), so a validation
+    // failure there can never reach the caller — entries were acknowledged
+    // with an id and then silently lost when the memory outgrew save limits.
+    try {
+      await manager.assertPersistable(targetMemory);
+    } catch (validationErr) {
+      targetMemory.removeEntry(entryResult.id);
+      // addEntry may have evicted old entries (retention/capacity policy)
+      // before validation failed. The eviction stands — it would happen on
+      // any future successful add — but it must reach disk, or RAM and disk
+      // silently diverge with no save scheduled.
+      if (targetMemory.getEntries().size !== entriesBefore) {
+        this.debouncedMemorySave(memoryName, targetMemory, manager);
+      }
+      throw new Error(
+        `Entry NOT saved to memory '${memoryName}': ` +
+        `${validationErr instanceof Error ? validationErr.message : validationErr}`
+      );
+    }
+
     this.trackSaveFrequency(memoryName);
     this.debouncedMemorySave(memoryName, targetMemory, manager);
     return entryResult;
@@ -129,9 +311,18 @@ export class MemorySaveHandler {
     );
   }
 
-  private async clear(memory: Memory, manager: MemoryManager): Promise<unknown> {
-    const clearResult = memory.clearAll(true);
-    await manager.save(memory);
+  private async clear(memoryName: string, memory: Memory, manager: MemoryManager): Promise<unknown> {
+    // Issue #2329: cancel any pending debounced save first — a stale timer
+    // firing after the clear would resurrect the pre-clear entries on disk.
+    const clearKey = this.saveKey(memoryName);
+    const pendingClear = this.pendingSaves.get(clearKey);
+    if (pendingClear) {
+      clearTimeout(pendingClear.timer);
+      this.pendingSaves.delete(clearKey);
+    }
+    const clearResult = await memory.clearAll(true);
+    // Tracked so a success clears any stale failure record for this memory.
+    await this.saveMemoryTracked(clearKey, memory, manager);
     return clearResult;
   }
 
@@ -140,7 +331,7 @@ export class MemorySaveHandler {
     memory: Memory,
     manager: MemoryManager,
   ): void {
-    const key = this.sessionKey(memoryName.toLowerCase());
+    const key = this.saveKey(memoryName);
     const existing = this.pendingSaves.get(key);
     if (existing) {
       clearTimeout(existing.timer);
@@ -151,7 +342,7 @@ export class MemorySaveHandler {
       this.pendingSaves.delete(key);
       this.debounceMetrics.written++;
       logger.debug(`[MCPAQLHandler] Flushing debounced save for memory '${memoryName}' (coalesced: ${this.debounceMetrics.coalesced}, written: ${this.debounceMetrics.written})`);
-      manager.save(memory).catch((err) => {
+      this.saveMemoryTracked(key, memory, manager).catch((err) => {
         logger.error(`[MCPAQLHandler] Debounced save failed for memory '${memoryName}' (pending: ${this.pendingSaves.size}, coalesced: ${this.debounceMetrics.coalesced}, written: ${this.debounceMetrics.written}): ${err}`);
       });
     }, STORAGE_LAYER_CONFIG.MEMORY_SAVE_DEBOUNCE_MS);
@@ -162,7 +353,7 @@ export class MemorySaveHandler {
   }
 
   private trackSaveFrequency(memoryName: string): void {
-    const key = this.sessionKey(memoryName.toLowerCase());
+    const key = this.saveKey(memoryName);
     const now = Date.now();
     const windowMs = STORAGE_LAYER_CONFIG.MEMORY_SAVE_MONITOR_WINDOW_MS;
     const warnThreshold = STORAGE_LAYER_CONFIG.MEMORY_SAVE_FREQUENCY_WARN_THRESHOLD;

--- a/src/security/contentValidator.ts
+++ b/src/security/contentValidator.ts
@@ -561,30 +561,71 @@ export class ContentValidator {
   /**
    * Validates YAML frontmatter for malicious content
    * SECURITY FIX #364: Added YAML bomb detection to prevent denial of service
+   *
+   * @param yamlContent - YAML string to validate
+   * @param maxLength - Size cap for the content. Defaults to MAX_YAML_LENGTH (64KB,
+   *   the frontmatter limit). Callers validating whole pure-YAML documents (e.g.
+   *   memory files, capped at 256KB — issue #2329) must pass their own limit.
+   *   Values above MAX_CONTENT_LENGTH (500KB) are clamped: an explicit maxLength
+   *   overrides RegexValidator's complexity-based ReDoS caps, and the
+   *   MALICIOUS_YAML_PATTERNS scan below is bounded by MAX_CONTENT_LENGTH, so
+   *   larger content is rejected here rather than scanned or thrown on.
    */
-  static validateYamlContent(yamlContent: string): boolean {
+  static validateYamlContent(yamlContent: string, maxLength: number = SECURITY_LIMITS.MAX_YAML_LENGTH): boolean {
+    const effectiveMaxLength = Math.min(maxLength, SECURITY_LIMITS.MAX_CONTENT_LENGTH);
     // Length validation before pattern matching
-    if (yamlContent.length > SECURITY_LIMITS.MAX_YAML_LENGTH) {
+    if (yamlContent.length > effectiveMaxLength) {
       SecurityMonitor.logSecurityEvent({
         type: 'YAML_INJECTION_ATTEMPT',
         severity: 'HIGH',
         source: 'yaml_validation',
-        details: `YAML content exceeds maximum length: ${yamlContent.length} > ${SECURITY_LIMITS.MAX_YAML_LENGTH}`
+        details: `YAML content exceeds maximum length: ${yamlContent.length} > ${effectiveMaxLength}`
       });
       return false;
     }
 
-    // SECURITY FIX #364: Check for YAML bombs before other validation
-    // SECURITY FIX (PR #552 review): Use RegexValidator for ReDoS protection
+    if (this.hasYamlBombPattern(yamlContent, effectiveMaxLength)) {
+      return false;
+    }
+
+    if (this.hasExcessiveAliasAmplification(yamlContent)) {
+      return false;
+    }
+
+    if (this.hasCircularAnchorReferences(yamlContent)) {
+      return false;
+    }
+
+    // Unicode normalization preprocessing for YAML content
+    const unicodeResult = UnicodeValidator.normalize(yamlContent);
+
+    if (!unicodeResult.isValid && unicodeResult.detectedIssues) {
+      SecurityMonitor.logSecurityEvent({
+        type: 'YAML_UNICODE_ATTACK',
+        severity: (unicodeResult.severity?.toUpperCase() || 'MEDIUM') as 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL',
+        source: 'yaml_validation',
+        details: `Unicode attack detected in YAML: ${unicodeResult.detectedIssues.join(', ')}`
+      });
+      return false;
+    }
+
+    return !this.hasMaliciousYamlPattern(unicodeResult.normalizedContent);
+  }
+
+  /**
+   * SECURITY FIX #364: Check for YAML bombs before other validation.
+   * SECURITY FIX (PR #552 review): Uses RegexValidator for ReDoS protection.
+   */
+  private static hasYamlBombPattern(yamlContent: string, effectiveMaxLength: number): boolean {
     for (const pattern of this.YAML_BOMB_PATTERNS) {
       // Use RegexValidator to safely check patterns with timeout protection
       // This prevents ReDoS attacks from maliciously crafted YAML
       const isMatch = RegexValidator.validate(yamlContent, pattern, {
-        maxLength: SECURITY_LIMITS.MAX_YAML_LENGTH,
+        maxLength: effectiveMaxLength,
         rejectDangerousPatterns: false, // Our patterns are trusted
         logEvents: false // We handle logging ourselves
       });
-      
+
       if (isMatch) {
         SecurityMonitor.logSecurityEvent({
           type: 'YAML_INJECTION_ATTEMPT',
@@ -606,12 +647,17 @@ export class ContentValidator {
           { patternType: 'YAML_BOMB', contentLength: yamlContent.length }
         );
 
-        return false;
+        return true;
       }
     }
-    
-    // SECURITY FIX #364: Count anchor/alias ratio for amplification detection
-    // SECURITY FIX #1298: Use configurable threshold for easier tuning
+    return false;
+  }
+
+  /**
+   * SECURITY FIX #364: Count anchor/alias ratio for amplification detection.
+   * SECURITY FIX #1298: Uses configurable threshold for easier tuning.
+   */
+  private static hasExcessiveAliasAmplification(yamlContent: string): boolean {
     const anchorMatches = yamlContent.match(/&\w+/g) || [];
     // Fix #906: Use negative lookbehind to exclude markdown bold (**word**) from
     // matching as YAML aliases. Without this, markdown bold inside YAML strings
@@ -631,15 +677,17 @@ export class ContentValidator {
           ratio: amplificationRatio
         }
       });
-      return false;
+      return true;
     }
-    
-    // SECURITY FIX #364: Detect circular reference chains
-    // SECURITY FIX (PR #552 review): Optimized from O(n²) to O(n) using Set-based lookups
+    return false;
+  }
+
+  /**
+   * First pass of circular-reference detection: map each anchor to the alias
+   * names referenced within its next 5 lines.
+   */
+  private static buildAnchorReferenceMap(lines: string[]): Map<string, Set<string>> {
     const anchorRefs = new Map<string, Set<string>>();
-    const lines = yamlContent.split('\n');
-    
-    // First pass: Build reference map efficiently
     for (let i = 0; i < lines.length; i++) {
       const anchorMatch = lines[i].match(/&(\w+)/);
       if (anchorMatch) {
@@ -647,7 +695,7 @@ export class ContentValidator {
         // Get references in next 5 lines
         const contextEnd = Math.min(i + 5, lines.length);
         const references = new Set<string>();
-        
+
         for (let j = i; j < contextEnd; j++) {
           const aliasMatches = lines[j].match(/\*(\w+)/g);
           if (aliasMatches) {
@@ -656,12 +704,21 @@ export class ContentValidator {
             });
           }
         }
-        
+
         anchorRefs.set(anchorName, references);
       }
     }
-    
-    // Second pass: Check for circular references (O(n) with Set lookups)
+    return anchorRefs;
+  }
+
+  /**
+   * SECURITY FIX #364: Detect circular reference chains.
+   * SECURITY FIX (PR #552 review): Optimized from O(n²) to O(n) using Set-based lookups.
+   */
+  private static hasCircularAnchorReferences(yamlContent: string): boolean {
+    const anchorRefs = this.buildAnchorReferenceMap(yamlContent.split('\n'));
+
+    // Check for circular references (O(n) with Set lookups)
     for (const [anchor1, refs1] of anchorRefs) {
       for (const refAnchor of refs1) {
         const refs2 = anchorRefs.get(refAnchor);
@@ -677,25 +734,15 @@ export class ContentValidator {
               anchors: [anchor1, refAnchor]
             }
           });
-          return false;
+          return true;
         }
       }
     }
-    
-    // Unicode normalization preprocessing for YAML content
-    const unicodeResult = UnicodeValidator.normalize(yamlContent);
-    const normalizedYaml = unicodeResult.normalizedContent;
-    
-    if (!unicodeResult.isValid && unicodeResult.detectedIssues) {
-      SecurityMonitor.logSecurityEvent({
-        type: 'YAML_UNICODE_ATTACK',
-        severity: (unicodeResult.severity?.toUpperCase() || 'MEDIUM') as 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL',
-        source: 'yaml_validation',
-        details: `Unicode attack detected in YAML: ${unicodeResult.detectedIssues.join(', ')}`
-      });
-      return false;
-    }
+    return false;
+  }
 
+  /** Scan normalized YAML for the MALICIOUS_YAML_PATTERNS set. */
+  private static hasMaliciousYamlPattern(normalizedYaml: string): boolean {
     for (const pattern of this.MALICIOUS_YAML_PATTERNS) {
       // These are trusted internal patterns, so we disable ReDoS rejection
       if (RegexValidator.validate(normalizedYaml, pattern, {
@@ -710,10 +757,10 @@ export class ContentValidator {
           details: `Malicious YAML pattern detected: ${pattern}`,
         });
         // Early exit on first match for performance
-        return false;
+        return true;
       }
     }
-    return true;
+    return false;
   }
 
   /**

--- a/src/security/secureYamlParser.ts
+++ b/src/security/secureYamlParser.ts
@@ -334,7 +334,10 @@ export class SecureYamlParser {
 
     // Fix #908: YAML bomb detection — previously skipped, allowing bomb payloads
     // through MCP-AQL create dispatcher and web routes that use parseRawYaml().
-    if (!ContentValidator.validateYamlContent(yamlContent)) {
+    // Issue #2329: pass maxSize through — validateYamlContent's own default cap is
+    // 64KB (frontmatter-sized), which rejected larger pure-YAML documents even
+    // when the caller allowed them.
+    if (!ContentValidator.validateYamlContent(yamlContent, maxSize)) {
       SecurityMonitor.logSecurityEvent({
         type: 'YAML_INJECTION_ATTEMPT',
         severity: 'CRITICAL',

--- a/src/storage/MemoryMetadataExtractor.ts
+++ b/src/storage/MemoryMetadataExtractor.ts
@@ -10,12 +10,16 @@
 
 import { SecureYamlParser } from '../security/secureYamlParser.js';
 import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
+import { MEMORY_CONSTANTS } from '../elements/memories/constants.js';
 import type { ElementIndexEntry } from './types.js';
 import { logger } from '../utils/logger.js';
 
 export class MemoryMetadataExtractor {
-  /** Align with SecureYamlParser default raw YAML limit (64KB). */
-  private static readonly MAX_YAML_SIZE = 64 * 1024;
+  /**
+   * Align with the memory save/load limit (256KB). Issue #2329: this was 64KB,
+   * so memories that grew past it indexed as 'unnamed' with default metadata.
+   */
+  private static readonly MAX_YAML_SIZE = MEMORY_CONSTANTS.MAX_YAML_SIZE;
 
   /**
    * Extract index-relevant metadata from raw YAML memory content.

--- a/tests/integration/mcp-aql/memory-addentry-persistence.test.ts
+++ b/tests/integration/mcp-aql/memory-addentry-persistence.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Integration tests for Issue #2329 — addEntry reported success while entries
+ * were silently never persisted to disk.
+ *
+ * Two production failure modes are covered:
+ * 1. Memories whose serialized YAML passed 64KB hit a hidden frontmatter-sized
+ *    cap on the save path; every save threw, the deferred (debounced) save
+ *    swallowed the error, and addEntry kept returning entry ids for data that
+ *    only existed in process RAM.
+ * 2. Any deferred save failure (e.g. disk error) was logged and forgotten; the
+ *    next addEntry accepted more entries behind the same failure.
+ *
+ * Fixed behavior under test:
+ * - addEntry on a >64KB memory succeeds AND the entries reach disk
+ * - addEntry that would push a memory past MAX_YAML_SIZE errors and rolls back
+ * - after a deferred save failure, the next addEntry retries the save and
+ *   surfaces the error instead of silently accepting more entries
+ */
+
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { DollhouseMCPServer } from '../../../src/index.js';
+import { DollhouseContainer } from '../../../src/di/Container.js';
+import { MCPAQLHandler } from '../../../src/handlers/mcp-aql/MCPAQLHandler.js';
+import { MemoryManager } from '../../../src/elements/memories/MemoryManager.js';
+import { MEMORY_CONSTANTS } from '../../../src/elements/memories/constants.js';
+import { createPortfolioTestEnvironment, preConfirmAllOperations, type PortfolioTestEnvironment } from '../../helpers/portfolioTestHelper.js';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+describe('Memory addEntry persistence (#2329)', () => {
+  let env: PortfolioTestEnvironment;
+  let container: DollhouseContainer;
+  let server: DollhouseMCPServer;
+  let mcpAqlHandler: MCPAQLHandler;
+  let memoryManager: MemoryManager;
+
+  beforeEach(async () => {
+    env = await createPortfolioTestEnvironment('mcp-aql-memory-persistence');
+    container = new DollhouseContainer();
+    server = new DollhouseMCPServer(container);
+    await server.listPersonas(); // Initialize server
+    preConfirmAllOperations(container);
+    mcpAqlHandler = container.resolve<MCPAQLHandler>('mcpAqlHandler');
+    memoryManager = container.resolve<MemoryManager>('MemoryManager');
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await server.dispose();
+    await env.cleanup();
+  });
+
+  async function createMemory(name: string) {
+    const result = await mcpAqlHandler.handleCreate({
+      operation: 'create_element',
+      params: {
+        element_name: name,
+        element_type: 'memories',
+        description: `Test memory ${name}`,
+      },
+    });
+    expect(result.success).toBe(true);
+  }
+
+  function addEntry(name: string, content: string) {
+    return mcpAqlHandler.handleCreate({
+      operation: 'addEntry',
+      params: { element_name: name, content },
+    });
+  }
+
+  /** Locate a memory's YAML file on disk (date-sharded folders). */
+  async function findMemoryFile(name: string): Promise<string> {
+    const memoriesDir = path.join(env.testDir, 'memories');
+    const files = await fs.readdir(memoriesDir, { recursive: true });
+    const match = files.find(f => String(f).includes(name) && String(f).endsWith('.yaml'));
+    expect(match).toBeDefined();
+    return path.join(memoriesDir, String(match));
+  }
+
+  // ~17KB of plain prose per entry — several of these push the serialized YAML
+  // past the old hidden 64KB cap while staying under MAX_ENTRY_SIZE (100KB).
+  const bigEntry = (marker: string) =>
+    `${marker} ` + 'research finding lorem ipsum dolor sit amet consectetur adipiscing elit '.repeat(240);
+
+  it('persists entries to disk after the memory grows past 64KB (#2329 repro)', async () => {
+    await createMemory('forge-findings-2329');
+
+    for (let i = 0; i < 6; i++) {
+      const result = await addEntry('forge-findings-2329', bigEntry(`entry-${i}`));
+      expect(result.success).toBe(true);
+    }
+
+    // Force the debounced save to run now (same code path as the timer).
+    await mcpAqlHandler.flushPendingSaves();
+
+    const filePath = await findMemoryFile('forge-findings-2329');
+    const stat = await fs.stat(filePath);
+    expect(stat.size).toBeGreaterThan(64 * 1024);
+
+    const raw = await fs.readFile(filePath, 'utf-8');
+    // First and last entries both present — nothing silently dropped.
+    expect(raw).toContain('entry-0');
+    expect(raw).toContain('entry-5');
+  });
+
+  it('returns an error and rolls back the entry when the memory cannot be persisted', async () => {
+    await createMemory('overflow-2329');
+
+    // ~90KB per entry: two fit under MAX_YAML_SIZE (256KB), the third does not.
+    const hugeEntry = (marker: string) =>
+      `${marker} ` + 'oversized entry content padding words repeated for scale '.repeat(1550);
+
+    expect((await addEntry('overflow-2329', hugeEntry('huge-1'))).success).toBe(true);
+    expect((await addEntry('overflow-2329', hugeEntry('huge-2'))).success).toBe(true);
+
+    const overflowResult = await addEntry('overflow-2329', hugeEntry('huge-3'));
+    expect(overflowResult.success).toBe(false);
+    if (!overflowResult.success) {
+      expect(overflowResult.error).toContain('NOT saved');
+      expect(overflowResult.error).toContain('maximum serialized size');
+    }
+
+    // The rejected entry must not linger in RAM: the memory still persists fine
+    // and the file contains the accepted entries but not the rejected one.
+    await mcpAqlHandler.flushPendingSaves();
+    const filePath = await findMemoryFile('overflow-2329');
+    const raw = await fs.readFile(filePath, 'utf-8');
+    expect(raw.length).toBeLessThanOrEqual(MEMORY_CONSTANTS.MAX_YAML_SIZE);
+    expect(raw).toContain('huge-1');
+    expect(raw).toContain('huge-2');
+    expect(raw).not.toContain('huge-3');
+  });
+
+  it('surfaces a failed deferred save on the next addEntry and recovers', async () => {
+    await createMemory('flaky-disk-2329');
+
+    expect((await addEntry('flaky-disk-2329', 'first entry before failure')).success).toBe(true);
+
+    // Simulate a one-off disk failure on the deferred save.
+    const saveSpy = jest.spyOn(memoryManager, 'save')
+      .mockRejectedValueOnce(new Error('EIO: simulated disk failure'));
+    await mcpAqlHandler.flushPendingSaves();
+    expect(saveSpy).toHaveBeenCalled();
+
+    // Next addEntry must first retry the failed save (succeeds now that the
+    // mock is consumed), then proceed normally.
+    const result = await addEntry('flaky-disk-2329', 'second entry after recovery');
+    expect(result.success).toBe(true);
+
+    await mcpAqlHandler.flushPendingSaves();
+    const filePath = await findMemoryFile('flaky-disk-2329');
+    const raw = await fs.readFile(filePath, 'utf-8');
+    expect(raw).toContain('first entry before failure');
+    expect(raw).toContain('second entry after recovery');
+  });
+
+  it('does not resurrect a deleted memory from the failure ledger (Codex P2)', async () => {
+    await createMemory('doomed-2329');
+    expect((await addEntry('doomed-2329', 'entry that will fail to save')).success).toBe(true);
+
+    // Deferred save fails once → failure ledger holds the in-RAM instance.
+    jest.spyOn(memoryManager, 'save')
+      .mockRejectedValueOnce(new Error('EIO: simulated disk failure'));
+    await mcpAqlHandler.flushPendingSaves();
+    jest.restoreAllMocks();
+
+    // Delete the memory — must also drop the ledger entry.
+    const deleteResult = await mcpAqlHandler.handleDelete({
+      operation: 'delete_element',
+      params: { element_name: 'doomed-2329', element_type: 'memories' },
+    });
+    expect(deleteResult.success).toBe(true);
+
+    // A later flush must NOT re-save the retained instance and resurrect the file.
+    await mcpAqlHandler.flushPendingSaves();
+    const memoriesDir = path.join(env.testDir, 'memories');
+    const files = await fs.readdir(memoriesDir, { recursive: true });
+    expect(files.filter(f => String(f).includes('doomed-2329'))).toHaveLength(0);
+  });
+
+  it('reports an error when both the deferred save and the retry fail', async () => {
+    await createMemory('dead-disk-2329');
+
+    expect((await addEntry('dead-disk-2329', 'entry before persistent failure')).success).toBe(true);
+
+    // Persistent failure: deferred save fails AND the retry fails.
+    jest.spyOn(memoryManager, 'save')
+      .mockRejectedValue(new Error('EIO: simulated persistent disk failure'));
+    await mcpAqlHandler.flushPendingSaves();
+
+    const result = await addEntry('dead-disk-2329', 'entry that must be rejected');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('NOT saved');
+      expect(result.error).toContain('save failure');
+    }
+  });
+});

--- a/tests/unit/elements/memories/MemoryManager.saveLimits.test.ts
+++ b/tests/unit/elements/memories/MemoryManager.saveLimits.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression tests for Issue #2329 — memories whose serialized YAML exceeded
+ * 64KB (MAX_YAML_LENGTH, a frontmatter limit) failed EVERY save with
+ * "YAML content exceeds maximum allowed size", while the deferred save path
+ * swallowed the error and addEntry kept reporting success. Entries lived only
+ * in process RAM and were lost on restart.
+ *
+ * These tests pin the corrected behavior:
+ * - serialized memories up to MAX_YAML_SIZE (256KB, the load-path limit) save fine
+ * - memories past MAX_YAML_SIZE are rejected with an actionable error
+ * - assertPersistable() reports the same verdict as save() without writing
+ */
+
+import { MemoryManager } from '../../../../src/elements/memories/MemoryManager.js';
+import { Memory } from '../../../../src/elements/memories/Memory.js';
+import { PortfolioManager } from '../../../../src/portfolio/PortfolioManager.js';
+import { FileLockManager } from '../../../../src/security/fileLockManager.js';
+import { FileOperationsService } from '../../../../src/services/FileOperationsService.js';
+import { SerializationService } from '../../../../src/services/SerializationService.js';
+import { DollhouseContainer } from '../../../../src/di/Container.js';
+import { ValidationRegistry } from '../../../../src/services/validation/ValidationRegistry.js';
+import { TriggerValidationService } from '../../../../src/services/validation/TriggerValidationService.js';
+import { ValidationService } from '../../../../src/services/validation/ValidationService.js';
+import { MEMORY_CONSTANTS } from '../../../../src/elements/memories/constants.js';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { createTestMetadataService } from '../../../helpers/di-mocks.js';
+import { ElementEventDispatcher } from '../../../../src/events/ElementEventDispatcher.js';
+import { createTestStorageFactory } from '../../../helpers/createTestStorageFactory.js';
+
+const metadataService = createTestMetadataService();
+
+/** Build a memory whose serialized YAML lands near the requested size. */
+async function buildMemoryOfSize(name: string, targetBytes: number): Promise<Memory> {
+  const memory = new Memory({
+    name,
+    description: `Sized test memory targeting ${targetBytes} bytes`,
+  }, metadataService);
+
+  // ~16KB of plain prose per entry — well under MAX_ENTRY_SIZE (100KB) and
+  // survives sanitization unchanged.
+  const chunk = 'research finding lorem ipsum dolor sit amet consectetur adipiscing elit '.padEnd(80, 'x');
+  const entryContent = chunk.repeat(200);
+  const entryCount = Math.ceil(targetBytes / entryContent.length);
+  for (let i = 0; i < entryCount; i++) {
+    await memory.addEntry(`entry-${i}: ${entryContent}`, ['sized']);
+  }
+  return memory;
+}
+
+describe('MemoryManager save size limits (#2329)', () => {
+  let container: InstanceType<typeof DollhouseContainer>;
+  let manager: InstanceType<typeof MemoryManager>;
+  let testDir: string;
+  let memoriesDir: string;
+
+  beforeAll(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memory-save-limits-test-'));
+    process.env.DOLLHOUSE_PORTFOLIO_DIR = testDir;
+
+    container = new DollhouseContainer();
+    container.register('FileLockManager', () => new FileLockManager());
+    container.register('FileOperationsService', () => new FileOperationsService(container.resolve('FileLockManager')));
+    container.register('PortfolioManager', () => new PortfolioManager(container.resolve('FileOperationsService'), { baseDir: testDir }));
+    container.register('SerializationService', () => new SerializationService());
+    container.register('ValidationRegistry', () => new ValidationRegistry(
+      new ValidationService(),
+      new TriggerValidationService(),
+      metadataService
+    ));
+    container.register('MemoryManager', () => new MemoryManager({
+      portfolioManager: container.resolve('PortfolioManager'),
+      fileLockManager: container.resolve('FileLockManager'),
+      fileOperationsService: container.resolve('FileOperationsService'),
+      validationRegistry: container.resolve('ValidationRegistry'),
+      serializationService: container.resolve('SerializationService'),
+      metadataService,
+      eventDispatcher: new ElementEventDispatcher(),
+      storageLayerFactory: createTestStorageFactory(),
+    }));
+
+    manager = container.resolve('MemoryManager');
+    memoriesDir = path.join(testDir, 'memories');
+    await fs.mkdir(memoriesDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await container.dispose();
+    await fs.rm(testDir, { recursive: true, force: true });
+    delete process.env.DOLLHOUSE_PORTFOLIO_DIR;
+  });
+
+  it('saves and reloads a memory whose serialized YAML exceeds 64KB (#2329 repro)', async () => {
+    const memory = await buildMemoryOfSize('Large Memory 2329', 80 * 1024);
+
+    await manager.save(memory, 'large-memory-2329.yaml');
+
+    const filePath = path.join(memoriesDir, 'large-memory-2329.yaml');
+    const stat = await fs.stat(filePath);
+    // The whole point: past the old 64KB frontmatter cap, still persisted.
+    expect(stat.size).toBeGreaterThan(64 * 1024);
+
+    const raw = await fs.readFile(filePath, 'utf-8');
+    expect(raw).toContain('entry-0:');
+
+    const loaded = await manager.load('large-memory-2329.yaml');
+    const entries = await loaded.search({});
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a save past MAX_YAML_SIZE with an actionable error and writes nothing', async () => {
+    const memory = await buildMemoryOfSize('Oversized Memory 2329', MEMORY_CONSTANTS.MAX_YAML_SIZE + 32 * 1024);
+
+    await expect(manager.save(memory, 'oversized-memory-2329.yaml'))
+      .rejects.toThrow('maximum serialized size');
+
+    await expect(fs.stat(path.join(memoriesDir, 'oversized-memory-2329.yaml')))
+      .rejects.toThrow();
+  });
+
+  it('assertPersistable passes for a >64KB memory without writing anything', async () => {
+    const memory = await buildMemoryOfSize('Persistable Check', 80 * 1024);
+
+    await expect(manager.assertPersistable(memory)).resolves.toBeUndefined();
+
+    // Pre-flight only — no file may appear.
+    const files = await fs.readdir(memoriesDir, { recursive: true });
+    expect(files.filter(f => String(f).includes('persistable-check'))).toHaveLength(0);
+  });
+
+  it('assertPersistable rejects a memory past MAX_YAML_SIZE with the same error as save', async () => {
+    const memory = await buildMemoryOfSize('Unpersistable Check', MEMORY_CONSTANTS.MAX_YAML_SIZE + 32 * 1024);
+
+    await expect(manager.assertPersistable(memory))
+      .rejects.toThrow('maximum serialized size');
+  });
+});

--- a/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
+++ b/tests/unit/handlers/mcp-aql/MCPAQLHandler.test.ts
@@ -82,9 +82,13 @@ describe('MCPAQLHandler', () => {
         find: jest.fn().mockResolvedValue({
           metadata: { name: TEST_MEMORY_NAME },
           addEntry: jest.fn().mockResolvedValue({ entryId: 'entry-1' }),
+          removeEntry: jest.fn().mockReturnValue(true),
+          getEntries: jest.fn().mockReturnValue(new Map()),
           clearAll: jest.fn().mockResolvedValue({ cleared: true }),
         }),
         save: jest.fn().mockResolvedValue(undefined),
+        // Issue #2329: addEntry pre-flights persistence before reporting success
+        assertPersistable: jest.fn().mockResolvedValue(undefined),
       },
       agentManager: {
         executeAgent: jest.fn().mockResolvedValue({ result: 'executed' }),
@@ -1644,9 +1648,13 @@ describe('MCPAQLHandler', () => {
           find: jest.fn().mockResolvedValue({
             metadata: { name: TEST_MEMORY_NAME },
             addEntry: jest.fn().mockResolvedValue({ entryId: 'entry-1' }),
+            removeEntry: jest.fn().mockReturnValue(true),
+            getEntries: jest.fn().mockReturnValue(new Map()),
             clearAll: jest.fn().mockResolvedValue({ cleared: true }),
           }),
           save: jest.fn().mockResolvedValue(undefined),
+          // Issue #2329: addEntry pre-flights persistence before reporting success
+          assertPersistable: jest.fn().mockResolvedValue(undefined),
         },
         agentManager: {
           executeAgent: jest.fn().mockResolvedValue({ result: 'executed' }),

--- a/tests/unit/handlers/mcp-aql/UnifiedEndpoint.test.ts
+++ b/tests/unit/handlers/mcp-aql/UnifiedEndpoint.test.ts
@@ -39,9 +39,13 @@ describe('UnifiedEndpoint', () => {
         find: jest.fn().mockResolvedValue({
           metadata: { name: 'test-memory' },
           addEntry: jest.fn().mockResolvedValue({ entryId: 'entry-1' }),
+          removeEntry: jest.fn().mockReturnValue(true),
+          getEntries: jest.fn().mockReturnValue(new Map()),
           clearAll: jest.fn().mockResolvedValue({ cleared: true }),
         }),
         save: jest.fn().mockResolvedValue(undefined),
+        // Issue #2329: addEntry pre-flights persistence before reporting success
+        assertPersistable: jest.fn().mockResolvedValue(undefined),
       },
       agentManager: {
         executeAgent: jest.fn().mockResolvedValue({ result: 'executed' }),

--- a/tests/unit/storage/MemoryMetadataExtractor.test.ts
+++ b/tests/unit/storage/MemoryMetadataExtractor.test.ts
@@ -145,7 +145,9 @@ payload: !!js/function "function () { return process.env; }"
     });
 
     it('should fail closed for oversized YAML input', () => {
-      const hugeValue = 'a'.repeat(70 * 1024);
+      // Issue #2329: the cap is MAX_YAML_SIZE (256KB, matching save/load) — a
+      // 70KB memory is legitimate and must extract; past 256KB fails closed.
+      const hugeValue = 'a'.repeat(280 * 1024);
       const raw = `
 name: Oversized
 description: ${hugeValue}
@@ -310,6 +312,30 @@ tags:
       expect(result.description).toBe('Session for café notes');
       expect(result.author).toBe('José');
       expect(result.tags).toEqual(['café', 'notes']);
+    });
+
+    it('should extract metadata from memory files larger than 64KB (#2329)', () => {
+      // Memories up to MAX_YAML_SIZE (256KB) are valid on disk; the extractor
+      // previously capped at 64KB and indexed such files as 'unnamed'.
+      const bigEntry = 'research finding lorem ipsum dolor sit amet '.repeat(400);
+      const entries = Array.from({ length: 6 }, (_, i) =>
+        `  - content: "entry-${i} ${bigEntry}"`
+      ).join('\n');
+      const raw = `
+metadata:
+  name: Large Memory
+  description: Grown past the old 64KB extractor cap
+  version: 1.0.0
+entries:
+${entries}
+`;
+      expect(raw.length).toBeGreaterThan(64 * 1024);
+
+      const result = MemoryMetadataExtractor.extractMetadata(raw, 'large.yml');
+
+      expect(result.name).toBe('Large Memory');
+      expect(result.description).toBe('Grown past the old 64KB extractor cap');
+      expect(result.totalEntries).toBe(6);
     });
   });
 


### PR DESCRIPTION
Closes #2335. Ports the v2.0.36 hotfix (#2330 develop / #2332 main) into beta.

## Why this is a hand-port, not a cherry-pick

Beta's sub-handler refactor moved memory save logic into `MemorySaveHandler` and rebuilt `MemoryManager.save()` around `BaseElementManager.save()` with a `validateSerializedContent` override — the develop commits conflict structurally. The same guarantees are re-implemented in beta's architecture:

- **Root-cause fix**: `validateSerializedContent` capped its gatekeeper parse at `MAX_YAML_LENGTH` (64KB, a frontmatter limit) — every save of a memory past 64KB threw, and the debounced save swallowed the error after `addEntry` returned success. The cap is now `MEMORY_CONSTANTS.MAX_YAML_SIZE` (256KB, matching load), with the 2MB file gate tightened to match and bomb detection covering all sizes.
- **Fail loudly**: `addEntry` pre-flights `assertPersistable()` before reporting success and rolls back on failure; the failure ledger retains the failing instance (survives cache eviction) and retries on the next addEntry, at flush, and at session cleanup; a per-key attempt counter prevents stale in-flight saves from clearing newer failures.
- **Beta-specific fix**: `cleanupSession` previously **dropped** pending debounced saves when a session ended — entries added within the 2s window were silently discarded. It now flushes them.
- **Delete safety**: `delete_element` drops the memory's save bookkeeping so the flush retry can't resurrect a deleted file (Codex finding on #2330).
- Cleanly applied from develop: `MemoryMetadataExtractor` 64KB→256KB (index correctness for grown memories), `validateYamlContent` clamped `maxLength` param, `parseRawYaml` cap forwarding, `Memory.removeEntry` search-index consistency, constants doc.

## Testing

- develop's regression suites ported: `MemoryManager.saveLimits.test.ts` (adapted to beta's options-object constructor), `memory-addentry-persistence.test.ts`, extractor >64KB test, handler mock updates.
- Local: typecheck + lint clean, **2009 tests passing** across the affected suites. The only local failures are pre-existing on clean beta (`jose`/`oidc-provider` ESM transform errors in `Memory.wiring.test.ts` and the integration suites — reproduced identically without this change).

## Review focus

The `MemorySaveHandler` rewrite is the core of the port — the develop equivalent went through 3 review rounds (self-review fan-out + Codex + claudebot) on #2330; this file re-expresses that final state in beta's session-keyed idiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5NVm7Bn9QCmshrLK84X9t