### PR TITLE
fix: address Codex P2 findings on beta memory-fix port (#2336)

### DIFF
--- a/src/elements/memories/MemoryManager.ts
+++ b/src/elements/memories/MemoryManager.ts
@@ -685,6 +685,24 @@ export class MemoryManager extends BaseElementManager<Memory> {
   }
 
   /**
+   * Issue #2329 (Codex P1s, PR #2337): resolve a context-independent probe
+   * token for later deletion checks. MUST be called while the owning session's
+   * context is still live: `memoriesDir` is a dynamic getter that routes to the
+   * per-user portfolio only when a session context is active, so a path
+   * resolved at probe time (e.g. during dispose/cleanup) could point at the
+   * wrong portfolio and produce a false "deleted" verdict.
+   *
+   * Returns the element UUID in DB mode, the absolute file path in file mode,
+   * or null for a memory that was never persisted.
+   */
+  getMemoryProbeToken(element: Memory): string | null {
+    const persistedPath = element.getFilePath();
+    if (!persistedPath) return null;
+    if (isWritableStorageLayer(this.storageLayer)) return persistedPath;
+    return path.join(this.memoriesDir, persistedPath);
+  }
+
+  /**
    * Issue #2329 (Codex P1, PR #2337): positive deletion check for failure-ledger
    * retries. Returns true ONLY when the storage layer confirms absence (ENOENT);
    * transient lookup failures THROW so callers can fail closed — retry the save —
@@ -692,23 +710,23 @@ export class MemoryManager extends BaseElementManager<Memory> {
    * deliberately not find(): find() swallows storage errors into an empty list,
    * which conflates "deleted" with "lookup failed".
    *
-   * A memory with no persisted path was never saved and returns false — the
+   * A null token means the memory was never persisted and returns false — the
    * retry IS its first persist.
    */
-  async isMemoryDeleted(element: Memory): Promise<boolean> {
-    const persistedPath = element.getFilePath();
-    if (!persistedPath) return false;
+  async isMemoryDeletedAt(probeToken: string | null): Promise<boolean> {
+    if (!probeToken) return false;
 
     try {
       if (isWritableStorageLayer(this.storageLayer)) {
-        // DB mode: persistedPath is the element UUID. readContent throws
+        // DB mode: the token is the element UUID. readContent throws
         // code='ENOENT' for a missing row; query/connection failures throw
         // other errors and propagate.
-        await this.storageLayer.readContent(persistedPath);
+        await this.storageLayer.readContent(probeToken);
       } else {
-        // File mode: persistedPath is relative to memoriesDir. fs.stat throws
-        // code='ENOENT' for a missing file; other I/O errors propagate.
-        await fs.stat(path.join(this.memoriesDir, persistedPath));
+        // File mode: the token is an absolute path captured under the owning
+        // session's context. fs.stat throws code='ENOENT' for a missing file;
+        // other I/O errors propagate.
+        await fs.stat(probeToken);
       }
       return false;
     } catch (err) {

--- a/src/elements/memories/MemoryManager.ts
+++ b/src/elements/memories/MemoryManager.ts
@@ -40,6 +40,7 @@ import { ValidationService } from '../../services/validation/ValidationService.j
 import { SerializationService } from '../../services/SerializationService.js';
 import { MetadataService } from '../../services/MetadataService.js';
 import * as path from 'path';
+import * as fs from 'node:fs/promises';
 import * as crypto from 'crypto';
 import { ElementMessages } from '../../utils/elementMessages.js';
 import { sanitizeGatekeeperPolicy, getGatekeeperAuthoringErrors } from '../../handlers/mcp-aql/policies/ElementPolicies.js';
@@ -681,6 +682,39 @@ export class MemoryManager extends BaseElementManager<Memory> {
   async assertPersistable(element: Memory): Promise<void> {
     const yamlContent = await this.serializeElement(element);
     this.validateSerializedContent(yamlContent);
+  }
+
+  /**
+   * Issue #2329 (Codex P1, PR #2337): positive deletion check for failure-ledger
+   * retries. Returns true ONLY when the storage layer confirms absence (ENOENT);
+   * transient lookup failures THROW so callers can fail closed — retry the save —
+   * instead of dropping the last in-RAM copy of unpersisted entries. This is
+   * deliberately not find(): find() swallows storage errors into an empty list,
+   * which conflates "deleted" with "lookup failed".
+   *
+   * A memory with no persisted path was never saved and returns false — the
+   * retry IS its first persist.
+   */
+  async isMemoryDeleted(element: Memory): Promise<boolean> {
+    const persistedPath = element.getFilePath();
+    if (!persistedPath) return false;
+
+    try {
+      if (isWritableStorageLayer(this.storageLayer)) {
+        // DB mode: persistedPath is the element UUID. readContent throws
+        // code='ENOENT' for a missing row; query/connection failures throw
+        // other errors and propagate.
+        await this.storageLayer.readContent(persistedPath);
+      } else {
+        // File mode: persistedPath is relative to memoriesDir. fs.stat throws
+        // code='ENOENT' for a missing file; other I/O errors propagate.
+        await fs.stat(path.join(this.memoriesDir, persistedPath));
+      }
+      return false;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return true;
+      throw err;
+    }
   }
 
   /**

--- a/src/handlers/mcp-aql/MemorySaveHandler.ts
+++ b/src/handlers/mcp-aql/MemorySaveHandler.ts
@@ -18,11 +18,17 @@ interface PendingSave {
  * exist only in that instance, so recovery must retry it (a freshly loaded
  * instance would lack them), and holding the reference keeps it alive across
  * cache eviction.
+ *
+ * probeToken (Codex P1, PR #2337): the deletion-probe target resolved at
+ * record time, while the owning session's path context is still live. Probing
+ * via live resolution during dispose/cleanup would fall back to the flat
+ * portfolio dir in per-user HTTP mode and misread a live memory as deleted.
  */
 interface FailedSave {
   error: Error;
   memory: Memory;
   manager: MemoryManager;
+  probeToken: string | null;
 }
 
 interface SaveFrequencyCounter {
@@ -157,7 +163,7 @@ export class MemorySaveHandler {
   ): Promise<boolean> {
     let confirmedDeleted = false;
     try {
-      confirmedDeleted = await entry.manager.isMemoryDeleted(entry.memory);
+      confirmedDeleted = await entry.manager.isMemoryDeletedAt(entry.probeToken);
     } catch (probeErr) {
       logger.warn(`[MCPAQLHandler] ${context}: could not confirm whether memory '${key}' still exists (${probeErr instanceof Error ? probeErr.message : probeErr}); failing closed and retrying the save`);
     }
@@ -262,6 +268,10 @@ export class MemorySaveHandler {
           error: err instanceof Error ? err : new Error(String(err)),
           memory,
           manager,
+          // Codex P1 (PR #2337): resolve the deletion-probe target NOW, while
+          // the owning session's path context is live — dispose-time
+          // resolution can point at the wrong portfolio in per-user mode.
+          probeToken: manager.getMemoryProbeToken(memory),
         });
       }
       throw err;

--- a/src/handlers/mcp-aql/MemorySaveHandler.ts
+++ b/src/handlers/mcp-aql/MemorySaveHandler.ts
@@ -136,25 +136,32 @@ export class MemorySaveHandler {
   }
 
   /**
-   * Issue #2329 (Codex review, PR #2336): retry a failure-ledger entry only if
-   * the memory still exists — another session sharing the same portfolio may
-   * have deleted it, and re-saving the retained instance would resurrect the
-   * deleted memory. The existence check goes through the entry's OWN manager,
-   * so in multi-user mode it resolves against the correct user's portfolio.
+   * Issue #2329 (Codex review, PR #2336): retry a failure-ledger entry unless
+   * the memory is POSITIVELY confirmed deleted — another session sharing the
+   * same portfolio may have deleted it, and re-saving the retained instance
+   * would resurrect the deleted memory. The check goes through the entry's OWN
+   * manager, so in multi-user mode it resolves against the correct portfolio.
+   *
+   * Codex P1 (PR #2337): the check must fail closed. isMemoryDeleted() returns
+   * true only on a storage-confirmed ENOENT and throws on transient lookup
+   * failures; on any ambiguity we RETRY rather than drop — the ledger holds the
+   * last in-RAM copy of unpersisted entries, and dropping it on a transient
+   * read blip would be exactly the silent loss #2329 eliminated. The worst case
+   * of retrying under ambiguity is resurrecting a deleted memory, which is
+   * recoverable; dropped entries are not.
    */
   private async retryLedgerEntryIfAlive(
     key: string,
     entry: FailedSave,
     context: string,
   ): Promise<boolean> {
-    const memoryName = entry.memory.metadata.name;
-    let exists = true;
+    let confirmedDeleted = false;
     try {
-      exists = await entry.manager.find(m => m.metadata.name === memoryName) !== undefined;
-    } catch {
-      // Lookup failure must not drop data — proceed and let the save decide.
+      confirmedDeleted = await entry.manager.isMemoryDeleted(entry.memory);
+    } catch (probeErr) {
+      logger.warn(`[MCPAQLHandler] ${context}: could not confirm whether memory '${key}' still exists (${probeErr instanceof Error ? probeErr.message : probeErr}); failing closed and retrying the save`);
     }
-    if (!exists) {
+    if (confirmedDeleted) {
       logger.info(`[MCPAQLHandler] ${context}: memory '${key}' was deleted; dropping failed-save ledger entry instead of retrying`);
       this.failedMemorySaves.delete(key);
       this.memorySaveAttempts.delete(key);

--- a/src/handlers/mcp-aql/MemorySaveHandler.ts
+++ b/src/handlers/mcp-aql/MemorySaveHandler.ts
@@ -98,9 +98,7 @@ export class MemorySaveHandler {
     }
     for (const [key, entry] of this.failedMemorySaves) {
       if (key.startsWith(prefix) && !this.pendingSaves.has(key)) {
-        this.saveMemoryTracked(key, entry.memory, entry.manager).catch((err) => {
-          logger.error(`[MCPAQLHandler] Session-cleanup retry failed for memory '${key}' — unpersisted entries will be lost: ${err}`);
-        }).finally(() => {
+        this.retryLedgerEntryIfAlive(key, entry, 'Session-cleanup').finally(() => {
           // Session is gone either way — release the retained instance.
           this.failedMemorySaves.delete(key);
           this.memorySaveAttempts.delete(key);
@@ -116,6 +114,14 @@ export class MemorySaveHandler {
    * and the flush/retry paths re-save it, resurrecting the deleted file. A save
    * already in flight when the delete lands can still race the file back — that
    * narrow window is inherent to fire-and-forget writes and unchanged here.
+   *
+   * Scope: this clears the CURRENT session's bookkeeping only — keys are
+   * session-scoped, and in multi-user HTTP mode a same-named memory in another
+   * session may belong to a different user's portfolio, so clearing across
+   * sessions by name would drop a legitimate recovery record. Cross-session
+   * resurrection is prevented at the retry sites instead: every ledger retry
+   * first re-checks existence through the entry's own manager
+   * (retryLedgerEntryIfAlive), which resolves against the correct portfolio.
    */
   clearMemorySaveBookkeeping(memoryName: string): void {
     const key = this.saveKey(memoryName);
@@ -127,6 +133,40 @@ export class MemorySaveHandler {
     this.failedMemorySaves.delete(key);
     this.memorySaveAttempts.delete(key);
     this.saveFrequencyCounters.delete(key);
+  }
+
+  /**
+   * Issue #2329 (Codex review, PR #2336): retry a failure-ledger entry only if
+   * the memory still exists — another session sharing the same portfolio may
+   * have deleted it, and re-saving the retained instance would resurrect the
+   * deleted memory. The existence check goes through the entry's OWN manager,
+   * so in multi-user mode it resolves against the correct user's portfolio.
+   */
+  private async retryLedgerEntryIfAlive(
+    key: string,
+    entry: FailedSave,
+    context: string,
+  ): Promise<boolean> {
+    const memoryName = entry.memory.metadata.name;
+    let exists = true;
+    try {
+      exists = await entry.manager.find(m => m.metadata.name === memoryName) !== undefined;
+    } catch {
+      // Lookup failure must not drop data — proceed and let the save decide.
+    }
+    if (!exists) {
+      logger.info(`[MCPAQLHandler] ${context}: memory '${key}' was deleted; dropping failed-save ledger entry instead of retrying`);
+      this.failedMemorySaves.delete(key);
+      this.memorySaveAttempts.delete(key);
+      return false;
+    }
+    try {
+      await this.saveMemoryTracked(key, entry.memory, entry.manager);
+      return true;
+    } catch (err) {
+      logger.error(`[MCPAQLHandler] ${context} retry failed for memory '${key}' — unpersisted entries will be lost: ${err}`);
+      return false;
+    }
   }
 
   async dispose(): Promise<void> {
@@ -157,17 +197,14 @@ export class MemorySaveHandler {
         logger.error(`[MCPAQLHandler] Flush save failed for memory '${key}' (entries: ${entryCount}, pending remaining: ${pending.length}): ${err}`);
       }
     }
-    // Direct Map iteration is safe here: saveMemoryTracked only deletes the
-    // current key on success, which the iteration protocol tolerates.
-    for (const [key, { memory, manager }] of this.failedMemorySaves) {
+    // Direct Map iteration is safe here: retryLedgerEntryIfAlive only deletes
+    // the current key, which the iteration protocol tolerates.
+    for (const [key, entry] of this.failedMemorySaves) {
       if (flushedKeys.has(key)) continue; // just attempted above
-      try {
-        await this.saveMemoryTracked(key, memory, manager);
+      const recovered = await this.retryLedgerEntryIfAlive(key, entry, 'Final flush');
+      if (recovered) {
         this.debounceMetrics.written++;
         logger.info(`[MCPAQLHandler] Recovered previously failed save for memory '${key}' during flush`);
-      } catch (err) {
-        const entryCount = typeof memory.getEntries === 'function' ? memory.getEntries().size : 'unknown';
-        logger.error(`[MCPAQLHandler] Final flush retry failed for memory '${key}' (entries: ${entryCount}) — unpersisted entries will be lost if the process exits: ${err}`);
       }
     }
   }

--- a/src/storage/DatabaseMemoryStorageLayer.ts
+++ b/src/storage/DatabaseMemoryStorageLayer.ts
@@ -21,6 +21,7 @@ import type { UserIdResolver } from '../database/UserContext.js';
 import { isUniqueViolation, type DrizzleTx } from '../database/db-utils.js';
 import { MemoryMetadataExtractor } from './MemoryMetadataExtractor.js';
 import { SecureYamlParser } from '../security/secureYamlParser.js';
+import { MEMORY_CONSTANTS } from '../elements/memories/constants.js';
 import { AbstractDatabaseStorageLayer } from './AbstractDatabaseStorageLayer.js';
 import { logger } from '../utils/logger.js';
 import type { ElementIndexEntry } from './types.js';
@@ -374,7 +375,10 @@ export class DatabaseMemoryStorageLayer extends AbstractDatabaseStorageLayer {
   ): Promise<void> {
     let parsed: Record<string, unknown>;
     try {
-      parsed = SecureYamlParser.parseRawYaml(yamlContent, 64 * 1024);
+      // Issue #2329: cap matches the memory save/load limit (256KB) — the old
+      // 64KB frontmatter cap made entry sync silently skip for grown memories,
+      // leaving memory_entries stale while the element row persisted.
+      parsed = SecureYamlParser.parseRawYaml(yamlContent, MEMORY_CONSTANTS.MAX_YAML_SIZE);
     } catch (err) {
       // Parse failure drops entries silently — element row still persists.
       // Log so operators see skipped entry sync and can investigate corrupted YAML.
@@ -454,7 +458,9 @@ export class DatabaseMemoryStorageLayer extends AbstractDatabaseStorageLayer {
 
   private extractMemoryMetadata(content: string): Record<string, unknown> {
     try {
-      const parsed = SecureYamlParser.parseRawYaml(content, 64 * 1024);
+      // Issue #2329: same cap as save/load — a 64KB cap here returned empty
+      // metadata for any memory that grew past it.
+      const parsed = SecureYamlParser.parseRawYaml(content, MEMORY_CONSTANTS.MAX_YAML_SIZE);
       const { name, description, version, author, tags, entries, stats, ...rest } = parsed;
       const metadataObj = (rest.metadata && typeof rest.metadata === 'object' && !Array.isArray(rest.metadata))
         ? rest.metadata as Record<string, unknown>

--- a/tests/integration/database/DatabaseMemoryStorageLayer.test.ts
+++ b/tests/integration/database/DatabaseMemoryStorageLayer.test.ts
@@ -66,6 +66,33 @@ describe('DatabaseMemoryStorageLayer', () => {
     expect(entries[0].content).toBeTruthy();
   });
 
+  it('should sync entries for memories whose YAML exceeds 64KB (#2329)', async () => {
+    if (!dbAvailable) return;
+    const userId = await ensureTestUser();
+    const layer = new DatabaseMemoryStorageLayer(getTestDb(), fixedUserId(userId));
+
+    // Issue #2329: memories up to MAX_YAML_SIZE (256KB) are valid; entry sync
+    // previously parsed with a 64KB frontmatter cap and silently skipped,
+    // leaving memory_entries stale while the element row persisted.
+    const bigText = 'research finding lorem ipsum dolor sit amet '.repeat(400);
+    const content = buildMemoryContent('large-memory-2329', Array.from({ length: 6 }, (_, i) => ({
+      id: `big-entry-${i}`,
+      content: `entry-${i} ${bigText}`,
+    })));
+    expect(content.length).toBeGreaterThan(64 * 1024);
+
+    const elementId = await layer.writeContent('memories', 'large-memory-2329', content, {
+      author: '', version: '', description: '', tags: [],
+    });
+
+    const entries = await layer.getEntries(elementId);
+    expect(entries).toHaveLength(6);
+
+    const summaries = await layer.listSummaries();
+    const summary = summaries.find(s => s.name === 'large-memory-2329');
+    expect(summary?.totalEntries).toBe(6);
+  });
+
   it('should replace entries on update (not duplicate)', async () => {
     if (!dbAvailable) return;
     const userId = await ensureTestUser();

--- a/tests/unit/handlers/mcp-aql/MemorySaveHandler.ledger.test.ts
+++ b/tests/unit/handlers/mcp-aql/MemorySaveHandler.ledger.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for MemorySaveHandler's failure-ledger retry guard (#2329,
+ * Codex review on PR #2336).
+ *
+ * The ledger retains the failing Memory instance so recovery can re-save the
+ * exact state that was lost. But bookkeeping keys are session-scoped: if a
+ * DIFFERENT session (sharing the same portfolio) deletes the memory, this
+ * session's ledger entry survives — and a blind retry at flush would re-save
+ * the retained instance, resurrecting the deleted memory. Every ledger retry
+ * must therefore re-check existence through the entry's own manager first.
+ */
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { MemorySaveHandler } from '../../../../src/handlers/mcp-aql/MemorySaveHandler.js';
+import type { HandlerRegistry } from '../../../../src/handlers/mcp-aql/MCPAQLHandler.js';
+
+function makeMemory(name: string) {
+  return {
+    metadata: { name },
+    addEntry: jest.fn(async () => ({ id: 'entry-1' })),
+    removeEntry: jest.fn(() => true),
+    getEntries: jest.fn(() => new Map()),
+    clearAll: jest.fn(async () => undefined),
+  };
+}
+
+describe('MemorySaveHandler failure-ledger retry guard (#2329)', () => {
+  let memory: ReturnType<typeof makeMemory>;
+  let manager: { find: jest.Mock; save: jest.Mock; assertPersistable: jest.Mock };
+  let handler: MemorySaveHandler;
+
+  beforeEach(() => {
+    memory = makeMemory('doomed-memory');
+    manager = {
+      find: jest.fn(async () => memory),
+      save: jest.fn(async () => undefined),
+      assertPersistable: jest.fn(async () => undefined),
+    };
+    handler = new MemorySaveHandler(
+      { memoryManager: manager } as unknown as HandlerRegistry,
+      (name) => `session-a:${name}`,
+    );
+  });
+
+  async function seedFailedSave() {
+    // addEntry succeeds (pre-flight passes), then the deferred save fails at flush.
+    await handler.dispatch('addEntry', { element_name: 'doomed-memory', content: 'entry content' });
+    manager.save.mockRejectedValueOnce(new Error('EIO: simulated disk failure'));
+    await handler.flushPendingSaves();
+    expect(manager.save).toHaveBeenCalledTimes(1);
+  }
+
+  it('drops the ledger entry instead of retrying when the memory no longer exists', async () => {
+    await seedFailedSave();
+
+    // Another session (same portfolio) deleted the memory: find() now misses.
+    manager.find.mockResolvedValue(undefined);
+    manager.save.mockClear();
+
+    await handler.flushPendingSaves();
+    // No resurrection: the retained instance must NOT be re-saved.
+    expect(manager.save).not.toHaveBeenCalled();
+
+    // Ledger cleared: a further flush does nothing either.
+    await handler.flushPendingSaves();
+    expect(manager.save).not.toHaveBeenCalled();
+  });
+
+  it('retries and recovers when the memory still exists', async () => {
+    await seedFailedSave();
+    manager.save.mockClear();
+
+    await handler.flushPendingSaves();
+    expect(manager.save).toHaveBeenCalledTimes(1);
+    expect(manager.save).toHaveBeenCalledWith(memory);
+
+    // Success cleared the ledger — nothing left to retry.
+    manager.save.mockClear();
+    await handler.flushPendingSaves();
+    expect(manager.save).not.toHaveBeenCalled();
+  });
+
+  it('still retries when the existence check itself fails (lookup errors must not drop data)', async () => {
+    await seedFailedSave();
+    manager.find.mockRejectedValue(new Error('transient index failure'));
+    manager.save.mockClear();
+
+    await handler.flushPendingSaves();
+    expect(manager.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the same guard during session cleanup', async () => {
+    await seedFailedSave();
+    manager.find.mockResolvedValue(undefined);
+    manager.save.mockClear();
+
+    handler.cleanupSession('session-a');
+    // cleanupSession fires asynchronously; give the microtask queue a turn.
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(manager.save).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/handlers/mcp-aql/MemorySaveHandler.ledger.test.ts
+++ b/tests/unit/handlers/mcp-aql/MemorySaveHandler.ledger.test.ts
@@ -1,13 +1,17 @@
 /**
  * Unit tests for MemorySaveHandler's failure-ledger retry guard (#2329,
- * Codex review on PR #2336).
+ * Codex review on PR #2336, hardened per Codex P1 on PR #2337).
  *
  * The ledger retains the failing Memory instance so recovery can re-save the
  * exact state that was lost. But bookkeeping keys are session-scoped: if a
  * DIFFERENT session (sharing the same portfolio) deletes the memory, this
  * session's ledger entry survives — and a blind retry at flush would re-save
- * the retained instance, resurrecting the deleted memory. Every ledger retry
- * must therefore re-check existence through the entry's own manager first.
+ * the retained instance, resurrecting the deleted memory.
+ *
+ * The guard must fail closed (Codex P1): the ledger holds the LAST copy of
+ * unpersisted entries, so it is dropped only on a storage-confirmed deletion
+ * (manager.isMemoryDeleted() === true). Ambiguous lookups (probe throws)
+ * retry the save rather than drop.
  */
 
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
@@ -26,7 +30,12 @@ function makeMemory(name: string) {
 
 describe('MemorySaveHandler failure-ledger retry guard (#2329)', () => {
   let memory: ReturnType<typeof makeMemory>;
-  let manager: { find: jest.Mock; save: jest.Mock; assertPersistable: jest.Mock };
+  let manager: {
+    find: jest.Mock;
+    save: jest.Mock;
+    assertPersistable: jest.Mock;
+    isMemoryDeleted: jest.Mock;
+  };
   let handler: MemorySaveHandler;
 
   beforeEach(() => {
@@ -35,6 +44,7 @@ describe('MemorySaveHandler failure-ledger retry guard (#2329)', () => {
       find: jest.fn(async () => memory),
       save: jest.fn(async () => undefined),
       assertPersistable: jest.fn(async () => undefined),
+      isMemoryDeleted: jest.fn(async () => false),
     };
     handler = new MemorySaveHandler(
       { memoryManager: manager } as unknown as HandlerRegistry,
@@ -50,11 +60,11 @@ describe('MemorySaveHandler failure-ledger retry guard (#2329)', () => {
     expect(manager.save).toHaveBeenCalledTimes(1);
   }
 
-  it('drops the ledger entry instead of retrying when the memory no longer exists', async () => {
+  it('drops the ledger entry instead of retrying when deletion is storage-confirmed', async () => {
     await seedFailedSave();
 
-    // Another session (same portfolio) deleted the memory: find() now misses.
-    manager.find.mockResolvedValue(undefined);
+    // Another session (same portfolio) deleted the memory: storage confirms ENOENT.
+    manager.isMemoryDeleted.mockResolvedValue(true);
     manager.save.mockClear();
 
     await handler.flushPendingSaves();
@@ -80,18 +90,19 @@ describe('MemorySaveHandler failure-ledger retry guard (#2329)', () => {
     expect(manager.save).not.toHaveBeenCalled();
   });
 
-  it('still retries when the existence check itself fails (lookup errors must not drop data)', async () => {
+  it('fails closed and retries when the deletion probe throws (Codex P1: transient lookup failures must not drop the last copy)', async () => {
     await seedFailedSave();
-    manager.find.mockRejectedValue(new Error('transient index failure'));
+    manager.isMemoryDeleted.mockRejectedValue(new Error('transient storage read failure'));
     manager.save.mockClear();
 
     await handler.flushPendingSaves();
     expect(manager.save).toHaveBeenCalledTimes(1);
+    expect(manager.save).toHaveBeenCalledWith(memory);
   });
 
   it('applies the same guard during session cleanup', async () => {
     await seedFailedSave();
-    manager.find.mockResolvedValue(undefined);
+    manager.isMemoryDeleted.mockResolvedValue(true);
     manager.save.mockClear();
 
     handler.cleanupSession('session-a');

--- a/tests/unit/handlers/mcp-aql/MemorySaveHandler.ledger.test.ts
+++ b/tests/unit/handlers/mcp-aql/MemorySaveHandler.ledger.test.ts
@@ -34,7 +34,8 @@ describe('MemorySaveHandler failure-ledger retry guard (#2329)', () => {
     find: jest.Mock;
     save: jest.Mock;
     assertPersistable: jest.Mock;
-    isMemoryDeleted: jest.Mock;
+    isMemoryDeletedAt: jest.Mock;
+    getMemoryProbeToken: jest.Mock;
   };
   let handler: MemorySaveHandler;
 
@@ -44,7 +45,8 @@ describe('MemorySaveHandler failure-ledger retry guard (#2329)', () => {
       find: jest.fn(async () => memory),
       save: jest.fn(async () => undefined),
       assertPersistable: jest.fn(async () => undefined),
-      isMemoryDeleted: jest.fn(async () => false),
+      isMemoryDeletedAt: jest.fn(async () => false),
+      getMemoryProbeToken: jest.fn(() => '/portfolio/users/a/memories/doomed-memory.yaml'),
     };
     handler = new MemorySaveHandler(
       { memoryManager: manager } as unknown as HandlerRegistry,
@@ -63,11 +65,17 @@ describe('MemorySaveHandler failure-ledger retry guard (#2329)', () => {
   it('drops the ledger entry instead of retrying when deletion is storage-confirmed', async () => {
     await seedFailedSave();
 
+    // Codex P1 (PR #2337): the probe target must have been resolved when the
+    // failure was RECORDED (session context live), not at retry time — and the
+    // retry must probe that captured token.
+    expect(manager.getMemoryProbeToken).toHaveBeenCalledWith(memory);
+
     // Another session (same portfolio) deleted the memory: storage confirms ENOENT.
-    manager.isMemoryDeleted.mockResolvedValue(true);
+    manager.isMemoryDeletedAt.mockResolvedValue(true);
     manager.save.mockClear();
 
     await handler.flushPendingSaves();
+    expect(manager.isMemoryDeletedAt).toHaveBeenCalledWith('/portfolio/users/a/memories/doomed-memory.yaml');
     // No resurrection: the retained instance must NOT be re-saved.
     expect(manager.save).not.toHaveBeenCalled();
 
@@ -92,7 +100,7 @@ describe('MemorySaveHandler failure-ledger retry guard (#2329)', () => {
 
   it('fails closed and retries when the deletion probe throws (Codex P1: transient lookup failures must not drop the last copy)', async () => {
     await seedFailedSave();
-    manager.isMemoryDeleted.mockRejectedValue(new Error('transient storage read failure'));
+    manager.isMemoryDeletedAt.mockRejectedValue(new Error('transient storage read failure'));
     manager.save.mockClear();
 
     await handler.flushPendingSaves();
@@ -102,7 +110,7 @@ describe('MemorySaveHandler failure-ledger retry guard (#2329)', () => {
 
   it('applies the same guard during session cleanup', async () => {
     await seedFailedSave();
-    manager.isMemoryDeleted.mockResolvedValue(true);
+    manager.isMemoryDeletedAt.mockResolvedValue(true);
     manager.save.mockClear();
 
     handler.cleanupSession('session-a');


### PR DESCRIPTION
Follow-up to #2336, which merged before Codex's late review landed. Both P2 findings were valid and are fixed here:

**P2-1 — DB entry sync still capped at 64KB.** `DatabaseMemoryStorageLayer.syncEntriesInTx()` (and `extractMemoryMetadata()`, same bug) parsed with the 64KB frontmatter cap, so a DB-backed memory past 64KB persisted its element row while `memory_entries` silently went stale — wrong `totalEntries`, missed entry queries, empty metadata. Both now use `MEMORY_CONSTANTS.MAX_YAML_SIZE` (256KB). Added a Postgres-gated integration test syncing a >64KB memory.

**P2-2 — cross-session deleted-memory resurrection.** Bookkeeping keys are session-scoped, so `delete_element` in session B couldn't clear session A's failure-ledger record, and a later flush would re-save the retained instance. Note the fix is deliberately NOT "clear all sessions by name": in multi-user HTTP mode, a same-named memory in another session may belong to a **different user's portfolio**, and clearing it would drop a legitimate recovery record. Instead, every ledger retry (final flush + session cleanup) now re-checks existence through the entry's **own** manager — which resolves against the correct portfolio — and drops the record if the memory is gone. Lookup failures never drop data. Four unit tests cover drop-on-deleted, recover-on-alive, retry-on-lookup-error, and the session-cleanup path.

Replied inline on #2336 pointing here.

Local validation: typecheck + lint clean; 1,935 tests passing across the affected suites (only failures are the pre-existing `jose` ESM transform in `Memory.wiring.test.ts`, identical on clean beta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5NVm7Bn9QCmshrLK84X9t