### PR TITLE
hotfix(beta): stop NVM launcher tests from patching real MCP client configs (#2338)

### DIFF
--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -583,6 +583,13 @@ export function createSetupRoutes(opts?: {
   _installPermissionHook?: (client: string) => Promise<InstallPermissionHookResult>;
   /** Override permission hook status reconciler. For testing only. */
   _reconcilePermissionHookStatus?: (client: string) => Promise<PermissionHookStatus>;
+  /**
+   * Override the NVM launcher mitigation applied after a successful install.
+   * For testing only. Without this seam the install handler runs the real
+   * applyNvmLauncherIfNeeded against the real homedir(); on a machine WITH NVM
+   * that patches the developer's real client configs (issue #2338).
+   */
+  _applyNvmLauncher?: (client: string) => Promise<NvmLauncherResult>;
   /** Enable automatic hook asset repair during detect. Defaults off in tests. */
   _autoRepairPermissionHooksOnDetect?: boolean;
   /** Skip the sliding-window rate limiter. For testing only. */
@@ -600,6 +607,7 @@ export function createSetupRoutes(opts?: {
 } {
   const installer = opts?._runInstallMcp ?? runInstallMcp;
   const permissionHookInstaller = opts?._installPermissionHook ?? installPermissionHook;
+  const nvmLauncherApplier = opts?._applyNvmLauncher ?? applyNvmLauncherIfNeeded;
   const autoRepairPermissionHooksOnDetect = opts?._autoRepairPermissionHooksOnDetect ?? process.env.NODE_ENV !== 'test';
   const hookStatusReconciler = opts?._reconcilePermissionHookStatus ?? (async (client: string) =>
     reconcilePermissionHookStatus(client, { autoRepair: autoRepairPermissionHooksOnDetect }));
@@ -709,7 +717,8 @@ export function createSetupRoutes(opts?: {
       // Best-effort NVM mitigation (macOS/Linux only).
       // Extracted into applyNvmLauncherIfNeeded to keep this handler's
       // cognitive complexity within bounds (SonarCloud S3776).
-      const nvmResult = await applyNvmLauncherIfNeeded(normalizedClient);
+      // Injectable (_applyNvmLauncher) so tests don't touch the real homedir.
+      const nvmResult = await nvmLauncherApplier(normalizedClient);
 
       const nvmMitigationApplied = toNvmMitigationApplied(nvmResult);
 
@@ -1090,9 +1099,17 @@ function captureInstallAnalytics(event: string, properties: Record<string, unkno
 /** Result of attempting to apply the NVM launcher mitigation. */
 export type NvmLauncherResult = 'applied' | 'not-applicable' | 'failed';
 
-/** JSON-format clients eligible for NVM launcher repair on startup. */
+/**
+ * JSON-format clients eligible for NVM launcher patch/repair/heal.
+ *
+ * This MUST be the full set of clients whose JSON config the install flow can
+ * patch via applyNvmLauncherIfNeeded → patchConfigForNvmLauncher — otherwise a
+ * client that was patched at install time (e.g. VS Code or Cline pointing at a
+ * now-dead wrapper) would never self-heal on startup (issue #2338). Codex is
+ * excluded because its config is TOML, which patchConfigForNvmLauncher skips.
+ */
 const JSON_FORMAT_CLIENTS = [
-  'claude', 'claude-code', 'cursor', 'windsurf', 'lmstudio', 'gemini-cli',
+  'claude', 'claude-code', 'cursor', 'vscode', 'cline', 'windsurf', 'lmstudio', 'gemini-cli',
 ] as const;
 
 /**

--- a/src/web/routes/setupRoutes.ts
+++ b/src/web/routes/setupRoutes.ts
@@ -10,10 +10,10 @@
 
 import type { Request, Response } from 'express';
 import { execFile } from 'node:child_process';
-import { accessSync, constants as fsConstants } from 'node:fs';
+import { accessSync, existsSync, constants as fsConstants } from 'node:fs';
 import { access, chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
-import { join, dirname } from 'node:path';
-import { homedir, platform } from 'node:os';
+import { join, dirname, sep } from 'node:path';
+import { homedir, platform, tmpdir } from 'node:os';
 import { PackageResourceLocator } from '../../paths/PackageResourceLocator.js';
 
 const _locator = new PackageResourceLocator();
@@ -108,9 +108,15 @@ const installLimiter = new SlidingWindowRateLimiter(5, 60_000);
 /**
  * Known config file paths per client.
  * Returns the absolute path for the current platform.
+ *
+ * @param home - Home directory used to resolve every path. Defaults to
+ *               os.homedir(), but is injectable so callers (and tests) can make
+ *               `home` authoritative and keep config writes inside a sandbox.
+ *               See https://github.com/DollhouseMCP/mcp-server/issues/2338 —
+ *               without this override, NVM helpers driven by a fake home still
+ *               resolved to the real client configs and patched them.
  */
-function getConfigPath(client: string): string | null {
-  const home = homedir();
+function getConfigPath(client: string, home = homedir()): string | null {
   const plat = platform();
 
   const paths: Record<ConfigPathClient, () => string | null> = {
@@ -1105,7 +1111,11 @@ export async function applyNvmLauncherIfNeeded(client: string, home = homedir())
   }
   try {
     const wrapperPath = await ensureNvmLauncher(home);
-    await patchConfigForNvmLauncher(client, wrapperPath);
+    // Derive the config path from the SAME `home` that located NVM and the
+    // wrapper. Passing it explicitly (rather than letting patchConfigForNvmLauncher
+    // fall back to the real homedir()) is what makes `home` authoritative and
+    // keeps a fake-home test from patching real client configs (#2338).
+    await patchConfigForNvmLauncher(client, wrapperPath, getConfigPath(client, home) ?? undefined);
     logger.info(`[Setup] NVM-aware launcher applied for ${client}`);
     captureInstallAnalytics('nvm_launcher_applied', { client, platform: platform() });
     return 'applied';
@@ -1121,27 +1131,40 @@ export async function applyNvmLauncherIfNeeded(client: string, home = homedir())
 }
 
 /**
- * Startup repair: re-creates the wrapper and re-patches all known JSON-format
- * client configs on every server start. Handles two cases:
- *   1. Wrapper was deleted — recreates it so configs pointing to it keep working.
- *   2. Pre-existing install (user installed before this fix shipped) — patches
- *      configs that still use bare `npx`.
+ * Startup repair + self-heal: reconciles every known JSON-format client config
+ * on each server start. Behaviour depends on whether NVM is installed, matching
+ * the acceptance matrix in https://github.com/DollhouseMCP/mcp-server/issues/2338:
+ *
+ *   • NVM present  → (re)create the wrapper and point each config at it. Covers a
+ *     deleted wrapper, a pre-fix install still on bare `npx`, and a config left
+ *     pointing at a dead temp-dir wrapper (regenerates the real one). Healthy
+ *     configs re-serialise byte-identically, so this is a no-op for them.
+ *   • NVM absent   → never create a wrapper, but SELF-HEAL any config whose
+ *     command points at a `dollhousemcp-nvm.sh` that no longer exists (e.g. the
+ *     #2338 test leak, or a user who removed ~/.dollhouse/bin) back to bare `npx`,
+ *     preserving args so the client can launch DollhouseMCP again.
  *
  * Fire-and-forget from startWebServer. All errors are swallowed and logged.
  *
  * @param home               - Override home directory (injectable for tests)
  * @param configPathResolver - Override config path lookup (injectable for tests).
- *                             Return null to skip a client entirely.
- *                             Defaults to the production getConfigPath.
+ *                             Return null to skip a client entirely. Defaults to a
+ *                             home-derived resolver so `home` stays authoritative
+ *                             — the default must NOT reach the real homedir() when
+ *                             a fake home is supplied (#2338).
  */
 export async function repairNvmLauncherOnStartup(
   home = homedir(),
-  configPathResolver: (client: string) => string | null = getConfigPath,
+  configPathResolver: (client: string) => string | null = (client) => getConfigPath(client, home),
 ): Promise<void> {
   if (platform() === 'win32') return;
   logger.debug('[Setup] NVM launcher startup repair: checking for NVM...');
+
   if (!await isNvmPresent(home)) {
-    logger.debug('[Setup] NVM launcher startup repair: NVM not present — nothing to repair');
+    // NVM absent: we must NOT create a wrapper, but we DO restore any config
+    // still pointing at a now-missing wrapper so the client is not left broken.
+    logger.debug('[Setup] NVM launcher startup repair: NVM not present — scanning for dead wrapper references');
+    await healClientsWithoutNvm(configPathResolver);
     return;
   }
 
@@ -1153,6 +1176,19 @@ export async function repairNvmLauncherOnStartup(
     return;
   }
 
+  await patchClientsForNvm(wrapperPath, configPathResolver);
+  logger.info('[Setup] NVM launcher startup repair complete');
+}
+
+/**
+ * Point every resolvable JSON-format client config at the (real) NVM wrapper.
+ * Extracted from repairNvmLauncherOnStartup to keep its cognitive complexity
+ * within SonarCloud limits (S3776).
+ */
+async function patchClientsForNvm(
+  wrapperPath: string,
+  configPathResolver: (client: string) => string | null,
+): Promise<void> {
   await Promise.allSettled(
     JSON_FORMAT_CLIENTS.map(client => {
       const configPath = configPathResolver(client);
@@ -1163,8 +1199,70 @@ export async function repairNvmLauncherOnStartup(
         );
     })
   );
+}
 
-  logger.info('[Setup] NVM launcher startup repair complete');
+/**
+ * Self-heal path for machines WITHOUT NVM: restore any config that points at a
+ * missing wrapper back to bare `npx`. Extracted for cognitive-complexity limits.
+ */
+async function healClientsWithoutNvm(
+  configPathResolver: (client: string) => string | null,
+): Promise<void> {
+  await Promise.allSettled(
+    JSON_FORMAT_CLIENTS.map(client => {
+      const configPath = configPathResolver(client);
+      if (!configPath) return Promise.resolve(); // resolver returned null — skip this client
+      return restoreNpxIfWrapperMissing(client, configPath)
+        .catch(err =>
+          logger.warn(`[Setup] NVM self-heal: failed to heal ${client}: ${err instanceof Error ? err.message : String(err)}`)
+        );
+    })
+  );
+}
+
+/**
+ * If a client's dollhousemcp entry points at a `dollhousemcp-nvm.sh` wrapper
+ * that no longer exists on disk, rewrite `command` back to `npx` (args preserved)
+ * and persist the config. Any other state is left byte-for-byte untouched.
+ *
+ * The trigger is intentionally prefix-independent (command ends with
+ * `dollhousemcp-nvm.sh` AND the file is missing) so it heals not just the
+ * original `dollhouse-nvm-test-*` leak but any future temp-dir leak or a user
+ * who wiped ~/.dollhouse/bin. A wrapper that still exists is deliberately kept.
+ */
+async function restoreNpxIfWrapperMissing(client: string, configPath: string): Promise<void> {
+  let raw: string;
+  try {
+    raw = await readFile(configPath, 'utf-8');
+  } catch {
+    return; // Config not present/readable — nothing to heal
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return; // Malformed JSON — don't touch it
+  }
+
+  let healed = false;
+  for (const key of ['mcpServers', 'servers']) {
+    const section = parsed[key] as Record<string, Record<string, unknown>> | undefined;
+    const entry = section?.dollhousemcp;
+    if (!entry) continue;
+    const command = entry.command;
+    if (typeof command === 'string' && command.endsWith('dollhousemcp-nvm.sh') && !existsSync(command)) {
+      entry.command = 'npx';
+      healed = true;
+    }
+    break; // dollhousemcp entry located (healed or already healthy) — stop scanning keys
+  }
+
+  if (!healed) return;
+
+  const indent = detectIndent(raw);
+  await writeFile(configPath, JSON.stringify(parsed, null, indent) + '\n', 'utf-8');
+  logger.info(`[Setup] NVM self-heal: restored ${client} config to bare npx (dead wrapper path removed)`);
 }
 
 /**
@@ -1297,6 +1395,17 @@ function detectIndent(raw: string): number | string {
 }
 
 /**
+ * Returns true if `p` resolves inside the OS temp directory.
+ * Used as a production guardrail so a wrapper created in a throwaway temp dir
+ * (the shape of the #2338 test leak) can never be persisted into a real,
+ * long-lived client config.
+ */
+function isUnderTmpdir(p: string): boolean {
+  const t = tmpdir();
+  return p === t || p.startsWith(t + sep);
+}
+
+/**
  * Patches the dollhousemcp entry in an MCP client's JSON config to use
  * the NVM-aware launcher instead of bare `npx`.
  *
@@ -1313,6 +1422,19 @@ export async function patchConfigForNvmLauncher(client: string, wrapperPath: str
   }
   if (configPath.endsWith('.toml')) {
     logger.debug(`[Setup] patchConfigForNvmLauncher: TOML config for ${client} — skipping (not JSON-format)`);
+    return;
+  }
+  // Guardrail (#2338): never persist a temp-dir wrapper into a real, persistent
+  // client config. A wrapper under os.tmpdir() is a throwaway path that will be
+  // deleted, so writing it into a durable config would break the client on the
+  // next launch. When BOTH the wrapper and the config live under tmpdir we are
+  // in a sandboxed test and allow it, so NVM-present coverage still exercises
+  // the real patch path.
+  if (isUnderTmpdir(wrapperPath) && !isUnderTmpdir(configPath)) {
+    logger.warn(
+      `[Setup] patchConfigForNvmLauncher: refusing to write a temp-dir wrapper (${wrapperPath}) ` +
+      `into a persistent ${client} config (${configPath}) — see issue #2338`,
+    );
     return;
   }
 

--- a/tests/jest.setup.mjs
+++ b/tests/jest.setup.mjs
@@ -97,9 +97,25 @@ function detectConfigPollution(configPath) {
   return null;
 }
 
+// Baseline: a config may already be polluted before this run starts — e.g. a
+// pre-fix `npm test` left a dead wrapper, which is exactly the state #2338
+// repairs. We must NOT blame the first unrelated test for that. Record which
+// paths are already polluted at setup and only fail on NEW pollution.
+const PRE_EXISTING_POLLUTION = new Set(
+  REAL_CLIENT_CONFIG_PATHS.filter((p) => detectConfigPollution(p)),
+);
+if (PRE_EXISTING_POLLUTION.size > 0) {
+  console.warn(
+    `[#2338 guard] Pre-existing MCP client config pollution detected before this ` +
+    `run (NOT caused by these tests): ${[...PRE_EXISTING_POLLUTION].join(', ')}. ` +
+    `Ignoring as baseline — repair these separately (see setupRoutes NVM self-heal).`,
+  );
+}
+
 afterEach(() => {
   const violations = [];
   for (const p of REAL_CLIENT_CONFIG_PATHS) {
+    if (PRE_EXISTING_POLLUTION.has(p)) continue; // already polluted before the run — not this test's fault
     const reason = detectConfigPollution(p);
     if (reason) violations.push(`  - ${p} — ${reason}`);
   }

--- a/tests/jest.setup.mjs
+++ b/tests/jest.setup.mjs
@@ -43,16 +43,21 @@ const REAL_CLIENT_CONFIG_PATHS = (() => {
   const home = homedir();
   const plat = platform();
   const appData = process.env.APPDATA || join(home, 'AppData', 'Roaming');
-  const codeUserDir = plat === 'darwin'
-    ? join(home, 'Library', 'Application Support', 'Code', 'User')
-    : plat === 'win32'
-      ? join(appData, 'Code', 'User')
-      : join(home, '.config', 'Code', 'User');
-  const claudeDesktop = plat === 'darwin'
-    ? join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json')
-    : plat === 'win32'
-      ? join(appData, 'Claude', 'claude_desktop_config.json')
-      : join(home, '.config', 'Claude', 'claude_desktop_config.json');
+  const byPlatform = (darwinPath, win32Path, linuxPath) => {
+    if (plat === 'darwin') return darwinPath;
+    if (plat === 'win32') return win32Path;
+    return linuxPath;
+  };
+  const codeUserDir = byPlatform(
+    join(home, 'Library', 'Application Support', 'Code', 'User'),
+    join(appData, 'Code', 'User'),
+    join(home, '.config', 'Code', 'User'),
+  );
+  const claudeDesktop = byPlatform(
+    join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json'),
+    join(appData, 'Claude', 'claude_desktop_config.json'),
+    join(home, '.config', 'Claude', 'claude_desktop_config.json'),
+  );
   return [
     claudeDesktop,                                              // Claude Desktop
     join(home, '.claude.json'),                                 // Claude Code

--- a/tests/jest.setup.mjs
+++ b/tests/jest.setup.mjs
@@ -7,3 +7,112 @@ process.env.PERSONAS_DIR = 'test-personas';
 // Use discrete mode for tests - integration tests use individual tools like activate_element
 // Production default is 'mcpaql' but tests need discrete tools to be registered
 process.env.MCP_INTERFACE_MODE = 'discrete';
+
+// ── Real MCP-client-config pollution guard (issue #2338) ─────────────────────
+// A unit test must never patch a user's REAL MCP client config. The NVM
+// mitigation helpers in src/web/routes/setupRoutes.ts resolve those paths from
+// os.homedir(); a test that forgets to inject a fake home / configPathOverride
+// silently rewrites the developer's Claude Desktop / Cursor / Windsurf / LM
+// Studio / Gemini CLI / Claude Code config to point at a temp-dir wrapper that
+// is then deleted, breaking those apps.
+//
+// Design constraints on this machine:
+//   • ESM named imports of node:fs cannot be monkeypatched, so we cannot
+//     intercept the write itself.
+//   • Some of these files are LIVE app state that changes on its own during a
+//     test run (e.g. ~/.claude.json is rewritten by the running Claude Code /
+//     Claude Desktop). So we must NOT diff for "any change" (ambient churn would
+//     false-positive) and must NEVER write to these files (restoring stale bytes
+//     over live state would corrupt it).
+//
+// Instead we detect the unambiguous #2338 *pollution signature* after each test:
+// a dollhousemcp `command` that points under os.tmpdir(), or at a
+// `dollhousemcp-nvm.sh` wrapper that does not exist. No real app produces that;
+// only a leaking test does. Detect-only, read-only, prefix-independent.
+import { homedir, platform, tmpdir } from 'node:os';
+import { join, sep } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+
+// Mirror of getConfigPath() in src/web/routes/setupRoutes.ts for EVERY client the
+// install/open-config endpoints can resolve — not just the JSON NVM clients. Kept
+// in lockstep with that resolver so the guard covers every real config setup can
+// write (Cline, VS Code, Codex included). It can't import the compiled TS here, so
+// the mapping is replicated; a drift would only make the guard miss a path, never
+// false-positive.
+const REAL_CLIENT_CONFIG_PATHS = (() => {
+  const home = homedir();
+  const plat = platform();
+  const appData = process.env.APPDATA || join(home, 'AppData', 'Roaming');
+  const codeUserDir = plat === 'darwin'
+    ? join(home, 'Library', 'Application Support', 'Code', 'User')
+    : plat === 'win32'
+      ? join(appData, 'Code', 'User')
+      : join(home, '.config', 'Code', 'User');
+  const claudeDesktop = plat === 'darwin'
+    ? join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json')
+    : plat === 'win32'
+      ? join(appData, 'Claude', 'claude_desktop_config.json')
+      : join(home, '.config', 'Claude', 'claude_desktop_config.json');
+  return [
+    claudeDesktop,                                              // Claude Desktop
+    join(home, '.claude.json'),                                 // Claude Code
+    join(home, '.cursor', 'mcp.json'),                          // Cursor
+    join(codeUserDir, 'settings.json'),                         // VS Code
+    join(codeUserDir, 'globalStorage', 'saoudrizwan.claude-dev', 'settings', 'cline_mcp_settings.json'), // Cline
+    join(home, '.codeium', 'windsurf', 'mcp_config.json'),      // Windsurf
+    join(home, '.lmstudio', 'mcp.json'),                        // LM Studio
+    join(home, '.gemini', 'settings.json'),                     // Gemini CLI
+    join(home, '.codex', 'config.toml'),                        // Codex (TOML — parse-skipped, listed for completeness)
+  ];
+})();
+
+/**
+ * Returns a reason string if the dollhousemcp entry in a real client config
+ * looks like #2338 test pollution, or null otherwise. Read-only.
+ */
+function detectConfigPollution(configPath) {
+  let raw;
+  try {
+    raw = readFileSync(configPath, 'utf-8');
+  } catch {
+    return null; // absent/unreadable — nothing to inspect
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null; // not JSON (or mid-write by a live app) — ignore
+  }
+  const tmp = tmpdir();
+  for (const key of ['mcpServers', 'servers']) {
+    const command = parsed?.[key]?.dollhousemcp?.command;
+    if (typeof command !== 'string') continue;
+    if (command === tmp || command.startsWith(tmp + sep)) {
+      return `dollhousemcp.command points under os.tmpdir(): ${command}`;
+    }
+    if (command.endsWith('dollhousemcp-nvm.sh') && !existsSync(command)) {
+      return `dollhousemcp.command points at a missing NVM wrapper: ${command}`;
+    }
+  }
+  return null;
+}
+
+afterEach(() => {
+  const violations = [];
+  for (const p of REAL_CLIENT_CONFIG_PATHS) {
+    const reason = detectConfigPollution(p);
+    if (reason) violations.push(`  - ${p} — ${reason}`);
+  }
+
+  if (violations.length > 0) {
+    const testName = expect.getState().currentTestName ?? '(unknown test)';
+    throw new Error(
+      `[#2338 guard] A unit test polluted a real MCP client config:\n` +
+      violations.join('\n') +
+      `\nTest: ${testName}\n` +
+      `Route config writes to a temp dir by injecting a fake home / ` +
+      `configPathOverride (see setupRoutes NVM helpers). The real file was left ` +
+      `untouched by this guard — repair it if the leak actually landed.`,
+    );
+  }
+});

--- a/tests/unit/web/setupRoutes.nvm.test.ts
+++ b/tests/unit/web/setupRoutes.nvm.test.ts
@@ -689,6 +689,9 @@ describe('repairNvmLauncherOnStartup', () => {
 
 describe('repairNvmLauncherOnStartup — #2338 self-heal acceptance matrix', () => {
   it('Row 1: no NVM + config points at a dead wrapper → restores command to npx (args preserved)', async () => {
+    // repairNvmLauncherOnStartup (and the whole NVM mitigation) is macOS/Linux
+    // only — on win32 it returns before self-heal, so the heal cannot happen.
+    if (isWindows) return;
     // tempDir has NO .nvm — this machine has no NVM installed.
     const deadWrapper = join(tempDir, '.dollhouse', 'bin', 'dollhousemcp-nvm.sh'); // never created
     const configPath = join(tempDir, 'claude.json');
@@ -767,5 +770,34 @@ describe('repairNvmLauncherOnStartup — #2338 self-heal acceptance matrix', () 
     // Second repair on an already-healthy config must be byte-identical.
     await repairNvmLauncherOnStartup(tempDir, resolver);
     expect(await readFile(configPath, 'utf-8')).toBe(configHealthy);
+  });
+
+  it('self-heal covers VS Code (servers key) and Cline — now in JSON_FORMAT_CLIENTS', async () => {
+    if (isWindows) return;
+    // No NVM on this machine. The install flow can patch vscode/cline JSON
+    // configs, so startup self-heal must iterate them too (#2338). The resolver
+    // is only consulted for clients repairNvmLauncherOnStartup actually visits,
+    // so a heal here proves vscode + cline are in the iterated client set.
+    const deadWrapper = join(tempDir, '.dollhouse', 'bin', 'dollhousemcp-nvm.sh'); // never created
+    const vscodeCfg = join(tempDir, 'vscode-settings.json');
+    const clineCfg = join(tempDir, 'cline-settings.json');
+    // VS Code uses the `servers` key; Cline uses `mcpServers`.
+    await writeFile(vscodeCfg, JSON.stringify({
+      servers: { dollhousemcp: { command: deadWrapper, args: ['@dollhousemcp/mcp-server@latest'] } },
+    }, null, 2));
+    await writeFile(clineCfg, JSON.stringify({
+      mcpServers: { dollhousemcp: { command: deadWrapper, args: ['@dollhousemcp/mcp-server@rc'] } },
+    }, null, 2));
+
+    const resolver = (client: string) =>
+      client === 'vscode' ? vscodeCfg : client === 'cline' ? clineCfg : null;
+    await repairNvmLauncherOnStartup(tempDir, resolver);
+
+    const vscodeAfter = JSON.parse(await readFile(vscodeCfg, 'utf-8'));
+    const clineAfter = JSON.parse(await readFile(clineCfg, 'utf-8'));
+    expect(vscodeAfter.servers.dollhousemcp.command).toBe('npx');
+    expect(vscodeAfter.servers.dollhousemcp.args).toEqual(['@dollhousemcp/mcp-server@latest']);
+    expect(clineAfter.mcpServers.dollhousemcp.command).toBe('npx');
+    expect(clineAfter.mcpServers.dollhousemcp.args).toEqual(['@dollhousemcp/mcp-server@rc']);
   });
 });

--- a/tests/unit/web/setupRoutes.nvm.test.ts
+++ b/tests/unit/web/setupRoutes.nvm.test.ts
@@ -12,8 +12,14 @@
 
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 import { mkdtemp, rm, mkdir, writeFile, readFile, stat } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import { tmpdir } from 'node:os';
+
+// True when the repo checkout itself lives under os.tmpdir() (e.g. an ad-hoc CI
+// worktree in /tmp). In that case a "non-tmpdir" fixture cannot be created under
+// process.cwd(), so the tmpdir-guardrail test that needs a real (non-temp) config
+// location is skipped rather than asserting the wrong branch.
+const CWD_UNDER_TMPDIR = process.cwd() === tmpdir() || process.cwd().startsWith(tmpdir() + sep);
 
 import {
   isNvmPresent,
@@ -454,9 +460,56 @@ describe('patchConfigForNvmLauncher', () => {
     const result = await readFile(configPath, 'utf-8');
     expect(result).toContain('\t"mcpServers"');
   });
+
+  // ── Production guardrail (issue #2338, fix item 3) ────────────────────────
+  it('refuses to persist a temp-dir wrapper into a config OUTSIDE tmpdir', async () => {
+    // Needs a config location guaranteed to be outside os.tmpdir(); when the
+    // checkout itself is under tmpdir we cannot construct one, so skip.
+    if (CWD_UNDER_TMPDIR) return;
+    // Wrapper lives under os.tmpdir() (the shape of the #2338 leak); the config
+    // lives OUTSIDE tmpdir (a persistent, "real" config). The guardrail must
+    // warn and no-op so the temp-dir path is never written into a durable config.
+    const tmpWrapper = join(tempDir, '.dollhouse', 'bin', 'dollhousemcp-nvm.sh');
+
+    // Create a non-tmpdir directory to stand in for a real config location.
+    const outsideDir = await mkdtemp(join(process.cwd(), 'guardrail-2338-'));
+    try {
+      const outsideConfig = join(outsideDir, 'config.json');
+      const original = JSON.stringify({
+        mcpServers: { dollhousemcp: { command: 'npx', args: ['@dollhousemcp/mcp-server@latest'] } },
+      }, null, 2) + '\n';
+      await writeFile(outsideConfig, original);
+
+      await patchConfigForNvmLauncher('claude', tmpWrapper, outsideConfig);
+
+      // Config must be byte-identical — the guardrail refused the write.
+      expect(await readFile(outsideConfig, 'utf-8')).toBe(original);
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('still patches when BOTH wrapper and config are under tmpdir (sandboxed test path)', async () => {
+    // The guardrail must NOT block sandboxed tests, or NVM-present coverage would
+    // be impossible (the wrapper is always created inside the fake temp home).
+    const tmpWrapper = join(tempDir, '.dollhouse', 'bin', 'dollhousemcp-nvm.sh');
+    const tmpConfig = join(tempDir, 'claude.json');
+    await writeFile(tmpConfig, JSON.stringify({
+      mcpServers: { dollhousemcp: { command: 'npx', args: [] } },
+    }, null, 2));
+
+    await patchConfigForNvmLauncher('claude', tmpWrapper, tmpConfig);
+
+    const after = JSON.parse(await readFile(tmpConfig, 'utf-8'));
+    expect(after.mcpServers.dollhousemcp.command).toBe(tmpWrapper);
+  });
 });
 
 // ── applyNvmLauncherIfNeeded ─────────────────────────────────────────────────
+// NOTE (#2338): passing `tempDir` as `home` is now authoritative — the helper
+// derives the config path from that same home (getConfigPath(client, home)), so
+// the NVM-present path below writes only inside tempDir and never touches a real
+// client config. The global guard in tests/jest.setup.mjs backstops this.
 
 describe('applyNvmLauncherIfNeeded', () => {
   it('returns not-applicable when NVM is not present', async () => {
@@ -492,6 +545,11 @@ describe('applyNvmLauncherIfNeeded', () => {
 });
 
 // ── repairNvmLauncherOnStartup ───────────────────────────────────────────────
+// NOTE (#2338): calls that pass only `tempDir` rely on the default resolver,
+// which is now home-derived — `(client) => getConfigPath(client, tempDir)`.
+// Config writes therefore stay inside tempDir; the previous default reached the
+// real homedir() and patched live client configs. Tests that assert config
+// patching still inject an explicit resolver so intent is unambiguous.
 
 describe('repairNvmLauncherOnStartup', () => {
   it('is a function', () => {
@@ -622,5 +680,92 @@ describe('repairNvmLauncherOnStartup', () => {
 
     expect(wrapperFirst).toBe(wrapperSecond);
     expect(configFirst).toBe(configSecond);
+  });
+});
+
+// ── #2338 self-heal acceptance matrix ────────────────────────────────────────
+// All three user states must end healthy after repairNvmLauncherOnStartup runs.
+// See the acceptance matrix in issue #2338's clarifying comment.
+
+describe('repairNvmLauncherOnStartup — #2338 self-heal acceptance matrix', () => {
+  it('Row 1: no NVM + config points at a dead wrapper → restores command to npx (args preserved)', async () => {
+    // tempDir has NO .nvm — this machine has no NVM installed.
+    const deadWrapper = join(tempDir, '.dollhouse', 'bin', 'dollhousemcp-nvm.sh'); // never created
+    const configPath = join(tempDir, 'claude.json');
+    await writeFile(configPath, JSON.stringify({
+      mcpServers: { dollhousemcp: { command: deadWrapper, args: ['@dollhousemcp/mcp-server@latest'] } },
+    }, null, 2));
+
+    const resolver = (client: string) => client === 'claude' ? configPath : null;
+    await repairNvmLauncherOnStartup(tempDir, resolver);
+
+    const after = JSON.parse(await readFile(configPath, 'utf-8'));
+    expect(after.mcpServers.dollhousemcp.command).toBe('npx');
+    expect(after.mcpServers.dollhousemcp.args).toEqual(['@dollhousemcp/mcp-server@latest']);
+
+    // No wrapper must be created when NVM is absent.
+    await expect(
+      stat(join(tempDir, '.dollhouse', 'bin', 'dollhousemcp-nvm.sh'))
+    ).rejects.toThrow();
+  });
+
+  it('Row 1b: no NVM + healthy npx config → left byte-identical (no spurious heal)', async () => {
+    const configPath = join(tempDir, 'claude.json');
+    const original = JSON.stringify({
+      mcpServers: { dollhousemcp: { command: 'npx', args: ['@dollhousemcp/mcp-server@latest'] } },
+    }, null, 2) + '\n';
+    await writeFile(configPath, original);
+
+    const resolver = (client: string) => client === 'claude' ? configPath : null;
+    await repairNvmLauncherOnStartup(tempDir, resolver);
+
+    expect(await readFile(configPath, 'utf-8')).toBe(original);
+  });
+
+  it('Row 2: NVM present + config points at a dead wrapper → regenerates real wrapper and repoints config', async () => {
+    if (isWindows) return;
+    await mkdir(join(tempDir, '.nvm'), { recursive: true });
+    await writeFile(join(tempDir, '.nvm', 'nvm.sh'), '# nvm');
+
+    // Simulate a config left pointing at a now-deleted temp-dir wrapper.
+    const deadWrapper = join(tmpdir(), 'dollhouse-nvm-test-GONE', '.dollhouse', 'bin', 'dollhousemcp-nvm.sh');
+    const configPath = join(tempDir, 'claude.json');
+    await writeFile(configPath, JSON.stringify({
+      mcpServers: { dollhousemcp: { command: deadWrapper, args: ['@dollhousemcp/mcp-server@latest'] } },
+    }, null, 2));
+
+    const resolver = (client: string) => client === 'claude' ? configPath : null;
+    await repairNvmLauncherOnStartup(tempDir, resolver);
+
+    // The real wrapper is regenerated inside the (fake) home...
+    const realWrapper = join(tempDir, '.dollhouse', 'bin', 'dollhousemcp-nvm.sh');
+    expect((await stat(realWrapper)).isFile()).toBe(true);
+
+    // ...and the config now points at it, keeping the #1902 protection (not bare npx).
+    const after = JSON.parse(await readFile(configPath, 'utf-8'));
+    expect(after.mcpServers.dollhousemcp.command).toBe(realWrapper);
+    expect(after.mcpServers.dollhousemcp.args).toEqual(['@dollhousemcp/mcp-server@latest']);
+  });
+
+  it('Row 3: NVM present + healthy config already pointing at the real wrapper → byte-identical no-op', async () => {
+    if (isWindows) return;
+    await mkdir(join(tempDir, '.nvm'), { recursive: true });
+    await writeFile(join(tempDir, '.nvm', 'nvm.sh'), '# nvm');
+
+    const configPath = join(tempDir, 'claude.json');
+    await writeFile(configPath, JSON.stringify({
+      mcpServers: { dollhousemcp: { command: 'npx', args: ['@dollhousemcp/mcp-server@latest'] } },
+    }, null, 2));
+    const resolver = (client: string) => client === 'claude' ? configPath : null;
+
+    // First repair establishes the wrapper and a healthy config pointing at it.
+    await repairNvmLauncherOnStartup(tempDir, resolver);
+    const realWrapper = join(tempDir, '.dollhouse', 'bin', 'dollhousemcp-nvm.sh');
+    const configHealthy = await readFile(configPath, 'utf-8');
+    expect(JSON.parse(configHealthy).mcpServers.dollhousemcp.command).toBe(realWrapper);
+
+    // Second repair on an already-healthy config must be byte-identical.
+    await repairNvmLauncherOnStartup(tempDir, resolver);
+    expect(await readFile(configPath, 'utf-8')).toBe(configHealthy);
   });
 });

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -39,6 +39,36 @@ describe('Setup Routes — API Endpoints', () => {
   });
 
   describe('POST /api/setup/install', () => {
+    // Isolate the install block from real MCP client configs (issue #2338).
+    // The default install handler runs the REAL install-mcp binary and installs a
+    // real permission hook, so `npm test` patched the developer's real
+    // claude_desktop_config.json (install-mcp resolves it via os.userInfo, which
+    // even ignores $HOME) and ~/.claude.json (the claude-code hook). Rebuild the
+    // app with stubbed _runInstallMcp / _installPermissionHook so no real external
+    // process or hook install runs. NOTE: HOME-sandboxing does NOT help here —
+    // jest's sandboxed process.env is not visible to libuv, so os.homedir()
+    // ignores a mutated HOME. The only client that still writes a real config
+    // in-process is LM Studio (installLmStudioConfig has no path override), so it
+    // is exercised by the dedicated "direct JSON MCP installs" tests below (which
+    // pass a temp configPath) rather than here.
+    beforeEach(async () => {
+      const { createSetupRoutes } = await import('../../../src/web/routes/setupRoutes.js');
+      const { installHandler } = createSetupRoutes({
+        _runInstallMcp: async () => 'Installed successfully.',
+        _installPermissionHook: async (client: string) => ({
+          supported: false,
+          installed: false,
+          configured: false,
+          host: client,
+          message: 'stubbed for tests',
+        }),
+        _skipRateLimit: true,
+      });
+      app = express();
+      app.use(express.json());
+      app.post('/api/setup/install', installHandler);
+    });
+
     it('rejects missing client field', async () => {
       const res = await request(app)
         .post('/api/setup/install')
@@ -78,10 +108,16 @@ describe('Setup Routes — API Endpoints', () => {
     });
 
     it('accepts all documented client names', async () => {
+      // 'lmstudio' is intentionally omitted: unlike every other client (which is
+      // routed through the stubbed _runInstallMcp), it is installed in-process via
+      // installLmStudioConfig(), which writes the REAL ~/.lmstudio/mcp.json with no
+      // path-override seam. Its validation acceptance is covered by the detect
+      // support-level tests and its write behaviour by the "direct JSON MCP
+      // installs" tests below (which pass a temp configPath). See issue #2338.
       const validClients = [
         'claude', 'claude-code', 'cursor', 'vscode', 'cline',
         'roo-cline', 'windsurf', 'witsy', 'enconvo', 'gemini-cli',
-        'goose', 'zed', 'warp', 'codex', 'lmstudio',
+        'goose', 'zed', 'warp', 'codex',
       ];
 
       for (const client of validClients) {

--- a/tests/unit/web/setupRoutes.test.ts
+++ b/tests/unit/web/setupRoutes.test.ts
@@ -55,6 +55,9 @@ describe('Setup Routes — API Endpoints', () => {
       const { createSetupRoutes } = await import('../../../src/web/routes/setupRoutes.js');
       const { installHandler } = createSetupRoutes({
         _runInstallMcp: async () => 'Installed successfully.',
+        // Stub the NVM mitigation: the real one runs against the real homedir()
+        // and, on a machine WITH NVM, would patch real client configs (#2338).
+        _applyNvmLauncher: async () => 'not-applicable',
         _installPermissionHook: async (client: string) => ({
           supported: false,
           installed: false,
@@ -201,6 +204,7 @@ describe('Setup Routes — API Endpoints', () => {
       const { createSetupRoutes } = await import('../../../src/web/routes/setupRoutes.js');
       const { installHandler } = createSetupRoutes({
         _runInstallMcp: async () => 'Installed successfully.',
+        _applyNvmLauncher: async () => 'not-applicable',
         _installPermissionHook: async () => ({
           supported: true,
           installed: true,
@@ -245,6 +249,7 @@ describe('Setup Routes — API Endpoints', () => {
       const { createSetupRoutes } = await import('../../../src/web/routes/setupRoutes.js');
       const { installHandler } = createSetupRoutes({
         _runInstallMcp: async () => 'Installed successfully.',
+        _applyNvmLauncher: async () => 'not-applicable',
         _installPermissionHook: installPermissionHookMock,
         _skipRateLimit: true,
       });


### PR DESCRIPTION
## Summary

Part of #2338 (kept open until the develop fix #2339 merges). `origin/beta` carries the same defect as develop: unit tests for the NVM mitigation helpers in `src/web/routes/setupRoutes.ts` drove `applyNvmLauncherIfNeeded` / `repairNvmLauncherOnStartup` with a fake temp home but **no config-path override**, and `getConfigPath()` always used the real `homedir()` — so any `npm test` run rewrote the developer's **real** MCP client configs (Claude Desktop, Cursor, Windsurf, LM Studio, Gemini CLI, Claude Code) with a temp-dir wrapper path that then got deleted, breaking those apps.

This is the develop fix (#2339) ported to beta. The NVM launcher itself is **kept intact** — it fixes #1902 for real NVM users.

## Fix, by layer (identical to #2339)

1. **Test hygiene** — leaking call sites are safe because `home` is authoritative; NVM coverage retained and extended.
2. **API hardening** — `getConfigPath(client, home = homedir())`; `applyNvmLauncherIfNeeded` passes `getConfigPath(client, home)` down; `repairNvmLauncherOnStartup`'s default resolver is `(client) => getConfigPath(client, home)`.
3. **Production guardrail** — `patchConfigForNvmLauncher` refuses (warn + no-op) to persist a wrapper under `os.tmpdir()` into a config outside `os.tmpdir()`; fully-sandboxed test paths still exercised.
4. **Global test guard** (`tests/jest.setup.mjs`) — after every unit test, scans **every** real config `getConfigPath` can resolve for the #2338 **pollution signature** (a `dollhousemcp.command` under `os.tmpdir()`, or at a missing `dollhousemcp-nvm.sh`) and fails loudly. Detect-only / read-only because several of these files are live app state (e.g. `~/.claude.json` is rewritten by the running Claude Code), so a diff-and-restore guard would false-positive on ambient churn and corrupt live state.
   - **Surfaced a second, pre-existing leak present on beta too:** the `POST /api/setup/install` tests ran the real `install-mcp` binary (resolves the Claude path via `os.userInfo`, ignoring `$HOME`) and installed a real `claude-code` hook into `~/.claude.json`. Fixed by stubbing `_runInstallMcp` / `_installPermissionHook`; LM Studio dropped from the "all documented clients" case (`installLmStudioConfig` writes a real config in-process with no override seam, and jest's sandboxed `process.env` is invisible to libuv so HOME-sandboxing can't contain it).
5. **Startup self-heal** — no-NVM restores `command: "npx"` (args preserved); NVM-present regenerates the real wrapper and repoints; healthy config is a byte-identical no-op. Regression tests for all three acceptance-matrix rows + the tmpdir guardrail (which skips when the checkout itself is under `tmpdir`).

## Verification

- `tsc` build clean; `eslint --max-warnings=0` on changed files clean.
- `setupRoutes.nvm.test.ts` + `setupRoutes.test.ts`: 338/338 pass. Full unit suite: 12154 pass, `[#2338 guard]` never fires. Remaining local failures are pre-existing beta env flakes unrelated to this change (auth tests that need Node 22 for `oidc-provider` / read a real `.env.local`, plus the timing-sensitive `BuildInfoService.parallel` and hook-server `permissionRoutes`) — none run on CI's Node 20/22 clean environment.
- All five real client configs verified valid JSON with `command: "npx"` after the runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ughz92rhDUkghgYD2boQ