### PR TITLE
fix(security): vet missing base paths through nearest existing ancestor (#2342)

### DIFF
--- a/src/utils/pathSecurity.ts
+++ b/src/utils/pathSecurity.ts
@@ -1,20 +1,56 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-function assertNotSymlink(pathToCheck: string, message: string): void {
-  try {
-    const stats = fs.lstatSync(pathToCheck);
-    if (stats.isSymbolicLink()) {
-      throw new Error(message);
+function isMissingPathError(error: unknown): boolean {
+  const code = typeof error === 'object' && error !== null && 'code' in error
+    ? (error as NodeJS.ErrnoException).code
+    : undefined;
+  return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
+/**
+ * lstat of the deepest ancestor of `startPath` that exists, or null when
+ * nothing up to the filesystem root exists. Used to vet paths that will be
+ * created later: their containment depends on the directory they will be
+ * created inside.
+ */
+function nearestExistingAncestorStats(startPath: string): fs.Stats | null {
+  let previous = startPath;
+  let current = path.dirname(startPath);
+  while (current !== previous) {
+    try {
+      return fs.lstatSync(current);
+    } catch (error) {
+      if (!isMissingPathError(error)) {
+        throw error;
+      }
     }
+    previous = current;
+    current = path.dirname(current);
+  }
+  return null;
+}
+
+function assertNotSymlink(pathToCheck: string, message: string): void {
+  let stats: fs.Stats;
+  try {
+    stats = fs.lstatSync(pathToCheck);
   } catch (error) {
-    const code = typeof error === 'object' && error !== null && 'code' in error
-      ? (error as NodeJS.ErrnoException).code
-      : undefined;
-    if (code === 'ENOENT' || code === 'ENOTDIR') {
+    if (isMissingPathError(error)) {
+      // The path does not exist yet, so it will be created by a later
+      // mkdir/write. That is only safe if the directory it gets created
+      // inside is real: a symlinked existing ancestor would redirect the
+      // recursive create outside the containment boundary (#2342).
+      const ancestorStats = nearestExistingAncestorStats(pathToCheck);
+      if (ancestorStats?.isSymbolicLink()) {
+        throw new Error(message);
+      }
       return;
     }
     throw error;
+  }
+  if (stats.isSymbolicLink()) {
+    throw new Error(message);
   }
 }
 
@@ -40,7 +76,10 @@ function assertNoSymlinkedDescendants(resolvedBase: string, resolvedTarget: stri
  * directory. This is separator-aware, so sibling paths such as `/tmp/base2`
  * are not treated as children of `/tmp/base`. Existing symlinked base paths
  * and symlinked descendants under the base are rejected because writes would
- * follow them outside the lexical containment boundary.
+ * follow them outside the lexical containment boundary. A base that does not
+ * exist yet is vetted through its nearest existing ancestor: if that ancestor
+ * is a symlink, the recursive mkdir/write that follows would be redirected
+ * outside the intended tree, so it is rejected too (#2342).
  */
 export function resolvePathWithinBase(baseDir: string, ...segments: string[]): string {
   if (!baseDir || typeof baseDir !== 'string') {

--- a/tests/unit/utils/pathSecurity.test.ts
+++ b/tests/unit/utils/pathSecurity.test.ts
@@ -105,4 +105,57 @@ describe('resolvePathWithinBase', () => {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }
   });
+
+  // #2342: a base that does not exist yet must be vetted through its nearest
+  // existing ancestor — otherwise `/safe/link/new` (where `/safe/link` is a
+  // symlink to an outside directory) passes the lstat-ENOENT check and the
+  // recursive mkdir/write that follows escapes the intended tree.
+  it('rejects a missing base directory whose nearest existing ancestor is a symlink', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    const outside = path.join(sandbox, 'outside-target');
+    const link = path.join(sandbox, 'link');
+
+    try {
+      fs.mkdirSync(outside, { recursive: true });
+
+      try {
+        fs.symlinkSync(outside, link, 'dir');
+      } catch (error) {
+        const code = typeof error === 'object' && error !== null && 'code' in error
+          ? (error as NodeJS.ErrnoException).code
+          : undefined;
+        if (code === 'EPERM' || code === 'EACCES') {
+          return;
+        }
+        throw error;
+      }
+
+      // Base does not exist yet; its nearest existing ancestor is the symlink.
+      const missingBase = path.join(link, 'new-base');
+      expect(() => resolvePathWithinBase(missingBase, 'file.md')).toThrow(
+        'Base directory resolves through a symbolic link'
+      );
+
+      // Same for a base several missing levels below the symlink.
+      const deepMissingBase = path.join(link, 'a', 'b', 'new-base');
+      expect(() => resolvePathWithinBase(deepMissingBase, 'file.md')).toThrow(
+        'Base directory resolves through a symbolic link'
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('allows a missing base directory under real existing ancestors', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+
+    try {
+      const missingBase = path.join(sandbox, 'not-created-yet', 'sub');
+      expect(resolvePathWithinBase(missingBase, 'file.md')).toBe(
+        path.resolve(missingBase, 'file.md')
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Closes the symlink containment bypass flagged by codex on the v2.0.37 release PR (#2341) and tracked in #2342.

`resolvePathWithinBase` treated `lstat` ENOENT as safe, so a base directory that does not exist yet was never vetted. With `/safe/link -> /outside`, a base of `/safe/link/new` passed the check (`lstat('/safe/link/new')` → ENOENT, descendant checks also ENOENT) and the recursive mkdir/write that followed escaped the intended tree through the symlinked ancestor — e.g. `src/cli/convert.ts` resolves `options.output` before `writeToDirectory()` creates it.

## Fix

- A missing path is now vetted through its **nearest existing ancestor**: `nearestExistingAncestorStats()` walks up the parent chain to the first path that exists, and if that ancestor is a symlink the resolution is rejected with the same containment error.
- Existing bases behave exactly as before — ancestors of an *existing* base are not re-vetted, so legitimate setups like macOS `/tmp -> /private/tmp` keep working for existing directories. The walk-up only engages for paths that will be created later, which is precisely where the recursive-create redirection risk lives.
- Also restructured `assertNotSymlink` so its own rejection error no longer round-trips through its `catch` block.

## Tests

- New: missing base directly under a symlinked ancestor → rejected; missing base several levels below a symlinked ancestor → rejected; missing base under real ancestors → resolves (no regression).
- Existing suite: 11/11 pathSecurity tests pass; 73/73 converter/CLI caller tests pass; `tsc --noEmit` clean.
- Windows symlink-privilege guard convention (EPERM/EACCES skip) preserved.

Fixes #2342

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ughz92rhDUkghgYD2boQ