### PR TITLE
hotfix(beta): vet missing base paths through nearest existing ancestor (#2342)

### DIFF
--- a/src/utils/pathSecurity.ts
+++ b/src/utils/pathSecurity.ts
@@ -1,20 +1,56 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-function assertNotSymlink(pathToCheck: string, message: string): void {
-  try {
-    const stats = fs.lstatSync(pathToCheck);
-    if (stats.isSymbolicLink()) {
-      throw new Error(message);
+function isMissingPathError(error: unknown): boolean {
+  const code = typeof error === 'object' && error !== null && 'code' in error
+    ? (error as NodeJS.ErrnoException).code
+    : undefined;
+  return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
+/**
+ * lstat of the deepest ancestor of `startPath` that exists, or null when
+ * nothing up to the filesystem root exists. Used to vet paths that will be
+ * created later: their containment depends on the directory they will be
+ * created inside.
+ */
+function nearestExistingAncestorStats(startPath: string): fs.Stats | null {
+  let previous = startPath;
+  let current = path.dirname(startPath);
+  while (current !== previous) {
+    try {
+      return fs.lstatSync(current);
+    } catch (error) {
+      if (!isMissingPathError(error)) {
+        throw error;
+      }
     }
+    previous = current;
+    current = path.dirname(current);
+  }
+  return null;
+}
+
+function assertNotSymlink(pathToCheck: string, message: string): void {
+  let stats: fs.Stats;
+  try {
+    stats = fs.lstatSync(pathToCheck);
   } catch (error) {
-    const code = typeof error === 'object' && error !== null && 'code' in error
-      ? (error as NodeJS.ErrnoException).code
-      : undefined;
-    if (code === 'ENOENT' || code === 'ENOTDIR') {
+    if (isMissingPathError(error)) {
+      // The path does not exist yet, so it will be created by a later
+      // mkdir/write. That is only safe if the directory it gets created
+      // inside is real: a symlinked existing ancestor would redirect the
+      // recursive create outside the containment boundary (#2342).
+      const ancestorStats = nearestExistingAncestorStats(pathToCheck);
+      if (ancestorStats?.isSymbolicLink()) {
+        throw new Error(message);
+      }
       return;
     }
     throw error;
+  }
+  if (stats.isSymbolicLink()) {
+    throw new Error(message);
   }
 }
 
@@ -40,7 +76,10 @@ function assertNoSymlinkedDescendants(resolvedBase: string, resolvedTarget: stri
  * directory. This is separator-aware, so sibling paths such as `/tmp/base2`
  * are not treated as children of `/tmp/base`. Existing symlinked base paths
  * and symlinked descendants under the base are rejected because writes would
- * follow them outside the lexical containment boundary.
+ * follow them outside the lexical containment boundary. A base that does not
+ * exist yet is vetted through its nearest existing ancestor: if that ancestor
+ * is a symlink, the recursive mkdir/write that follows would be redirected
+ * outside the intended tree, so it is rejected too (#2342).
  */
 export function resolvePathWithinBase(baseDir: string, ...segments: string[]): string {
   if (!baseDir || typeof baseDir !== 'string') {

--- a/tests/unit/utils/pathSecurity.test.ts
+++ b/tests/unit/utils/pathSecurity.test.ts
@@ -105,4 +105,57 @@ describe('resolvePathWithinBase', () => {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }
   });
+
+  // #2342: a base that does not exist yet must be vetted through its nearest
+  // existing ancestor — otherwise `/safe/link/new` (where `/safe/link` is a
+  // symlink to an outside directory) passes the lstat-ENOENT check and the
+  // recursive mkdir/write that follows escapes the intended tree.
+  it('rejects a missing base directory whose nearest existing ancestor is a symlink', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    const outside = path.join(sandbox, 'outside-target');
+    const link = path.join(sandbox, 'link');
+
+    try {
+      fs.mkdirSync(outside, { recursive: true });
+
+      try {
+        fs.symlinkSync(outside, link, 'dir');
+      } catch (error) {
+        const code = typeof error === 'object' && error !== null && 'code' in error
+          ? (error as NodeJS.ErrnoException).code
+          : undefined;
+        if (code === 'EPERM' || code === 'EACCES') {
+          return;
+        }
+        throw error;
+      }
+
+      // Base does not exist yet; its nearest existing ancestor is the symlink.
+      const missingBase = path.join(link, 'new-base');
+      expect(() => resolvePathWithinBase(missingBase, 'file.md')).toThrow(
+        'Base directory resolves through a symbolic link'
+      );
+
+      // Same for a base several missing levels below the symlink.
+      const deepMissingBase = path.join(link, 'a', 'b', 'new-base');
+      expect(() => resolvePathWithinBase(deepMissingBase, 'file.md')).toThrow(
+        'Base directory resolves through a symbolic link'
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('allows a missing base directory under real existing ancestors', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+
+    try {
+      const missingBase = path.join(sandbox, 'not-created-yet', 'sub');
+      expect(resolvePathWithinBase(missingBase, 'file.md')).toBe(
+        path.resolve(missingBase, 'file.md')
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
Port of PR #2343 (merged to develop) to the beta line.

Closes the filed #2342 case on beta: a base directory that does not exist yet is now vetted through its nearest existing ancestor — if that ancestor is a symlink, resolution is rejected before the recursive mkdir/write can escape through it. Existing bases behave exactly as before (macOS `/tmp -> /private/tmp` style system links keep working).

The residual existing-through-symlink variant (codex P1 on #2343) is tracked in #2344, scoped to the convert CLI with a canonical-containment fix; that will be ported to beta when it lands on develop.

Part of #2342

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ughz92rhDUkghgYD2boQ