### PR TITLE
hotfix(beta): canonical containment for convert CLI output paths (#2344)

### DIFF
--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -43,9 +43,23 @@ import {
 } from '../converters/index.js';
 import { SecurityMonitor } from '../security/securityMonitor.js';
 import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
-import { resolvePathWithinBase } from '../utils/pathSecurity.js';
+import { resolvePathWithinBase, vetOutputBase } from '../utils/pathSecurity.js';
 
 const program = new Command();
+
+/**
+ * Vet the user's output base and return the canonical directory to write to
+ * (#2344). Relative outputs are contained within the working directory even
+ * when a symlink tries to redirect them; explicit outside destinations are
+ * honoured but their real location is disclosed when it differs.
+ */
+function vetConvertOutput(requestedOutput: string): string {
+    return vetOutputBase(requestedOutput, {
+        onDisclose: (canonicalBase) => {
+            console.log(chalk.yellow(`  Note: output resolves through a symbolic link — real destination: ${canonicalBase}`));
+        }
+    });
+}
 
 /**
  * Maximum ZIP file size (100MB) - prevents DoS attacks and system resource exhaustion
@@ -344,8 +358,9 @@ async function convertToAnthropic(input: string, options: ConvertOptions): Promi
         const structure = await converter.convertSkill(inputContent);
         logConversionSteps(structure, operationsLog, options.verbose);
 
-        // Determine output directory
-        const outputDir = resolvePathWithinBase(options.output || './anthropic-skills', skillName);
+        // Determine output directory (canonical containment per #2344)
+        const outputBase = vetConvertOutput(options.output || './anthropic-skills');
+        const outputDir = resolvePathWithinBase(outputBase, skillName);
 
         if (options.dryRun) {
             console.log(chalk.yellow('\n[DRY RUN] Would create:'));
@@ -459,8 +474,8 @@ async function convertFromAnthropic(input: string, options: ConvertOptions): Pro
         const dollhouseSkill = await converter.convertSkill(actualInput);
         logReverseConversionSteps(actualInput, operationsLog, options.verbose);
 
-        // Determine output file
-        const outputDir = path.resolve(options.output || getDefaultSkillsDirectory());
+        // Determine output file (canonical containment per #2344)
+        const outputDir = vetConvertOutput(options.output || getDefaultSkillsDirectory());
         const outputFile = resolvePathWithinBase(outputDir, `${skillName}.md`);
 
         if (options.dryRun) {

--- a/src/utils/pathSecurity.ts
+++ b/src/utils/pathSecurity.ts
@@ -110,3 +110,92 @@ export function resolvePathWithinBase(baseDir: string, ...segments: string[]): s
 
   throw new Error('Resolved path escapes the base directory');
 }
+
+/** True when a base-relative path points outside the base. */
+function escapesBase(relativePath: string): boolean {
+  return relativePath === '..'
+    || relativePath.startsWith('..' + path.sep)
+    || path.isAbsolute(relativePath);
+}
+
+/**
+ * Canonical (realpath) form of a path that may not fully exist yet: the
+ * deepest existing ancestor is resolved through every symlink, and the
+ * not-yet-created suffix is appended unchanged. This answers "where would a
+ * recursive mkdir/write on this path REALLY land?" — which per-component
+ * lstat checks cannot, because lstat resolves intermediate symlinks and only
+ * reports on the final component (#2344).
+ */
+export function canonicalizePath(inputPath: string): string {
+  const resolved = path.resolve(inputPath);
+  const missing: string[] = [];
+  let current = resolved;
+  for (;;) {
+    try {
+      const canonical = fs.realpathSync(current);
+      return missing.length ? path.join(canonical, ...missing) : canonical;
+    } catch (error) {
+      if (!isMissingPathError(error)) {
+        throw error;
+      }
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      // Nothing on the chain exists (should not happen for absolute paths —
+      // the root exists — but keep a lexical fallback rather than throwing).
+      return missing.length ? path.join(current, ...missing) : current;
+    }
+    missing.unshift(path.basename(current));
+    current = parent;
+  }
+}
+
+/**
+ * Vets a user-supplied output base for CLI writes and returns the canonical
+ * path all subsequent writes should use (#2344).
+ *
+ * Two regimes, split by what the user lexically named:
+ *
+ *  - Base inside the anchor (relative outputs like the './anthropic-skills'
+ *    default): the canonical base must stay inside the canonical anchor.
+ *    A symlink that redirects it elsewhere — including one whose target
+ *    already contains matching subdirectories, the case per-component lstat
+ *    checks miss — is rejected. Comparing in canonical space means system
+ *    links above the anchor (macOS /tmp -> /private/tmp) never false-positive.
+ *
+ *  - Base outside the anchor (explicit absolute or ../ outputs): the user
+ *    named that destination, so there is no boundary to defend. Instead of
+ *    guessing intent, the real destination is disclosed via `onDisclose`
+ *    whenever it differs from the lexical path, and the canonical path is
+ *    returned so what was vetted is what gets written.
+ */
+export function vetOutputBase(
+  baseDir: string,
+  options?: { anchor?: string; onDisclose?: (canonicalBase: string) => void },
+): string {
+  if (!baseDir || typeof baseDir !== 'string') {
+    throw new TypeError('Base directory must be a non-empty string');
+  }
+  if (baseDir.includes('\0')) {
+    throw new Error('Path segment contains a null byte');
+  }
+
+  const resolvedAnchor = path.resolve(options?.anchor ?? process.cwd());
+  const resolvedBase = path.resolve(baseDir);
+  const canonicalBase = canonicalizePath(resolvedBase);
+
+  if (!escapesBase(path.relative(resolvedAnchor, resolvedBase))) {
+    const canonicalAnchor = canonicalizePath(resolvedAnchor);
+    if (escapesBase(path.relative(canonicalAnchor, canonicalBase))) {
+      throw new Error(
+        `Output path resolves outside the working directory through a symbolic link (real destination: ${canonicalBase})`,
+      );
+    }
+    return canonicalBase;
+  }
+
+  if (canonicalBase !== resolvedBase) {
+    options?.onDisclose?.(canonicalBase);
+  }
+  return canonicalBase;
+}

--- a/tests/unit/utils/pathSecurity.test.ts
+++ b/tests/unit/utils/pathSecurity.test.ts
@@ -2,7 +2,27 @@ import { describe, expect, it } from '@jest/globals';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { tmpdir } from 'node:os';
-import { resolvePathWithinBase } from '../../../src/utils/pathSecurity.js';
+import { resolvePathWithinBase, canonicalizePath, vetOutputBase } from '../../../src/utils/pathSecurity.js';
+
+/**
+ * Creates a symlink or skips the calling test on platforms where symlink
+ * creation needs elevated privileges (Windows without developer mode).
+ * Returns false when the test should bail out early.
+ */
+function trySymlink(target: string, linkPath: string): boolean {
+  try {
+    fs.symlinkSync(target, linkPath, 'dir');
+    return true;
+  } catch (error) {
+    const code = typeof error === 'object' && error !== null && 'code' in error
+      ? (error as NodeJS.ErrnoException).code
+      : undefined;
+    if (code === 'EPERM' || code === 'EACCES') {
+      return false;
+    }
+    throw error;
+  }
+}
 
 describe('resolvePathWithinBase', () => {
   const baseDir = path.join(tmpdir(), 'dollhouse-path-security-base');
@@ -157,5 +177,160 @@ describe('resolvePathWithinBase', () => {
     } finally {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }
+  });
+});
+
+// ── #2344: canonical containment for user-supplied output bases ──────────────
+
+describe('canonicalizePath', () => {
+  it('resolves the existing prefix and appends the missing suffix unchanged', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    try {
+      const canonicalSandbox = fs.realpathSync(sandbox);
+      const missing = path.join(sandbox, 'not-yet', 'created', 'dir');
+      expect(canonicalizePath(missing)).toBe(
+        path.join(canonicalSandbox, 'not-yet', 'created', 'dir')
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves symlinks in the existing prefix', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    try {
+      const outside = path.join(sandbox, 'outside-target');
+      fs.mkdirSync(outside, { recursive: true });
+      const link = path.join(sandbox, 'link');
+      if (!trySymlink(outside, link)) return;
+
+      expect(canonicalizePath(path.join(link, 'new'))).toBe(
+        path.join(fs.realpathSync(outside), 'new')
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('vetOutputBase', () => {
+  it('returns the canonical base for a relative output under real ancestors', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    try {
+      const requested = path.join(sandbox, 'exports', 'skills');
+      expect(vetOutputBase(requested, { anchor: sandbox })).toBe(
+        path.join(fs.realpathSync(sandbox), 'exports', 'skills')
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an in-anchor output redirected outside by a symlink (missing target)', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    try {
+      const anchor = path.join(sandbox, 'anchor');
+      const outside = path.join(sandbox, 'outside-target');
+      fs.mkdirSync(anchor, { recursive: true });
+      fs.mkdirSync(outside, { recursive: true });
+      const link = path.join(anchor, 'exports');
+      if (!trySymlink(outside, link)) return;
+
+      expect(() => vetOutputBase(path.join(link, 'new'), { anchor })).toThrow(
+        'through a symbolic link'
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects the existing-through-symlink variant (codex P1 on #2343)', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    try {
+      const anchor = path.join(sandbox, 'anchor');
+      const outside = path.join(sandbox, 'outside-target');
+      fs.mkdirSync(anchor, { recursive: true });
+      // The attacker's target ALREADY CONTAINS the matching subdirectory —
+      // per-component lstat checks pass this shape; canonical containment must not.
+      fs.mkdirSync(path.join(outside, 'existing'), { recursive: true });
+      const link = path.join(anchor, 'exports');
+      if (!trySymlink(outside, link)) return;
+
+      expect(() => vetOutputBase(path.join(link, 'existing', 'new'), { anchor })).toThrow(
+        'through a symbolic link'
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('does not false-positive when the anchor itself is reached via a symlink (macOS /tmp shape)', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    try {
+      const realAnchor = path.join(sandbox, 'real-anchor');
+      fs.mkdirSync(realAnchor, { recursive: true });
+      const anchorLink = path.join(sandbox, 'anchor-link');
+      if (!trySymlink(realAnchor, anchorLink)) return;
+
+      // Base lexically under the symlinked anchor: both sides canonicalize
+      // through the same link, so this must be allowed.
+      const requested = path.join(anchorLink, 'exports');
+      expect(vetOutputBase(requested, { anchor: anchorLink })).toBe(
+        path.join(fs.realpathSync(realAnchor), 'exports')
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('discloses the real destination for an outside-anchor output routed through a symlink', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    try {
+      const anchor = path.join(sandbox, 'anchor');
+      const outside = path.join(sandbox, 'outside-target');
+      fs.mkdirSync(anchor, { recursive: true });
+      fs.mkdirSync(outside, { recursive: true });
+      const link = path.join(sandbox, 'elsewhere-link');
+      if (!trySymlink(outside, link)) return;
+
+      const disclosed: string[] = [];
+      const result = vetOutputBase(path.join(link, 'new'), {
+        anchor,
+        onDisclose: (p) => disclosed.push(p),
+      });
+
+      const canonical = path.join(fs.realpathSync(outside), 'new');
+      expect(result).toBe(canonical);
+      expect(disclosed).toEqual([canonical]);
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('does not disclose for an outside-anchor output with no symlink divergence', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    try {
+      const anchor = path.join(sandbox, 'anchor');
+      fs.mkdirSync(anchor, { recursive: true });
+      // Use the canonical sandbox so no divergence comes from tmpdir itself
+      // (macOS /var -> /private/var would otherwise always disclose).
+      const canonicalSandbox = fs.realpathSync(sandbox);
+      const requested = path.join(canonicalSandbox, 'plain-exports');
+
+      const disclosed: string[] = [];
+      const result = vetOutputBase(requested, {
+        anchor,
+        onDisclose: (p) => disclosed.push(p),
+      });
+
+      expect(result).toBe(requested);
+      expect(disclosed).toEqual([]);
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects null bytes', () => {
+    expect(() => vetOutputBase('bad\0dir')).toThrow('null byte');
   });
 });


### PR DESCRIPTION
Port of PR #2346 (merged to develop) to the beta line — closes the existing-through-symlink variant (the P1 flagged on #2343/#2345) on beta.

Relative convert outputs are contained canonically within the canonical working directory; explicit outside destinations disclose their real location when a symlink diverts them and are written at the vetted canonical path. See #2344 for the full design rationale and threat-model scoping.

Same verification as develop: 20/20 pathSecurity tests, 73/73 convert-suite tests, tsc clean.

Part of #2344

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ughz92rhDUkghgYD2boQ