### PR TITLE
Release v2.0.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.0.38] - 2026-07-04
+
+- Close the remaining symlink containment bypasses for convert CLI output paths. Output directories that do not exist yet are vetted through their nearest existing ancestor (#2342, #2343), and output bases are now contained canonically: relative outputs (including the default) must truly resolve inside the working directory even when a symlink tries to redirect them, and explicit outside destinations disclose their real location when a symlink diverts them (#2344, #2346).
+
+## [2.0.37] - 2026-07-04
+
+- Fix MCP client configs (Claude Desktop, Cursor, Windsurf, LM Studio, Gemini CLI, VS Code, Cline) left pointing at a dead NVM launcher wrapper: the server now self-heals broken entries on startup — restoring bare `npx` when NVM is absent, or regenerating the real wrapper when NVM is present — and refuses to ever persist a temp-directory wrapper into a client config. Also isolates the test suite so it can no longer write to real client configs. (#2338, #2339)
+- Harden path containment to reject symlink-based escapes from allowed directories, and preserve element metadata and base-path handling through edit operations. (#2334)
+- Tighten content validator input-length checks and make ensemble element updates explicit. (#2334)
+
 ## [2.0.36] - 2026-07-03
 
 - Fix silent memory data loss: `addEntry` reported success while entries were never persisted when a memory's serialized YAML exceeded 64KB. Saves now persist correctly and surface errors instead of failing silently. (#2329, #2330, #2332)

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dollhousemcp",
   "display_name": "DollhouseMCP",
-  "version": "2.0.36",
+  "version": "2.0.38",
   "description": "Open-source AI customization through modular Dollhouse elements — personas, skills, templates, agents, memories, and ensembles.",
   "long_description": "DollhouseMCP is an MCP server that lets you customize your AI with modular Dollhouse elements. Create personas that shape behavior and permissions, skills that add capabilities, templates for consistent outputs, agents for autonomous multi-step goals, memories for persistent context, and ensembles that bundle elements together. Includes MCP-AQL query language with 5 semantic CRUDE endpoints, Gatekeeper permission system, community collection, and a built-in portfolio browser.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.36",
+  "version": "2.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.36",
+      "version": "2.0.38",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"
@@ -141,6 +141,7 @@
       "version": "7.28.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -164,8 +165,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      },
-      "peer": true
+      }
     },
     "node_modules/@babel/generator": {
       "version": "7.28.3",
@@ -656,13 +656,13 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@csstools/css-tokenizer": "^3.0.4"
-      },
-      "peer": true
+      }
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "3.0.4",
@@ -679,10 +679,10 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
-      },
-      "peer": true
+      }
     },
     "node_modules/@dollhousemcp/safety": {
       "resolved": "packages/safety",
@@ -2558,6 +2558,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
       "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2591,8 +2592,7 @@
         "zod": {
           "optional": false
         }
-      },
-      "peer": true
+      }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
       "version": "8.18.0",
@@ -4116,6 +4116,7 @@
       "version": "8.48.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -4133,8 +4134,7 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
-      },
-      "peer": true
+      }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
       "version": "8.48.1",
@@ -4735,13 +4735,13 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      },
-      "peer": true
+      }
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
@@ -5178,6 +5178,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -5189,8 +5190,7 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      },
-      "peer": true
+      }
     },
     "node_modules/bs-logger": {
       "version": "0.2.6",
@@ -6136,6 +6136,7 @@
       "version": "9.39.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6188,8 +6189,7 @@
         "jiti": {
           "optional": true
         }
-      },
-      "peer": true
+      }
     },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
@@ -6509,6 +6509,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6545,8 +6546,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      },
-      "peer": true
+      }
     },
     "node_modules/express-rate-limit": {
       "version": "8.3.1",
@@ -7078,10 +7078,10 @@
     "node_modules/graphql": {
       "version": "16.12.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      },
-      "peer": true
+      }
     },
     "node_modules/graphql-tag": {
       "version": "2.12.6",
@@ -7197,10 +7197,10 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
       "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
-      },
-      "peer": true
+      }
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -7654,6 +7654,7 @@
       "version": "30.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -7673,8 +7674,7 @@
         "node-notifier": {
           "optional": true
         }
-      },
-      "peer": true
+      }
     },
     "node_modules/jest-changed-files": {
       "version": "30.2.0",
@@ -9696,13 +9696,13 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
-      },
-      "peer": true
+      }
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
@@ -9710,14 +9710,14 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
       },
       "peerDependencies": {
         "react": "^18.3.1"
-      },
-      "peer": true
+      }
     },
     "node_modules/react-is": {
       "version": "18.3.1",
@@ -10860,13 +10860,13 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      },
-      "peer": true
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -11253,6 +11253,7 @@
       "version": "10.9.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11289,8 +11290,7 @@
         "@swc/wasm": {
           "optional": true
         }
-      },
-      "peer": true
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -11360,14 +11360,14 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
-      },
-      "peer": true
+      }
     },
     "node_modules/ufo": {
       "version": "1.6.3",
@@ -11917,10 +11917,10 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      },
-      "peer": true
+      }
     },
     "node_modules/zod-to-json-schema": {
       "version": "3.25.1",
@@ -11953,6 +11953,7 @@
       "version": "7.28.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -11976,8 +11977,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      },
-      "peer": true
+      }
     },
     "packages/safety/node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
@@ -12522,6 +12522,7 @@
       "version": "7.18.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -12543,8 +12544,7 @@
         "typescript": {
           "optional": true
         }
-      },
-      "peer": true
+      }
     },
     "packages/safety/node_modules/@typescript-eslint/scope-manager": {
       "version": "7.18.0",
@@ -12876,6 +12876,7 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -12924,8 +12925,7 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      },
-      "peer": true
+      }
     },
     "packages/safety/node_modules/eslint-scope": {
       "version": "7.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.36",
+  "version": "2.0.38",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.36",
+  "version": "2.0.38",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.36",
+      "version": "2.0.38",
       "transport": {
         "type": "stdio"
       }

--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -43,9 +43,23 @@ import {
 } from '../converters/index.js';
 import { SecurityMonitor } from '../security/securityMonitor.js';
 import { UnicodeValidator } from '../security/validators/unicodeValidator.js';
-import { resolvePathWithinBase } from '../utils/pathSecurity.js';
+import { resolvePathWithinBase, vetOutputBase } from '../utils/pathSecurity.js';
 
 const program = new Command();
+
+/**
+ * Vet the user's output base and return the canonical directory to write to
+ * (#2344). Relative outputs are contained within the working directory even
+ * when a symlink tries to redirect them; explicit outside destinations are
+ * honoured but their real location is disclosed when it differs.
+ */
+function vetConvertOutput(requestedOutput: string): string {
+    return vetOutputBase(requestedOutput, {
+        onDisclose: (canonicalBase) => {
+            console.log(chalk.yellow(`  Note: output resolves through a symbolic link — real destination: ${canonicalBase}`));
+        }
+    });
+}
 
 /**
  * Maximum ZIP file size (100MB) - prevents DoS attacks and system resource exhaustion
@@ -344,8 +358,9 @@ async function convertToAnthropic(input: string, options: ConvertOptions): Promi
         const structure = await converter.convertSkill(inputContent);
         logConversionSteps(structure, operationsLog, options.verbose);
 
-        // Determine output directory
-        const outputDir = resolvePathWithinBase(options.output || './anthropic-skills', skillName);
+        // Determine output directory (canonical containment per #2344)
+        const outputBase = vetConvertOutput(options.output || './anthropic-skills');
+        const outputDir = resolvePathWithinBase(outputBase, skillName);
 
         if (options.dryRun) {
             console.log(chalk.yellow('\n[DRY RUN] Would create:'));
@@ -459,8 +474,8 @@ async function convertFromAnthropic(input: string, options: ConvertOptions): Pro
         const dollhouseSkill = await converter.convertSkill(actualInput);
         logReverseConversionSteps(actualInput, operationsLog, options.verbose);
 
-        // Determine output file
-        const outputDir = path.resolve(options.output || getDefaultSkillsDirectory());
+        // Determine output file (canonical containment per #2344)
+        const outputDir = vetConvertOutput(options.output || getDefaultSkillsDirectory());
         const outputFile = resolvePathWithinBase(outputDir, `${skillName}.md`);
 
         if (options.dryRun) {

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.36';
-export const BUILD_TIMESTAMP = '2026-07-03T19:08:52.386Z';
+export const PACKAGE_VERSION = '2.0.38';
+export const BUILD_TIMESTAMP = '2026-07-04T18:32:15.882Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';

--- a/src/utils/pathSecurity.ts
+++ b/src/utils/pathSecurity.ts
@@ -13,6 +13,15 @@ function isMissingPathError(error: unknown): boolean {
  * nothing up to the filesystem root exists. Used to vet paths that will be
  * created later: their containment depends on the directory they will be
  * created inside.
+ *
+ * KNOWN LIMIT (#2344): this stops at the first ancestor lstat can see, and
+ * lstat resolves intermediate symlinks — so a symlink whose target already
+ * contains a matching subdirectory is reported as a plain directory and the
+ * symlink component itself is never inspected. Walking every lexical ancestor
+ * instead is not an option: system symlinks (macOS /tmp -> /private/tmp,
+ * /var -> /private/var) sit above every temp path and would false-positive.
+ * Full protection needs a caller-known boundary, which is exactly what
+ * vetOutputBase() provides — see the contract note on resolvePathWithinBase.
  */
 function nearestExistingAncestorStats(startPath: string): fs.Stats | null {
   let previous = startPath;
@@ -80,6 +89,14 @@ function assertNoSymlinkedDescendants(resolvedBase: string, resolvedTarget: stri
  * exist yet is vetted through its nearest existing ancestor: if that ancestor
  * is a symlink, the recursive mkdir/write that follows would be redirected
  * outside the intended tree, so it is rejected too (#2342).
+ *
+ * CONTRACT (#2344): the base's own ancestry can only be best-effort vetted
+ * here — a symlink whose target pre-contains matching subdirectories is not
+ * detectable without a caller-known boundary (see nearestExistingAncestorStats
+ * for why walking every ancestor false-positives on system symlinks). Do NOT
+ * pass user-controlled base paths directly to this function: vet them first
+ * with vetOutputBase(), which contains them canonically against an anchor and
+ * returns the canonical base to use here. Every current caller does this.
  */
 export function resolvePathWithinBase(baseDir: string, ...segments: string[]): string {
   if (!baseDir || typeof baseDir !== 'string') {

--- a/src/utils/pathSecurity.ts
+++ b/src/utils/pathSecurity.ts
@@ -110,3 +110,92 @@ export function resolvePathWithinBase(baseDir: string, ...segments: string[]): s
 
   throw new Error('Resolved path escapes the base directory');
 }
+
+/** True when a base-relative path points outside the base. */
+function escapesBase(relativePath: string): boolean {
+  return relativePath === '..'
+    || relativePath.startsWith('..' + path.sep)
+    || path.isAbsolute(relativePath);
+}
+
+/**
+ * Canonical (realpath) form of a path that may not fully exist yet: the
+ * deepest existing ancestor is resolved through every symlink, and the
+ * not-yet-created suffix is appended unchanged. This answers "where would a
+ * recursive mkdir/write on this path REALLY land?" — which per-component
+ * lstat checks cannot, because lstat resolves intermediate symlinks and only
+ * reports on the final component (#2344).
+ */
+export function canonicalizePath(inputPath: string): string {
+  const resolved = path.resolve(inputPath);
+  const missing: string[] = [];
+  let current = resolved;
+  for (;;) {
+    try {
+      const canonical = fs.realpathSync(current);
+      return missing.length ? path.join(canonical, ...missing) : canonical;
+    } catch (error) {
+      if (!isMissingPathError(error)) {
+        throw error;
+      }
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      // Nothing on the chain exists (should not happen for absolute paths —
+      // the root exists — but keep a lexical fallback rather than throwing).
+      return missing.length ? path.join(current, ...missing) : current;
+    }
+    missing.unshift(path.basename(current));
+    current = parent;
+  }
+}
+
+/**
+ * Vets a user-supplied output base for CLI writes and returns the canonical
+ * path all subsequent writes should use (#2344).
+ *
+ * Two regimes, split by what the user lexically named:
+ *
+ *  - Base inside the anchor (relative outputs like the './anthropic-skills'
+ *    default): the canonical base must stay inside the canonical anchor.
+ *    A symlink that redirects it elsewhere — including one whose target
+ *    already contains matching subdirectories, the case per-component lstat
+ *    checks miss — is rejected. Comparing in canonical space means system
+ *    links above the anchor (macOS /tmp -> /private/tmp) never false-positive.
+ *
+ *  - Base outside the anchor (explicit absolute or ../ outputs): the user
+ *    named that destination, so there is no boundary to defend. Instead of
+ *    guessing intent, the real destination is disclosed via `onDisclose`
+ *    whenever it differs from the lexical path, and the canonical path is
+ *    returned so what was vetted is what gets written.
+ */
+export function vetOutputBase(
+  baseDir: string,
+  options?: { anchor?: string; onDisclose?: (canonicalBase: string) => void },
+): string {
+  if (!baseDir || typeof baseDir !== 'string') {
+    throw new TypeError('Base directory must be a non-empty string');
+  }
+  if (baseDir.includes('\0')) {
+    throw new Error('Path segment contains a null byte');
+  }
+
+  const resolvedAnchor = path.resolve(options?.anchor ?? process.cwd());
+  const resolvedBase = path.resolve(baseDir);
+  const canonicalBase = canonicalizePath(resolvedBase);
+
+  if (!escapesBase(path.relative(resolvedAnchor, resolvedBase))) {
+    const canonicalAnchor = canonicalizePath(resolvedAnchor);
+    if (escapesBase(path.relative(canonicalAnchor, canonicalBase))) {
+      throw new Error(
+        `Output path resolves outside the working directory through a symbolic link (real destination: ${canonicalBase})`,
+      );
+    }
+    return canonicalBase;
+  }
+
+  if (canonicalBase !== resolvedBase) {
+    options?.onDisclose?.(canonicalBase);
+  }
+  return canonicalBase;
+}

--- a/src/utils/pathSecurity.ts
+++ b/src/utils/pathSecurity.ts
@@ -1,20 +1,56 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-function assertNotSymlink(pathToCheck: string, message: string): void {
-  try {
-    const stats = fs.lstatSync(pathToCheck);
-    if (stats.isSymbolicLink()) {
-      throw new Error(message);
+function isMissingPathError(error: unknown): boolean {
+  const code = typeof error === 'object' && error !== null && 'code' in error
+    ? (error as NodeJS.ErrnoException).code
+    : undefined;
+  return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
+/**
+ * lstat of the deepest ancestor of `startPath` that exists, or null when
+ * nothing up to the filesystem root exists. Used to vet paths that will be
+ * created later: their containment depends on the directory they will be
+ * created inside.
+ */
+function nearestExistingAncestorStats(startPath: string): fs.Stats | null {
+  let previous = startPath;
+  let current = path.dirname(startPath);
+  while (current !== previous) {
+    try {
+      return fs.lstatSync(current);
+    } catch (error) {
+      if (!isMissingPathError(error)) {
+        throw error;
+      }
     }
+    previous = current;
+    current = path.dirname(current);
+  }
+  return null;
+}
+
+function assertNotSymlink(pathToCheck: string, message: string): void {
+  let stats: fs.Stats;
+  try {
+    stats = fs.lstatSync(pathToCheck);
   } catch (error) {
-    const code = typeof error === 'object' && error !== null && 'code' in error
-      ? (error as NodeJS.ErrnoException).code
-      : undefined;
-    if (code === 'ENOENT' || code === 'ENOTDIR') {
+    if (isMissingPathError(error)) {
+      // The path does not exist yet, so it will be created by a later
+      // mkdir/write. That is only safe if the directory it gets created
+      // inside is real: a symlinked existing ancestor would redirect the
+      // recursive create outside the containment boundary (#2342).
+      const ancestorStats = nearestExistingAncestorStats(pathToCheck);
+      if (ancestorStats?.isSymbolicLink()) {
+        throw new Error(message);
+      }
       return;
     }
     throw error;
+  }
+  if (stats.isSymbolicLink()) {
+    throw new Error(message);
   }
 }
 
@@ -40,7 +76,10 @@ function assertNoSymlinkedDescendants(resolvedBase: string, resolvedTarget: stri
  * directory. This is separator-aware, so sibling paths such as `/tmp/base2`
  * are not treated as children of `/tmp/base`. Existing symlinked base paths
  * and symlinked descendants under the base are rejected because writes would
- * follow them outside the lexical containment boundary.
+ * follow them outside the lexical containment boundary. A base that does not
+ * exist yet is vetted through its nearest existing ancestor: if that ancestor
+ * is a symlink, the recursive mkdir/write that follows would be redirected
+ * outside the intended tree, so it is rejected too (#2342).
  */
 export function resolvePathWithinBase(baseDir: string, ...segments: string[]): string {
   if (!baseDir || typeof baseDir !== 'string') {

--- a/tests/unit/utils/pathSecurity.test.ts
+++ b/tests/unit/utils/pathSecurity.test.ts
@@ -2,7 +2,27 @@ import { describe, expect, it } from '@jest/globals';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { tmpdir } from 'node:os';
-import { resolvePathWithinBase } from '../../../src/utils/pathSecurity.js';
+import { resolvePathWithinBase, canonicalizePath, vetOutputBase } from '../../../src/utils/pathSecurity.js';
+
+/**
+ * Creates a symlink or skips the calling test on platforms where symlink
+ * creation needs elevated privileges (Windows without developer mode).
+ * Returns false when the test should bail out early.
+ */
+function trySymlink(target: string, linkPath: string): boolean {
+  try {
+    fs.symlinkSync(target, linkPath, 'dir');
+    return true;
+  } catch (error) {
+    const code = typeof error === 'object' && error !== null && 'code' in error
+      ? (error as NodeJS.ErrnoException).code
+      : undefined;
+    if (code === 'EPERM' || code === 'EACCES') {
+      return false;
+    }
+    throw error;
+  }
+}
 
 describe('resolvePathWithinBase', () => {
   const baseDir = path.join(tmpdir(), 'dollhouse-path-security-base');
@@ -157,5 +177,160 @@ describe('resolvePathWithinBase', () => {
     } finally {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }
+  });
+});
+
+// ── #2344: canonical containment for user-supplied output bases ──────────────
+
+describe('canonicalizePath', () => {
+  it('resolves the existing prefix and appends the missing suffix unchanged', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    try {
+      const canonicalSandbox = fs.realpathSync(sandbox);
+      const missing = path.join(sandbox, 'not-yet', 'created', 'dir');
+      expect(canonicalizePath(missing)).toBe(
+        path.join(canonicalSandbox, 'not-yet', 'created', 'dir')
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves symlinks in the existing prefix', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    try {
+      const outside = path.join(sandbox, 'outside-target');
+      fs.mkdirSync(outside, { recursive: true });
+      const link = path.join(sandbox, 'link');
+      if (!trySymlink(outside, link)) return;
+
+      expect(canonicalizePath(path.join(link, 'new'))).toBe(
+        path.join(fs.realpathSync(outside), 'new')
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('vetOutputBase', () => {
+  it('returns the canonical base for a relative output under real ancestors', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    try {
+      const requested = path.join(sandbox, 'exports', 'skills');
+      expect(vetOutputBase(requested, { anchor: sandbox })).toBe(
+        path.join(fs.realpathSync(sandbox), 'exports', 'skills')
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an in-anchor output redirected outside by a symlink (missing target)', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    try {
+      const anchor = path.join(sandbox, 'anchor');
+      const outside = path.join(sandbox, 'outside-target');
+      fs.mkdirSync(anchor, { recursive: true });
+      fs.mkdirSync(outside, { recursive: true });
+      const link = path.join(anchor, 'exports');
+      if (!trySymlink(outside, link)) return;
+
+      expect(() => vetOutputBase(path.join(link, 'new'), { anchor })).toThrow(
+        'through a symbolic link'
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects the existing-through-symlink variant (codex P1 on #2343)', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    try {
+      const anchor = path.join(sandbox, 'anchor');
+      const outside = path.join(sandbox, 'outside-target');
+      fs.mkdirSync(anchor, { recursive: true });
+      // The attacker's target ALREADY CONTAINS the matching subdirectory —
+      // per-component lstat checks pass this shape; canonical containment must not.
+      fs.mkdirSync(path.join(outside, 'existing'), { recursive: true });
+      const link = path.join(anchor, 'exports');
+      if (!trySymlink(outside, link)) return;
+
+      expect(() => vetOutputBase(path.join(link, 'existing', 'new'), { anchor })).toThrow(
+        'through a symbolic link'
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('does not false-positive when the anchor itself is reached via a symlink (macOS /tmp shape)', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    try {
+      const realAnchor = path.join(sandbox, 'real-anchor');
+      fs.mkdirSync(realAnchor, { recursive: true });
+      const anchorLink = path.join(sandbox, 'anchor-link');
+      if (!trySymlink(realAnchor, anchorLink)) return;
+
+      // Base lexically under the symlinked anchor: both sides canonicalize
+      // through the same link, so this must be allowed.
+      const requested = path.join(anchorLink, 'exports');
+      expect(vetOutputBase(requested, { anchor: anchorLink })).toBe(
+        path.join(fs.realpathSync(realAnchor), 'exports')
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('discloses the real destination for an outside-anchor output routed through a symlink', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    try {
+      const anchor = path.join(sandbox, 'anchor');
+      const outside = path.join(sandbox, 'outside-target');
+      fs.mkdirSync(anchor, { recursive: true });
+      fs.mkdirSync(outside, { recursive: true });
+      const link = path.join(sandbox, 'elsewhere-link');
+      if (!trySymlink(outside, link)) return;
+
+      const disclosed: string[] = [];
+      const result = vetOutputBase(path.join(link, 'new'), {
+        anchor,
+        onDisclose: (p) => disclosed.push(p),
+      });
+
+      const canonical = path.join(fs.realpathSync(outside), 'new');
+      expect(result).toBe(canonical);
+      expect(disclosed).toEqual([canonical]);
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('does not disclose for an outside-anchor output with no symlink divergence', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    try {
+      const anchor = path.join(sandbox, 'anchor');
+      fs.mkdirSync(anchor, { recursive: true });
+      // Use the canonical sandbox so no divergence comes from tmpdir itself
+      // (macOS /var -> /private/var would otherwise always disclose).
+      const canonicalSandbox = fs.realpathSync(sandbox);
+      const requested = path.join(canonicalSandbox, 'plain-exports');
+
+      const disclosed: string[] = [];
+      const result = vetOutputBase(requested, {
+        anchor,
+        onDisclose: (p) => disclosed.push(p),
+      });
+
+      expect(result).toBe(requested);
+      expect(disclosed).toEqual([]);
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects null bytes', () => {
+    expect(() => vetOutputBase('bad\0dir')).toThrow('null byte');
   });
 });

--- a/tests/unit/utils/pathSecurity.test.ts
+++ b/tests/unit/utils/pathSecurity.test.ts
@@ -105,4 +105,57 @@ describe('resolvePathWithinBase', () => {
       fs.rmSync(sandbox, { recursive: true, force: true });
     }
   });
+
+  // #2342: a base that does not exist yet must be vetted through its nearest
+  // existing ancestor — otherwise `/safe/link/new` (where `/safe/link` is a
+  // symlink to an outside directory) passes the lstat-ENOENT check and the
+  // recursive mkdir/write that follows escapes the intended tree.
+  it('rejects a missing base directory whose nearest existing ancestor is a symlink', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+    const outside = path.join(sandbox, 'outside-target');
+    const link = path.join(sandbox, 'link');
+
+    try {
+      fs.mkdirSync(outside, { recursive: true });
+
+      try {
+        fs.symlinkSync(outside, link, 'dir');
+      } catch (error) {
+        const code = typeof error === 'object' && error !== null && 'code' in error
+          ? (error as NodeJS.ErrnoException).code
+          : undefined;
+        if (code === 'EPERM' || code === 'EACCES') {
+          return;
+        }
+        throw error;
+      }
+
+      // Base does not exist yet; its nearest existing ancestor is the symlink.
+      const missingBase = path.join(link, 'new-base');
+      expect(() => resolvePathWithinBase(missingBase, 'file.md')).toThrow(
+        'Base directory resolves through a symbolic link'
+      );
+
+      // Same for a base several missing levels below the symlink.
+      const deepMissingBase = path.join(link, 'a', 'b', 'new-base');
+      expect(() => resolvePathWithinBase(deepMissingBase, 'file.md')).toThrow(
+        'Base directory resolves through a symbolic link'
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it('allows a missing base directory under real existing ancestors', () => {
+    const sandbox = fs.mkdtempSync(path.join(tmpdir(), 'dollhouse-path-security-'));
+
+    try {
+      const missingBase = path.join(sandbox, 'not-created-yet', 'sub');
+      expect(resolvePathWithinBase(missingBase, 'file.md')).toBe(
+        path.resolve(missingBase, 'file.md')
+      );
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Release v2.0.38

Patch release from `develop` to `main` — completes the path-security work disclosed in v2.0.37.

### Changes

- **Symlink containment completed (#2342, #2343, #2344, #2346)** — closes both bypasses for convert CLI output paths:
  - Output directories that do not exist yet are vetted through their nearest existing ancestor (#2343).
  - Canonical containment (#2346): relative outputs — including the default — must truly resolve inside the working directory even when a symlink (or a symlink whose target pre-contains matching subdirectories) tries to redirect them; explicit outside destinations disclose their real location when a symlink diverts them, and writes use the vetted canonical path.

Closes the "remaining missing-base ancestor case" disclosed in the v2.0.37 release notes. No known path-security issues remain open.

### Verification

- All four source PRs (#2343, #2346 on develop; #2345, #2347 beta ports) merged with CI fully green, SonarCloud 0 issues / quality gate OK on every PR, and zero codex findings on the canonical-containment implementation.
- Changelog also backfills the 2.0.37 entry onto develop's history for the upcoming main→develop sync.

Fixes #2342
Fixes #2344

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ughz92rhDUkghgYD2boQ