### PR TITLE
chore: sync main (v2.0.38) into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.37] - 2026-07-04
+
+- Fix MCP client configs (Claude Desktop, Cursor, Windsurf, LM Studio, Gemini CLI, VS Code, Cline) left pointing at a dead NVM launcher wrapper: the server now self-heals broken entries on startup — restoring bare `npx` when NVM is absent, or regenerating the real wrapper when NVM is present — and refuses to ever persist a temp-directory wrapper into a client config. Also isolates the test suite so it can no longer write to real client configs. (#2338, #2339)
+- Harden path containment to reject symlink-based escapes from allowed directories, and preserve element metadata and base-path handling through edit operations. (#2334)
+- Tighten content validator input-length checks and make ensemble element updates explicit. (#2334)
+
 ## [2.0.36] - 2026-07-03
 
 - Fix silent memory data loss: `addEntry` reported success while entries were never persisted when a memory's serialized YAML exceeded 64KB. Saves now persist correctly and surface errors instead of failing silently. (#2329, #2330, #2332)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.0.38] - 2026-07-04
+
+- Close the remaining symlink containment bypasses for convert CLI output paths. Output directories that do not exist yet are vetted through their nearest existing ancestor (#2342, #2343), and output bases are now contained canonically: relative outputs (including the default) must truly resolve inside the working directory even when a symlink tries to redirect them, and explicit outside destinations disclose their real location when a symlink diverts them (#2344, #2346).
+
+## [2.0.37] - 2026-07-04
+
+- Fix MCP client configs (Claude Desktop, Cursor, Windsurf, LM Studio, Gemini CLI, VS Code, Cline) left pointing at a dead NVM launcher wrapper: the server now self-heals broken entries on startup — restoring bare `npx` when NVM is absent, or regenerating the real wrapper when NVM is present — and refuses to ever persist a temp-directory wrapper into a client config. Also isolates the test suite so it can no longer write to real client configs. (#2338, #2339)
+- Harden path containment to reject symlink-based escapes from allowed directories, and preserve element metadata and base-path handling through edit operations. (#2334)
+- Tighten content validator input-length checks and make ensemble element updates explicit. (#2334)
+
 ## [2.0.36] - 2026-07-03
 
 - Fix silent memory data loss: `addEntry` reported success while entries were never persisted when a memory's serialized YAML exceeded 64KB. Saves now persist correctly and surface errors instead of failing silently. (#2329, #2330, #2332)

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dollhousemcp",
   "display_name": "DollhouseMCP",
-  "version": "2.0.36",
+  "version": "2.0.37",
   "description": "Open-source AI customization through modular Dollhouse elements — personas, skills, templates, agents, memories, and ensembles.",
   "long_description": "DollhouseMCP is an MCP server that lets you customize your AI with modular Dollhouse elements. Create personas that shape behavior and permissions, skills that add capabilities, templates for consistent outputs, agents for autonomous multi-step goals, memories for persistent context, and ensembles that bundle elements together. Includes MCP-AQL query language with 5 semantic CRUDE endpoints, Gatekeeper permission system, community collection, and a built-in portfolio browser.",
   "author": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dollhousemcp",
   "display_name": "DollhouseMCP",
-  "version": "2.0.36",
+  "version": "2.0.38",
   "description": "Open-source AI customization through modular Dollhouse elements — personas, skills, templates, agents, memories, and ensembles.",
   "long_description": "DollhouseMCP is an MCP server that lets you customize your AI with modular Dollhouse elements. Create personas that shape behavior and permissions, skills that add capabilities, templates for consistent outputs, agents for autonomous multi-step goals, memories for persistent context, and ensembles that bundle elements together. Includes MCP-AQL query language with 5 semantic CRUDE endpoints, Gatekeeper permission system, community collection, and a built-in portfolio browser.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.36",
+  "version": "2.0.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.36",
+      "version": "2.0.37",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"
@@ -141,6 +141,7 @@
       "version": "7.28.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -164,8 +165,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      },
-      "peer": true
+      }
     },
     "node_modules/@babel/generator": {
       "version": "7.28.3",
@@ -656,13 +656,13 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@csstools/css-tokenizer": "^3.0.4"
-      },
-      "peer": true
+      }
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "3.0.4",
@@ -679,10 +679,10 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
-      },
-      "peer": true
+      }
     },
     "node_modules/@dollhousemcp/safety": {
       "resolved": "packages/safety",
@@ -2558,6 +2558,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
       "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2591,8 +2592,7 @@
         "zod": {
           "optional": false
         }
-      },
-      "peer": true
+      }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
       "version": "8.18.0",
@@ -4116,6 +4116,7 @@
       "version": "8.48.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -4133,8 +4134,7 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
-      },
-      "peer": true
+      }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
       "version": "8.48.1",
@@ -4735,13 +4735,13 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      },
-      "peer": true
+      }
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
@@ -5178,6 +5178,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -5189,8 +5190,7 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      },
-      "peer": true
+      }
     },
     "node_modules/bs-logger": {
       "version": "0.2.6",
@@ -6136,6 +6136,7 @@
       "version": "9.39.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6188,8 +6189,7 @@
         "jiti": {
           "optional": true
         }
-      },
-      "peer": true
+      }
     },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
@@ -6509,6 +6509,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6545,8 +6546,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      },
-      "peer": true
+      }
     },
     "node_modules/express-rate-limit": {
       "version": "8.3.1",
@@ -7078,10 +7078,10 @@
     "node_modules/graphql": {
       "version": "16.12.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      },
-      "peer": true
+      }
     },
     "node_modules/graphql-tag": {
       "version": "2.12.6",
@@ -7197,10 +7197,10 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
       "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
-      },
-      "peer": true
+      }
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -7654,6 +7654,7 @@
       "version": "30.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -7673,8 +7674,7 @@
         "node-notifier": {
           "optional": true
         }
-      },
-      "peer": true
+      }
     },
     "node_modules/jest-changed-files": {
       "version": "30.2.0",
@@ -9696,13 +9696,13 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
-      },
-      "peer": true
+      }
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
@@ -9710,14 +9710,14 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
       },
       "peerDependencies": {
         "react": "^18.3.1"
-      },
-      "peer": true
+      }
     },
     "node_modules/react-is": {
       "version": "18.3.1",
@@ -10860,13 +10860,13 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      },
-      "peer": true
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -11253,6 +11253,7 @@
       "version": "10.9.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11289,8 +11290,7 @@
         "@swc/wasm": {
           "optional": true
         }
-      },
-      "peer": true
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -11360,14 +11360,14 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
-      },
-      "peer": true
+      }
     },
     "node_modules/ufo": {
       "version": "1.6.3",
@@ -11917,10 +11917,10 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      },
-      "peer": true
+      }
     },
     "node_modules/zod-to-json-schema": {
       "version": "3.25.1",
@@ -11953,6 +11953,7 @@
       "version": "7.28.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -11976,8 +11977,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      },
-      "peer": true
+      }
     },
     "packages/safety/node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
@@ -12522,6 +12522,7 @@
       "version": "7.18.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -12543,8 +12544,7 @@
         "typescript": {
           "optional": true
         }
-      },
-      "peer": true
+      }
     },
     "packages/safety/node_modules/@typescript-eslint/scope-manager": {
       "version": "7.18.0",
@@ -12876,6 +12876,7 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -12924,8 +12925,7 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      },
-      "peer": true
+      }
     },
     "packages/safety/node_modules/eslint-scope": {
       "version": "7.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.36",
+  "version": "2.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.36",
+      "version": "2.0.38",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"
@@ -141,6 +141,7 @@
       "version": "7.28.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -164,8 +165,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      },
-      "peer": true
+      }
     },
     "node_modules/@babel/generator": {
       "version": "7.28.3",
@@ -656,13 +656,13 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@csstools/css-tokenizer": "^3.0.4"
-      },
-      "peer": true
+      }
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "3.0.4",
@@ -679,10 +679,10 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
-      },
-      "peer": true
+      }
     },
     "node_modules/@dollhousemcp/safety": {
       "resolved": "packages/safety",
@@ -2558,6 +2558,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
       "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2591,8 +2592,7 @@
         "zod": {
           "optional": false
         }
-      },
-      "peer": true
+      }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
       "version": "8.18.0",
@@ -4116,6 +4116,7 @@
       "version": "8.48.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -4133,8 +4134,7 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
-      },
-      "peer": true
+      }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
       "version": "8.48.1",
@@ -4735,13 +4735,13 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      },
-      "peer": true
+      }
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
@@ -5178,6 +5178,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -5189,8 +5190,7 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      },
-      "peer": true
+      }
     },
     "node_modules/bs-logger": {
       "version": "0.2.6",
@@ -6136,6 +6136,7 @@
       "version": "9.39.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6188,8 +6189,7 @@
         "jiti": {
           "optional": true
         }
-      },
-      "peer": true
+      }
     },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
@@ -6509,6 +6509,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6545,8 +6546,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      },
-      "peer": true
+      }
     },
     "node_modules/express-rate-limit": {
       "version": "8.3.1",
@@ -7078,10 +7078,10 @@
     "node_modules/graphql": {
       "version": "16.12.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      },
-      "peer": true
+      }
     },
     "node_modules/graphql-tag": {
       "version": "2.12.6",
@@ -7197,10 +7197,10 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
       "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
-      },
-      "peer": true
+      }
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -7654,6 +7654,7 @@
       "version": "30.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -7673,8 +7674,7 @@
         "node-notifier": {
           "optional": true
         }
-      },
-      "peer": true
+      }
     },
     "node_modules/jest-changed-files": {
       "version": "30.2.0",
@@ -9696,13 +9696,13 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
-      },
-      "peer": true
+      }
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
@@ -9710,14 +9710,14 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
       },
       "peerDependencies": {
         "react": "^18.3.1"
-      },
-      "peer": true
+      }
     },
     "node_modules/react-is": {
       "version": "18.3.1",
@@ -10860,13 +10860,13 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      },
-      "peer": true
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -11253,6 +11253,7 @@
       "version": "10.9.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11289,8 +11290,7 @@
         "@swc/wasm": {
           "optional": true
         }
-      },
-      "peer": true
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -11360,14 +11360,14 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
-      },
-      "peer": true
+      }
     },
     "node_modules/ufo": {
       "version": "1.6.3",
@@ -11917,10 +11917,10 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      },
-      "peer": true
+      }
     },
     "node_modules/zod-to-json-schema": {
       "version": "3.25.1",
@@ -11953,6 +11953,7 @@
       "version": "7.28.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -11976,8 +11977,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      },
-      "peer": true
+      }
     },
     "packages/safety/node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
@@ -12522,6 +12522,7 @@
       "version": "7.18.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -12543,8 +12544,7 @@
         "typescript": {
           "optional": true
         }
-      },
-      "peer": true
+      }
     },
     "packages/safety/node_modules/@typescript-eslint/scope-manager": {
       "version": "7.18.0",
@@ -12876,6 +12876,7 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -12924,8 +12925,7 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      },
-      "peer": true
+      }
     },
     "packages/safety/node_modules/eslint-scope": {
       "version": "7.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.36",
+  "version": "2.0.38",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.36",
+  "version": "2.0.37",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.36",
+  "version": "2.0.38",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.36",
+      "version": "2.0.38",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.36",
+  "version": "2.0.37",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.36",
+      "version": "2.0.37",
       "transport": {
         "type": "stdio"
       }

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.36';
-export const BUILD_TIMESTAMP = '2026-07-03T19:08:52.386Z';
+export const PACKAGE_VERSION = '2.0.37';
+export const BUILD_TIMESTAMP = '2026-07-04T16:57:04.821Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.36';
-export const BUILD_TIMESTAMP = '2026-07-03T19:08:52.386Z';
+export const PACKAGE_VERSION = '2.0.38';
+export const BUILD_TIMESTAMP = '2026-07-04T18:32:15.882Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';

--- a/src/utils/pathSecurity.ts
+++ b/src/utils/pathSecurity.ts
@@ -13,6 +13,15 @@ function isMissingPathError(error: unknown): boolean {
  * nothing up to the filesystem root exists. Used to vet paths that will be
  * created later: their containment depends on the directory they will be
  * created inside.
+ *
+ * KNOWN LIMIT (#2344): this stops at the first ancestor lstat can see, and
+ * lstat resolves intermediate symlinks — so a symlink whose target already
+ * contains a matching subdirectory is reported as a plain directory and the
+ * symlink component itself is never inspected. Walking every lexical ancestor
+ * instead is not an option: system symlinks (macOS /tmp -> /private/tmp,
+ * /var -> /private/var) sit above every temp path and would false-positive.
+ * Full protection needs a caller-known boundary, which is exactly what
+ * vetOutputBase() provides — see the contract note on resolvePathWithinBase.
  */
 function nearestExistingAncestorStats(startPath: string): fs.Stats | null {
   let previous = startPath;
@@ -80,6 +89,14 @@ function assertNoSymlinkedDescendants(resolvedBase: string, resolvedTarget: stri
  * exist yet is vetted through its nearest existing ancestor: if that ancestor
  * is a symlink, the recursive mkdir/write that follows would be redirected
  * outside the intended tree, so it is rejected too (#2342).
+ *
+ * CONTRACT (#2344): the base's own ancestry can only be best-effort vetted
+ * here — a symlink whose target pre-contains matching subdirectories is not
+ * detectable without a caller-known boundary (see nearestExistingAncestorStats
+ * for why walking every ancestor false-positives on system symlinks). Do NOT
+ * pass user-controlled base paths directly to this function: vet them first
+ * with vetOutputBase(), which contains them canonically against an anchor and
+ * returns the canonical base to use here. Every current caller does this.
  */
 export function resolvePathWithinBase(baseDir: string, ...segments: string[]): string {
   if (!baseDir || typeof baseDir !== 'string') {


### PR DESCRIPTION
Standard post-release sync: brings the v2.0.37 and v2.0.38 release commits (version files, changelog entries, and the #2344 pathSecurity contract docs added on the release branch) back to develop.

Clean merge — no conflicts (the 2.0.38 release branch pre-reconciled the changelog and merged main before landing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ughz92rhDUkghgYD2boQ