### PR TITLE
chore: bump beta version to 2.1.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.1.0-beta.1] - 2026-07-04
+
+First versioned build of the 2.1 beta line. Not published to npm; deployed to the hosted beta environment.
+
+- Package the web console UI: `src/web-console/ui` is copied into `dist/web-console/ui` during postbuild, included in the package file list, and required by the asset verifier — `/ui/` no longer depends on a manual hot-copy into the running image. (#2312)
+- Port the memory silent-save-loss fix (#2329) with hardened recovery paths and deleted-memory ledger guards. (#2336, #2337)
+- Port the OAuth helper token handoff hardening. (#2325 ports)
+- Port the NVM launcher config self-heal and test isolation. (#2338, #2340)
+- Port the symlink containment fixes for convert CLI output paths, including canonical containment. (#2342, #2344, #2345, #2347)
+
 ## [2.1.0-beta] - 2026-06-25
 
 Start beta line for 2.1 hosted HTTP and expanded description limits.

--- a/docs/developer-guide/beta-release-cd.md
+++ b/docs/developer-guide/beta-release-cd.md
@@ -22,7 +22,7 @@ Allowed deployment refs are:
 
 - `beta`
 - `refs/heads/beta`
-- SemVer beta tags, such as `v2.1.0-beta` or `v2.1.0-beta.1`
+- SemVer beta tags, such as `v2.1.0-beta.1` or `v2.1.0-beta.1.1`
 
 The workflow requires the `alpha` GitHub environment to provide these secrets:
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dollhousemcp",
   "display_name": "DollhouseMCP",
-  "version": "2.1.0-beta",
+  "version": "2.1.0-beta.1",
   "description": "Open-source AI customization through modular Dollhouse elements — personas, skills, templates, agents, memories, and ensembles.",
   "long_description": "DollhouseMCP is an MCP server that lets you customize your AI with modular Dollhouse elements. Create personas that shape behavior and permissions, skills that add capabilities, templates for consistent outputs, agents for autonomous multi-step goals, memories for persistent context, and ensembles that bundle elements together. Includes MCP-AQL query language with 5 semantic CRUDE endpoints, Gatekeeper permission system, community collection, and a built-in portfolio browser.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.1.0-beta",
+  "version": "2.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.1.0-beta",
+      "version": "2.1.0-beta.1",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"
@@ -155,6 +155,7 @@
       "version": "7.28.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -671,6 +672,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -693,6 +695,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3063,6 +3066,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
       "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -4722,6 +4726,7 @@
       "version": "8.48.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -5152,9 +5157,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5169,9 +5171,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5186,9 +5185,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5203,9 +5199,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5220,9 +5213,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5237,9 +5227,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5360,6 +5347,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5833,6 +5821,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7458,6 +7447,7 @@
       "version": "9.39.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7842,6 +7832,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -8413,6 +8404,7 @@
     "node_modules/graphql": {
       "version": "16.12.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -8531,6 +8523,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
       "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9034,6 +9027,7 @@
       "version": "30.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -9963,6 +9957,7 @@
       "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.0.tgz",
       "integrity": "sha512-TrM4/tnNY7uJ1aW55sIIa+dqBvc4V14WRIAlGcWat9wV5pRS9Wr5Zk2ZTjQP1jtfIHDoHiSbPuV08P0fUZo2pg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^1.3.8",
         "content-disposition": "~1.0.1",
@@ -10945,6 +10940,7 @@
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.9.tgz",
       "integrity": "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==",
       "license": "Unlicense",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11280,6 +11276,7 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11293,6 +11290,7 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -12433,6 +12431,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12827,6 +12826,7 @@
       "version": "10.9.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12942,6 +12942,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13500,6 +13501,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -13535,6 +13537,7 @@
       "version": "7.28.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -14095,6 +14098,7 @@
       "version": "7.18.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -14448,6 +14452,7 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.1.0-beta",
+  "version": "2.1.0-beta.1",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.1.0-beta",
+  "version": "2.1.0-beta.1",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.1.0-beta",
+      "version": "2.1.0-beta.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.1.0-beta';
-export const BUILD_TIMESTAMP = '2026-06-25T18:46:25.258Z';
+export const PACKAGE_VERSION = '2.1.0-beta.1';
+export const BUILD_TIMESTAMP = '2026-07-04T19:05:36.130Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';


### PR DESCRIPTION
First versioned build of the 2.1 beta line — versions the batch of fixes merged to `beta` since 2.1.0-beta: console UI packaging (#2312), memory save-loss port (#2336/#2337), OAuth handoff hardening, NVM config self-heal (#2340), and the complete symlink containment chain (#2345, #2347).

Intended for the hosted beta deployment; NOT published to npm (the beta line has never been distributed there — verified: no beta dist-tag, no `-beta` versions among all 134 published versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ughz92rhDUkghgYD2boQ