### PR TITLE
fix(ci): enforce release channels across all publish workflows

### DIFF
--- a/.github/workflows/npm-dist-tag-audit.yml
+++ b/.github/workflows/npm-dist-tag-audit.yml
@@ -1,0 +1,44 @@
+name: npm dist-tag audit
+
+# Detection net for out-of-band publishes: the prepublishOnly guard and the
+# CI channel mapping prevent a prerelease from landing on `latest` through
+# any path that runs our code — but a registry-side mistake (npm dist-tag
+# add by hand, support intervention) can still move tags. This audit reads
+# the live dist-tags weekly and fails loudly if `latest` points at a
+# prerelease, so the failure notification reaches maintainers within days
+# instead of at the next release.
+
+on:
+  schedule:
+    - cron: '0 14 * * 1'  # Mondays 14:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Verify latest dist-tag points at a stable version
+        shell: bash
+        run: |
+          TAGS=$(npm view @dollhousemcp/mcp-server dist-tags --json)
+          echo "Current dist-tags: ${TAGS}"
+          LATEST=$(echo "${TAGS}" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).latest")
+          if [[ -z "${LATEST}" || "${LATEST}" == "undefined" ]]; then
+            echo "::error::Could not resolve dist-tags.latest"
+            exit 1
+          fi
+          if [[ "${LATEST}" == *-* ]]; then
+            echo "::error::dist-tags.latest points at a PRERELEASE (${LATEST})."
+            echo "::error::Every default install (npx @dollhousemcp/mcp-server, @latest pins) is serving it to stable users."
+            echo "::error::Repair: npm dist-tag add @dollhousemcp/mcp-server@<highest-stable> latest"
+            exit 1
+          fi
+          echo "✅ dist-tags.latest = ${LATEST} (stable)"

--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -12,16 +12,15 @@ name: Publish to GitHub Packages
 # 3. Invalid/empty version → should fail gracefully with error
 # 4. Authentication issues → should proceed to publish (fails safely if duplicate)
 
+# Trigger: GitHub Releases only (plus manual dispatch). The old push-tags
+# trigger is deliberately removed — a stable release emits BOTH the tag push
+# and release.published, double-publishing the same version in racing runs,
+# and a prerelease tag push would bypass the release-flag channel guard below.
+# Every publish therefore goes through an explicit GitHub Release, where the
+# guard can validate the version against the release's prerelease flag.
 on:
   release:
     types: [published]
-  push:
-    tags:
-      # Stable version tags only (v1.2.3). Prerelease tags (v2.1.0-beta.1)
-      # deliberately do NOT trigger on push — prerelease publishes must go
-      # through an explicit GitHub prerelease Release so the channel guard
-      # below can validate them.
-      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:  # Allow manual trigger
     inputs:
       dry_run:

--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -13,10 +13,22 @@ name: Publish to GitHub Packages
 # 4. Authentication issues → should proceed to publish (fails safely if duplicate)
 
 on:
+  release:
+    types: [published]
   push:
     tags:
-      - 'v*'  # Triggers on version tags like v1.2.3
+      # Stable version tags only (v1.2.3). Prerelease tags (v2.1.0-beta.1)
+      # deliberately do NOT trigger on push — prerelease publishes must go
+      # through an explicit GitHub prerelease Release so the channel guard
+      # below can validate them.
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:  # Allow manual trigger
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (test without publishing)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -95,14 +107,71 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve GitHub Packages dist-tag
+        id: package_dist_tag
+        shell: bash
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          case "${PACKAGE_VERSION}" in
+            *-alpha.*)
+              dist_tag="alpha"
+              ;;
+            *-beta|*-beta.*)
+              dist_tag="beta"
+              ;;
+            *-rc.*)
+              dist_tag="next"
+              ;;
+            *-*)
+              echo "::error::Unsupported prerelease channel in ${PACKAGE_VERSION}; expected -alpha., -beta, -beta., or -rc."
+              exit 1
+              ;;
+            *)
+              dist_tag="latest"
+              ;;
+          esac
+
+          echo "dist_tag=${dist_tag}" >> "$GITHUB_OUTPUT"
+          echo "GitHub Packages dist-tag: ${dist_tag}"
+
+      - name: Guard GitHub Packages release channel
+        if: ${{ github.event_name == 'release' }}
+        shell: bash
+        env:
+          DIST_TAG: ${{ steps.package_dist_tag.outputs.dist_tag }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          if [[ "${RELEASE_PRERELEASE}" == "true" && "${DIST_TAG}" == "latest" ]]; then
+            echo "::error::Refusing to publish a GitHub prerelease to GitHub Packages latest"
+            exit 1
+          fi
+
+          if [[ "${RELEASE_PRERELEASE}" != "true" && "${DIST_TAG}" != "latest" ]]; then
+            echo "::error::Prerelease version must be published from a GitHub prerelease"
+            exit 1
+          fi
+
       - name: Publish to GitHub Packages
-        if: steps.check_version.outputs.already_published == 'false'
+        if: ${{ steps.check_version.outputs.already_published == 'false' && (github.event_name != 'workflow_dispatch' || inputs.dry_run != true) }}
         shell: bash
         run: |
           # Publish to GitHub Packages
           # Registry is configured via setup-node step's registry-url parameter
           # NODE_AUTH_TOKEN provides authentication to GitHub Packages
-          npm publish
+          npm publish --tag "${{ steps.package_dist_tag.outputs.dist_tag }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Dry run (skip GitHub Packages publish)
+        if: ${{ steps.check_version.outputs.already_published == 'false' && github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
+        shell: bash
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          echo "DRY RUN MODE - Skipping GitHub Packages publication"
+          echo "Package would be published: @DollhouseMCP/mcp-server@${PACKAGE_VERSION}"
+          echo "GitHub Packages dist-tag: ${{ steps.package_dist_tag.outputs.dist_tag }}"
+          npm publish --dry-run --tag "${{ steps.package_dist_tag.outputs.dist_tag }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -121,8 +190,9 @@ jobs:
           git checkout -- package.json
 
       - name: Notify success
-        if: success()
+        if: ${{ success() && (github.event_name != 'workflow_dispatch' || inputs.dry_run != true) }}
         shell: bash
         run: |
           echo "✅ Successfully published to GitHub Packages!"
+          echo "🏷️ Dist-tag: ${{ steps.package_dist_tag.outputs.dist_tag }}"
           echo "📦 Package will appear in the repository's Packages section"

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -25,6 +25,7 @@ permissions:
 
 jobs:
   publish:
+    if: github.event_name != 'release' || github.event.release.prerelease != true
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -60,6 +60,25 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.source-ref.outputs.ref }}
 
+      - name: Guard stable channel (version string, not just release flag)
+        shell: bash
+        env:
+          SOURCE_REF: ${{ steps.source-ref.outputs.ref }}
+        run: |
+          # Belt-and-braces on top of the job-level prerelease-flag check: a
+          # beta tag released with the prerelease checkbox unset, or a manual
+          # workflow_dispatch rerun with release_ref=refs/tags/v2.1.0-beta.1,
+          # must still be refused. The MCP Registry lists stable builds only.
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          TAG_PART="${SOURCE_REF#refs/tags/v}"
+          for candidate in "${PACKAGE_VERSION}" "${TAG_PART}"; do
+            if [[ -n "${candidate}" && "${candidate}" != refs/* && "${candidate}" == *-* ]]; then
+              echo "::error::Refusing to publish prerelease '${candidate}' to the MCP Registry (package.json: ${PACKAGE_VERSION}, ref: ${SOURCE_REF}). Stable releases only."
+              exit 1
+            fi
+          done
+          echo "✅ Stable channel confirmed (version ${PACKAGE_VERSION}, ref ${SOURCE_REF})"
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -32,6 +32,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Guard stable channel (version string, not just release flag)
+        shell: bash
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name || inputs.tag_name || '' }}
+        run: |
+          # Belt-and-braces on top of the job-level prerelease-flag check: a
+          # beta tag released with the prerelease checkbox unset, or a manual
+          # workflow_dispatch rerun with a prerelease tag_name, must still be
+          # refused — MCPB bundles are an end-user install surface.
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          for candidate in "${PACKAGE_VERSION}" "${EVENT_TAG#v}"; do
+            if [[ -n "${candidate}" && "${candidate}" == *-* ]]; then
+              echo "::error::Refusing to publish an MCPB bundle for prerelease '${candidate}' (package.json: ${PACKAGE_VERSION}, tag: ${EVENT_TAG:-<none>}). Stable releases only."
+              exit 1
+            fi
+          done
+          echo "✅ Stable channel confirmed (version ${PACKAGE_VERSION}, tag ${EVENT_TAG:-<none>})"
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -23,6 +23,9 @@ permissions:
 jobs:
   publish-mcpb:
     name: Build and upload .mcpb
+    # Stable releases only: MCPB bundles are an end-user install surface, so
+    # prerelease (alpha/beta/rc) GitHub Releases must not publish one.
+    if: github.event_name != 'release' || github.event.release.prerelease != true
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: boolean
         default: false
+      debug_oidc:
+        description: 'Print OIDC/npm environment diagnostics without secret values'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: release-publish-${{ github.workflow }}
@@ -81,7 +86,48 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Publishing version: $VERSION"
 
+      - name: Resolve npm dist-tag
+        id: npm_dist_tag
+        shell: bash
+        env:
+          PACKAGE_VERSION: ${{ steps.package_version.outputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease || false }}
+        run: |
+          case "${PACKAGE_VERSION}" in
+            *-alpha.*)
+              dist_tag="alpha"
+              ;;
+            *-beta|*-beta.*)
+              dist_tag="beta"
+              ;;
+            *-rc.*)
+              dist_tag="next"
+              ;;
+            *-*)
+              echo "::error::Unsupported prerelease channel in ${PACKAGE_VERSION}; expected -alpha., -beta, -beta., or -rc."
+              exit 1
+              ;;
+            *)
+              dist_tag="latest"
+              ;;
+          esac
+
+          if [[ "${EVENT_NAME}" == "release" && "${RELEASE_PRERELEASE}" == "true" && "${dist_tag}" == "latest" ]]; then
+            echo "::error::Refusing to publish a GitHub prerelease to npm latest"
+            exit 1
+          fi
+
+          if [[ "${EVENT_NAME}" == "release" && "${RELEASE_PRERELEASE}" != "true" && "${dist_tag}" != "latest" ]]; then
+            echo "::error::Prerelease version ${PACKAGE_VERSION} must be published from a GitHub prerelease"
+            exit 1
+          fi
+
+          echo "dist_tag=${dist_tag}" >> "$GITHUB_OUTPUT"
+          echo "npm dist-tag: ${dist_tag}"
+
       - name: Debug OIDC Environment
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_oidc == true }}
         shell: bash
         run: |
           echo "=== OIDC Environment Check ==="
@@ -103,28 +149,57 @@ jobs:
           echo "NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-NOT SET}"
 
       - name: Publish to npm (with provenance)
-        if: github.event.inputs.dry_run != 'true'
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
         shell: bash
         env:
           # Ensure provenance is enabled for OIDC detection
           NPM_CONFIG_PROVENANCE: 'true'
+          DIST_TAG: ${{ steps.npm_dist_tag.outputs.dist_tag }}
         run: |
           # Publish with provenance via OIDC Trusted Publishing.
           # Requires: npm 11+ (Node 24), id-token: write, NODE_AUTH_TOKEN cleared,
           # and a Trusted Publisher configured at npmjs.com/package/@dollhousemcp/mcp-server/access
-          npm publish --provenance --access public --loglevel verbose
+          npm publish --provenance --access public --tag "${DIST_TAG}" --loglevel verbose
 
       - name: Dry run (skip publish)
-        if: github.event.inputs.dry_run == 'true'
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
         shell: bash
+        env:
+          DIST_TAG: ${{ steps.npm_dist_tag.outputs.dist_tag }}
         run: |
           echo "🧪 DRY RUN MODE - Skipping publication"
-          echo "Package would be published: @dollhousemcp/mcp-server@${{ steps.package_version.outputs.version }}"
-          npm publish --dry-run
+          echo "Package would be published: @dollhousemcp/mcp-server@${{ steps.package_version.outputs.version }} with npm dist-tag ${DIST_TAG}"
+          npm publish --dry-run --tag "${DIST_TAG}"
+
+      - name: Verify latest dist-tag integrity
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
+        shell: bash
+        run: |
+          # Post-publish invariant: `latest` must NEVER point at a prerelease.
+          # Every default install path (npx @dollhousemcp/mcp-server, bare
+          # npm install, and the @latest pin our installer writes into client
+          # configs) resolves through this dist-tag — including installs by
+          # users on OLD versions that predate any client-side checks. If a
+          # prerelease ever lands on `latest` (manual publish without --tag,
+          # registry hiccup), stable users would silently update onto beta.
+          sleep 10  # allow registry propagation before reading back
+          LATEST=$(npm view @dollhousemcp/mcp-server dist-tags.latest 2>/dev/null || echo "")
+          echo "npm dist-tags.latest resolves to: ${LATEST:-<unreadable>}"
+          if [[ -z "${LATEST}" ]]; then
+            echo "::warning::Could not read back dist-tags.latest (registry propagation delay?) — verify manually"
+            exit 0
+          fi
+          if [[ "${LATEST}" == *-* ]]; then
+            echo "::error::dist-tags.latest points at a PRERELEASE (${LATEST}). Stable users installing via npx/@latest will receive it. Repair immediately:"
+            echo "::error::  npm dist-tag add @dollhousemcp/mcp-server@<highest-stable-version> latest"
+            exit 1
+          fi
+          echo "✅ latest dist-tag integrity OK (${LATEST} is a stable version)"
 
       - name: Notify success
-        if: success() && github.event.inputs.dry_run != 'true'
+        if: ${{ success() && (github.event_name != 'workflow_dispatch' || inputs.dry_run != true) }}
         shell: bash
         run: |
           echo "✅ Successfully published @dollhousemcp/mcp-server@${{ steps.package_version.outputs.version }} to npm!"
+          echo "🏷️ Dist-tag: ${{ steps.npm_dist_tag.outputs.dist_tag }}"
           echo "📦 View at: https://www.npmjs.com/package/@dollhousemcp/mcp-server/v/${{ steps.package_version.outputs.version }}"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "clean": "rm -rf dist",
     "rebuild": "npm run clean && npm run build",
     "setup": "npm install && npm run build",
-    "prepublishOnly": "cp README.md README.md.backup 2>/dev/null || true && cp README.npm.md README.md && BUILD_TYPE=npm npm run build",
+    "prepublishOnly": "node scripts/verify-publish-channel.mjs && { cp README.md README.md.backup 2>/dev/null || true; } && cp README.npm.md README.md && BUILD_TYPE=npm npm run build",
     "postpublish": "if [ -f README.md.backup ]; then mv README.md.backup README.md; else echo 'No backup found, README.md unchanged'; fi",
     "test": "cross-env \"NODE_OPTIONS=$NODE_OPTIONS --experimental-vm-modules --no-warnings\" jest --config tests/jest.config.cjs",
     "test:watch": "cross-env \"NODE_OPTIONS=--experimental-vm-modules --no-warnings\" jest --config tests/jest.config.cjs --watch",

--- a/scripts/verify-publish-channel.mjs
+++ b/scripts/verify-publish-channel.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Publish-channel guard, run from prepublishOnly.
+ *
+ * This is the LAST line of defense and the only one that travels with the
+ * package: it guards every `npm publish` — including a manual publish from a
+ * developer laptop, where no CI workflow can intervene. A developer who is
+ * technical enough to run `npm publish` but doesn't notice the checkout has a
+ * prerelease version (e.g. 2.1.0-beta.1) would otherwise move the `latest`
+ * dist-tag onto that prerelease, and every default install path
+ * (`npx @dollhousemcp/mcp-server`, bare `npm install`, the `@latest` pin our
+ * installer writes into client configs) would silently serve beta to stable
+ * users on their next launch.
+ *
+ * Rules enforced (identical to the CI dist-tag mapping):
+ *   stable X.Y.Z      → must publish to `latest` (the default)
+ *   X.Y.Z-alpha.N     → must publish with --tag alpha
+ *   X.Y.Z-beta[.N]    → must publish with --tag beta
+ *   X.Y.Z-rc.N        → must publish with --tag next
+ *   anything else     → refused (unknown channel)
+ *
+ * npm exposes the --tag flag to lifecycle scripts as npm_config_tag; when the
+ * flag is omitted npm defaults the publish to `latest`.
+ */
+import { readFileSync } from 'node:fs';
+
+const version = process.env.npm_package_version
+  ?? JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version;
+
+function expectedTagFor(v) {
+  if (/-alpha\./.test(v)) return 'alpha';
+  if (/-beta(\.|$)/.test(v)) return 'beta';
+  if (/-rc\./.test(v)) return 'next';
+  if (v.includes('-')) return null; // unrecognized prerelease channel
+  return 'latest';
+}
+
+const expected = expectedTagFor(version);
+const actual = process.env.npm_config_tag || 'latest';
+
+if (expected === null) {
+  console.error(`✖ Version ${version} has an unsupported prerelease suffix.`);
+  console.error('  Supported channels: -alpha.N (alpha), -beta[.N] (beta), -rc.N (next).');
+  process.exit(1);
+}
+
+if (actual !== expected) {
+  console.error(`✖ Refusing to publish ${version} to dist-tag "${actual}".`);
+  if (expected !== 'latest') {
+    console.error('');
+    console.error(`  This checkout is a PRERELEASE. Publishing it to "${actual}" would make`);
+    console.error('  every default install (npx @dollhousemcp/mcp-server, npm install,');
+    console.error('  and existing client configs pinned to @latest) serve this prerelease');
+    console.error('  to stable users on their next launch.');
+    console.error('');
+    console.error(`  Publish it to its channel instead:`);
+    console.error(`    npm publish --tag ${expected}`);
+  } else {
+    console.error('');
+    console.error(`  This is a STABLE version — it belongs on "latest", not "${actual}".`);
+    console.error('  Publish without a --tag flag (or with --tag latest).');
+  }
+  process.exit(1);
+}
+
+console.log(`✔ Publish channel OK: ${version} → dist-tag "${actual}"`);


### PR DESCRIPTION
## Why

Preparation for distributing beta builds: today, only the `beta` branch's copies of `publish-npm.yml`/`publish-github-packages.yml` carry dist-tag channel logic — develop/main run bare `npm publish`, which would move `latest` onto a prerelease. Since every default install path (`npx @dollhousemcp/mcp-server`, bare `npm install`, and the `@latest` pin the installer writes into client configs — including configs written by OLD versions with no client-side checks) resolves through `dist-tags.latest`, that would silently update stable users onto beta.

## What

- **`publish-npm.yml` / `publish-github-packages.yml`**: adopt beta's version→dist-tag mapping (`-alpha.*`→`alpha`, `-beta*`→`beta`, `-rc.*`→`next`, stable→`latest`, unknown suffix→hard error) plus the guard requiring prerelease versions to come from GitHub prereleases (and stable versions NOT to), publishing with `--tag "$DIST_TAG"`.
- **`publish-npm.yml` (new)**: post-publish integrity check — reads back `dist-tags.latest` after publishing and fails loudly with repair instructions if it ever points at a prerelease. Catches manual/out-of-band publishes that bypass the workflow.
- **`publish-github-packages.yml`**: tag-push trigger restricted to stable tags (`v[0-9]+.[0-9]+.[0-9]+`). Prerelease tags (like today's `v2.1.0-beta.1`, whose run had to be cancelled mid-build) no longer trigger on push; prerelease publishes must go through an explicit GitHub prerelease Release where the guard validates them.
- **`publish-mcpb.yml`**: prerelease releases skipped entirely (bundles are an end-user install surface).
- **`publish-mcp-registry.yml`**: adopt beta's prerelease skip.

## Resulting invariant

`npx @dollhousemcp/mcp-server` / `@latest` always resolves to the newest **stable**; alpha/beta builds require an explicit `@alpha` / `@beta`. Enforced at publish time (dist-tag mapping), validated at release time (prerelease-flag guard), and re-verified after publish (latest read-back).

## Notes

- Beta branch already carries most of this; after merge, the deltas (mcpb guard, tag-trigger restriction, latest read-back) should be ported to `beta` so the branches stay aligned.
- `main` picks this up with the next release merge (release branches carry develop's workflows).
- All four YAMLs validated with a YAML parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ughz92rhDUkghgYD2boQ