### PR TITLE
hotfix(beta): port publish channel guards from develop (#2351)

### DIFF
--- a/.github/workflows/npm-dist-tag-audit.yml
+++ b/.github/workflows/npm-dist-tag-audit.yml
@@ -1,0 +1,44 @@
+name: npm dist-tag audit
+
+# Detection net for out-of-band publishes: the prepublishOnly guard and the
+# CI channel mapping prevent a prerelease from landing on `latest` through
+# any path that runs our code — but a registry-side mistake (npm dist-tag
+# add by hand, support intervention) can still move tags. This audit reads
+# the live dist-tags weekly and fails loudly if `latest` points at a
+# prerelease, so the failure notification reaches maintainers within days
+# instead of at the next release.
+
+on:
+  schedule:
+    - cron: '0 14 * * 1'  # Mondays 14:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Verify latest dist-tag points at a stable version
+        shell: bash
+        run: |
+          TAGS=$(npm view @dollhousemcp/mcp-server dist-tags --json)
+          echo "Current dist-tags: ${TAGS}"
+          LATEST=$(echo "${TAGS}" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).latest")
+          if [[ -z "${LATEST}" || "${LATEST}" == "undefined" ]]; then
+            echo "::error::Could not resolve dist-tags.latest"
+            exit 1
+          fi
+          if [[ "${LATEST}" == *-* ]]; then
+            echo "::error::dist-tags.latest points at a PRERELEASE (${LATEST})."
+            echo "::error::Every default install (npx @dollhousemcp/mcp-server, @latest pins) is serving it to stable users."
+            echo "::error::Repair: npm dist-tag add @dollhousemcp/mcp-server@<highest-stable> latest"
+            exit 1
+          fi
+          echo "✅ dist-tags.latest = ${LATEST} (stable)"

--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -12,12 +12,15 @@ name: Publish to GitHub Packages
 # 3. Invalid/empty version → should fail gracefully with error
 # 4. Authentication issues → should proceed to publish (fails safely if duplicate)
 
+# Trigger: GitHub Releases only (plus manual dispatch). The old push-tags
+# trigger is deliberately removed — a stable release emits BOTH the tag push
+# and release.published, double-publishing the same version in racing runs,
+# and a prerelease tag push would bypass the release-flag channel guard below.
+# Every publish therefore goes through an explicit GitHub Release, where the
+# guard can validate the version against the release's prerelease flag.
 on:
   release:
     types: [published]
-  push:
-    tags:
-      - 'v*'  # Triggers on version tags like v1.2.3
   workflow_dispatch:  # Allow manual trigger
     inputs:
       dry_run:

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -60,6 +60,25 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.source-ref.outputs.ref }}
 
+      - name: Guard stable channel (version string, not just release flag)
+        shell: bash
+        env:
+          SOURCE_REF: ${{ steps.source-ref.outputs.ref }}
+        run: |
+          # Belt-and-braces on top of the job-level prerelease-flag check: a
+          # beta tag released with the prerelease checkbox unset, or a manual
+          # workflow_dispatch rerun with release_ref=refs/tags/v2.1.0-beta.1,
+          # must still be refused. The MCP Registry lists stable builds only.
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          TAG_PART="${SOURCE_REF#refs/tags/v}"
+          for candidate in "${PACKAGE_VERSION}" "${TAG_PART}"; do
+            if [[ -n "${candidate}" && "${candidate}" != refs/* && "${candidate}" == *-* ]]; then
+              echo "::error::Refusing to publish prerelease '${candidate}' to the MCP Registry (package.json: ${PACKAGE_VERSION}, ref: ${SOURCE_REF}). Stable releases only."
+              exit 1
+            fi
+          done
+          echo "✅ Stable channel confirmed (version ${PACKAGE_VERSION}, ref ${SOURCE_REF})"
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -23,11 +23,32 @@ permissions:
 jobs:
   publish-mcpb:
     name: Build and upload .mcpb
+    # Stable releases only: MCPB bundles are an end-user install surface, so
+    # prerelease (alpha/beta/rc) GitHub Releases must not publish one.
+    if: github.event_name != 'release' || github.event.release.prerelease != true
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Guard stable channel (version string, not just release flag)
+        shell: bash
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name || inputs.tag_name || '' }}
+        run: |
+          # Belt-and-braces on top of the job-level prerelease-flag check: a
+          # beta tag released with the prerelease checkbox unset, or a manual
+          # workflow_dispatch rerun with a prerelease tag_name, must still be
+          # refused — MCPB bundles are an end-user install surface.
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          for candidate in "${PACKAGE_VERSION}" "${EVENT_TAG#v}"; do
+            if [[ -n "${candidate}" && "${candidate}" == *-* ]]; then
+              echo "::error::Refusing to publish an MCPB bundle for prerelease '${candidate}' (package.json: ${PACKAGE_VERSION}, tag: ${EVENT_TAG:-<none>}). Stable releases only."
+              exit 1
+            fi
+          done
+          echo "✅ Stable channel confirmed (version ${PACKAGE_VERSION}, tag ${EVENT_TAG:-<none>})"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -23,32 +23,66 @@ permissions:
 jobs:
   publish-mcpb:
     name: Build and upload .mcpb
-    # Stable releases only: MCPB bundles are an end-user install surface, so
-    # prerelease (alpha/beta/rc) GitHub Releases must not publish one.
-    if: github.event_name != 'release' || github.event.release.prerelease != true
+    # Channel consistency (not stable-only): stable versions attach to normal
+    # releases; prerelease versions attach ONLY to releases explicitly flagged
+    # prerelease — their bundle lands on that prerelease page, an opt-in
+    # surface used by the Publish Beta Release flow. Mismatches are refused.
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Guard stable channel (version string, not just release flag)
+      - name: Guard release channel consistency
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           EVENT_TAG: ${{ github.event.release.tag_name || inputs.tag_name || '' }}
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease || false }}
         run: |
-          # Belt-and-braces on top of the job-level prerelease-flag check: a
-          # beta tag released with the prerelease checkbox unset, or a manual
-          # workflow_dispatch rerun with a prerelease tag_name, must still be
-          # refused — MCPB bundles are an end-user install surface.
+          # The channel is derived from the VERSION STRING (which nobody can
+          # mislabel by accident), then required to agree with the release's
+          # prerelease flag and the tag. A beta accidentally released without
+          # the prerelease checkbox, or a stable release mislabeled as a
+          # prerelease, is refused — but a properly-flagged beta prerelease
+          # still gets its .mcpb (the Publish Beta Release contract).
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          for candidate in "${PACKAGE_VERSION}" "${EVENT_TAG#v}"; do
-            if [[ -n "${candidate}" && "${candidate}" == *-* ]]; then
-              echo "::error::Refusing to publish an MCPB bundle for prerelease '${candidate}' (package.json: ${PACKAGE_VERSION}, tag: ${EVENT_TAG:-<none>}). Stable releases only."
+
+          case "${PACKAGE_VERSION}" in
+            *-alpha.*|*-beta|*-beta.*|*-rc.*) VERSION_IS_PRERELEASE=true ;;
+            *-*)
+              echo "::error::Unsupported prerelease suffix in ${PACKAGE_VERSION}; expected -alpha.N, -beta[.N], or -rc.N."
               exit 1
-            fi
-          done
-          echo "✅ Stable channel confirmed (version ${PACKAGE_VERSION}, tag ${EVENT_TAG:-<none>})"
+              ;;
+            *) VERSION_IS_PRERELEASE=false ;;
+          esac
+
+          TAG_IS_PRERELEASE=false
+          if [[ -n "${EVENT_TAG}" && "${EVENT_TAG#v}" == *-* ]]; then
+            TAG_IS_PRERELEASE=true
+          fi
+          if [[ -n "${EVENT_TAG}" && "${TAG_IS_PRERELEASE}" != "${VERSION_IS_PRERELEASE}" ]]; then
+            echo "::error::Tag ${EVENT_TAG} and package.json version ${PACKAGE_VERSION} disagree about prerelease status."
+            exit 1
+          fi
+
+          if [[ "${EVENT_NAME}" == "release" ]]; then
+            FLAG_IS_PRERELEASE="${RELEASE_PRERELEASE}"
+          else
+            # Manual dispatch: look up the target release's actual flag.
+            FLAG_IS_PRERELEASE=$(gh release view "${EVENT_TAG}" --json isPrerelease --jq '.isPrerelease' 2>/dev/null || echo "unknown")
+          fi
+          if [[ "${FLAG_IS_PRERELEASE}" == "unknown" ]]; then
+            echo "::error::Could not resolve the release for tag '${EVENT_TAG}' to verify its prerelease flag."
+            exit 1
+          fi
+          if [[ "${VERSION_IS_PRERELEASE}" != "${FLAG_IS_PRERELEASE}" ]]; then
+            echo "::error::Version ${PACKAGE_VERSION} (prerelease=${VERSION_IS_PRERELEASE}) does not match the release's prerelease flag (${FLAG_IS_PRERELEASE}). Refusing to attach the bundle to a mislabeled release."
+            exit 1
+          fi
+
+          echo "✅ Channel consistency OK (version ${PACKAGE_VERSION}, tag ${EVENT_TAG:-<none>}, prerelease=${VERSION_IS_PRERELEASE})"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -171,6 +171,31 @@ jobs:
           echo "Package would be published: @dollhousemcp/mcp-server@${{ steps.package_version.outputs.version }} with npm dist-tag ${DIST_TAG}"
           npm publish --dry-run --tag "${DIST_TAG}"
 
+      - name: Verify latest dist-tag integrity
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run != true }}
+        shell: bash
+        run: |
+          # Post-publish invariant: `latest` must NEVER point at a prerelease.
+          # Every default install path (npx @dollhousemcp/mcp-server, bare
+          # npm install, and the @latest pin our installer writes into client
+          # configs) resolves through this dist-tag — including installs by
+          # users on OLD versions that predate any client-side checks. If a
+          # prerelease ever lands on `latest` (manual publish without --tag,
+          # registry hiccup), stable users would silently update onto beta.
+          sleep 10  # allow registry propagation before reading back
+          LATEST=$(npm view @dollhousemcp/mcp-server dist-tags.latest 2>/dev/null || echo "")
+          echo "npm dist-tags.latest resolves to: ${LATEST:-<unreadable>}"
+          if [[ -z "${LATEST}" ]]; then
+            echo "::warning::Could not read back dist-tags.latest (registry propagation delay?) — verify manually"
+            exit 0
+          fi
+          if [[ "${LATEST}" == *-* ]]; then
+            echo "::error::dist-tags.latest points at a PRERELEASE (${LATEST}). Stable users installing via npx/@latest will receive it. Repair immediately:"
+            echo "::error::  npm dist-tag add @dollhousemcp/mcp-server@<highest-stable-version> latest"
+            exit 1
+          fi
+          echo "✅ latest dist-tag integrity OK (${LATEST} is a stable version)"
+
       - name: Notify success
         if: ${{ success() && (github.event_name != 'workflow_dispatch' || inputs.dry_run != true) }}
         shell: bash

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean": "rm -rf dist",
     "rebuild": "npm run clean && npm run build",
     "setup": "npm install && npm run build",
-    "prepublishOnly": "cp README.md README.md.backup 2>/dev/null || true && cp README.npm.md README.md && BUILD_TYPE=npm npm run build",
+    "prepublishOnly": "node scripts/verify-publish-channel.mjs && { cp README.md README.md.backup 2>/dev/null || true; } && cp README.npm.md README.md && BUILD_TYPE=npm npm run build",
     "postpublish": "if [ -f README.md.backup ]; then mv README.md.backup README.md; else echo 'No backup found, README.md unchanged'; fi",
     "test": "cross-env \"NODE_OPTIONS=$NODE_OPTIONS --experimental-vm-modules --no-warnings\" jest --config tests/jest.config.cjs",
     "test:watch": "cross-env \"NODE_OPTIONS=--experimental-vm-modules --no-warnings\" jest --config tests/jest.config.cjs --watch",

--- a/scripts/verify-publish-channel.mjs
+++ b/scripts/verify-publish-channel.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Publish-channel guard, run from prepublishOnly.
+ *
+ * This is the LAST line of defense and the only one that travels with the
+ * package: it guards every `npm publish` — including a manual publish from a
+ * developer laptop, where no CI workflow can intervene. A developer who is
+ * technical enough to run `npm publish` but doesn't notice the checkout has a
+ * prerelease version (e.g. 2.1.0-beta.1) would otherwise move the `latest`
+ * dist-tag onto that prerelease, and every default install path
+ * (`npx @dollhousemcp/mcp-server`, bare `npm install`, the `@latest` pin our
+ * installer writes into client configs) would silently serve beta to stable
+ * users on their next launch.
+ *
+ * Rules enforced (identical to the CI dist-tag mapping):
+ *   stable X.Y.Z      → must publish to `latest` (the default)
+ *   X.Y.Z-alpha.N     → must publish with --tag alpha
+ *   X.Y.Z-beta[.N]    → must publish with --tag beta
+ *   X.Y.Z-rc.N        → must publish with --tag next
+ *   anything else     → refused (unknown channel)
+ *
+ * npm exposes the --tag flag to lifecycle scripts as npm_config_tag; when the
+ * flag is omitted npm defaults the publish to `latest`.
+ */
+import { readFileSync } from 'node:fs';
+
+const version = process.env.npm_package_version
+  ?? JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version;
+
+function expectedTagFor(v) {
+  if (/-alpha\./.test(v)) return 'alpha';
+  if (/-beta(\.|$)/.test(v)) return 'beta';
+  if (/-rc\./.test(v)) return 'next';
+  if (v.includes('-')) return null; // unrecognized prerelease channel
+  return 'latest';
+}
+
+const expected = expectedTagFor(version);
+const actual = process.env.npm_config_tag || 'latest';
+
+if (expected === null) {
+  console.error(`✖ Version ${version} has an unsupported prerelease suffix.`);
+  console.error('  Supported channels: -alpha.N (alpha), -beta[.N] (beta), -rc.N (next).');
+  process.exit(1);
+}
+
+if (actual !== expected) {
+  console.error(`✖ Refusing to publish ${version} to dist-tag "${actual}".`);
+  if (expected === 'latest') {
+    console.error('');
+    console.error(`  This is a STABLE version — it belongs on "latest", not "${actual}".`);
+    console.error('  Publish without a --tag flag (or with --tag latest).');
+  } else {
+    console.error('');
+    console.error(`  This checkout is a PRERELEASE. Publishing it to "${actual}" would make`);
+    console.error('  every default install (npx @dollhousemcp/mcp-server, npm install,');
+    console.error('  and existing client configs pinned to @latest) serve this prerelease');
+    console.error('  to stable users on their next launch.');
+    console.error('');
+    console.error(`  Publish it to its channel instead:`);
+    console.error(`    npm publish --tag ${expected}`);
+  }
+  process.exit(1);
+}
+
+console.log(`✔ Publish channel OK: ${version} → dist-tag "${actual}"`);


### PR DESCRIPTION
Ports the complete channel-enforcement set from develop PR #2351 so both branches carry identical publish protections: prepublishOnly package-level guard, GHP release-only triggers, npm latest read-back, MCPB/registry version-string guards, and the weekly dist-tag audit. Includes the SonarCloud S7735 fix in the guard script (also being applied to develop in a parallel PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9ughz92rhDUkghgYD2boQ