### PR TITLE
feat(web-console): collection catalog browse and install

### DIFF
--- a/docs/guides/v2-migration-guide.md
+++ b/docs/guides/v2-migration-guide.md
@@ -322,6 +322,7 @@ New configuration options in v2.0:
 | `DOLLHOUSE_CONSOLE_TOKEN_FILE` | `~/.dollhouse/run/console-token.auth.json` | Optional override for the console token file path. |
 | `DOLLHOUSE_CONSOLE_ROTATION_REQUIRE_CONFIRMATION` | `true` | Require out-of-band confirmation (Phase 2: OS dialog or TOTP) for token rotation. Set `false` for headless CI. |
 | `DOLLHOUSE_INTEGRATION_DESCRIPTOR_SEED_DIR` | *(unset)* | Directory of curated integration descriptor seed files (data, not code) loaded into the descriptor store at web-console bootstrap. Per-provider deployment OAuth credentials are read separately from `DOLLHOUSE_INTEGRATION_<ID>_CLIENT_ID` / `_CLIENT_SECRET`. |
+| `DOLLHOUSE_WEB_CONSOLE_COLLECTION_ENABLED` | `false` | Enable collection catalog browse routes (`/api/v1/collection/*`) and the Portfolio tab's Collection source. Drives server-funded outbound GitHub traffic under a shared rate budget — opt in deliberately, and set a zero-scope `GITHUB_TOKEN` to raise the budget from 60 to 5,000 req/hr. Install into the portfolio additionally requires `DOLLHOUSE_WEB_CONSOLE_PORTFOLIO_WRITE_ROUTES_ENABLED`. |
 
 ---
 

--- a/src/cache/CollectionCache.ts
+++ b/src/cache/CollectionCache.ts
@@ -5,7 +5,8 @@
 import * as path from 'path';
 import { logger } from '../utils/logger.js';
 import { SecurityMonitor } from '../security/securityMonitor.js';
-import { IFileOperationsService } from '../services/FileOperationsService.js';
+import type { IFileOperationsService } from '../services/FileOperationsService.js';
+import type { ISharedCacheStore } from '../storage/sharedCache/ISharedCacheStore.js';
 
 export interface CollectionItem {
   name: string;
@@ -29,12 +30,24 @@ export class CollectionCache {
   private cacheFile: string;
   private readonly CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours for collection cache
 
+  // Single shared-cache key for the whole browse cache (one entry: {items}).
+  // Distinct from CollectionIndexManager's 'collection-index' and
+  // CollectionIndexCache's 'collection-index-cache' keys.
+  private static readonly SHARED_CACHE_KEY = 'collection-browse-cache';
+
   // File operations service for secure file I/O
   private readonly fileOperations: IFileOperationsService;
 
-  constructor(fileOperations: IFileOperationsService, baseDir?: string) {
+  // Backend-honesty seam. When injected (DB/hosted mode), all persistence
+  // routes through the shared cache store instead of the filesystem, so DB-mode
+  // deployments never write the browse cache to disk. When null (CLI/local),
+  // the legacy filesystem path below is used unchanged.
+  private readonly sharedCache: ISharedCacheStore | null;
+
+  constructor(fileOperations: IFileOperationsService, baseDir?: string, sharedCache?: ISharedCacheStore) {
     // Initialize file operations service
     this.fileOperations = fileOperations;
+    this.sharedCache = sharedCache ?? null;
 
     // Use environment variable if set, otherwise fall back to parameter or default
     const envCacheDir = process.env.DOLLHOUSE_CACHE_DIR;
@@ -65,6 +78,10 @@ export class CollectionCache {
    * Load collection data from persistent cache
    */
   async loadCache(): Promise<CollectionCacheEntry | null> {
+    if (this.sharedCache) {
+      return this.loadFromSharedCache(this.sharedCache);
+    }
+
     try {
       // Validate cache file path (basic security check)
       if (this.cacheFile.includes('..') || this.cacheFile.includes('\0')) {
@@ -105,6 +122,11 @@ export class CollectionCache {
    * Save collection data to persistent cache
    */
   async saveCache(items: CollectionItem[], etag?: string): Promise<void> {
+    if (this.sharedCache) {
+      await this.saveToSharedCache(this.sharedCache, items, etag);
+      return;
+    }
+
     try {
       await this.ensureCacheDir();
 
@@ -188,6 +210,16 @@ export class CollectionCache {
    * Clear the cache
    */
   async clearCache(): Promise<void> {
+    if (this.sharedCache) {
+      try {
+        await this.sharedCache.delete(CollectionCache.SHARED_CACHE_KEY);
+        logger.debug('Collection cache cleared (shared cache store)');
+      } catch (error) {
+        logger.debug(`Failed to clear collection cache from shared store: ${error}`);
+      }
+      return;
+    }
+
     try {
       await this.fileOperations.deleteFile(this.cacheFile, undefined, {
         source: 'CollectionCache.clearCache'
@@ -197,6 +229,54 @@ export class CollectionCache {
       if ((error as any).code !== 'ENOENT') {
         logger.debug(`Failed to clear collection cache: ${error}`);
       }
+    }
+  }
+
+  /**
+   * Load the browse cache from the shared cache store (backend-honest path).
+   * Mirrors the filesystem loadCache contract: returns null when absent or
+   * past its TTL so callers refresh from GitHub.
+   */
+  private async loadFromSharedCache(store: ISharedCacheStore): Promise<CollectionCacheEntry | null> {
+    try {
+      const entry = await store.get(CollectionCache.SHARED_CACHE_KEY);
+      if (!entry) {
+        return null;
+      }
+
+      // Honor the TTL the same way the filesystem path does.
+      if (typeof entry.expiresAt === 'number' && Date.now() > entry.expiresAt) {
+        logger.debug('Collection cache expired (shared store), will refresh from GitHub');
+        return null;
+      }
+
+      const payload = entry.payload as { items?: CollectionItem[] } | null;
+      const items = Array.isArray(payload?.items) ? payload.items : [];
+      logger.debug(`Loaded ${items.length} items from collection cache (shared store)`);
+      return { items, timestamp: entry.fetchedAt, etag: entry.etag };
+    } catch (error) {
+      logger.debug(`Failed to load collection cache from shared store: ${error}`);
+      return null;
+    }
+  }
+
+  /**
+   * Persist the browse cache to the shared cache store (backend-honest path).
+   * Swallows errors like the filesystem path — caching failures must not break
+   * browsing.
+   */
+  private async saveToSharedCache(store: ISharedCacheStore, items: CollectionItem[], etag?: string): Promise<void> {
+    try {
+      await store.set({
+        cacheKey: CollectionCache.SHARED_CACHE_KEY,
+        payload: { items },
+        etag,
+        expiresAt: Date.now() + this.CACHE_TTL_MS
+      });
+      logger.debug(`Saved ${items.length} items to collection cache (shared store)`);
+    } catch (error) {
+      logger.error(`Failed to save collection cache to shared store: ${error}`);
+      // Don't throw - caching failures shouldn't break functionality
     }
   }
   

--- a/src/collection/CollectionBrowser.ts
+++ b/src/collection/CollectionBrowser.ts
@@ -2,26 +2,30 @@
  * Browse collection content from GitHub
  */
 
-import { GitHubClient } from './GitHubClient.js';
-import { CollectionCache, CollectionItem } from '../cache/CollectionCache.js';
+import type { GitHubClient } from './GitHubClient.js';
+import type { CollectionCache, CollectionItem } from '../cache/CollectionCache.js';
 import { CollectionSeeder } from './CollectionSeeder.js';
-import { CollectionIndexManager } from './CollectionIndexManager.js';
-import { CollectionIndex, IndexEntry } from '../types/collection.js';
+import type { CollectionIndexManager } from './CollectionIndexManager.js';
+import type { CollectionIndex, IndexEntry } from '../types/collection.js';
 import { logger } from '../utils/logger.js';
 import { ElementType } from '../portfolio/types.js';
+
+// Top-level collection sections. Used as an allowlist so untrusted `section`
+// input can never be interpolated into a GitHub API URL (SSRF guard).
+const COLLECTION_SECTIONS: ReadonlySet<string> = new Set(['library', 'showcase', 'catalog']);
 
 // Content types supported by MCP server
 // Now includes memories (IP concerns resolved)
 // ⚠️ CRITICAL: When adding new element types, you MUST update this array!
 // Also update validTypes array in src/index.ts
 // See docs/developer-guide/ADDING_NEW_ELEMENT_TYPES_CHECKLIST.md for complete guide
-const MCP_SUPPORTED_TYPES = [
+const MCP_SUPPORTED_TYPES = new Set([
   ElementType.PERSONA,    // personas - supported by PersonaTools and ElementTools
   ElementType.SKILL,      // skills - supported by ElementTools
   ElementType.AGENT,      // agents - supported by ElementTools
   ElementType.TEMPLATE,   // templates - supported by ElementTools
   ElementType.MEMORY      // memories - supported by ElementTools (restored)
-];
+]);
 
 /**
  * Type guard to safely check if a string is a valid ElementType
@@ -34,7 +38,7 @@ function isElementType(value: string): value is ElementType {
  * Type guard to safely check if an ElementType is supported by MCP
  */
 function isMCPSupportedType(elementType: ElementType): boolean {
-  return MCP_SUPPORTED_TYPES.includes(elementType);
+  return MCP_SUPPORTED_TYPES.has(elementType);
 }
 
 export class CollectionBrowser {
@@ -57,6 +61,21 @@ export class CollectionBrowser {
    * @param type - Optional content type within the library section (personas, skills, etc.)
    */
   async browseCollection(section?: string, type?: string): Promise<{ items: any[], categories: any[], sections?: any[] }> {
+    // SECURITY (SSRF guard): validate section/type against fixed allowlists
+    // BEFORE they can reach any URL interpolation. Untrusted values (e.g. from
+    // the web console) that fail validation are treated as "no such listing"
+    // rather than being interpolated into a GitHub API path. The GitHub-API
+    // fallback below builds `${baseUrl}/${section}/${type}` directly, so this
+    // is the primary defense; GitHubClient's path-traversal check is secondary.
+    if (section !== undefined && !COLLECTION_SECTIONS.has(section)) {
+      logger.debug('Rejecting browse request for unknown collection section', { section });
+      return { items: [], categories: [] };
+    }
+    if (type !== undefined && !isElementType(type)) {
+      logger.debug('Rejecting browse request for unknown element type', { type });
+      return { items: [], categories: [] };
+    }
+
     try {
       // Try using collection index first for faster browsing
       const indexResult = await this.browseFromIndex(section, type);
@@ -164,7 +183,7 @@ export class CollectionBrowser {
     
     // Extract types from index keys and filter for MCP-supported types
     Object.keys(index.index).forEach(typeName => {
-      const elementType = isElementType(typeName) ? typeName as ElementType : null;
+      const elementType = isElementType(typeName) ? typeName : null;
       if (elementType && isMCPSupportedType(elementType)) {
         types.add(typeName);
       }
@@ -182,7 +201,7 @@ export class CollectionBrowser {
   private getItemsFromIndex(index: CollectionIndex, section: string, type?: string): IndexEntry[] {
     // For library section with type, get items from that type
     if (section === 'library' && type) {
-      return index.index[type] || [];
+      return Object.hasOwn(index.index, type) ? index.index[type] : [];
     }
     
     // For library section without type, return empty (should show categories)
@@ -286,7 +305,7 @@ export class CollectionBrowser {
       if (pathParts.length >= 2 && pathParts[0] === 'library') {
         // Only include MCP-supported types in cache browsing
         const typeName = pathParts[1];
-        const elementType = isElementType(typeName) ? typeName as ElementType : null;
+        const elementType = isElementType(typeName) ? typeName : null;
         if (elementType && isMCPSupportedType(elementType)) {
           types.add(typeName);
         }
@@ -337,6 +356,7 @@ export class CollectionBrowser {
    */
   formatBrowseResults(items: any[], categories: any[], section?: string, type?: string, personaIndicator: string = ''): string {
     const textParts = [`${personaIndicator}🏪 **DollhouseMCP Collection**\n\n`];
+    const typeSuffix = type ? `/${type}` : '';
     
     // Show top-level sections if no section specified
     if (!section && categories.length > 0) {
@@ -379,7 +399,7 @@ export class CollectionBrowser {
       textParts.push('\n');
     } else if (categories.length > 0) {
       // Only show category navigation for non-library sections (showcase, catalog)
-      textParts.push(`**📁 Subdirectories in ${section}${type ? `/${type}` : ''} (${categories.length}):**\n`);
+      textParts.push(`**📁 Subdirectories in ${section}${typeSuffix} (${categories.length}):**\n`);
       categories.forEach((cat: any) => {
         const browsePath = type ? `"${section}" "${type}/${cat.name}"` : `"${section}" "${cat.name}"`;
         textParts.push(`   📂 **${cat.name}** - Browse: \`browse_collection ${browsePath}\`\n`);
@@ -399,7 +419,7 @@ export class CollectionBrowser {
       };
       const icon = contentIcons[contentType] || '📄';
       
-      textParts.push(`**${icon} ${contentType.charAt(0).toUpperCase() + contentType.slice(1)} in ${section}${type ? `/${type}` : ''} (${items.length}):**\n`);
+      textParts.push(`**${icon} ${contentType.charAt(0).toUpperCase() + contentType.slice(1)} in ${section}${typeSuffix} (${items.length}):**\n`);
       items.forEach((item: any) => {
         // Use item.path for correct GitHub file path, item.name for display
         // This fixes the mismatch where browse returned "Code Review.md" but file is "code-review.md"

--- a/src/collection/CollectionErrors.ts
+++ b/src/collection/CollectionErrors.ts
@@ -1,0 +1,55 @@
+/**
+ * Typed errors for the collection fetch/validate pipeline.
+ *
+ * Consumers (the web-console install/browse surfaces, MCP collection handlers)
+ * classify failures into user-facing statuses. Matching on `instanceof` keeps
+ * that classification stable when a message is reworded; the messages
+ * themselves are preserved verbatim from the previous plain-Error throws so
+ * existing message-based handling keeps working during the transition.
+ */
+
+/** The requested collection element does not exist (or is not a file). */
+export class CollectionElementNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CollectionElementNotFoundError';
+  }
+}
+
+/** The collection path is structurally invalid (shape, type segment, extension). */
+export class CollectionPathInvalidError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CollectionPathInvalidError';
+  }
+}
+
+/**
+ * The element's content failed install-grade validation (size, security scan,
+ * required fields) — permanent for this element, not a transient outage.
+ */
+export class CollectionContentInvalidError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CollectionContentInvalidError';
+  }
+}
+
+/**
+ * instanceof check that also walks the `cause` chain. The GitHub client wraps
+ * everything it catches in an McpError (token redaction + MCP error contract)
+ * but attaches the original error as `cause` — so a typed collection error
+ * survives the wrap and classification stays typed end-to-end. Depth-bounded
+ * against pathological cause cycles.
+ */
+export function isCollectionError<T extends Error>(
+  error: unknown,
+  errorClass: new (message: string) => T,
+): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current instanceof Error; depth += 1) {
+    if (current instanceof errorClass) return true;
+    current = current.cause;
+  }
+  return false;
+}

--- a/src/collection/ElementInstaller.ts
+++ b/src/collection/ElementInstaller.ts
@@ -23,24 +23,28 @@
  */
 
 import * as path from 'node:path';
-import { GitHubClient } from './GitHubClient.js';
-import { IElementMetadata } from '../types/elements/IElement.js';
+import { randomUUID } from 'node:crypto';
+import type { GitHubClient } from './GitHubClient.js';
+import type { IElementMetadata } from '../types/elements/IElement.js';
 import { validatePath, validateFilename, validateContentSize } from '../security/InputValidator.js';
 import { SECURITY_LIMITS } from '../security/constants.js';
 import { ContentValidator } from '../security/contentValidator.js';
 import { SecureYamlParser } from '../security/secureYamlParser.js';
 import { SecurityError } from '../errors/SecurityError.js';
-import { PortfolioManager, ElementType } from '../portfolio/PortfolioManager.js';
+import type { PortfolioManager } from '../portfolio/PortfolioManager.js';
+import { ElementType } from '../portfolio/PortfolioManager.js';
+import type { SourcePriorityConfig } from '../config/sourcePriority.js';
 import {
   getSourcePriorityConfig,
-  SourcePriorityConfig,
   ElementSource,
   getSourceDisplayName
 } from '../config/sourcePriority.js';
 import { createSafeObject, FORBIDDEN_KEYS } from '../utils/securityUtils.js';
-import { UnifiedIndexManager } from '../portfolio/UnifiedIndexManager.js';
+import type { UnifiedIndexManager } from '../portfolio/UnifiedIndexManager.js';
 import { logger } from '../utils/logger.js';
-import { IFileOperationsService } from '../services/FileOperationsService.js';
+import type { IFileOperationsService } from '../services/FileOperationsService.js';
+import type { ISharedPoolInstaller } from '../collection/shared-pool/ISharedPoolInstaller.js';
+import type { IStorageLayerFactory } from '../storage/IStorageLayerFactory.js';
 
 /**
  * Result of an element installation operation
@@ -82,6 +86,33 @@ export interface InstallOptions {
   fallbackOnError?: boolean;
 }
 
+/**
+ * A collection element fetched and fully validated but NOT written — the output
+ * of `ElementInstaller.fetchAndValidate`. `content` is what a caller should
+ * persist: the frontmatter-stripped body for markdown types, and the whole
+ * sanitized YAML document for memories.
+ */
+export interface CollectionFetchAndValidateResult {
+  readonly elementType: ElementType;
+  readonly name: string;
+  readonly metadata: IElementMetadata;
+  readonly content: string;
+}
+
+/** Path second-segment → element type, covering all six collection types. */
+const COLLECTION_ELEMENT_TYPE_BY_SEGMENT: Readonly<Record<string, ElementType>> = {
+  personas: ElementType.PERSONA,
+  skills: ElementType.SKILL,
+  templates: ElementType.TEMPLATE,
+  agents: ElementType.AGENT,
+  memories: ElementType.MEMORY,
+  ensembles: ElementType.ENSEMBLE,
+};
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 export class ElementInstaller {
   private githubClient: GitHubClient;
   private portfolioManager: PortfolioManager;
@@ -97,7 +128,7 @@ export class ElementInstaller {
   // Step 4.6: Optional shared-pool installer for collection content.
   // When set, installContent() routes through the shared pool instead
   // of writing to the user's per-user portfolio.
-  private readonly sharedPoolInstaller?: import('../collection/shared-pool/ISharedPoolInstaller.js').ISharedPoolInstaller;
+  private readonly sharedPoolInstaller?: ISharedPoolInstaller;
 
   // Phase 4.5 follow-up: optional storage-layer factory. When present AND the
   // factory produces a writable (database-backed) storage layer for the
@@ -107,7 +138,7 @@ export class ElementInstaller {
   // DB-mode but never persisted to Postgres — meaning installs vanished on
   // every container restart with tmpfs. Same correctness pattern as Phase H's
   // CollectionIndexCache and CollectionIndexManager wiring.
-  private readonly storageLayerFactory?: import('../storage/IStorageLayerFactory.js').IStorageLayerFactory;
+  private readonly storageLayerFactory?: IStorageLayerFactory;
 
   constructor(
     githubClient: GitHubClient,
@@ -115,8 +146,8 @@ export class ElementInstaller {
       portfolioManager: PortfolioManager;
       unifiedIndexManager: UnifiedIndexManager;
       fileOperations?: IFileOperationsService;
-      sharedPoolInstaller?: import('../collection/shared-pool/ISharedPoolInstaller.js').ISharedPoolInstaller;
-      storageLayerFactory?: import('../storage/IStorageLayerFactory.js').IStorageLayerFactory;
+      sharedPoolInstaller?: ISharedPoolInstaller;
+      storageLayerFactory?: IStorageLayerFactory;
     }
   ) {
     this.githubClient = githubClient;
@@ -126,11 +157,14 @@ export class ElementInstaller {
     if (!options?.unifiedIndexManager) {
       throw new Error('ElementInstaller requires a UnifiedIndexManager instance');
     }
+    if (!options.fileOperations) {
+      throw new Error('ElementInstaller requires a FileOperationsService instance');
+    }
     this.portfolioManager = options.portfolioManager;
     this.unifiedIndexManager = options.unifiedIndexManager;
     this.sourcePriorityConfig = getSourcePriorityConfig();
     // Initialize file operations service
-    this.fileOperations = options.fileOperations!;
+    this.fileOperations = options.fileOperations;
     this.sharedPoolInstaller = options.sharedPoolInstaller;
     this.storageLayerFactory = options.storageLayerFactory;
   }
@@ -754,7 +788,7 @@ export class ElementInstaller {
     const content = await this.fetchCollectionContent(sanitizedPath);
 
     // STEP 2: PERFORM ALL VALIDATION BEFORE ANY DISK OPERATIONS
-    const { sanitizedContent, metadata } = await this.validateCollectionContent(content);
+    const { sanitizedContent, metadata } = this.validateCollectionContent(content);
 
     // STEP 3: PREPARE FILE PATH AND CHECK EXISTENCE
     // FIX (SonarCloud L704): Remove unused elementDir variable
@@ -805,6 +839,102 @@ export class ElementInstaller {
       metadata,
       filename,
       elementType
+    };
+  }
+
+  /**
+   * Fetch a collection element and run the full install-grade validation
+   * pipeline WITHOUT writing it anywhere. This is the no-write seam the web
+   * console uses so it can route the validated element through its own
+   * (backend-honest, per-user) portfolio write path instead of this class's
+   * filesystem/storage-layer write.
+   *
+   * Supports all six element types: the five markdown types validate via the
+   * frontmatter pipeline; memories are pure YAML and validate via a dedicated
+   * secure branch. Throws on invalid path/type, fetch failure, or any security
+   * or required-field validation failure — the caller never sees an element
+   * that would not pass a normal install.
+   *
+   * @param collectionPath - Path in the collection (e.g. `library/skills/x.md`)
+   */
+  async fetchAndValidate(collectionPath: string): Promise<CollectionFetchAndValidateResult> {
+    const sanitizedPath = validatePath(collectionPath);
+    const elementType = this.resolveCollectionElementType(sanitizedPath);
+    const raw = await this.fetchCollectionContent(sanitizedPath);
+
+    if (elementType === ElementType.MEMORY) {
+      return this.validateCollectionMemory(elementType, raw);
+    }
+    const { metadata, body } = this.validateCollectionContent(raw);
+    return {
+      elementType,
+      name: metadata.name ?? '',
+      metadata,
+      content: body,
+    };
+  }
+
+  /**
+   * Resolve the element type from a collection path for the no-write seam,
+   * covering all six element types and enforcing the per-type file extension
+   * (memories are `.yaml`/`.yml`; every other type is `.md`). Rejecting the
+   * mismatch keeps a `.md` payload from being treated as a memory and vice
+   * versa.
+   */
+  private resolveCollectionElementType(sanitizedPath: string): ElementType {
+    const pathParts = sanitizedPath.split('/');
+    if (pathParts.length < 3 || pathParts[0] !== 'library') {
+      throw new Error('Invalid collection path format. Expected: library/[element-type]/[element].[ext]');
+    }
+    const elementType = COLLECTION_ELEMENT_TYPE_BY_SEGMENT[pathParts[1]];
+    if (!elementType) {
+      throw new Error(`Unknown element type: ${pathParts[1]}. Valid types: ${Object.keys(COLLECTION_ELEMENT_TYPE_BY_SEGMENT).join(', ')}`);
+    }
+    const isMemory = elementType === ElementType.MEMORY;
+    const hasMemoryExtension = sanitizedPath.endsWith('.yaml') || sanitizedPath.endsWith('.yml');
+    const hasMarkdownExtension = sanitizedPath.endsWith('.md');
+    if (isMemory ? !hasMemoryExtension : !hasMarkdownExtension) {
+      throw new Error(`Invalid file type for ${pathParts[1]}. Expected ${isMemory ? '.yaml/.yml' : '.md'}.`);
+    }
+    return elementType;
+  }
+
+  /**
+   * Validate a pure-YAML memory document from the collection (memories carry no
+   * markdown frontmatter). Runs the same security gates as the markdown path —
+   * size limit, content sanitization, YAML-bomb detection, metadata injection
+   * validation, required fields — then returns the sanitized document as the
+   * install content (the console portfolio store parses the memory document on
+   * the write side).
+   */
+  private validateCollectionMemory(elementType: ElementType, content: string): CollectionFetchAndValidateResult {
+    validateContentSize(content, SECURITY_LIMITS.MAX_PERSONA_SIZE_BYTES);
+    const sanitizedContent = ContentValidator.sanitizePersonaContent(content);
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = SecureYamlParser.parseRawYaml(sanitizedContent, SECURITY_LIMITS.MAX_PERSONA_SIZE_BYTES);
+    } catch (error) {
+      if (error instanceof SecurityError) {
+        throw new Error(`Security threat in content: ${error.message}`);
+      }
+      throw error;
+    }
+
+    // Memory documents nest identity under `metadata:`; fall back to the
+    // top-level object for flatter shapes.
+    const rawMetadata = isPlainRecord(parsed.metadata) ? parsed.metadata : parsed;
+    const metadata = this.sanitizeMetadata(rawMetadata as unknown as IElementMetadata);
+    this.validateMetadataSecurity(metadata);
+    if (!metadata.name || !metadata.description) {
+      throw new Error('Invalid content: missing required name or description');
+    }
+
+    return {
+      elementType,
+      name: metadata.name,
+      metadata,
+      content: sanitizedContent,
     };
   }
 
@@ -932,10 +1062,11 @@ export class ElementInstaller {
    * @throws Error if validation fails
    * @private
    */
-  private async validateCollectionContent(content: string): Promise<{
+  private validateCollectionContent(content: string): {
     sanitizedContent: string;
     metadata: IElementMetadata;
-  }> {
+    body: string;
+  } {
     // SECURITY: Validate content size after decoding
     validateContentSize(content, SECURITY_LIMITS.MAX_PERSONA_SIZE_BYTES);
 
@@ -944,7 +1075,7 @@ export class ElementInstaller {
 
     // SECURITY: Use secure YAML parser to prevent YAML bombs and injection
     const parsed = this.parseSecureYaml(sanitizedContent);
-    const metadata = this.sanitizeMetadata(parsed.data as IElementMetadata);
+    const metadata = this.sanitizeMetadata(parsed.data);
 
     // SECURITY: Additional metadata validation for injection attacks
     this.validateMetadataSecurity(metadata);
@@ -954,7 +1085,7 @@ export class ElementInstaller {
       throw new Error('Invalid content: missing required name or description');
     }
 
-    return { sanitizedContent, metadata };
+    return { sanitizedContent, metadata, body: parsed.content };
   }
 
   /**
@@ -1085,13 +1216,17 @@ export class ElementInstaller {
    * but writes to the shared pool instead of the user's portfolio.
    */
   private async installViaSharedPool(collectionPath: string): Promise<InstallResult> {
+    const sharedPoolInstaller = this.sharedPoolInstaller;
+    if (!sharedPoolInstaller) {
+      throw new Error('installViaSharedPool called without a shared-pool installer');
+    }
     const sanitizedPath = validatePath(collectionPath);
     const elementType = this.validateAndExtractElementType(sanitizedPath);
     const content = await this.fetchCollectionContent(sanitizedPath);
-    const { sanitizedContent, metadata } = await this.validateCollectionContent(content);
+    const { sanitizedContent, metadata } = this.validateCollectionContent(content);
 
     const sourceUrl = `github://DollhouseMCP/collection/${sanitizedPath}`;
-    const result = await this.sharedPoolInstaller!.install({
+    const result = await sharedPoolInstaller.install({
       content: sanitizedContent,
       elementType,
       name: metadata.name,
@@ -1143,7 +1278,7 @@ export class ElementInstaller {
    */
   private async atomicWriteFile(destination: string, content: string): Promise<void> {
     // Generate unique temporary file name to avoid collisions
-    const tempFile = `${destination}.tmp.${Date.now()}.${Math.random().toString(36).substring(2)}`;
+    const tempFile = `${destination}.tmp.${Date.now()}.${randomUUID()}`;
 
     try {
       // SECURITY: Write to temporary file first
@@ -1209,9 +1344,10 @@ export class ElementInstaller {
 
     const emoji = typeEmojis[elementType] || '📦';
     const typeName = elementType.charAt(0).toUpperCase() + elementType.slice(1);
+    const authorSuffix = metadata.author ? `by ${metadata.author}` : '';
 
     return `✅ **AI Customization Element Installed Successfully!**\n\n` +
-      `${emoji} **${metadata.name}** ${metadata.author ? `by ${metadata.author}` : ''}\n` +
+      `${emoji} **${metadata.name}** ${authorSuffix}\n` +
       `📁 Type: ${typeName}\n` +
       `📄 Saved as: ${filename}\n\n` +
       `🚀 **Ready to use!**`;

--- a/src/collection/ElementInstaller.ts
+++ b/src/collection/ElementInstaller.ts
@@ -31,6 +31,11 @@ import { SECURITY_LIMITS } from '../security/constants.js';
 import { ContentValidator } from '../security/contentValidator.js';
 import { SecureYamlParser } from '../security/secureYamlParser.js';
 import { SecurityError } from '../errors/SecurityError.js';
+import {
+  CollectionContentInvalidError,
+  CollectionElementNotFoundError,
+  CollectionPathInvalidError,
+} from './CollectionErrors.js';
 import type { PortfolioManager } from '../portfolio/PortfolioManager.js';
 import { ElementType } from '../portfolio/PortfolioManager.js';
 import type { SourcePriorityConfig } from '../config/sourcePriority.js';
@@ -111,6 +116,11 @@ const COLLECTION_ELEMENT_TYPE_BY_SEGMENT: Readonly<Record<string, ElementType>> 
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Canonical on-disk extension per element type: memories are YAML, the rest markdown. */
+function elementFileExtension(elementType: ElementType): string {
+  return elementType === ElementType.MEMORY ? '.yaml' : '.md';
 }
 
 export class ElementInstaller {
@@ -788,7 +798,7 @@ export class ElementInstaller {
     const content = await this.fetchCollectionContent(sanitizedPath);
 
     // STEP 2: PERFORM ALL VALIDATION BEFORE ANY DISK OPERATIONS
-    const { sanitizedContent, metadata } = this.validateCollectionContent(content);
+    const { sanitizedContent, metadata } = this.validateCollectionElement(elementType, content);
 
     // STEP 3: PREPARE FILE PATH AND CHECK EXISTENCE
     // FIX (SonarCloud L704): Remove unused elementDir variable
@@ -884,17 +894,17 @@ export class ElementInstaller {
   private resolveCollectionElementType(sanitizedPath: string): ElementType {
     const pathParts = sanitizedPath.split('/');
     if (pathParts.length < 3 || pathParts[0] !== 'library') {
-      throw new Error('Invalid collection path format. Expected: library/[element-type]/[element].[ext]');
+      throw new CollectionPathInvalidError('Invalid collection path format. Expected: library/[element-type]/[element].[ext]');
     }
     const elementType = COLLECTION_ELEMENT_TYPE_BY_SEGMENT[pathParts[1]];
     if (!elementType) {
-      throw new Error(`Unknown element type: ${pathParts[1]}. Valid types: ${Object.keys(COLLECTION_ELEMENT_TYPE_BY_SEGMENT).join(', ')}`);
+      throw new CollectionPathInvalidError(`Unknown element type: ${pathParts[1]}. Valid types: ${Object.keys(COLLECTION_ELEMENT_TYPE_BY_SEGMENT).join(', ')}`);
     }
     const isMemory = elementType === ElementType.MEMORY;
     const hasMemoryExtension = sanitizedPath.endsWith('.yaml') || sanitizedPath.endsWith('.yml');
     const hasMarkdownExtension = sanitizedPath.endsWith('.md');
     if (isMemory ? !hasMemoryExtension : !hasMarkdownExtension) {
-      throw new Error(`Invalid file type for ${pathParts[1]}. Expected ${isMemory ? '.yaml/.yml' : '.md'}.`);
+      throw new CollectionPathInvalidError(`Invalid file type for ${pathParts[1]}. Expected ${isMemory ? '.yaml/.yml' : '.md'}.`);
     }
     return elementType;
   }
@@ -916,7 +926,7 @@ export class ElementInstaller {
       parsed = SecureYamlParser.parseRawYaml(sanitizedContent, SECURITY_LIMITS.MAX_PERSONA_SIZE_BYTES);
     } catch (error) {
       if (error instanceof SecurityError) {
-        throw new Error(`Security threat in content: ${error.message}`);
+        throw new CollectionContentInvalidError(`Security threat in content: ${error.message}`);
       }
       throw error;
     }
@@ -934,7 +944,7 @@ export class ElementInstaller {
     const description: unknown = metadata.description;
     if (typeof name !== 'string' || name.trim() === '' ||
         typeof description !== 'string' || description.trim() === '') {
-      throw new Error('Invalid content: missing required name or description');
+      throw new CollectionContentInvalidError('Invalid content: missing required name or description');
     }
 
     return {
@@ -967,7 +977,7 @@ export class ElementInstaller {
     // path stays consistent if someone wires this through it.
     const layer = this.storageLayerFactory.createForElement(elementType, {
       elementDir: this.portfolioManager.getElementDir(elementType),
-      fileExtension: '.md',
+      fileExtension: elementFileExtension(elementType),
       scanCooldownMs: 0,
     });
     if (!isWritableStorageLayer(layer)) {
@@ -1018,20 +1028,11 @@ export class ElementInstaller {
    * @private
    */
   private validateAndExtractElementType(sanitizedPath: string): ElementType {
-    // SECURITY: Detect element type from path structure and validate format
-    // Expected format: library/[element-type]/[category]/[element].md
-    const pathParts = sanitizedPath.split('/');
-    if (pathParts.length < 3 || pathParts[0] !== 'library') {
-      throw new Error('Invalid collection path format. Expected: library/[element-type]/[category]/[element].md');
-    }
-
-    // SECURITY: Ensure the path ends with .md to prevent arbitrary file types
-    if (!sanitizedPath.endsWith('.md')) {
-      throw new Error('Invalid file type. Only .md files are allowed.');
-    }
-
-    const elementTypeStr = pathParts[1];
-    return this.getElementTypeFromString(elementTypeStr);
+    // All six element types with per-type extension enforcement (memories are
+    // .yaml/.yml, everything else .md) — the same resolution the web-console
+    // seam uses, so the MCP install path and the console path can never
+    // disagree about what is installable.
+    return this.resolveCollectionElementType(sanitizedPath);
   }
 
   /**
@@ -1048,12 +1049,12 @@ export class ElementInstaller {
     const data = await this.githubClient.fetchFromGitHub(url);
 
     if (data.type !== 'file') {
-      throw new Error('Path does not point to a file');
+      throw new CollectionElementNotFoundError('Path does not point to a file');
     }
 
     // SECURITY: Check file size before downloading to prevent DoS attacks
     if (data.size > SECURITY_LIMITS.MAX_PERSONA_SIZE_BYTES) {
-      throw new Error(`File too large (${data.size} bytes, max ${SECURITY_LIMITS.MAX_PERSONA_SIZE_BYTES} bytes)`);
+      throw new CollectionContentInvalidError(`File too large (${data.size} bytes, max ${SECURITY_LIMITS.MAX_PERSONA_SIZE_BYTES} bytes)`);
     }
 
     // Decode Base64 content into memory only
@@ -1061,8 +1062,25 @@ export class ElementInstaller {
   }
 
   /**
-   * Validate and sanitize collection content
-   * Extracted from installFromCollection() to reduce cognitive complexity
+   * Type-aware validation dispatch for the install paths: memories are pure
+   * YAML with their own secure branch; every other type runs the markdown
+   * frontmatter pipeline. Keeps the MCP install paths and the web-console
+   * seam validating identically for all six element types.
+   */
+  private validateCollectionElement(elementType: ElementType, content: string): {
+    sanitizedContent: string;
+    metadata: IElementMetadata;
+  } {
+    if (elementType === ElementType.MEMORY) {
+      const validated = this.validateCollectionMemory(elementType, content);
+      return { sanitizedContent: validated.content, metadata: validated.metadata };
+    }
+    const { sanitizedContent, metadata } = this.validateCollectionContent(content);
+    return { sanitizedContent, metadata };
+  }
+
+  /**
+   * Validate and sanitize collection content (markdown frontmatter pipeline)
    *
    * @param content - Raw content from collection
    * @returns Sanitized content and parsed metadata
@@ -1089,7 +1107,7 @@ export class ElementInstaller {
 
     // SECURITY: Validate required metadata fields
     if (!metadata.name || !metadata.description) {
-      throw new Error('Invalid content: missing required name or description');
+      throw new CollectionContentInvalidError('Invalid content: missing required name or description');
     }
 
     return { sanitizedContent, metadata, body: parsed.content };
@@ -1127,7 +1145,7 @@ export class ElementInstaller {
       return { data: parsed.data as IElementMetadata, content: parsed.content };
     } catch (error) {
       if (error instanceof SecurityError) {
-        throw new Error(`Security threat in content: ${error.message}`);
+        throw new CollectionContentInvalidError(`Security threat in content: ${error.message}`);
       }
       throw error;
     }
@@ -1144,7 +1162,7 @@ export class ElementInstaller {
   private validateMetadataSecurity(metadata: IElementMetadata): void {
     const metadataValidation = ContentValidator.validateMetadata(metadata);
     if (!metadataValidation.isValid) {
-      throw new Error(`Security validation failed: ${metadataValidation.detectedPatterns?.join(', ')}`);
+      throw new CollectionContentInvalidError(`Security validation failed: ${metadataValidation.detectedPatterns?.join(', ')}`);
     }
   }
 
@@ -1230,7 +1248,7 @@ export class ElementInstaller {
     const sanitizedPath = validatePath(collectionPath);
     const elementType = this.validateAndExtractElementType(sanitizedPath);
     const content = await this.fetchCollectionContent(sanitizedPath);
-    const { sanitizedContent, metadata } = this.validateCollectionContent(content);
+    const { sanitizedContent, metadata } = this.validateCollectionElement(elementType, content);
 
     const sourceUrl = `github://DollhouseMCP/collection/${sanitizedPath}`;
     const result = await sharedPoolInstaller.install({
@@ -1248,7 +1266,7 @@ export class ElementInstaller {
           success: true,
           message: 'AI customization element installed to shared pool!',
           metadata,
-          filename: `${metadata.name}.md`,
+          filename: `${metadata.name}${elementFileExtension(elementType)}`,
           elementType,
         };
 
@@ -1257,7 +1275,7 @@ export class ElementInstaller {
           success: true,
           message: result.reason,
           metadata,
-          filename: `${metadata.name}.md`,
+          filename: `${metadata.name}${elementFileExtension(elementType)}`,
           elementType,
           alreadyExists: true,
         };
@@ -1315,25 +1333,6 @@ export class ElementInstaller {
       // Re-throw the original error to maintain error handling semantics
       throw error;
     }
-  }
-
-  /**
-   * Get ElementType from string
-   */
-  private getElementTypeFromString(typeStr: string): ElementType {
-    const typeMap: Record<string, ElementType> = {
-      'personas': ElementType.PERSONA,
-      'skills': ElementType.SKILL,
-      'templates': ElementType.TEMPLATE,
-      'agents': ElementType.AGENT
-    };
-
-    const elementType = typeMap[typeStr];
-    if (!elementType) {
-      throw new Error(`Unknown element type: ${typeStr}. Valid types: ${Object.keys(typeMap).join(', ')}`);
-    }
-
-    return elementType;
   }
 
   /**

--- a/src/collection/ElementInstaller.ts
+++ b/src/collection/ElementInstaller.ts
@@ -926,13 +926,20 @@ export class ElementInstaller {
     const rawMetadata = isPlainRecord(parsed.metadata) ? parsed.metadata : parsed;
     const metadata = this.sanitizeMetadata(rawMetadata as unknown as IElementMetadata);
     this.validateMetadataSecurity(metadata);
-    if (!metadata.name || !metadata.description) {
+    // The parsed YAML is untrusted: unlike the markdown path (whose parser
+    // enforces string-typed identity fields), parseRawYaml happily yields
+    // `name: 2024` as a number — which would escape here typed as string and
+    // TypeError deep in the portfolio store. Require real non-empty strings.
+    const name: unknown = metadata.name;
+    const description: unknown = metadata.description;
+    if (typeof name !== 'string' || name.trim() === '' ||
+        typeof description !== 'string' || description.trim() === '') {
       throw new Error('Invalid content: missing required name or description');
     }
 
     return {
       elementType,
-      name: metadata.name,
+      name,
       metadata,
       content: sanitizedContent,
     };

--- a/src/collection/GitHubClient.ts
+++ b/src/collection/GitHubClient.ts
@@ -62,7 +62,10 @@ export class GitHubClient {
    *    its own: a caller that interpolates untrusted input (e.g.
    *    `.../contents/library/../../../orgs/X`) would parse to a *different*
    *    api.github.com endpoint that still passes the hostname check — and be
-   *    fetched with the server token attached. No legitimate GitHub URL has a
+   *    fetched with the server token attached. The check runs on a
+   *    percent-decoded, backslash-normalized copy of the path so encoded forms
+   *    (`%2e%2e`, `..%5c`) — which `fetch`/WHATWG still collapse to traversal —
+   *    cannot slip past a literal `..` scan. No legitimate GitHub URL has a
    *    `.`/`..` path segment (search queries live in the query string, which we
    *    exclude here), so this breaks nothing legitimate.
    * 2. Reject any host not on the allowlist (default api.github.com +
@@ -70,7 +73,16 @@ export class GitHubClient {
    */
   private assertUrlAllowed(url: string): void {
     const rawPath = url.split('#')[0].split('?')[0];
-    if (rawPath.split('/').some(segment => segment === '..' || segment === '.')) {
+    let decodedPath: string;
+    try {
+      decodedPath = decodeURIComponent(rawPath);
+    } catch {
+      throw new Error('GitHubClient: Refusing to fetch URL with malformed percent-encoding');
+    }
+    // Backslashes are treated as path separators by the URL parser, so fold
+    // them in before splitting.
+    const segments = decodedPath.replaceAll('\\', '/').split('/');
+    if (segments.some(segment => segment === '..' || segment === '.')) {
       throw new Error('GitHubClient: Refusing to fetch URL with path-traversal segments');
     }
 

--- a/src/collection/GitHubClient.ts
+++ b/src/collection/GitHubClient.ts
@@ -3,6 +3,7 @@
  */
 
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { CollectionElementNotFoundError } from './CollectionErrors.js';
 import type { APICache } from '../cache/APICache.js';
 import { SECURITY_LIMITS } from '../security/constants.js';
 import type { TokenManager } from '../security/tokenManager.js';
@@ -170,7 +171,7 @@ export class GitHubClient {
       throw new Error('GitHub API authentication failed. Please check your GITHUB_TOKEN.');
     }
     if (response.status === 404) {
-      throw new Error('File not found in collection. Try using search to get the correct path: search_collection_enhanced "your-search-term"');
+      throw new CollectionElementNotFoundError('File not found in collection. Try using search to get the correct path: search_collection_enhanced "your-search-term"');
     }
     throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
   }

--- a/src/collection/GitHubClient.ts
+++ b/src/collection/GitHubClient.ts
@@ -3,9 +3,9 @@
  */
 
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
-import { APICache } from '../cache/APICache.js';
+import type { APICache } from '../cache/APICache.js';
 import { SECURITY_LIMITS } from '../security/constants.js';
-import { TokenManager } from '../security/tokenManager.js';
+import type { TokenManager } from '../security/tokenManager.js';
 
 /** Default hosts that are always allowed for GitHub API access. */
 const DEFAULT_ALLOWED_HOSTS: ReadonlySet<string> = new Set([
@@ -55,19 +55,39 @@ export class GitHubClient {
   }
   
   /**
+   * Validate a URL against the SSRF defenses before it is fetched.
+   *
+   * 1. Reject path-traversal segments in the RAW url before the WHATWG URL
+   *    constructor collapses them. The hostname allowlist is not sufficient on
+   *    its own: a caller that interpolates untrusted input (e.g.
+   *    `.../contents/library/../../../orgs/X`) would parse to a *different*
+   *    api.github.com endpoint that still passes the hostname check — and be
+   *    fetched with the server token attached. No legitimate GitHub URL has a
+   *    `.`/`..` path segment (search queries live in the query string, which we
+   *    exclude here), so this breaks nothing legitimate.
+   * 2. Reject any host not on the allowlist (default api.github.com +
+   *    raw.githubusercontent.com; extendable via DOLLHOUSE_COLLECTION_ALLOWLIST).
+   */
+  private assertUrlAllowed(url: string): void {
+    const rawPath = url.split('#')[0].split('?')[0];
+    if (rawPath.split('/').some(segment => segment === '..' || segment === '.')) {
+      throw new Error('GitHubClient: Refusing to fetch URL with path-traversal segments');
+    }
+
+    const parsedUrl = new URL(url);
+    if (!this.allowedHosts.has(parsedUrl.hostname)) {
+      throw new Error(`GitHubClient: Refusing to fetch non-allowed URL: ${parsedUrl.hostname}`);
+    }
+  }
+
+  /**
    * Fetch data from GitHub API with caching and rate limiting
    */
   async fetchFromGitHub(url: string, requireAuth: boolean = false): Promise<any> {
     let timeoutId: NodeJS.Timeout | null = null;
     const controller = new AbortController();
 
-    // Validate URL hostname against the allowlist to prevent SSRF.
-    // Default: api.github.com + raw.githubusercontent.com.
-    // Deployments can extend via DOLLHOUSE_COLLECTION_ALLOWLIST env var.
-    const parsedUrl = new URL(url);
-    if (!this.allowedHosts.has(parsedUrl.hostname)) {
-      throw new Error(`GitHubClient: Refusing to fetch non-allowed URL: ${parsedUrl.hostname}`);
-    }
+    this.assertUrlAllowed(url);
 
     try {
       // Check rate limit
@@ -106,67 +126,79 @@ export class GitHubClient {
       });
       
       if (!response.ok) {
-        if (response.status === 403) {
-          const errorMsg = token 
-            ? 'GitHub API rate limit exceeded or token lacks required permissions.'
-            : 'GitHub API rate limit exceeded. Consider using setup_github_auth or setting GITHUB_TOKEN environment variable.';
-          throw new Error(errorMsg);
-        }
-        if (response.status === 401) {
-          throw new Error('GitHub API authentication failed. Please check your GITHUB_TOKEN.');
-        }
-        // Provide helpful error messages based on status code
-        if (response.status === 404) {
-          throw new Error(`File not found in collection. Try using search to get the correct path: search_collection_enhanced "your-search-term"`);
-        }
-        throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+        this.throwForErrorResponse(response, token);
       }
-      
+
       const data = await response.json();
-      
+
       // Cache the successful response
       this.apiCache.set(url, data);
-      
+
       return data;
     } catch (error) {
-      // Use TokenManager for safe error handling
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      const safeMessage = this.tokenManager.createSafeErrorMessage(errorMessage);
-      
-      // codeql[js/clear-text-logging] — URL is a GitHub API endpoint (api.github.com/raw.githubusercontent.com),
-      // validated at method entry. Auth tokens are in headers, not the URL.
-      const errorDetails: any = {
-        originalMessage: safeMessage,
-        url
-      };
-      
-      // Preserve stack trace and error type information
-      if (error instanceof Error) {
-        errorDetails.errorType = error.constructor.name;
-        errorDetails.stack = error.stack;
-        
-        // Special handling for common error types
-        if (error.name === 'AbortError') {
-          errorDetails.timeout = true;
-        }
-      }
-      
-      const mcpError = new McpError(
-        ErrorCode.InternalError,
-        `Failed to fetch from GitHub: ${safeMessage}`,
-        errorDetails
-      );
-      
-      // Also preserve original error for debugging
-      (mcpError as any).cause = error;
-      
-      throw mcpError;
+      throw this.buildFetchError(error, url);
     } finally {
       if (timeoutId) {
         clearTimeout(timeoutId);
         timeoutId = null;
       }
     }
+  }
+
+  /**
+   * Translate a non-OK GitHub response into a helpful error. Always throws.
+   */
+  private throwForErrorResponse(response: Response, token: string | null): never {
+    if (response.status === 403) {
+      throw new Error(token
+        ? 'GitHub API rate limit exceeded or token lacks required permissions.'
+        : 'GitHub API rate limit exceeded. Consider using setup_github_auth or setting GITHUB_TOKEN environment variable.');
+    }
+    if (response.status === 401) {
+      throw new Error('GitHub API authentication failed. Please check your GITHUB_TOKEN.');
+    }
+    if (response.status === 404) {
+      throw new Error('File not found in collection. Try using search to get the correct path: search_collection_enhanced "your-search-term"');
+    }
+    throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+  }
+
+  /**
+   * Wrap a caught fetch error in an McpError with safe, preserved details.
+   */
+  private buildFetchError(error: unknown, url: string): McpError {
+    // Use TokenManager for safe error handling
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const safeMessage = this.tokenManager.createSafeErrorMessage(errorMessage);
+
+    // codeql[js/clear-text-logging] — URL is a GitHub API endpoint (api.github.com/raw.githubusercontent.com),
+    // validated at method entry. Auth tokens are in headers, not the URL.
+    const errorDetails: any = {
+      originalMessage: safeMessage,
+      url
+    };
+
+    // Preserve stack trace and error type information
+    if (error instanceof Error) {
+      errorDetails.errorType = error.constructor.name;
+      errorDetails.stack = error.stack;
+
+      // Special handling for common error types
+      if (error.name === 'AbortError') {
+        errorDetails.timeout = true;
+      }
+    }
+
+    const mcpError = new McpError(
+      ErrorCode.InternalError,
+      `Failed to fetch from GitHub: ${safeMessage}`,
+      errorDetails
+    );
+
+    // Also preserve original error for debugging
+    (mcpError as any).cause = error;
+
+    return mcpError;
   }
 
   /**

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -415,6 +415,13 @@ const envSchema = z.object({
    */
   DOLLHOUSE_WEB_CONSOLE_PORTFOLIO_WRITE_ROUTES_ENABLED: envBool(false),
   /**
+   * Enables the collection catalog browse routes (/api/v1/collection/*) on the
+   * replacement console. Defaults off: serving the catalog drives server-funded
+   * outbound GitHub traffic under a budget shared by every user, so operators
+   * opt in deliberately (and can kill the surface independently of the console).
+   */
+  DOLLHOUSE_WEB_CONSOLE_COLLECTION_ENABLED: envBool(false),
+  /**
    * Enables the sign-in allowlist admin routes (/api/v1/admin/accounts/allowlist*)
    * on the replacement console. Defaults on: the console is the operator surface
    * for managing the sign-in allowlist, and the routes are admin-capability +

--- a/src/di/registrars/CollectionServiceRegistrar.ts
+++ b/src/di/registrars/CollectionServiceRegistrar.ts
@@ -16,7 +16,8 @@
 
 import { env } from '../../config/env.js';
 import { getPortfolioRepositoryName } from '../../config/portfolioConfig.js';
-import { APICache, CollectionCache } from '../../cache/index.js';
+import type { APICache} from '../../cache/index.js';
+import { CollectionCache } from '../../cache/index.js';
 import {
   GitHubClient,
   CollectionBrowser,
@@ -30,6 +31,9 @@ import { GitHubRateLimiter } from '../../utils/GitHubRateLimiter.js';
 import { PortfolioRepoManager } from '../../portfolio/PortfolioRepoManager.js';
 import { GitHubPortfolioIndexer } from '../../portfolio/GitHubPortfolioIndexer.js';
 import type { DiContainerFacade } from '../DiContainerFacade.js';
+import type { ISharedCacheStore } from '../../storage/sharedCache/ISharedCacheStore.js';
+import type { PathService } from '../../paths/PathService.js';
+import type { ContextTracker } from '../../security/encryption/ContextTracker.js';
 
 export class CollectionServiceRegistrar {
   public register(container: DiContainerFacade): void {
@@ -64,7 +68,7 @@ export class CollectionServiceRegistrar {
       fileOperations: container.resolve('FileOperationsService'),
       indexUrl: env.DOLLHOUSE_COLLECTION_URL,
       cache: container.hasRegistration('SharedCacheStore')
-        ? container.resolve<import('../../storage/sharedCache/ISharedCacheStore.js').ISharedCacheStore>('SharedCacheStore')
+        ? container.resolve<ISharedCacheStore>('SharedCacheStore')
         : undefined,
     }));
 
@@ -83,10 +87,18 @@ export class CollectionServiceRegistrar {
       container.resolve('CollectionIndexCache')
     ));
 
+    // Backend honesty: when SharedCacheStore is registered (DB/hosted mode),
+    // inject it so the browse cache routes through the store backend instead of
+    // the filesystem — mirrors the CollectionIndexManager wiring above. Falls
+    // back to the filesystem path when the store isn't registered (e.g. unit-test
+    // containers that skip the full bootstrap).
     container.register('CollectionCache', () => new CollectionCache(
       container.resolve('FileOperationsService'),
       container.hasRegistration('PathService')
-        ? container.resolve<import('../../paths/PathService.js').PathService>('PathService').resolveDataDir('cache')
+        ? container.resolve<PathService>('PathService').resolveDataDir('cache')
+        : undefined,
+      container.hasRegistration('SharedCacheStore')
+        ? container.resolve<ISharedCacheStore>('SharedCacheStore')
         : undefined,
     ));
 
@@ -116,7 +128,7 @@ export class CollectionServiceRegistrar {
 
     container.register('GitHubPortfolioIndexer', () => new GitHubPortfolioIndexer(
       container.resolve('PortfolioRepoManager'),
-      () => container.resolve<import('../../security/encryption/ContextTracker.js').ContextTracker>('ContextTracker')
+      () => container.resolve<ContextTracker>('ContextTracker')
         .getSessionContext()?.userId ?? 'system',
     ));
   }

--- a/src/web-console/WebConsoleHttpBootstrap.ts
+++ b/src/web-console/WebConsoleHttpBootstrap.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises';
 
 import { env, type Env } from '../config/env.js';
+import { isLoopbackHost } from '../auth/oauth/url.js';
 import { logger } from '../utils/logger.js';
 import type { DiContainerFacade } from '../di/DiContainerFacade.js';
 import type { AuthMethodId } from '../auth/embedded-as/AuthMethodFactory.js';
@@ -31,6 +32,7 @@ export type WebConsoleHttpBootstrapEnv = Pick<
   | 'DOLLHOUSE_HTTP_HOST'
   | 'DOLLHOUSE_AUTH_METHODS'
   | 'GITHUB_REPOSITORY'
+  | 'GITHUB_TOKEN'
   | 'DOLLHOUSE_WEB_CONSOLE_PRODUCTION_DATABASE_NAME'
   | 'DOLLHOUSE_WEB_CONSOLE_PRODUCTION_DATABASE_USER'
   | 'DOLLHOUSE_WEB_CONSOLE_OPAQUE_HMAC_KEY'
@@ -70,6 +72,7 @@ export function resolveWebConsoleHttpBootstrapOptions(
   if (!sourceEnv.DOLLHOUSE_WEB_CONSOLE_REPLACEMENT_READINESS_EVIDENCE) {
     throw new Error(API_V1_REPLACEMENT_REQUIRES_EVIDENCE);
   }
+  warnCollectionBrowseWithoutGitHubToken(sourceEnv);
   const githubIntegrationProviderConfig = sourceEnv.DOLLHOUSE_INTEGRATION_GITHUB_CLIENT_ID &&
     sourceEnv.DOLLHOUSE_INTEGRATION_GITHUB_CLIENT_SECRET
     ? {
@@ -117,6 +120,29 @@ export function resolveWebConsoleHttpBootstrapOptions(
       });
     },
   };
+}
+
+/**
+ * Hosted collection-browse token nudge. Catalog browse makes server-funded
+ * outbound GitHub calls; without GITHUB_TOKEN those fall under GitHub's
+ * unauthenticated budget of 60 requests/hour per egress IP, shared across
+ * every console user AND portfolio sync. Warn (never fail — the surface
+ * degrades gracefully to cached/empty responses) so operators of non-loopback
+ * deployments set a token. Skip for loopback binds: dev/CI doesn't need the
+ * nudge, and a single local user rarely exhausts the anonymous budget.
+ */
+function warnCollectionBrowseWithoutGitHubToken(sourceEnv: WebConsoleHttpBootstrapEnv): void {
+  if (!sourceEnv.DOLLHOUSE_WEB_CONSOLE_COLLECTION_ENABLED) return;
+  if (sourceEnv.GITHUB_TOKEN) return;
+  if (isLoopbackHost(sourceEnv.DOLLHOUSE_HTTP_HOST)) return;
+  logger.warn(
+    '[WebConsoleHttpBootstrap] Collection browse is enabled (DOLLHOUSE_WEB_CONSOLE_COLLECTION_ENABLED=true) ' +
+    `on a non-loopback bind '${sourceEnv.DOLLHOUSE_HTTP_HOST}' without GITHUB_TOKEN. Catalog fetches will ` +
+    "use GitHub's unauthenticated rate budget (60 requests/hour per egress IP), shared across all console " +
+    'users and portfolio sync. Set GITHUB_TOKEN to a zero-scope personal access token — public catalog ' +
+    'reads need no scopes, and scopes like public_repo would grant public-repository write — to raise ' +
+    'the budget to 5,000 requests/hour.',
+  );
 }
 
 export async function assertWebConsoleReplacementEvidenceReady(

--- a/src/web-console/WebConsoleHttpBootstrap.ts
+++ b/src/web-console/WebConsoleHttpBootstrap.ts
@@ -24,6 +24,7 @@ export type WebConsoleHttpBootstrapEnv = Pick<
   Env,
   | 'DOLLHOUSE_WEB_CONSOLE_API_V1_ENABLED'
   | 'DOLLHOUSE_WEB_CONSOLE_PORTFOLIO_WRITE_ROUTES_ENABLED'
+  | 'DOLLHOUSE_WEB_CONSOLE_COLLECTION_ENABLED'
   | 'DOLLHOUSE_WEB_CONSOLE_ALLOWLIST_ROUTES_ENABLED'
   | 'DOLLHOUSE_HTTP_WEB_CONSOLE'
   | 'DOLLHOUSE_PUBLIC_BASE_URL'
@@ -86,6 +87,7 @@ export function resolveWebConsoleHttpBootstrapOptions(
     },
     enableApiV1Mount: true,
     enablePortfolioWriteRoutes: sourceEnv.DOLLHOUSE_WEB_CONSOLE_PORTFOLIO_WRITE_ROUTES_ENABLED,
+    enableCollectionRoutes: sourceEnv.DOLLHOUSE_WEB_CONSOLE_COLLECTION_ENABLED,
     enableAccountAllowlistRoutes: sourceEnv.DOLLHOUSE_WEB_CONSOLE_ALLOWLIST_ROUTES_ENABLED,
     requireExplicitProductionAdapterMetadata: true,
     productionDatabaseVerification: resolveWebConsoleProductionDatabaseVerificationFromEnv(sourceEnv),

--- a/src/web-console/WebConsoleRegistrar.ts
+++ b/src/web-console/WebConsoleRegistrar.ts
@@ -148,6 +148,7 @@ import {
   createCollectionModule,
   type CollectionDetailPort,
   type CollectionIndexPort,
+  type CollectionInstallPort,
   type CollectionSearchPort,
 } from './modules/collection/index.js';
 import { createPortfolioModule } from './modules/portfolio/PortfolioModule.js';
@@ -617,12 +618,22 @@ export class WebConsoleRegistrar {
       now: this.options.now,
     }));
     // Whole-module gate (not per-route like portfolio writes): when the flag is
-    // off, the catalog surface is absent from the manifest entirely.
+    // off, the catalog surface is absent from the manifest entirely. The install
+    // route additionally requires the portfolio write flag — install is a
+    // portfolio mutation sourced from the catalog.
     if (this.options.enableCollectionRoutes === true) {
+      const enableInstall = this.options.enablePortfolioWriteRoutes === true;
       registerRouteModule(registry, this.options, 'collection', () => createCollectionModule({
         index: resolveCollectionEngineService<CollectionIndexPort>(container, 'CollectionIndexManager'),
         search: resolveCollectionEngineService<CollectionSearchPort>(container, 'CollectionSearch'),
         details: resolveCollectionEngineService<CollectionDetailPort>(container, 'PersonaDetails'),
+        install: enableInstall
+          ? {
+              installer: resolveCollectionEngineService<CollectionInstallPort>(container, 'ElementInstaller'),
+              portfolioStore: stores.portfolioStore,
+              now: this.options.now,
+            }
+          : undefined,
       }));
     }
     registerRouteModule(registry, this.options, 'selfService', () => createSelfServiceModule({

--- a/src/web-console/WebConsoleRegistrar.ts
+++ b/src/web-console/WebConsoleRegistrar.ts
@@ -1,6 +1,7 @@
 import type { DiContainerFacade } from '../di/DiContainerFacade.js';
 import type { DatabaseInstance } from '../database/connection.js';
 import { env } from '../config/env.js';
+import { logger } from '../utils/logger.js';
 import type { Router } from 'express';
 import type { IAuthStorageLayer } from '../auth/embedded-as/storage/IAuthStorageLayer.js';
 import type { Gatekeeper } from '../handlers/mcp-aql/Gatekeeper.js';
@@ -650,6 +651,18 @@ export class WebConsoleRegistrar {
     const collectionFetchRateLimiter = this.options.enableCollectionRoutes === true
       ? resolveCollectionFetchRateLimiter(container, this.options)
       : null;
+    if (this.options.enableCollectionRoutes === true && env.DOLLHOUSE_RATE_LIMIT_BACKEND !== 'postgres') {
+      // The collection-fetch deployment budget lives in the rate-limit store.
+      // With the process-local (in-memory) backend each replica keeps its own
+      // budget, so a multi-replica deployment multiplies the shared GitHub
+      // budget it is meant to cap. Warn so operators set a shared backend.
+      logger.warn(
+        '[WebConsoleRegistrar] Collection browse is enabled but DOLLHOUSE_RATE_LIMIT_BACKEND is not "postgres". ' +
+        'The collection-fetch deployment budget is process-local, so a multi-replica deployment enforces one budget ' +
+        'per replica and multiplies the shared GitHub API budget it exists to protect. Set ' +
+        'DOLLHOUSE_RATE_LIMIT_BACKEND=postgres for a single cross-replica budget.',
+      );
+    }
     const protectedCorrelationRateLimitStore = resolveRateLimitStore(container);
     assertWebConsoleProductionActivation({
       activationProfile,

--- a/src/web-console/WebConsoleRegistrar.ts
+++ b/src/web-console/WebConsoleRegistrar.ts
@@ -144,6 +144,12 @@ import {
   type OperationsHealthChecks,
 } from './modules/operations/index.js';
 import type { ISystemMetricsSource } from './modules/operations/SystemMetricsSource.js';
+import {
+  createCollectionModule,
+  type CollectionDetailPort,
+  type CollectionIndexPort,
+  type CollectionSearchPort,
+} from './modules/collection/index.js';
 import { createPortfolioModule } from './modules/portfolio/PortfolioModule.js';
 import { createRuntimeSessionModule } from './modules/runtime-sessions/RuntimeSessionModule.js';
 import { createSelfServiceModule } from './modules/self-service/SelfServiceModule.js';
@@ -167,6 +173,7 @@ import {
 } from './modules/account-admin/AccountAdminMutationTransaction.js';
 import type { IRateLimitStore } from '../auth/embedded-as/storage/IRateLimitStore.js';
 import { ConsoleProtectedCorrelationRateLimiter } from './services/rate-limit/ConsoleProtectedCorrelationRateLimiter.js';
+import { ConsoleCollectionFetchRateLimiter } from './services/rate-limit/ConsoleCollectionFetchRateLimiter.js';
 import {
   assertWebConsoleProductionActivation,
   markWebConsoleProductionAdapter,
@@ -280,6 +287,12 @@ export interface WebConsoleRegistrarOptions {
   readonly portfolioStore?: IPortfolioElementStore | null;
   readonly enableManagerBackedPortfolioStore?: boolean;
   readonly enablePortfolioWriteRoutes?: boolean;
+  /**
+   * Registers the collection catalog browse routes (/api/v1/collection/*).
+   * Off by default: the surface spends server-funded outbound GitHub budget,
+   * so operators opt in via DOLLHOUSE_WEB_CONSOLE_COLLECTION_ENABLED.
+   */
+  readonly enableCollectionRoutes?: boolean;
   readonly portfolioSyncJobStore?: IPortfolioSyncJobStore | null;
   readonly portfolioSyncWorker?: IConsolePortfolioSyncWorker | null;
   readonly portfolioSyncJobExecutor?: IPortfolioSyncJobExecutor | null;
@@ -603,6 +616,15 @@ export class WebConsoleRegistrar {
       enablePortfolioWriteRoutes: this.options.enablePortfolioWriteRoutes === true,
       now: this.options.now,
     }));
+    // Whole-module gate (not per-route like portfolio writes): when the flag is
+    // off, the catalog surface is absent from the manifest entirely.
+    if (this.options.enableCollectionRoutes === true) {
+      registerRouteModule(registry, this.options, 'collection', () => createCollectionModule({
+        index: resolveCollectionEngineService<CollectionIndexPort>(container, 'CollectionIndexManager'),
+        search: resolveCollectionEngineService<CollectionSearchPort>(container, 'CollectionSearch'),
+        details: resolveCollectionEngineService<CollectionDetailPort>(container, 'PersonaDetails'),
+      }));
+    }
     registerRouteModule(registry, this.options, 'selfService', () => createSelfServiceModule({
       accountAdminStore: stores.accountAdminStore,
       userConfigStore,
@@ -614,6 +636,9 @@ export class WebConsoleRegistrar {
       now: this.options.now,
     }));
     const protectedCorrelationRateLimiter = resolveProtectedCorrelationRateLimiter(container, this.options);
+    const collectionFetchRateLimiter = this.options.enableCollectionRoutes === true
+      ? resolveCollectionFetchRateLimiter(container, this.options)
+      : null;
     const protectedCorrelationRateLimitStore = resolveRateLimitStore(container);
     assertWebConsoleProductionActivation({
       activationProfile,
@@ -630,6 +655,7 @@ export class WebConsoleRegistrar {
           oauthGrantRevocationService,
           protectedCorrelationRateLimiter,
           protectedCorrelationRateLimitStore,
+          collectionFetchRateLimiter,
           adminAuditQuery,
           approvalAuditQuery,
           authenticationAuditQuery,
@@ -672,6 +698,7 @@ export class WebConsoleRegistrar {
       runtimeStore: stores.runtimeSessionControlStore,
       authPolicyStore,
       protectedCorrelationRateLimiter,
+      collectionFetchRateLimiter,
       apiV1MountState,
       userContext: resolveConsoleUserContext(container),
     });
@@ -785,6 +812,7 @@ export function createProductionRouteDependencies(options: {
     readonly oauthGrantRevocationService: IOAuthGrantRevocationService | null;
     readonly protectedCorrelationRateLimiter: ConsoleProtectedCorrelationRateLimiter | null;
     readonly protectedCorrelationRateLimitStore: IRateLimitStore | null;
+    readonly collectionFetchRateLimiter: ConsoleCollectionFetchRateLimiter | null;
     readonly adminAuditQuery: IAdminAuditQuery;
     readonly approvalAuditQuery: IApprovalAuditQuery;
     readonly authenticationAuditQuery: IAuthenticationAuditQuery;
@@ -820,6 +848,8 @@ export function createProductionRouteDependencies(options: {
       'accountAdmin protected correlation routes require a production protected-correlation rate limiter or must be omitted before hosted/shared mount.'),
     routeDependency('accountAdmin', 'protectedCorrelationRateLimitStore', options.services.protectedCorrelationRateLimitStore,
       'accountAdmin protected correlation routes require a production rate-limit store or must be omitted before hosted/shared mount.'),
+    routeDependency('collection', 'collectionFetchRateLimiter', options.services.collectionFetchRateLimiter,
+      'collection catalog routes require a production collection-fetch rate limiter or must be omitted before hosted/shared mount.'),
     routeDependency('runtimeSessions', 'runtimeSessionControlStore', options.stores.runtimeSessionControlStore,
       'runtime session routes require production runtime-control persistence or must be omitted before hosted/shared mount.'),
     routeDependency('runtimeSessions', 'accountAdminStore', options.stores.accountAdminStore,
@@ -1027,6 +1057,7 @@ function createApiV1Mount(options: {
   readonly runtimeStore: IRuntimeSessionControlStore;
   readonly authPolicyStore: IConsoleAuthPolicyStore;
   readonly protectedCorrelationRateLimiter: ConsoleProtectedCorrelationRateLimiter | null;
+  readonly collectionFetchRateLimiter: ConsoleCollectionFetchRateLimiter | null;
   readonly apiV1MountState: Pick<WebConsoleApiV1Mount, 'mounted' | 'markMounted'>;
   readonly userContext: ReturnType<typeof resolveConsoleUserContext>;
 }): WebConsoleApiV1Mount | null {
@@ -1045,6 +1076,7 @@ function createApiV1Mount(options: {
     runtimeStore: options.runtimeStore,
     authPolicyStore: options.authPolicyStore,
     protectedCorrelationRateLimiter: options.protectedCorrelationRateLimiter,
+    collectionFetchRateLimiter: options.collectionFetchRateLimiter,
     idleTimeoutMs: options.options.consoleSessionIdleTimeoutMs ?? 30 * 60 * 1000,
     now: options.options.now,
     reportInternalError: options.options.reportApiV1InternalError,
@@ -1420,6 +1452,43 @@ function resolveProtectedCorrelationRateLimiter(
     selectorHmacKey: Buffer.from(key),
     now: options.now,
   }), 'ConsoleProtectedCorrelationRateLimiter');
+}
+
+/**
+ * Collection-fetch limiter for the catalog routes. Reuses the protected
+ * correlation selector HMAC key (the limiter derives its own selectors under a
+ * distinct prefix) so enabling the collection surface needs no extra key
+ * material; the shared RateLimitStore keeps the budget replica-wide.
+ */
+function resolveCollectionFetchRateLimiter(
+  container: DiContainerFacade,
+  options: WebConsoleRegistrarOptions,
+): ConsoleCollectionFetchRateLimiter | null {
+  const key = options.protectedCorrelationSelectorHmacKey ??
+    (container.hasRegistration('WebConsoleProtectedCorrelationSelectorHmacKey')
+      ? container.resolve<Buffer>('WebConsoleProtectedCorrelationSelectorHmacKey')
+      : null);
+  if (!key) return null;
+  if (!container.hasRegistration('RateLimitStore')) {
+    throw new Error('Web console collection routes require RateLimitStore');
+  }
+  return markProductionAdapter(new ConsoleCollectionFetchRateLimiter({
+    store: container.resolve<IRateLimitStore>('RateLimitStore'),
+    selectorHmacKey: Buffer.from(key),
+    now: options.now,
+  }), 'ConsoleCollectionFetchRateLimiter');
+}
+
+/**
+ * The collection engine services live in the main DI container (registered by
+ * CollectionServiceRegistrar during server bootstrap). Resolve with a clear
+ * failure when a partial container enables the collection routes without them.
+ */
+function resolveCollectionEngineService<T>(container: DiContainerFacade, name: string): T {
+  if (!container.hasRegistration(name)) {
+    throw new Error(`Web console collection routes require the "${name}" collection engine service`);
+  }
+  return container.resolve<T>(name);
 }
 
 function resolveRateLimitStore(container: DiContainerFacade): IRateLimitStore | null {

--- a/src/web-console/WebConsoleReplacementReadiness.ts
+++ b/src/web-console/WebConsoleReplacementReadiness.ts
@@ -1,10 +1,14 @@
 import type { WebConsoleComposition } from './WebConsoleRegistrar.js';
-import { WEB_CONSOLE_OMITTABLE_ROUTE_MODULE_IDS } from './WebConsoleRouteModuleIds.js';
+import { WEB_CONSOLE_BASELINE_ROUTE_MODULE_IDS } from './WebConsoleRouteModuleIds.js';
 
+// Modules a complete console replacement must register. Only the baseline
+// feature modules count — optional, default-off modules (e.g. collection) are
+// intentionally excluded so a console that leaves them off is still a valid,
+// ready replacement.
 export const WEB_CONSOLE_REPLACEMENT_REQUIRED_ROUTE_MODULE_IDS = [
   'auth',
   'health',
-  ...WEB_CONSOLE_OMITTABLE_ROUTE_MODULE_IDS,
+  ...WEB_CONSOLE_BASELINE_ROUTE_MODULE_IDS,
 ] as const;
 
 export const WEB_CONSOLE_REPLACEMENT_LIVE_CHECK_IDS = [

--- a/src/web-console/WebConsoleRouteModuleIds.ts
+++ b/src/web-console/WebConsoleRouteModuleIds.ts
@@ -1,11 +1,14 @@
 export const SECURITY_ADMIN_MODULE_ID = 'security-admin';
 
-export const WEB_CONSOLE_OMITTABLE_ROUTE_MODULE_IDS = [
+// Baseline feature modules: expected present for a complete console replacement
+// (auth + health are added by the readiness required-list). Each can be omitted
+// individually via `omittedRouteModuleIds`, but its absence means the console is
+// not a full replacement.
+export const WEB_CONSOLE_BASELINE_ROUTE_MODULE_IDS = [
   'accountAdmin',
   'activations',
   'approvals',
   'audit',
-  'collection',
   'executions',
   'integrations',
   'me-logs',
@@ -16,6 +19,18 @@ export const WEB_CONSOLE_OMITTABLE_ROUTE_MODULE_IDS = [
   'selfSecurity',
   'selfService',
   'session-telemetry',
+] as const;
+
+// Optional, default-off feature modules: registerable and omittable, but NOT
+// part of the replacement baseline — a console without them is still a complete
+// replacement, so they must never be required for readiness.
+export const WEB_CONSOLE_OPTIONAL_ROUTE_MODULE_IDS = [
+  'collection',
+] as const;
+
+export const WEB_CONSOLE_OMITTABLE_ROUTE_MODULE_IDS = [
+  ...WEB_CONSOLE_BASELINE_ROUTE_MODULE_IDS,
+  ...WEB_CONSOLE_OPTIONAL_ROUTE_MODULE_IDS,
 ] as const;
 
 export type WebConsoleOmittableRouteModuleId = typeof WEB_CONSOLE_OMITTABLE_ROUTE_MODULE_IDS[number];

--- a/src/web-console/WebConsoleRouteModuleIds.ts
+++ b/src/web-console/WebConsoleRouteModuleIds.ts
@@ -5,6 +5,7 @@ export const WEB_CONSOLE_OMITTABLE_ROUTE_MODULE_IDS = [
   'activations',
   'approvals',
   'audit',
+  'collection',
   'executions',
   'integrations',
   'me-logs',

--- a/src/web-console/middleware/ConsoleRateLimit.ts
+++ b/src/web-console/middleware/ConsoleRateLimit.ts
@@ -6,6 +6,12 @@ import type {
 import {
   ConsoleProtectedCorrelationRateLimitDependencyError,
 } from '../services/rate-limit/ConsoleProtectedCorrelationRateLimiter.js';
+import type {
+  ConsoleCollectionFetchRateLimiter,
+} from '../services/rate-limit/ConsoleCollectionFetchRateLimiter.js';
+import {
+  ConsoleCollectionFetchRateLimitDependencyError,
+} from '../services/rate-limit/ConsoleCollectionFetchRateLimiter.js';
 import { requireConsoleAuthentication } from './ConsoleAuthentication.js';
 import { requireConsoleRequestContext } from '../platform/ConsoleRequestContext.js';
 import { sendProblemResponse } from '../platform/ProblemResponses.js';
@@ -13,6 +19,7 @@ import type { ConsoleRateLimitPolicy, ConsoleRequest, ConsoleRouteDefinition } f
 
 export interface ConsoleRateLimitOptions {
   readonly protectedCorrelationRateLimiter?: ConsoleProtectedCorrelationRateLimiter | null;
+  readonly collectionFetchRateLimiter?: ConsoleCollectionFetchRateLimiter | null;
 }
 
 export function createConsoleRateLimitMiddleware(
@@ -21,22 +28,23 @@ export function createConsoleRateLimitMiddleware(
 ): RequestHandler {
   const policy: ConsoleRateLimitPolicy = route.rateLimit ?? 'none';
   if (policy === 'none') return (_request, _response, next): void => next();
-  if (!options.protectedCorrelationRateLimiter) {
-    throw new Error('protected_correlation_resolution route requires a protected correlation rate limiter');
-  }
+  const enforce = resolveEnforcer(policy, options);
 
   return (request, response, next): void => {
     const req = request as ConsoleRequest;
     void (async (): Promise<void> => {
       try {
-        await enforceProtectedCorrelationResolution(req, response, options.protectedCorrelationRateLimiter);
+        await enforce(req, response);
       } catch (error) {
-        if (error instanceof ConsoleProtectedCorrelationRateLimitDependencyError) {
+        if (
+          error instanceof ConsoleProtectedCorrelationRateLimitDependencyError ||
+          error instanceof ConsoleCollectionFetchRateLimitDependencyError
+        ) {
           sendProblemResponse(response, {
             status: 503,
             code: 'service_unavailable',
             title: 'Service unavailable',
-            detail: 'The protected rate-limit policy could not be evaluated.',
+            detail: 'The rate-limit policy could not be evaluated.',
           }, requireConsoleRequestContext(req).correlationId);
           return;
         }
@@ -47,6 +55,56 @@ export function createConsoleRateLimitMiddleware(
       next();
     })();
   };
+}
+
+type RateLimitEnforcer = (
+  req: ConsoleRequest,
+  response: Parameters<typeof sendProblemResponse>[0],
+) => Promise<void>;
+
+function resolveEnforcer(
+  policy: Exclude<ConsoleRateLimitPolicy, 'none'>,
+  options: ConsoleRateLimitOptions,
+): RateLimitEnforcer {
+  if (policy === 'collection_fetch') {
+    const limiter = options.collectionFetchRateLimiter;
+    if (!limiter) {
+      throw new Error('collection_fetch route requires a collection fetch rate limiter');
+    }
+    return (req, response) => enforceCollectionFetch(req, response, limiter);
+  }
+  const limiter = options.protectedCorrelationRateLimiter;
+  if (!limiter) {
+    throw new Error('protected_correlation_resolution route requires a protected correlation rate limiter');
+  }
+  return (req, response) => enforceProtectedCorrelationResolution(req, response, limiter);
+}
+
+async function enforceCollectionFetch(
+  req: ConsoleRequest,
+  response: Parameters<typeof sendProblemResponse>[0],
+  limiter: ConsoleCollectionFetchRateLimiter,
+): Promise<void> {
+  const authentication = requireConsoleAuthentication(req);
+  const result = await limiter.consume({
+    consoleSessionIdHash: authentication.sessionIdHash,
+    ip: req.ip,
+  });
+  if (result.allowed) return;
+
+  if (result.retryAfterSeconds !== null) {
+    response.setHeader('Retry-After', String(result.retryAfterSeconds));
+  }
+  sendProblemResponse(response, {
+    status: 429,
+    code: 'rate_limited',
+    title: 'Rate limited',
+    detail: 'The collection fetch rate limit was exceeded.',
+    extensions: {
+      window_resets_at: result.windowResetsAt.toISOString(),
+      exceeded_scopes: result.exceededScopes,
+    },
+  }, requireConsoleRequestContext(req).correlationId);
 }
 
 async function enforceProtectedCorrelationResolution(

--- a/src/web-console/modules/collection/CollectionDtos.ts
+++ b/src/web-console/modules/collection/CollectionDtos.ts
@@ -62,6 +62,12 @@ export interface CollectionElementListDto {
   readonly has_more: boolean;
   readonly source_status: CollectionSourceStatus;
   readonly source_detail: string | null;
+  /**
+   * Whether this deployment registers the install route (collection AND
+   * portfolio-write flags both on). Lets the UI hide Install affordances on
+   * browse-only deployments instead of offering a button that can only 404.
+   */
+  readonly install_enabled: boolean;
 }
 
 /**
@@ -114,6 +120,7 @@ export function serializeCollectionElementList(input: {
    * Omit it when the caller holds the full result set and slices it locally.
    */
   readonly hasMore?: boolean;
+  readonly installEnabled: boolean;
 }): CollectionElementListDto {
   return {
     elements: input.elements,
@@ -123,5 +130,6 @@ export function serializeCollectionElementList(input: {
     has_more: input.hasMore ?? input.page * input.pageSize < input.total,
     source_status: input.sourceStatus,
     source_detail: input.sourceDetail ?? null,
+    install_enabled: input.installEnabled,
   };
 }

--- a/src/web-console/modules/collection/CollectionDtos.ts
+++ b/src/web-console/modules/collection/CollectionDtos.ts
@@ -1,0 +1,90 @@
+import type { IndexEntry } from '../../../types/collection.js';
+import type { ConsolePortfolioElementType } from '../../stores/IPortfolioElementStore.js';
+
+export const COLLECTION_LIST_DEFAULT_PAGE_SIZE = 50;
+export const COLLECTION_LIST_MAX_PAGE_SIZE = 100;
+export const COLLECTION_SEARCH_QUERY_MAX_LENGTH = 200;
+
+/**
+ * `ok` — the catalog index was served (from cache or a fresh fetch).
+ * `degraded` — the index and its fallbacks were unreachable; the response is
+ * an intentional empty listing, not "the collection is empty". The UI renders
+ * a distinct unavailable state from this, and deploy smoke tests assert on it.
+ */
+export type CollectionSourceStatus = 'ok' | 'degraded';
+
+export interface CollectionElementSummaryDto {
+  readonly type: ConsolePortfolioElementType;
+  /** Canonical element name (catalog file stem), used in detail-route paths. */
+  readonly name: string;
+  readonly display_name: string | null;
+  readonly description: string;
+  readonly version: string;
+  readonly author: string;
+  readonly tags: readonly string[];
+  /** Catalog path (`library/<type>/<file>.md`) — install input in later slices. */
+  readonly path: string;
+  readonly source: 'collection';
+}
+
+export interface CollectionElementDetailDto extends CollectionElementSummaryDto {
+  readonly metadata: Readonly<Record<string, unknown>>;
+  readonly content: string;
+}
+
+export interface CollectionElementListDto {
+  readonly elements: readonly CollectionElementSummaryDto[];
+  readonly total: number;
+  readonly page: number;
+  readonly page_size: number;
+  readonly has_more: boolean;
+  readonly source_status: CollectionSourceStatus;
+  readonly source_detail: string | null;
+}
+
+/**
+ * Canonical element name from a catalog path: the file stem of the last
+ * segment (`library/personas/code-review.md` → `code-review`). Falls back to
+ * the entry name when the path has no usable basename.
+ */
+export function collectionElementNameFromPath(path: string, fallback: string): string {
+  const basename = path.split('/').pop() ?? '';
+  const stem = basename.endsWith('.md') ? basename.slice(0, -3) : basename;
+  return stem === '' ? fallback : stem;
+}
+
+export function serializeCollectionIndexEntry(
+  entry: IndexEntry,
+  type: ConsolePortfolioElementType,
+): CollectionElementSummaryDto {
+  return {
+    type,
+    name: collectionElementNameFromPath(entry.path, entry.name),
+    display_name: entry.name === '' ? null : entry.name,
+    description: entry.description,
+    version: entry.version,
+    author: entry.author,
+    tags: Array.isArray(entry.tags) ? entry.tags.filter(tag => typeof tag === 'string') : [],
+    path: entry.path,
+    source: 'collection',
+  };
+}
+
+export function serializeCollectionElementList(input: {
+  readonly elements: readonly CollectionElementSummaryDto[];
+  readonly total: number;
+  readonly page: number;
+  readonly pageSize: number;
+  readonly sourceStatus: CollectionSourceStatus;
+  readonly sourceDetail?: string;
+}): CollectionElementListDto {
+  return {
+    elements: input.elements,
+    total: input.total,
+    page: input.page,
+    page_size: input.pageSize,
+    has_more: input.page * input.pageSize < input.total,
+    source_status: input.sourceStatus,
+    source_detail: input.sourceDetail ?? null,
+  };
+}

--- a/src/web-console/modules/collection/CollectionDtos.ts
+++ b/src/web-console/modules/collection/CollectionDtos.ts
@@ -5,6 +5,28 @@ export const COLLECTION_LIST_DEFAULT_PAGE_SIZE = 50;
 export const COLLECTION_LIST_MAX_PAGE_SIZE = 100;
 export const COLLECTION_SEARCH_QUERY_MAX_LENGTH = 200;
 
+// Catalog file extension per element type. Memories are stored as YAML across
+// DollhouseMCP (matching each element manager's getFileExtension()); every
+// other type is Markdown. Used to reconstruct a catalog path from a bare
+// type+name and to strip the correct suffix off a catalog basename.
+const COLLECTION_TYPE_EXTENSIONS: Readonly<Record<ConsolePortfolioElementType, string>> = {
+  personas: '.md',
+  skills: '.md',
+  templates: '.md',
+  agents: '.md',
+  memories: '.yaml',
+  ensembles: '.md',
+};
+
+export function collectionFileExtension(type: ConsolePortfolioElementType): string {
+  return COLLECTION_TYPE_EXTENSIONS[type];
+}
+
+/** Catalog path for a bare type+canonical-name, honoring the per-type extension. */
+export function collectionElementPath(type: ConsolePortfolioElementType, name: string): string {
+  return `library/${type}/${name}${collectionFileExtension(type)}`;
+}
+
 /**
  * `ok` — the catalog index was served (from cache or a fresh fetch).
  * `degraded` — the index and its fallbacks were unreachable; the response is
@@ -44,13 +66,21 @@ export interface CollectionElementListDto {
 
 /**
  * Canonical element name from a catalog path: the file stem of the last
- * segment (`library/personas/code-review.md` → `code-review`). Falls back to
- * the entry name when the path has no usable basename.
+ * segment (`library/personas/code-review.md` → `code-review`,
+ * `library/memories/guide.yaml` → `guide`). Falls back to the entry name when
+ * the path has no usable basename.
  */
 export function collectionElementNameFromPath(path: string, fallback: string): string {
   const basename = path.split('/').pop() ?? '';
-  const stem = basename.endsWith('.md') ? basename.slice(0, -3) : basename;
+  const stem = stripCatalogExtension(basename);
   return stem === '' ? fallback : stem;
+}
+
+function stripCatalogExtension(basename: string): string {
+  for (const extension of ['.md', '.yaml', '.yml']) {
+    if (basename.endsWith(extension)) return basename.slice(0, -extension.length);
+  }
+  return basename;
 }
 
 export function serializeCollectionIndexEntry(
@@ -77,13 +107,20 @@ export function serializeCollectionElementList(input: {
   readonly pageSize: number;
   readonly sourceStatus: CollectionSourceStatus;
   readonly sourceDetail?: string;
+  /**
+   * Authoritative "another page exists" signal. Pass it when the caller
+   * paginates upstream and post-filters this page (the engine total may then
+   * exceed the visible count, so deriving has_more from total would overstate).
+   * Omit it when the caller holds the full result set and slices it locally.
+   */
+  readonly hasMore?: boolean;
 }): CollectionElementListDto {
   return {
     elements: input.elements,
     total: input.total,
     page: input.page,
     page_size: input.pageSize,
-    has_more: input.page * input.pageSize < input.total,
+    has_more: input.hasMore ?? input.page * input.pageSize < input.total,
     source_status: input.sourceStatus,
     source_detail: input.sourceDetail ?? null,
   };

--- a/src/web-console/modules/collection/CollectionInstallService.ts
+++ b/src/web-console/modules/collection/CollectionInstallService.ts
@@ -11,6 +11,14 @@ import {
 } from '../../stores/IPortfolioElementStore.js';
 import { serializePortfolioElementDetail, portfolioElementEtag } from '../portfolio/PortfolioDtos.js';
 import { validateElementPayload } from '../portfolio/PortfolioService.js';
+import {
+  CollectionContentInvalidError,
+  CollectionElementNotFoundError,
+  CollectionPathInvalidError,
+  isCollectionError,
+} from '../../../collection/CollectionErrors.js';
+import { ApplicationError, ErrorCategory } from '../../../utils/ErrorHandler.js';
+import { ValidationErrorCodes } from '../../../utils/errorCodes.js';
 
 /**
  * A collection element fetched and fully validated but not written. Structural
@@ -149,6 +157,30 @@ function collectionPathFromBody(body: unknown):
 }
 
 function classifyFetchError(error: unknown): ConsoleHandlerResult {
+  // Typed classification first — stable against message rewording, and
+  // cause-chain-aware so a typed error survives the GitHub client's McpError
+  // wrapper. The installer/GitHub client throw CollectionErrors for their own
+  // failures; the shared input validators (validatePath / validateContentSize)
+  // throw ApplicationError with VALIDATION_ERROR category: INVALID_PATH codes
+  // are bad path input (400), the rest are content-shape failures (422 — e.g.
+  // GitHub's contents API omitting inline content for oversized files).
+  if (isCollectionError(error, CollectionElementNotFoundError)) {
+    return problem(404, 'collection_element_not_found', 'Not found', 'Collection element was not found.');
+  }
+  if (isCollectionError(error, CollectionPathInvalidError)) {
+    return problem(400, 'invalid_request', 'Invalid request', 'The collection path is not valid.');
+  }
+  if (error instanceof ApplicationError && error.code === ValidationErrorCodes.INVALID_PATH) {
+    return problem(400, 'invalid_request', 'Invalid request', 'The collection path is not valid.');
+  }
+  if (isCollectionError(error, CollectionContentInvalidError) ||
+      (error instanceof ApplicationError && error.category === ErrorCategory.VALIDATION_ERROR)) {
+    return problem(422, 'collection_element_invalid', 'Unprocessable element',
+      'The collection element failed validation and was not installed.');
+  }
+
+  // Message fallback, retained as belt-and-braces for errors from layers that
+  // neither throw typed collection errors nor preserve them as `cause`.
   const message = error instanceof Error ? error.message : String(error);
   if (message.includes('File not found in collection') || message.includes('Path does not point to a file')) {
     return problem(404, 'collection_element_not_found', 'Not found', 'Collection element was not found.');
@@ -168,9 +200,6 @@ function classifyFetchError(error: unknown): ConsoleHandlerResult {
     message.includes('Security validation failed') ||
     message.includes('missing required name or description') ||
     message.includes('File too large') ||
-    // GitHub's contents API omits inline content for oversized files, which
-    // surfaces as validateContentSize's non-empty-string failure — permanent
-    // for that element, not a transient outage.
     message.includes('Content must be a non-empty string')
   ) {
     return problem(422, 'collection_element_invalid', 'Unprocessable element',

--- a/src/web-console/modules/collection/CollectionInstallService.ts
+++ b/src/web-console/modules/collection/CollectionInstallService.ts
@@ -1,0 +1,172 @@
+import type {
+  ConsoleHandlerResult,
+  ConsoleRequest,
+} from '../../platform/ConsolePlatformTypes.js';
+import { requireConsoleAuthentication } from '../../middleware/ConsoleAuthentication.js';
+import {
+  isConsolePortfolioElementType,
+  PortfolioElementAlreadyExistsError,
+  type ConsolePortfolioElementType,
+  type IPortfolioElementStore,
+} from '../../stores/IPortfolioElementStore.js';
+import { serializePortfolioElementDetail, portfolioElementEtag } from '../portfolio/PortfolioDtos.js';
+
+/**
+ * A collection element fetched and fully validated but not written. Structural
+ * mirror of ElementInstaller.CollectionFetchAndValidateResult so the module
+ * depends on behavior, not the concrete installer class.
+ */
+export interface CollectionValidatedElement {
+  readonly elementType: string;
+  readonly name: string;
+  readonly metadata: Readonly<Record<string, unknown>>;
+  readonly content: string;
+}
+
+/** No-write fetch+validate seam over the collection installer. */
+export interface CollectionInstallPort {
+  fetchAndValidate(collectionPath: string): Promise<CollectionValidatedElement>;
+}
+
+export interface CollectionInstallServiceOptions {
+  readonly installer: CollectionInstallPort;
+  readonly portfolioStore: IPortfolioElementStore;
+  readonly now?: () => Date;
+}
+
+const CATALOG_PATH_MAX_LENGTH = 512;
+
+/**
+ * Installs a collection element into the authenticated user's portfolio. Fetch
+ * + validate happens through the shared installer's no-write seam; the write
+ * goes through the SAME manager-backed store portfolio CRUD uses, so a DB-mode
+ * deployment persists to Postgres with no filesystem fallback and full per-user
+ * scoping. CSRF and idempotency are enforced by the secured router BEFORE this
+ * handler runs, so a forged or replayed request never triggers the outbound
+ * fetch.
+ */
+export class CollectionInstallService {
+  private readonly now: () => Date;
+
+  constructor(private readonly options: CollectionInstallServiceOptions) {
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async install(req: ConsoleRequest): Promise<ConsoleHandlerResult> {
+    const auth = requireConsoleAuthentication(req);
+    const path = collectionPathFromBody(req.body);
+    if (path.kind === 'invalid') return invalidRequest(path.detail);
+
+    let validated: CollectionValidatedElement;
+    try {
+      validated = await this.options.installer.fetchAndValidate(path.value);
+    } catch (error) {
+      return classifyFetchError(error);
+    }
+
+    if (!isConsolePortfolioElementType(validated.elementType)) {
+      return problem(422, 'collection_element_unsupported', 'Unsupported element',
+        'The collection element is not a supported portfolio element type.');
+    }
+    const type: ConsolePortfolioElementType = validated.elementType;
+
+    try {
+      const record = await this.options.portfolioStore.create({
+        userId: auth.userId,
+        type,
+        name: validated.name,
+        displayName: displayNameFrom(validated.metadata) ?? validated.name,
+        metadata: validated.metadata,
+        content: validated.content,
+        tags: tagsFrom(validated.metadata),
+        now: this.now(),
+      });
+      return {
+        status: 201,
+        body: serializePortfolioElementDetail(record, null),
+        headers: { ETag: portfolioElementEtag(record) },
+      };
+    } catch (error) {
+      if (error instanceof PortfolioElementAlreadyExistsError) {
+        return problem(409, 'portfolio_element_exists', 'Conflict',
+          'A portfolio element with that name already exists.');
+      }
+      throw error;
+    }
+  }
+}
+
+function collectionPathFromBody(body: unknown):
+  | { readonly kind: 'valid'; readonly value: string }
+  | { readonly kind: 'invalid'; readonly detail: string } {
+  if (!body || typeof body !== 'object') {
+    return { kind: 'invalid', detail: 'Request body must be a JSON object with a "path" field.' };
+  }
+  const path = (body as { path?: unknown }).path;
+  if (typeof path !== 'string' || path.trim() === '') {
+    return { kind: 'invalid', detail: 'path is required and must be a non-empty string.' };
+  }
+  if (path.length > CATALOG_PATH_MAX_LENGTH) {
+    return { kind: 'invalid', detail: `path must be at most ${CATALOG_PATH_MAX_LENGTH} characters.` };
+  }
+  // Fail fast on obviously-wrong shapes; the installer's validatePath +
+  // resolveCollectionElementType do the authoritative traversal/type checks.
+  if (!path.startsWith('library/')) {
+    return { kind: 'invalid', detail: 'path must be a collection library path (library/<type>/...).' };
+  }
+  return { kind: 'valid', value: path };
+}
+
+function classifyFetchError(error: unknown): ConsoleHandlerResult {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes('File not found in collection') || message.includes('Path does not point to a file')) {
+    return problem(404, 'collection_element_not_found', 'Not found', 'Collection element was not found.');
+  }
+  if (
+    message.includes('Invalid collection path format') ||
+    message.includes('Unknown element type') ||
+    message.includes('Invalid file type') ||
+    message.includes('Path traversal') ||
+    message.includes('Invalid path')
+  ) {
+    return problem(400, 'invalid_request', 'Invalid request', 'The collection path is not valid.');
+  }
+  if (
+    message.includes('Security threat') ||
+    message.includes('Security validation failed') ||
+    message.includes('missing required name or description') ||
+    message.includes('File too large')
+  ) {
+    return problem(422, 'collection_element_invalid', 'Unprocessable element',
+      'The collection element failed validation and was not installed.');
+  }
+  return problem(503, 'collection_unavailable', 'Collection unavailable',
+    'The collection element could not be retrieved. Try again later.');
+}
+
+function displayNameFrom(metadata: Readonly<Record<string, unknown>>): string | null {
+  return typeof metadata.name === 'string' && metadata.name !== '' ? metadata.name : null;
+}
+
+function tagsFrom(metadata: Readonly<Record<string, unknown>>): readonly string[] {
+  return Array.isArray(metadata.tags)
+    ? metadata.tags.filter((tag): tag is string => typeof tag === 'string')
+    : [];
+}
+
+function invalidRequest(detail: string): ConsoleHandlerResult {
+  return problem(400, 'invalid_request', 'Invalid request', detail);
+}
+
+function problem(status: number, code: string, title: string, detail: string): ConsoleHandlerResult {
+  return {
+    status,
+    body: {
+      type: 'about:blank',
+      title,
+      status,
+      code,
+      detail,
+    },
+  };
+}

--- a/src/web-console/modules/collection/CollectionInstallService.ts
+++ b/src/web-console/modules/collection/CollectionInstallService.ts
@@ -10,6 +10,7 @@ import {
   type IPortfolioElementStore,
 } from '../../stores/IPortfolioElementStore.js';
 import { serializePortfolioElementDetail, portfolioElementEtag } from '../portfolio/PortfolioDtos.js';
+import { validateElementPayload } from '../portfolio/PortfolioService.js';
 
 /**
  * A collection element fetched and fully validated but not written. Structural
@@ -69,16 +70,46 @@ export class CollectionInstallService {
         'The collection element is not a supported portfolio element type.');
     }
     const type: ConsolePortfolioElementType = validated.elementType;
+    const displayName = displayNameFrom(validated.metadata) ?? validated.name;
+    const tags = tagsFrom(validated.metadata);
+
+    // The installer's own caps are looser than the console's portfolio record
+    // contract (name/displayName <= 200, tags <= 50 x 80 chars, content <= 1 MiB,
+    // metadata <= 64 KiB). Apply the SAME pre-write validation the direct create
+    // route uses, so an out-of-contract catalog element 422s here instead of
+    // being persisted by the manager-backed store and only failing afterwards
+    // in record validation — which would strand an element the console can
+    // neither read nor delete.
+    const issues = validateElementPayload({
+      name: validated.name,
+      displayName,
+      metadata: validated.metadata,
+      content: validated.content,
+      tags,
+    });
+    if (issues.length > 0) {
+      return {
+        status: 422,
+        body: {
+          type: 'about:blank',
+          title: 'Unprocessable element',
+          status: 422,
+          code: 'collection_element_invalid',
+          detail: 'The collection element does not meet portfolio element limits and was not installed.',
+          issues,
+        },
+      };
+    }
 
     try {
       const record = await this.options.portfolioStore.create({
         userId: auth.userId,
         type,
         name: validated.name,
-        displayName: displayNameFrom(validated.metadata) ?? validated.name,
+        displayName,
         metadata: validated.metadata,
         content: validated.content,
-        tags: tagsFrom(validated.metadata),
+        tags,
         now: this.now(),
       });
       return {
@@ -127,7 +158,8 @@ function classifyFetchError(error: unknown): ConsoleHandlerResult {
     message.includes('Unknown element type') ||
     message.includes('Invalid file type') ||
     message.includes('Path traversal') ||
-    message.includes('Invalid path')
+    message.includes('Invalid path') ||
+    message.includes('Path too deep')
   ) {
     return problem(400, 'invalid_request', 'Invalid request', 'The collection path is not valid.');
   }
@@ -135,7 +167,11 @@ function classifyFetchError(error: unknown): ConsoleHandlerResult {
     message.includes('Security threat') ||
     message.includes('Security validation failed') ||
     message.includes('missing required name or description') ||
-    message.includes('File too large')
+    message.includes('File too large') ||
+    // GitHub's contents API omits inline content for oversized files, which
+    // surfaces as validateContentSize's non-empty-string failure — permanent
+    // for that element, not a transient outage.
+    message.includes('Content must be a non-empty string')
   ) {
     return problem(422, 'collection_element_invalid', 'Unprocessable element',
       'The collection element failed validation and was not installed.');

--- a/src/web-console/modules/collection/CollectionModule.ts
+++ b/src/web-console/modules/collection/CollectionModule.ts
@@ -1,0 +1,81 @@
+import type {
+  ConsoleHandlerResult,
+  ConsoleModuleDescriptor,
+  ConsoleRequest,
+} from '../../platform/ConsolePlatformTypes.js';
+import {
+  projectCollectionElementDetail,
+  projectCollectionElementList,
+} from './CollectionPrivacyProjectors.js';
+import { CollectionService, type CollectionServiceOptions } from './CollectionService.js';
+
+const SELF_CAPABILITY = 'console:self';
+
+export type CollectionModuleOptions = CollectionServiceOptions;
+
+/**
+ * Read-only browse/search/detail surface over the public DollhouseMCP
+ * collection catalog. The catalog is global public data, but the routes stay
+ * session-gated: every request can drive server-funded outbound GitHub
+ * traffic, so anonymous access would hand that budget to the internet.
+ * Registration is operator-gated by DOLLHOUSE_WEB_CONSOLE_COLLECTION_ENABLED
+ * (wired in WebConsoleRegistrar); install lands in a later slice.
+ */
+export function createCollectionModule(options: CollectionModuleOptions): ConsoleModuleDescriptor {
+  const service = new CollectionService(options);
+  return {
+    id: 'collection',
+    apiVersion: 'v1',
+    capabilities: [SELF_CAPABILITY],
+    events: [],
+    routes: [
+      {
+        method: 'GET',
+        path: '/api/v1/collection/elements',
+        audience: 'self',
+        requiredCapability: SELF_CAPABILITY,
+        ownership: 'authenticated_user',
+        elevation: 'none',
+        privacyClass: 'public_catalog',
+        idempotency: 'not_applicable',
+        rateLimit: 'collection_fetch',
+        privacyProjector: projectCollectionElementList,
+        handler: req => service.listElements(req),
+      },
+      {
+        method: 'GET',
+        path: '/api/v1/collection/elements/:type/:name',
+        audience: 'self',
+        requiredCapability: SELF_CAPABILITY,
+        ownership: 'authenticated_user',
+        elevation: 'none',
+        privacyClass: 'public_catalog',
+        idempotency: 'not_applicable',
+        rateLimit: 'collection_fetch',
+        privacyProjector: projectCollectionElementDetail,
+        handler: req => withElementParams(req, (type, name) => service.getElement(req, type, name)),
+      },
+    ],
+  };
+}
+
+function withElementParams(
+  req: ConsoleRequest,
+  next: (type: string, name: string) => Promise<ConsoleHandlerResult>,
+): Promise<ConsoleHandlerResult> | ConsoleHandlerResult {
+  const type = req.params.type;
+  const name = req.params.name;
+  if (typeof type !== 'string' || typeof name !== 'string') {
+    return {
+      status: 400,
+      body: {
+        type: 'about:blank',
+        title: 'Invalid request',
+        status: 400,
+        code: 'invalid_request',
+        detail: 'type and name path parameters are required.',
+      },
+    };
+  }
+  return next(type, name);
+}

--- a/src/web-console/modules/collection/CollectionModule.ts
+++ b/src/web-console/modules/collection/CollectionModule.ts
@@ -33,7 +33,7 @@ export interface CollectionModuleOptions extends CollectionServiceOptions {
  * (wired in WebConsoleRegistrar); install lands in a later slice.
  */
 export function createCollectionModule(options: CollectionModuleOptions): ConsoleModuleDescriptor {
-  const service = new CollectionService(options);
+  const service = new CollectionService({ ...options, installEnabled: options.install !== undefined });
   const routes: ConsoleRouteDefinition[] = [
     {
       method: 'GET',

--- a/src/web-console/modules/collection/CollectionModule.ts
+++ b/src/web-console/modules/collection/CollectionModule.ts
@@ -1,17 +1,28 @@
 import type {
   ConsoleHandlerResult,
   ConsoleModuleDescriptor,
+  ConsoleRouteDefinition,
   ConsoleRequest,
 } from '../../platform/ConsolePlatformTypes.js';
+import { projectPortfolioElementDetail } from '../portfolio/PortfolioPrivacyProjectors.js';
 import {
   projectCollectionElementDetail,
   projectCollectionElementList,
 } from './CollectionPrivacyProjectors.js';
 import { CollectionService, type CollectionServiceOptions } from './CollectionService.js';
+import { CollectionInstallService, type CollectionInstallServiceOptions } from './CollectionInstallService.js';
 
 const SELF_CAPABILITY = 'console:self';
 
-export type CollectionModuleOptions = CollectionServiceOptions;
+export interface CollectionModuleOptions extends CollectionServiceOptions {
+  /**
+   * When present, registers the install route (POST
+   * /api/v1/me/portfolio/from-collection). The registrar supplies this only
+   * when BOTH the collection surface and portfolio write routes are enabled —
+   * install is a portfolio mutation sourced from the public catalog.
+   */
+  readonly install?: CollectionInstallServiceOptions;
+}
 
 /**
  * Read-only browse/search/detail surface over the public DollhouseMCP
@@ -23,39 +34,62 @@ export type CollectionModuleOptions = CollectionServiceOptions;
  */
 export function createCollectionModule(options: CollectionModuleOptions): ConsoleModuleDescriptor {
   const service = new CollectionService(options);
+  const routes: ConsoleRouteDefinition[] = [
+    {
+      method: 'GET',
+      path: '/api/v1/collection/elements',
+      audience: 'self',
+      requiredCapability: SELF_CAPABILITY,
+      ownership: 'authenticated_user',
+      elevation: 'none',
+      privacyClass: 'public_catalog',
+      idempotency: 'not_applicable',
+      rateLimit: 'collection_fetch',
+      privacyProjector: projectCollectionElementList,
+      handler: req => service.listElements(req),
+    },
+    {
+      method: 'GET',
+      path: '/api/v1/collection/elements/:type/:name',
+      audience: 'self',
+      requiredCapability: SELF_CAPABILITY,
+      ownership: 'authenticated_user',
+      elevation: 'none',
+      privacyClass: 'public_catalog',
+      idempotency: 'not_applicable',
+      rateLimit: 'collection_fetch',
+      privacyProjector: projectCollectionElementDetail,
+      handler: req => withElementParams(req, (type, name) => service.getElement(req, type, name)),
+    },
+  ];
+
+  if (options.install) {
+    const installService = new CollectionInstallService(options.install);
+    // Install writes into the user's portfolio, so it lives under the portfolio
+    // path with a self_private response (not the public_catalog catalog space).
+    // It still carries the collection_fetch limit because it drives an outbound
+    // GitHub fetch, and idempotency so a retried install is not duplicated.
+    routes.push({
+      method: 'POST',
+      path: '/api/v1/me/portfolio/from-collection',
+      audience: 'self',
+      requiredCapability: SELF_CAPABILITY,
+      ownership: 'authenticated_user',
+      elevation: 'none',
+      privacyClass: 'self_private',
+      idempotency: 'required',
+      rateLimit: 'collection_fetch',
+      privacyProjector: projectPortfolioElementDetail,
+      handler: req => installService.install(req),
+    });
+  }
+
   return {
     id: 'collection',
     apiVersion: 'v1',
     capabilities: [SELF_CAPABILITY],
     events: [],
-    routes: [
-      {
-        method: 'GET',
-        path: '/api/v1/collection/elements',
-        audience: 'self',
-        requiredCapability: SELF_CAPABILITY,
-        ownership: 'authenticated_user',
-        elevation: 'none',
-        privacyClass: 'public_catalog',
-        idempotency: 'not_applicable',
-        rateLimit: 'collection_fetch',
-        privacyProjector: projectCollectionElementList,
-        handler: req => service.listElements(req),
-      },
-      {
-        method: 'GET',
-        path: '/api/v1/collection/elements/:type/:name',
-        audience: 'self',
-        requiredCapability: SELF_CAPABILITY,
-        ownership: 'authenticated_user',
-        elevation: 'none',
-        privacyClass: 'public_catalog',
-        idempotency: 'not_applicable',
-        rateLimit: 'collection_fetch',
-        privacyProjector: projectCollectionElementDetail,
-        handler: req => withElementParams(req, (type, name) => service.getElement(req, type, name)),
-      },
-    ],
+    routes,
   };
 }
 

--- a/src/web-console/modules/collection/CollectionPrivacyProjectors.ts
+++ b/src/web-console/modules/collection/CollectionPrivacyProjectors.ts
@@ -1,0 +1,84 @@
+import {
+  CONSOLE_PORTFOLIO_ELEMENT_TYPES,
+  type ConsolePortfolioElementType,
+} from '../../stores/IPortfolioElementStore.js';
+import type {
+  CollectionElementDetailDto,
+  CollectionElementListDto,
+  CollectionElementSummaryDto,
+  CollectionSourceStatus,
+} from './CollectionDtos.js';
+
+export function projectCollectionElementList(value: unknown): CollectionElementListDto {
+  const input = asRecord(value);
+  return {
+    elements: Array.isArray(input.elements)
+      ? input.elements.map(projectCollectionElementSummary)
+      : [],
+    total: nonNegativeInteger(input.total),
+    page: positiveInteger(input.page),
+    page_size: positiveInteger(input.page_size),
+    has_more: input.has_more === true,
+    source_status: sourceStatus(input.source_status),
+    source_detail: nullableString(input.source_detail),
+  };
+}
+
+export function projectCollectionElementSummary(value: unknown): CollectionElementSummaryDto {
+  const input = asRecord(value);
+  return {
+    type: elementType(input.type),
+    name: stringField(input.name),
+    display_name: nullableString(input.display_name),
+    description: stringField(input.description),
+    version: stringField(input.version),
+    author: stringField(input.author),
+    tags: stringArray(input.tags),
+    path: stringField(input.path),
+    source: 'collection',
+  };
+}
+
+export function projectCollectionElementDetail(value: unknown): CollectionElementDetailDto {
+  const input = asRecord(value);
+  return {
+    ...projectCollectionElementSummary(input),
+    metadata: asRecord(input.metadata),
+    content: stringField(input.content),
+  };
+}
+
+function asRecord(value: unknown): Readonly<Record<string, unknown>> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function elementType(value: unknown): ConsolePortfolioElementType {
+  if (typeof value === 'string' && CONSOLE_PORTFOLIO_ELEMENT_TYPES.includes(value as ConsolePortfolioElementType)) {
+    return value as ConsolePortfolioElementType;
+  }
+  return 'skills';
+}
+
+function sourceStatus(value: unknown): CollectionSourceStatus {
+  return value === 'degraded' ? 'degraded' : 'ok';
+}
+
+function stringField(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function stringArray(value: unknown): readonly string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+function nonNegativeInteger(value: unknown): number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : 0;
+}
+
+function positiveInteger(value: unknown): number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : 1;
+}

--- a/src/web-console/modules/collection/CollectionPrivacyProjectors.ts
+++ b/src/web-console/modules/collection/CollectionPrivacyProjectors.ts
@@ -21,6 +21,7 @@ export function projectCollectionElementList(value: unknown): CollectionElementL
     has_more: input.has_more === true,
     source_status: sourceStatus(input.source_status),
     source_detail: nullableString(input.source_detail),
+    install_enabled: input.install_enabled === true,
   };
 }
 

--- a/src/web-console/modules/collection/CollectionService.ts
+++ b/src/web-console/modules/collection/CollectionService.ts
@@ -1,0 +1,235 @@
+import type { CollectionIndex, SearchOptions, SearchResults } from '../../../types/collection.js';
+import type {
+  ConsoleHandlerResult,
+  ConsoleRequest,
+} from '../../platform/ConsolePlatformTypes.js';
+import { requireConsoleAuthentication } from '../../middleware/ConsoleAuthentication.js';
+import {
+  CONSOLE_PORTFOLIO_ELEMENT_TYPES,
+  isConsolePortfolioElementType,
+  type ConsolePortfolioElementType,
+} from '../../stores/IPortfolioElementStore.js';
+import {
+  COLLECTION_LIST_DEFAULT_PAGE_SIZE,
+  COLLECTION_LIST_MAX_PAGE_SIZE,
+  COLLECTION_SEARCH_QUERY_MAX_LENGTH,
+  serializeCollectionElementList,
+  serializeCollectionIndexEntry,
+  type CollectionElementDetailDto,
+  type CollectionElementSummaryDto,
+} from './CollectionDtos.js';
+
+/**
+ * Narrow structural ports over the collection engine (`src/collection/`), so
+ * the module depends on behavior rather than the concrete engine classes.
+ * `CollectionIndexManager`, `CollectionSearch`, and `PersonaDetails` satisfy
+ * these as-is.
+ */
+export interface CollectionIndexPort {
+  getIndex(): Promise<CollectionIndex>;
+}
+
+export interface CollectionSearchPort {
+  searchCollectionWithOptions(query: string, options: SearchOptions): Promise<SearchResults>;
+}
+
+export interface CollectionDetailPort {
+  getCollectionContent(path: string): Promise<{ metadata: unknown; content: string }>;
+}
+
+export interface CollectionServiceOptions {
+  readonly index: CollectionIndexPort;
+  readonly search: CollectionSearchPort;
+  readonly details: CollectionDetailPort;
+  /** Observability hook for engine failures behind the degraded state. */
+  readonly reportSourceError?: (error: unknown) => void;
+}
+
+// Canonical catalog names are file stems: no separators, no leading dot, so a
+// name can never alter the constructed `library/<type>/<name>.md` path shape.
+const ELEMENT_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+
+const DEGRADED_DETAIL = 'The collection catalog is currently unavailable. Showing no elements; this is not an empty collection.';
+
+export class CollectionService {
+  constructor(private readonly options: CollectionServiceOptions) {}
+
+  async listElements(req: ConsoleRequest): Promise<ConsoleHandlerResult> {
+    requireConsoleAuthentication(req);
+    const type = optionalElementType(req.query.type);
+    if (type.kind === 'invalid') return invalidRequest('type query parameter must be a supported element type.');
+    const query = optionalSearchQuery(req.query.q);
+    if (query.kind === 'invalid') return invalidRequest(`q query parameter must be a non-empty string of at most ${COLLECTION_SEARCH_QUERY_MAX_LENGTH} characters.`);
+    const page = positiveIntParam(req.query.page, 1);
+    if (page === null) return invalidRequest('page query parameter must be a positive integer.');
+    const pageSize = positiveIntParam(req.query.page_size, COLLECTION_LIST_DEFAULT_PAGE_SIZE, COLLECTION_LIST_MAX_PAGE_SIZE);
+    if (pageSize === null) return invalidRequest(`page_size query parameter must be a positive integer of at most ${COLLECTION_LIST_MAX_PAGE_SIZE}.`);
+
+    const body = query.value === null
+      ? await this.browseList(type.value, page, pageSize)
+      : await this.searchList(query.value, type.value, page, pageSize);
+    return { status: 200, body };
+  }
+
+  async getElement(req: ConsoleRequest, type: string, name: string): Promise<ConsoleHandlerResult> {
+    requireConsoleAuthentication(req);
+    if (!isConsolePortfolioElementType(type)) {
+      return invalidRequest('type path parameter must be a supported element type.');
+    }
+    if (!ELEMENT_NAME_RE.test(name)) {
+      return invalidRequest('name path parameter must be a canonical collection element name.');
+    }
+
+    const path = `library/${type}/${name}.md`;
+    let fetched: { metadata: unknown; content: string };
+    try {
+      fetched = await this.options.details.getCollectionContent(path);
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return problem(404, 'collection_element_not_found', 'Not found', 'Collection element was not found.');
+      }
+      this.options.reportSourceError?.(error);
+      return problem(503, 'collection_unavailable', 'Collection unavailable', DEGRADED_DETAIL);
+    }
+
+    const metadata = asRecord(fetched.metadata);
+    const body: CollectionElementDetailDto = {
+      type,
+      name,
+      display_name: typeof metadata.name === 'string' && metadata.name !== '' ? metadata.name : null,
+      description: typeof metadata.description === 'string' ? metadata.description : '',
+      version: typeof metadata.version === 'string' ? metadata.version : '',
+      author: typeof metadata.author === 'string' ? metadata.author : '',
+      tags: Array.isArray(metadata.tags) ? metadata.tags.filter((tag): tag is string => typeof tag === 'string') : [],
+      path,
+      source: 'collection',
+      metadata,
+      content: fetched.content,
+    };
+    return { status: 200, body };
+  }
+
+  private async browseList(
+    type: ConsolePortfolioElementType | undefined,
+    page: number,
+    pageSize: number,
+  ): Promise<unknown> {
+    let index: CollectionIndex;
+    try {
+      index = await this.options.index.getIndex();
+    } catch (error) {
+      this.options.reportSourceError?.(error);
+      return degradedList(page, pageSize);
+    }
+
+    const types = type ? [type] : CONSOLE_PORTFOLIO_ELEMENT_TYPES;
+    const elements: CollectionElementSummaryDto[] = [];
+    for (const elementType of types) {
+      const entries = Object.hasOwn(index.index, elementType) ? index.index[elementType] : [];
+      for (const entry of entries) {
+        elements.push(serializeCollectionIndexEntry(entry, elementType));
+      }
+    }
+    const start = (page - 1) * pageSize;
+    return serializeCollectionElementList({
+      elements: elements.slice(start, start + pageSize),
+      total: elements.length,
+      page,
+      pageSize,
+      sourceStatus: 'ok',
+    });
+  }
+
+  private async searchList(
+    query: string,
+    type: ConsolePortfolioElementType | undefined,
+    page: number,
+    pageSize: number,
+  ): Promise<unknown> {
+    let results: SearchResults;
+    try {
+      results = await this.options.search.searchCollectionWithOptions(query, {
+        page,
+        pageSize,
+        elementType: type,
+      });
+    } catch (error) {
+      this.options.reportSourceError?.(error);
+      return degradedList(page, pageSize);
+    }
+
+    return serializeCollectionElementList({
+      elements: results.items
+        .filter(entry => isConsolePortfolioElementType(entry.type))
+        .map(entry => serializeCollectionIndexEntry(entry, entry.type as ConsolePortfolioElementType)),
+      total: results.total,
+      page: results.page,
+      pageSize: results.pageSize,
+      sourceStatus: 'ok',
+    });
+  }
+}
+
+function degradedList(page: number, pageSize: number): unknown {
+  return serializeCollectionElementList({
+    elements: [],
+    total: 0,
+    page,
+    pageSize,
+    sourceStatus: 'degraded',
+    sourceDetail: DEGRADED_DETAIL,
+  });
+}
+
+function optionalElementType(value: unknown):
+  | { readonly kind: 'valid'; readonly value: ConsolePortfolioElementType | undefined }
+  | { readonly kind: 'invalid' } {
+  if (value === undefined) return { kind: 'valid', value: undefined };
+  if (typeof value === 'string' && isConsolePortfolioElementType(value)) {
+    return { kind: 'valid', value };
+  }
+  return { kind: 'invalid' };
+}
+
+function optionalSearchQuery(value: unknown):
+  | { readonly kind: 'valid'; readonly value: string | null }
+  | { readonly kind: 'invalid' } {
+  if (value === undefined) return { kind: 'valid', value: null };
+  if (typeof value !== 'string') return { kind: 'invalid' };
+  const trimmed = value.trim();
+  if (trimmed === '' || trimmed.length > COLLECTION_SEARCH_QUERY_MAX_LENGTH) return { kind: 'invalid' };
+  return { kind: 'valid', value: trimmed };
+}
+
+function positiveIntParam(value: unknown, fallback: number, max?: number): number | null {
+  if (value === undefined) return fallback;
+  if (typeof value !== 'string' || !/^\d{1,6}$/.test(value)) return null;
+  const parsed = Number.parseInt(value, 10);
+  if (parsed < 1 || (max !== undefined && parsed > max)) return null;
+  return parsed;
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes('File not found in collection');
+}
+
+function asRecord(value: unknown): Readonly<Record<string, unknown>> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function invalidRequest(detail: string): ConsoleHandlerResult {
+  return problem(400, 'invalid_request', 'Invalid request', detail);
+}
+
+function problem(status: number, code: string, title: string, detail: string): ConsoleHandlerResult {
+  return {
+    status,
+    body: {
+      type: 'about:blank',
+      title,
+      status,
+      code,
+      detail,
+    },
+  };
+}

--- a/src/web-console/modules/collection/CollectionService.ts
+++ b/src/web-console/modules/collection/CollectionService.ts
@@ -13,6 +13,7 @@ import {
   COLLECTION_LIST_DEFAULT_PAGE_SIZE,
   COLLECTION_LIST_MAX_PAGE_SIZE,
   COLLECTION_SEARCH_QUERY_MAX_LENGTH,
+  collectionElementPath,
   serializeCollectionElementList,
   serializeCollectionIndexEntry,
   type CollectionElementDetailDto,
@@ -80,7 +81,7 @@ export class CollectionService {
       return invalidRequest('name path parameter must be a canonical collection element name.');
     }
 
-    const path = `library/${type}/${name}.md`;
+    const path = collectionElementPath(type, name);
     let fetched: { metadata: unknown; content: string };
     try {
       fetched = await this.options.details.getCollectionContent(path);
@@ -165,6 +166,10 @@ export class CollectionService {
       total: results.total,
       page: results.page,
       pageSize: results.pageSize,
+      // The engine paginates before we drop non-console-type hits, so its own
+      // hasMore is the authoritative next-page signal — deriving it from the
+      // (unfiltered) total would advertise pages the filtered view can't fill.
+      hasMore: results.hasMore,
       sourceStatus: 'ok',
     });
   }

--- a/src/web-console/modules/collection/CollectionService.ts
+++ b/src/web-console/modules/collection/CollectionService.ts
@@ -44,6 +44,11 @@ export interface CollectionServiceOptions {
   readonly details: CollectionDetailPort;
   /** Observability hook for engine failures behind the degraded state. */
   readonly reportSourceError?: (error: unknown) => void;
+  /**
+   * Whether this deployment registers the install route; surfaced on the list
+   * DTO (`install_enabled`) so the UI hides Install on browse-only deployments.
+   */
+  readonly installEnabled?: boolean;
 }
 
 // Canonical catalog names are file stems: no separators, no leading dot, so a
@@ -53,7 +58,11 @@ const ELEMENT_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
 const DEGRADED_DETAIL = 'The collection catalog is currently unavailable. Showing no elements; this is not an empty collection.';
 
 export class CollectionService {
-  constructor(private readonly options: CollectionServiceOptions) {}
+  private readonly installEnabled: boolean;
+
+  constructor(private readonly options: CollectionServiceOptions) {
+    this.installEnabled = options.installEnabled === true;
+  }
 
   async listElements(req: ConsoleRequest): Promise<ConsoleHandlerResult> {
     requireConsoleAuthentication(req);
@@ -120,7 +129,7 @@ export class CollectionService {
       index = await this.options.index.getIndex();
     } catch (error) {
       this.options.reportSourceError?.(error);
-      return degradedList(page, pageSize);
+      return degradedList(page, pageSize, this.installEnabled);
     }
 
     const types = type ? [type] : CONSOLE_PORTFOLIO_ELEMENT_TYPES;
@@ -138,6 +147,7 @@ export class CollectionService {
       page,
       pageSize,
       sourceStatus: 'ok',
+      installEnabled: this.installEnabled,
     });
   }
 
@@ -156,7 +166,7 @@ export class CollectionService {
       });
     } catch (error) {
       this.options.reportSourceError?.(error);
-      return degradedList(page, pageSize);
+      return degradedList(page, pageSize, this.installEnabled);
     }
 
     return serializeCollectionElementList({
@@ -171,11 +181,12 @@ export class CollectionService {
       // (unfiltered) total would advertise pages the filtered view can't fill.
       hasMore: results.hasMore,
       sourceStatus: 'ok',
+      installEnabled: this.installEnabled,
     });
   }
 }
 
-function degradedList(page: number, pageSize: number): unknown {
+function degradedList(page: number, pageSize: number, installEnabled: boolean): unknown {
   return serializeCollectionElementList({
     elements: [],
     total: 0,
@@ -183,6 +194,7 @@ function degradedList(page: number, pageSize: number): unknown {
     pageSize,
     sourceStatus: 'degraded',
     sourceDetail: DEGRADED_DETAIL,
+    installEnabled,
   });
 }
 

--- a/src/web-console/modules/collection/CollectionService.ts
+++ b/src/web-console/modules/collection/CollectionService.ts
@@ -1,4 +1,5 @@
 import type { CollectionIndex, SearchOptions, SearchResults } from '../../../types/collection.js';
+import { CollectionElementNotFoundError, isCollectionError } from '../../../collection/CollectionErrors.js';
 import type {
   ConsoleHandlerResult,
   ConsoleRequest,
@@ -227,7 +228,10 @@ function positiveIntParam(value: unknown, fallback: number, max?: number): numbe
 }
 
 function isNotFoundError(error: unknown): boolean {
-  return error instanceof Error && error.message.includes('File not found in collection');
+  // Typed check first (cause-chain-aware, so the GitHub client's McpError
+  // wrapper doesn't hide the type); message fallback as belt-and-braces.
+  return isCollectionError(error, CollectionElementNotFoundError) ||
+    (error instanceof Error && error.message.includes('File not found in collection'));
 }
 
 function asRecord(value: unknown): Readonly<Record<string, unknown>> {

--- a/src/web-console/modules/collection/index.ts
+++ b/src/web-console/modules/collection/index.ts
@@ -1,4 +1,5 @@
 export * from './CollectionDtos.js';
+export * from './CollectionInstallService.js';
 export * from './CollectionModule.js';
 export * from './CollectionPrivacyProjectors.js';
 export * from './CollectionService.js';

--- a/src/web-console/modules/collection/index.ts
+++ b/src/web-console/modules/collection/index.ts
@@ -1,0 +1,4 @@
+export * from './CollectionDtos.js';
+export * from './CollectionModule.js';
+export * from './CollectionPrivacyProjectors.js';
+export * from './CollectionService.js';

--- a/src/web-console/modules/index.ts
+++ b/src/web-console/modules/index.ts
@@ -1,6 +1,7 @@
 export * from './activations/index.js';
 export * from './audit/index.js';
 export * from './approvals/index.js';
+export * from './collection/index.js';
 export * from './executions/index.js';
 export * from './account-admin/index.js';
 export * from './health/index.js';

--- a/src/web-console/modules/portfolio/PortfolioService.ts
+++ b/src/web-console/modules/portfolio/PortfolioService.ts
@@ -15,6 +15,7 @@ import {
   type ConsolePortfolioElementType,
   type IPortfolioElementStore,
 } from '../../stores/IPortfolioElementStore.js';
+import { isValidDisplayString } from '../../stores/ConsoleStoreValidation.js';
 import { type IUserIntegrationStore, type UserIntegrationProvider, type UserIntegrationRecord, isIntegrationConnected } from '../../stores/IUserIntegrationStore.js';
 import {
   isPortfolioSyncJobConflictPolicy,
@@ -479,7 +480,13 @@ function parseSyncBody(body: unknown):
   };
 }
 
-function validateElementPayload(input: {
+/**
+ * Pre-write payload validation mirroring the store record contract
+ * (validatePortfolioElementSummaryRecord), so contract violations 422 BEFORE
+ * anything persists. Exported so the collection install path applies the same
+ * caps as the direct create/update routes.
+ */
+export function validateElementPayload(input: {
   readonly name?: string;
   readonly displayName?: string | null;
   readonly metadata?: Readonly<Record<string, unknown>>;
@@ -489,8 +496,13 @@ function validateElementPayload(input: {
   const issues: PortfolioElementValidationIssueDto[] = [];
   if (!input.name || input.name.trim() === '') issues.push(issue('name', 'required', 'name is required.'));
   if (input.name && canonicalizePortfolioElementName(input.name) === '') issues.push(issue('name', 'invalid', 'name must have a canonical form.'));
+  if (input.name && input.name.trim() !== '' && !isValidDisplayString(input.name, 200)) {
+    issues.push(issue('name', 'invalid', 'name must be a printable string of at most 200 characters.'));
+  }
   if (input.displayName?.trim() === '') {
     issues.push(issue('display_name', 'invalid', 'display_name must be non-empty when provided.'));
+  } else if (input.displayName != null && !isValidDisplayString(input.displayName, 200)) {
+    issues.push(issue('display_name', 'invalid', 'display_name must be a printable string of at most 200 characters.'));
   }
   issues.push(...validateMetadataPayload(input.metadata));
   if (input.content === undefined || input.content.trim() === '') issues.push(issue('content', 'required', 'content is required.'));
@@ -517,7 +529,11 @@ function validateTagsPayload(tags: readonly string[]): readonly PortfolioElement
     issues.push(issue('tags', 'too_many', `tags must contain at most ${PORTFOLIO_ELEMENT_TAGS_MAX} entries.`));
   }
   for (const [index, tag] of tags.entries()) {
-    if (tag.trim() === '') issues.push(issue(`tags.${index}`, 'invalid', 'tags must be non-empty strings.'));
+    if (tag.trim() === '') {
+      issues.push(issue(`tags.${index}`, 'invalid', 'tags must be non-empty strings.'));
+    } else if (!isValidDisplayString(tag, 80)) {
+      issues.push(issue(`tags.${index}`, 'invalid', 'tags must be printable strings of at most 80 characters.'));
+    }
   }
   return issues;
 }

--- a/src/web-console/platform/ConsoleModuleRegistry.ts
+++ b/src/web-console/platform/ConsoleModuleRegistry.ts
@@ -25,8 +25,11 @@ const IDEMPOTENCY_POLICIES = new Set<string>(['not_applicable', 'required']);
 const OWNERSHIP_POLICIES = new Set<string>(['none', 'flow_transaction', 'authenticated_user', 'owned_session']);
 const RESPONSE_KINDS = new Set<string>(['json', 'sse']);
 const MUTATING_METHODS = new Set<ConsoleHttpMethod>(['POST', 'PUT', 'PATCH', 'DELETE']);
-const SELF_PRIVACY_CLASSES = new Set<ConsolePrivacyClass>(['self_private', 'self_security']);
-const SELF_PATH_PATTERN = /^\/api\/v1\/(me|auth)(\/|$)/;
+// Privacy classes a self-audience route may declare. `public_catalog` is the
+// one non-personal member: collection catalog routes are session-gated (they
+// spend server-funded upstream budget) but serve global public data.
+const SELF_PRIVACY_CLASSES = new Set<ConsolePrivacyClass>(['self_private', 'self_security', 'public_catalog']);
+const SELF_PATH_PATTERN = /^\/api\/v1\/(me|auth|collection)(\/|$)/;
 const PUBLIC_AUTH_PATH_PATTERN = /^\/api\/v1\/auth(\/|$)/;
 const PUBLIC_HEALTH_PATH_PATTERN = /^\/api\/v1\/health(\/ready)?$/;
 const MAX_STREAM_EVENT_BYTES = 1024 * 1024;
@@ -430,6 +433,12 @@ export class ConsoleModuleRegistry {
     }
     if (!route.privacyClass || !SELF_PRIVACY_CLASSES.has(route.privacyClass)) {
       throw new ConsoleModuleRegistrationError(`Module "${module.id}" self-service route ${routeKey(route)} has invalid privacy class`);
+    }
+    // public_catalog and /api/v1/collection are pairwise-locked: catalog routes
+    // must not claim a personal privacy class, and personal routes must not
+    // launder data through the catalog class.
+    if ((route.privacyClass === 'public_catalog') !== route.path.startsWith('/api/v1/collection')) {
+      throw new ConsoleModuleRegistrationError(`Module "${module.id}" self-service route ${routeKey(route)} pairs the public_catalog privacy class and /api/v1/collection paths inconsistently`);
     }
     if (!route.ownership || route.ownership === 'none') {
       throw new ConsoleModuleRegistrationError(`Module "${module.id}" self-service route ${routeKey(route)} is missing an ownership policy`);

--- a/src/web-console/platform/ConsolePlatformTypes.ts
+++ b/src/web-console/platform/ConsolePlatformTypes.ts
@@ -19,6 +19,10 @@ export const CONSOLE_PRIVACY_CLASSES = [
   'approval_metadata',
   'admin_audit',
   'security_metadata',
+  // Global public-catalog data (the collection browse surface). Routes remain
+  // session-gated because serving them spends server-funded upstream budget,
+  // but the payload carries no per-user data.
+  'public_catalog',
 ] as const;
 
 export const CONSOLE_ELEVATION_POLICIES = [
@@ -39,6 +43,10 @@ export const CONSOLE_HTTP_METHODS = [
 export const CONSOLE_RATE_LIMIT_POLICIES = [
   'none',
   'protected_correlation_resolution',
+  // Per-session + per-deployment budget on collection catalog routes: they can
+  // drive server-funded outbound GitHub fetches, so one session must not be
+  // able to exhaust the shared upstream budget.
+  'collection_fetch',
 ] as const;
 
 export type ConsoleCapability = typeof CONSOLE_CAPABILITIES[number];

--- a/src/web-console/platform/ConsoleSecuredRouterAssembler.ts
+++ b/src/web-console/platform/ConsoleSecuredRouterAssembler.ts
@@ -21,6 +21,7 @@ import type { IConsoleAuthPolicyStore } from '../stores/IConsoleAuthPolicyStore.
 import type { IIdempotencyStore } from '../stores/IIdempotencyStore.js';
 import type { IRuntimeSessionControlStore } from '../services/runtime/IRuntimeSessionControlStore.js';
 import type { ConsoleProtectedCorrelationRateLimiter } from '../services/rate-limit/ConsoleProtectedCorrelationRateLimiter.js';
+import type { ConsoleCollectionFetchRateLimiter } from '../services/rate-limit/ConsoleCollectionFetchRateLimiter.js';
 import type { ConsoleHttpMethod, ConsoleRouteDefinition , ConsoleRequest } from './ConsolePlatformTypes.js';
 import { isElevationValidForRoute } from './ConsolePlatformTypes.js';
 import type { ConsoleModuleRegistry } from './ConsoleModuleRegistry.js';
@@ -43,6 +44,7 @@ export interface SecuredConsoleRouterOptions {
   readonly runtimeStore: IRuntimeSessionControlStore;
   readonly authPolicyStore?: IConsoleAuthPolicyStore;
   readonly protectedCorrelationRateLimiter?: ConsoleProtectedCorrelationRateLimiter | null;
+  readonly collectionFetchRateLimiter?: ConsoleCollectionFetchRateLimiter | null;
   readonly idleTimeoutMs: number;
   readonly now?: () => Date;
   readonly reportInternalError?: (error: unknown, correlationId: string) => void;

--- a/src/web-console/services/rate-limit/ConsoleCollectionFetchRateLimiter.ts
+++ b/src/web-console/services/rate-limit/ConsoleCollectionFetchRateLimiter.ts
@@ -1,0 +1,175 @@
+import { createHmac } from 'node:crypto';
+
+import { normalizeIp } from '../../../auth/embedded-as/rateLimit.js';
+import type { IRateLimitStore, RateLimitUpdate } from '../../../auth/embedded-as/storage/IRateLimitStore.js';
+import { SecurityMonitor } from '../../../security/securityMonitor.js';
+import {
+  assertHash,
+  ConsoleStoreValidationError,
+} from '../../stores/ConsoleStoreValidation.js';
+
+// One-minute windows: a session gets a browsing-speed budget, and the
+// deployment budget caps the total server-funded upstream (GitHub) exposure
+// per replica set. Index-served requests are cheap; the budget exists for the
+// fetch-through paths.
+const WINDOW_MS = 60 * 1000;
+const SESSION_LIMIT = 30;
+const DEPLOYMENT_LIMIT = 300;
+const SELECTOR_PREFIX = 'console-collection-rate-limit-v1';
+
+export interface ConsoleCollectionFetchRateLimitInput {
+  readonly consoleSessionIdHash: Buffer;
+  readonly ip: string | null | undefined;
+}
+
+export interface ConsoleCollectionFetchRateLimitResult {
+  readonly allowed: boolean;
+  readonly windowResetsAt: Date;
+  readonly retryAfterSeconds: number | null;
+  readonly exceededScopes: readonly ConsoleCollectionFetchRateLimitScope[];
+}
+
+export type ConsoleCollectionFetchRateLimitScope = 'session' | 'deployment';
+
+export interface ConsoleCollectionFetchRateLimiterOptions {
+  readonly store: IRateLimitStore;
+  readonly selectorHmacKey: Buffer;
+  readonly now?: () => Date;
+}
+
+interface WindowCounterState {
+  readonly windowStartedAt: number;
+  readonly attempts: number;
+}
+
+interface ConsumedBudget {
+  readonly scope: ConsoleCollectionFetchRateLimitScope;
+  readonly allowed: boolean;
+  readonly windowResetsAt: Date;
+  readonly retryAfterSeconds: number | null;
+}
+
+export class ConsoleCollectionFetchRateLimitDependencyError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'ConsoleCollectionFetchRateLimitDependencyError';
+  }
+}
+
+/**
+ * Per-session and per-deployment budget for the collection catalog routes.
+ * Backed by the shared `IRateLimitStore`, so multi-replica DB deployments
+ * enforce one budget rather than one per process.
+ */
+export class ConsoleCollectionFetchRateLimiter {
+  constructor(private readonly options: ConsoleCollectionFetchRateLimiterOptions) {
+    if (options.selectorHmacKey.length < 32) {
+      throw new ConsoleStoreValidationError('selectorHmacKey must contain at least 32 bytes');
+    }
+  }
+
+  async consume(input: ConsoleCollectionFetchRateLimitInput): Promise<ConsoleCollectionFetchRateLimitResult> {
+    assertHash(input.consoleSessionIdHash, 'consoleSessionIdHash');
+
+    const now = this.options.now?.() ?? new Date();
+    const sessionSelector = this.selector('session', input.consoleSessionIdHash.toString('hex'));
+    const deploymentSelector = this.selector('deployment', 'global');
+
+    let budgets: readonly ConsumedBudget[];
+    try {
+      budgets = await Promise.all([
+        this.consumeBudget('session', sessionSelector, SESSION_LIMIT, now),
+        this.consumeBudget('deployment', deploymentSelector, DEPLOYMENT_LIMIT, now),
+      ]);
+    } catch (error) {
+      throw new ConsoleCollectionFetchRateLimitDependencyError(
+        'collection fetch rate-limit store unavailable',
+        { cause: error },
+      );
+    }
+
+    const exceededScopes = budgets.filter(budget => !budget.allowed).map(budget => budget.scope);
+    if (exceededScopes.includes('deployment')) {
+      SecurityMonitor.logSecurityEvent({
+        type: 'RATE_LIMIT_EXCEEDED',
+        severity: 'MEDIUM',
+        source: 'web-console',
+        details: 'Collection catalog deployment fetch budget exhausted',
+        ip: normalizeIp(input.ip?.trim() || 'unknown'),
+        additionalData: {
+          policy: 'collection_fetch',
+          exceededScopes,
+        },
+      });
+    }
+
+    return {
+      allowed: exceededScopes.length === 0,
+      windowResetsAt: latestReset(budgets),
+      retryAfterSeconds: retryAfterSeconds(budgets),
+      exceededScopes,
+    };
+  }
+
+  private async consumeBudget(
+    scope: ConsoleCollectionFetchRateLimitScope,
+    key: string,
+    limit: number,
+    at: Date,
+  ): Promise<ConsumedBudget> {
+    const nowMs = at.getTime();
+    const update = await this.options.store.update<WindowCounterState, ConsumedBudget>(
+      `console:collection:fetch:${scope}`,
+      key,
+      prev => stepCounter(scope, prev, limit, nowMs),
+      { expiresAt: nowMs + WINDOW_MS * 2 },
+    );
+    if (!update.result) {
+      throw new Error(`rate-limit store did not return a ${scope} result`);
+    }
+    return update.result;
+  }
+
+  private selector(scope: string, value: string): string {
+    return createHmac('sha256', this.options.selectorHmacKey)
+      .update(SELECTOR_PREFIX)
+      .update('\0')
+      .update(scope)
+      .update('\0')
+      .update(value)
+      .digest('base64url');
+  }
+}
+
+function stepCounter(
+  scope: ConsoleCollectionFetchRateLimitScope,
+  prev: WindowCounterState | null,
+  limit: number,
+  nowMs: number,
+): RateLimitUpdate<WindowCounterState, ConsumedBudget> {
+  const state = prev && nowMs - prev.windowStartedAt < WINDOW_MS
+    ? { windowStartedAt: prev.windowStartedAt, attempts: prev.attempts + 1 }
+    : { windowStartedAt: nowMs, attempts: 1 };
+  const resetMs = state.windowStartedAt + WINDOW_MS;
+  const retryAfter = Math.max(0, Math.ceil((resetMs - nowMs) / 1000));
+  return {
+    state,
+    result: {
+      scope,
+      allowed: state.attempts <= limit,
+      windowResetsAt: new Date(resetMs),
+      retryAfterSeconds: state.attempts > limit ? retryAfter : null,
+    },
+  };
+}
+
+function latestReset(budgets: readonly ConsumedBudget[]): Date {
+  return new Date(Math.max(...budgets.map(budget => budget.windowResetsAt.getTime())));
+}
+
+function retryAfterSeconds(budgets: readonly ConsumedBudget[]): number | null {
+  const exceeded = budgets
+    .map(budget => budget.retryAfterSeconds)
+    .filter((value): value is number => value !== null);
+  return exceeded.length ? Math.max(...exceeded) : null;
+}

--- a/src/web-console/services/rate-limit/ConsoleCollectionFetchRateLimiter.ts
+++ b/src/web-console/services/rate-limit/ConsoleCollectionFetchRateLimiter.ts
@@ -75,12 +75,17 @@ export class ConsoleCollectionFetchRateLimiter {
     const sessionSelector = this.selector('session', input.consoleSessionIdHash.toString('hex'));
     const deploymentSelector = this.selector('deployment', 'global');
 
+    // Consume the session budget FIRST and only charge the shared deployment
+    // budget when the session is allowed. A session-rejected request never
+    // reaches the upstream GitHub fetch, so it must not spend the deployment
+    // budget — otherwise one abusive session could exhaust the shared budget
+    // and deny every other session (the invariant this policy exists to hold).
     let budgets: readonly ConsumedBudget[];
     try {
-      budgets = await Promise.all([
-        this.consumeBudget('session', sessionSelector, SESSION_LIMIT, now),
-        this.consumeBudget('deployment', deploymentSelector, DEPLOYMENT_LIMIT, now),
-      ]);
+      const session = await this.consumeBudget('session', sessionSelector, SESSION_LIMIT, now);
+      budgets = session.allowed
+        ? [session, await this.consumeBudget('deployment', deploymentSelector, DEPLOYMENT_LIMIT, now)]
+        : [session];
     } catch (error) {
       throw new ConsoleCollectionFetchRateLimitDependencyError(
         'collection fetch rate-limit store unavailable',

--- a/src/web-console/services/rate-limit/index.ts
+++ b/src/web-console/services/rate-limit/index.ts
@@ -1,1 +1,2 @@
+export * from './ConsoleCollectionFetchRateLimiter.js';
 export * from './ConsoleProtectedCorrelationRateLimiter.js';

--- a/src/web-console/stores/ConsoleStoreValidation.ts
+++ b/src/web-console/stores/ConsoleStoreValidation.ts
@@ -72,11 +72,20 @@ export function assertUuid(value: string, name: string): void {
   }
 }
 
+/**
+ * Non-throwing form of the display-string record rule, so route-layer payload
+ * validation can enforce the exact same contract BEFORE a store write instead
+ * of discovering the violation post-persist.
+ */
+export function isValidDisplayString(value: string, maxLength: number): boolean {
+  return typeof value === 'string' &&
+    value.trim() !== '' &&
+    value.length <= maxLength &&
+    !containsControlCharacter(value);
+}
+
 export function assertDisplayString(value: string, name: string, maxLength: number): void {
-  if (typeof value !== 'string' ||
-      value.trim() === '' ||
-      value.length > maxLength ||
-      containsControlCharacter(value)) {
+  if (!isValidDisplayString(value, maxLength)) {
     throw new ConsoleStoreValidationError(`${name} must be a printable non-empty string up to ${maxLength} characters`);
   }
 }

--- a/src/web-console/ui/portfolio.js
+++ b/src/web-console/ui/portfolio.js
@@ -40,7 +40,9 @@ const state = {
   page: 1,
   // Collection browse cache (lazy-loaded on first switch to the Collection tab).
   // status: idle | loading | ok | degraded | unavailable | error
-  collection: { status: 'idle', detail: '', elements: [] },
+  // installEnabled mirrors the list DTO's install_enabled: browse-only servers
+  // don't register the install route, so no Install affordances should render.
+  collection: { status: 'idle', detail: '', elements: [], installEnabled: true },
   // Catalog paths installed this session, so their cards can flip to "Installed".
   installed: new Set(),
 };
@@ -167,6 +169,7 @@ async function loadCollection() {
   render();
 
   const elements = [];
+  let installEnabled = true;
   let page = 1;
   try {
     for (; page <= COLLECTION_MAX_PAGES; page++) {
@@ -174,15 +177,16 @@ async function loadCollection() {
       if (res.status === 404) { state.collection.status = 'unavailable'; paint(); return; }
       if (res.status !== 200 || !res.body) { state.collection.status = 'error'; paint(); return; }
       const body = res.body;
+      if (typeof body.install_enabled === 'boolean') installEnabled = body.install_enabled;
       for (const el of (body.elements ?? []).filter(Boolean)) elements.push(mapCollectionElement(el));
       if (body.source_status === 'degraded') {
-        state.collection = { status: 'degraded', detail: str(body.source_detail) ?? '', elements };
+        state.collection = { status: 'degraded', detail: str(body.source_detail) ?? '', elements, installEnabled };
         paint();
         return;
       }
       if (!body.has_more) break;
     }
-    state.collection = { status: 'ok', detail: '', elements };
+    state.collection = { status: 'ok', detail: '', elements, installEnabled };
   } catch {
     state.collection.status = 'error';
   }
@@ -297,6 +301,7 @@ function card(el) {
   const isCollection = el.source === 'collection';
   return `
   <article class="element-card" data-type="${escapeAttr(singular)}" data-key="${escapeAttr(el.type)}" data-name="${escapeAttr(el.name)}"
+    ${isCollection && el.path ? `data-path="${escapeAttr(el.path)}"` : ''}
     role="listitem" tabindex="0" aria-label="View ${escapeHtml(title(el))}">
     <div class="card-header">
       <h3 class="card-title">${escapeHtml(title(el))}</h3>
@@ -343,8 +348,10 @@ function versionMeta(version) {
 }
 
 // Install action for collection cards. Always visible (unlike the list-only
-// download action) since installing is the primary collection interaction.
+// download action) since installing is the primary collection interaction —
+// except on browse-only servers, where the install route doesn't exist.
 function installAction(el) {
+  if (!state.collection.installEnabled) return '';
   if (state.installed.has(el.path)) {
     return '<div class="card-install-wrap"><button class="card-install-btn" data-action="install" disabled aria-disabled="true">Installed ✓</button></div>';
   }
@@ -382,8 +389,12 @@ function wireControls() {
   host.querySelector('#pf-source').addEventListener('click', (e) => toggleGroup(e, '.source-btn', '#pf-source', v => {
     state.source = v; state.page = 1;
     renderTypeFilters(); // counts follow the active source
-    // Lazy-load the catalog the first time the Collection tab is opened.
-    if (v === 'collection' && state.collection.status === 'idle') loadCollection();
+    // Lazy-load the catalog the first time the Collection tab is opened, and
+    // re-try when the last attempt failed or came back empty-degraded —
+    // otherwise a transient blip would brick the tab for the whole session.
+    const cst = state.collection.status;
+    if (v === 'collection' && (cst === 'idle' || cst === 'error' ||
+        (cst === 'degraded' && state.collection.elements.length === 0))) loadCollection();
   }));
   host.querySelector('#pf-type-filters').addEventListener('click', (e) => {
     const btn = e.target.closest('.type-filter'); if (!btn) return;
@@ -395,7 +406,11 @@ function wireControls() {
   host.querySelector('#pf-grid').addEventListener('click', (e) => {
     const cardEl = e.target.closest('.element-card'); if (!cardEl) return;
     const list = visibleElements();
-    const idx = list.findIndex(el => el.type === cardEl.dataset.key && el.name === cardEl.dataset.name);
+    // Collection cards resolve by catalog path — the only key unique across
+    // categorized catalogs (names are file stems, unique per directory only).
+    const idx = cardEl.dataset.path
+      ? list.findIndex(el => el.path === cardEl.dataset.path)
+      : list.findIndex(el => el.type === cardEl.dataset.key && el.name === cardEl.dataset.name);
     if (idx < 0) return;
     const installBtn = e.target.closest('[data-action="install"]');
     if (installBtn) { e.stopPropagation(); installCard(list[idx], installBtn); return; }   // install without opening
@@ -490,7 +505,7 @@ function setHeader(el) {
   // The Install action shows only for collection elements, and reflects whether
   // this session has already installed it.
   const installBtn = dlg.querySelector('.modal-install-btn');
-  const isCollection = el.source === 'collection';
+  const isCollection = el.source === 'collection' && state.collection.installEnabled;
   installBtn.hidden = !isCollection;
   if (isCollection) {
     const done = state.installed.has(el.path);
@@ -585,7 +600,15 @@ async function downloadCard(el, btn) {
 // portfolio in the background so the Portfolio tab reflects it. Returns true when
 // the element is now in the portfolio.
 async function performInstall(el) {
-  const res = await post('/me/portfolio/from-collection', { body: { path: el.path } });
+  let res;
+  try {
+    res = await post('/me/portfolio/from-collection', { body: { path: el.path } });
+  } catch {
+    // fetch() rejects on network-level failures (drop, restart mid-request) —
+    // the slowest console call must not strand the button at "Installing…".
+    notify(`Couldn't install “${title(el)}” — network error. Try again.`, 'error');
+    return false;
+  }
   if (res.status === 201 || res.status === 409) {
     state.installed.add(el.path);
     notify(res.status === 409

--- a/src/web-console/ui/portfolio.js
+++ b/src/web-console/ui/portfolio.js
@@ -4,15 +4,17 @@
  * Faithful port of the legacy console's collection/portfolio browser look:
  * the same card template, the singular-type → --family colour lanes, the
  * source toggle (All / Collection / Portfolio), search, type filters, sort,
- * Cards/List, pagination. Data comes from the new /api/v1/me/portfolio*.
+ * Cards/List, pagination. Portfolio data comes from /api/v1/me/portfolio*;
+ * Collection data from /api/v1/collection/* (browse) with install writing to
+ * /api/v1/me/portfolio/from-collection.
  *
- * Collection is deferred — the toggle is present but disabled until the new
- * backend grows a collection surface; today everything is local portfolio.
- * Rich card fields (description/author/category) populate once the list DTO is
- * enriched; the template omits whatever's absent, exactly like the legacy.
+ * Collection is lazy-loaded the first time its source tab is opened. When the
+ * server hasn't enabled the collection surface the browse call 404s and the tab
+ * shows a clear "not enabled" state; a degraded upstream shows the source's own
+ * message rather than a misleading "empty collection".
  */
 
-import { get } from './api.js';
+import { get, post } from './api.js';
 import { renderElementDetail } from './portfolio-detail.js';
 
 // Plural API type → singular CSS/display type (drives the --family colour lanes
@@ -30,13 +32,17 @@ const PAGE_SIZE = 24;
 
 const state = {
   elements: [],
-  counts: {},
   type: 'all',       // plural API type, or 'all'
-  source: 'all',     // all | collection | portfolio (collection deferred)
+  source: 'all',     // all | collection | portfolio
   search: '',
   sort: 'date-desc',
   view: 'grid',
   page: 1,
+  // Collection browse cache (lazy-loaded on first switch to the Collection tab).
+  // status: idle | loading | ok | degraded | unavailable | error
+  collection: { status: 'idle', detail: '', elements: [] },
+  // Catalog paths installed this session, so their cards can flip to "Installed".
+  installed: new Set(),
 };
 
 let host;
@@ -72,7 +78,7 @@ function template() {
     <fieldset class="source-toggle" id="pf-source">
       <legend class="sr-only">Filter by source</legend>
       <button class="source-btn active" data-source="all" aria-pressed="true">All</button>
-      <button class="source-btn" data-source="collection" aria-pressed="false" disabled title="Collection browsing is coming soon">Collection</button>
+      <button class="source-btn" data-source="collection" aria-pressed="false" title="Browse the community collection">Collection</button>
       <button class="source-btn" data-source="portfolio" aria-pressed="false">Portfolio</button>
     </fieldset>
     <label for="pf-sort" class="sr-only">Sort by</label>
@@ -105,16 +111,14 @@ function template() {
 async function load() {
   const grid = host.querySelector('#pf-grid');
   grid.innerHTML = '<li class="panel-placeholder">Loading portfolio…</li>';
-  const [summary, list] = await Promise.all([get('/me/portfolio'), get('/me/portfolio/elements')]);
+  const list = await get('/me/portfolio/elements');
   if (list.status !== 200) {
     grid.innerHTML = `<li class="panel-placeholder">Couldn't load your portfolio (status ${list.status}).</li>`;
     return;
   }
   // Local portfolio elements are flagged so the LOCAL badge + Portfolio source filter work.
   state.elements = (list.body?.elements ?? []).filter(Boolean).map(el => ({ ...el, _local: true }));
-  state.counts = summary.status === 200 ? (summary.body?.counts_by_type ?? {}) : {};
-  renderTypeFilters();
-  render();
+  paint();
   // The list DTO is lean; hydrate the rich card fields (description/author/
   // category) from each element's full detail — the legacy did the same. No
   // backend change: GET /me/portfolio/elements/:type/:name returns metadata.
@@ -150,26 +154,90 @@ async function hydrateDetails() {
 
 function str(v) { return typeof v === 'string' && v.trim() ? v : undefined; }
 
+/* ── Collection browse ──────────────────────────────────────────────────── */
+
+const COLLECTION_PAGE_SIZE = 100; // server cap; the catalog is small
+const COLLECTION_MAX_PAGES = 20;  // safety bound on the page walk
+
+// Lazy-load the whole catalog once, then filter/sort/search client-side like the
+// portfolio does. Re-entrancy guarded by the 'loading' status.
+async function loadCollection() {
+  if (state.collection.status === 'loading') return;
+  state.collection.status = 'loading';
+  render();
+
+  const elements = [];
+  let page = 1;
+  try {
+    for (; page <= COLLECTION_MAX_PAGES; page++) {
+      const res = await get(`/collection/elements?page=${page}&page_size=${COLLECTION_PAGE_SIZE}`);
+      if (res.status === 404) { state.collection.status = 'unavailable'; paint(); return; }
+      if (res.status !== 200 || !res.body) { state.collection.status = 'error'; paint(); return; }
+      const body = res.body;
+      for (const el of (body.elements ?? []).filter(Boolean)) elements.push(mapCollectionElement(el));
+      if (body.source_status === 'degraded') {
+        state.collection = { status: 'degraded', detail: str(body.source_detail) ?? '', elements };
+        paint();
+        return;
+      }
+      if (!body.has_more) break;
+    }
+    state.collection = { status: 'ok', detail: '', elements };
+  } catch {
+    state.collection.status = 'error';
+  }
+  paint();
+}
+
+// Map a collection list DTO to the shared card shape. Collection elements are
+// keyed by `path` (the install input) and carry source:'collection' so the card
+// renders a COLLECTION badge + Install action instead of LOCAL + download.
+function mapCollectionElement(el) {
+  return {
+    type: el.type,
+    name: el.name,
+    display_name: str(el.display_name),
+    description: str(el.description),
+    author: str(el.author),
+    version: str(el.version),
+    tags: Array.isArray(el.tags) ? el.tags : [],
+    path: el.path,
+    source: 'collection',
+  };
+}
+
 /* ── Rendering ──────────────────────────────────────────────────────────── */
 
+// Repaint both the type-filter counts and the grid (use when the source or the
+// underlying element set changed; plain render() suffices for search/sort/view).
+function paint() { renderTypeFilters(); render(); }
+
 function renderTypeFilters() {
-  const total = state.elements.length;
+  // Counts follow the active source, so the Collection tab shows catalog counts
+  // rather than the user's portfolio counts.
+  const items = sourceElements();
+  const counts = {};
+  for (const el of items) counts[el.type] = (counts[el.type] ?? 0) + 1;
   const chip = (key, label, singular, count) =>
     `<button class="type-filter${state.type === key ? ' active' : ''}" data-key="${key}"
        ${singular ? `data-type="${singular}"` : ''} aria-pressed="${state.type === key}">
        ${label} <span class="filter-count">${count}</span>
      </button>`;
-  const chips = [chip('all', 'All', '', total)];
-  for (const t of TYPES) chips.push(chip(t, TYPE_META[t].label, TYPE_META[t].singular, state.counts[t] ?? 0));
+  const chips = [chip('all', 'All', '', items.length)];
+  for (const t of TYPES) chips.push(chip(t, TYPE_META[t].label, TYPE_META[t].singular, counts[t] ?? 0));
   host.querySelector('#pf-type-filters').innerHTML =
     '<legend class="sr-only">Filter by element type</legend>' + chips.join('');
 }
 
+function sourceElements() {
+  // Collection tab draws from the lazily-loaded catalog; All/Portfolio draw from
+  // the user's local elements (identical today — everything local is portfolio).
+  return state.source === 'collection' ? state.collection.elements : state.elements;
+}
+
 function visibleElements() {
   const q = state.search.trim().toLowerCase();
-  let items = state.elements.filter(el => state.type === 'all' || el.type === state.type);
-  if (state.source === 'collection') items = []; // deferred
-  // (source 'portfolio' and 'all' are identical today — everything is local)
+  let items = sourceElements().filter(el => state.type === 'all' || el.type === state.type);
   if (q) {
     items = items.filter(el =>
       (el.name || '').toLowerCase().includes(q) ||
@@ -197,10 +265,13 @@ function render() {
   const start = (state.page - 1) * PAGE_SIZE;
   const pageItems = items.slice(start, start + PAGE_SIZE);
 
-  if (state.source === 'collection') {
-    grid.innerHTML = '<li class="panel-placeholder">Collection browsing is coming soon — the new backend doesn’t expose the community collection yet.</li>';
+  const collectionPlaceholder = state.source === 'collection' ? collectionStatusPlaceholder() : null;
+  if (collectionPlaceholder) {
+    grid.innerHTML = collectionPlaceholder;
   } else if (items.length === 0) {
-    grid.innerHTML = '<li class="panel-placeholder">No elements yet. Create one to get started.</li>';
+    grid.innerHTML = state.source === 'collection'
+      ? '<li class="panel-placeholder">No collection elements match your filters.</li>'
+      : '<li class="panel-placeholder">No elements yet. Create one to get started.</li>';
   } else {
     grid.innerHTML = pageItems.map(card).join('');
   }
@@ -211,7 +282,7 @@ function render() {
   host.querySelector('#pf-announcer').textContent = `${countText}, page ${state.page} of ${pages}`;
 
   const pag = host.querySelector('#pf-pagination');
-  pag.hidden = pages <= 1 || state.source === 'collection';
+  pag.hidden = pages <= 1 || Boolean(collectionPlaceholder);
   host.querySelector('#pf-pageinfo').textContent = `Page ${state.page} of ${pages}`;
   host.querySelector('#pf-prev').disabled = state.page <= 1;
   host.querySelector('#pf-next').disabled = state.page >= pages;
@@ -223,6 +294,7 @@ function card(el) {
   const label = capitalize(TYPE_META[el.type]?.singular ?? el.type);
   const stale = el.validation_status && el.validation_status !== 'valid';
   const tagItems = (el.tags || []).slice(0, 5).map(t => `<li class="tag">${escapeHtml(t)}</li>`).join('');
+  const isCollection = el.source === 'collection';
   return `
   <article class="element-card" data-type="${escapeAttr(singular)}" data-key="${escapeAttr(el.type)}" data-name="${escapeAttr(el.name)}"
     role="listitem" tabindex="0" aria-label="View ${escapeHtml(title(el))}">
@@ -231,6 +303,7 @@ function card(el) {
       <div class="card-badges">
         <span class="type-badge" data-type="${escapeAttr(singular)}">${escapeHtml(label)}</span>
         ${el._local ? '<span class="source-badge">LOCAL</span>' : ''}
+        ${isCollection ? '<span class="source-badge source-badge-collection">COLLECTION</span>' : ''}
         ${stale ? `<span class="unavailable-badge">${escapeHtml(el.validation_status)}</span>` : ''}
       </div>
       <span class="card-expand-icon" aria-hidden="true">&#9662;</span>
@@ -240,19 +313,56 @@ function card(el) {
     <footer class="card-footer">
       <div class="card-meta">
         ${el.author ? `<span class="meta-author">${escapeHtml(el.author)}</span>` : ''}
-        ${typeof el.version === 'number' ? `<span class="meta-version">v${el.version}</span>` : ''}
+        ${versionMeta(el.version)}
         ${el.category ? `<span class="meta-category">${escapeHtml(el.category)}</span>` : ''}
         ${el.updated_at ? `<span class="meta-date">${formatDate(el.updated_at)}</span>` : ''}
       </div>
+      ${isCollection ? installAction(el) : `
       <div class="card-actions">
         <button class="card-download-btn" data-action="download" aria-label="Download ${escapeHtml(title(el))}" title="Download">&#10515;</button>
-      </div>
+      </div>`}
       ${el.tags?.length
         ? `<ul class="card-tags" aria-label="Tags">${tagItems}</ul>`
         : ''}
     </footer>
     <div class="card-inline-detail"></div>
   </article>`;
+}
+
+// Version label for both the portfolio's numeric version and the collection's
+// string version (e.g. "1.2.0"); empty when there's no usable version.
+function versionText(version) {
+  if (typeof version === 'number') return `v${version}`;
+  if (typeof version === 'string' && version.trim()) return `v${version}`;
+  return '';
+}
+
+function versionMeta(version) {
+  const text = versionText(version);
+  return text ? `<span class="meta-version">${escapeHtml(text)}</span>` : '';
+}
+
+// Install action for collection cards. Always visible (unlike the list-only
+// download action) since installing is the primary collection interaction.
+function installAction(el) {
+  if (state.installed.has(el.path)) {
+    return '<div class="card-install-wrap"><button class="card-install-btn" data-action="install" disabled aria-disabled="true">Installed ✓</button></div>';
+  }
+  return `<div class="card-install-wrap"><button class="card-install-btn" data-action="install" aria-label="Install ${escapeHtml(title(el))} into your portfolio">Install</button></div>`;
+}
+
+// A non-card placeholder for the Collection tab when there are no browsable
+// cards to show: loading, server-disabled, upstream-degraded, or error. Returns
+// null when cards should render normally.
+function collectionStatusPlaceholder() {
+  const { status, detail } = state.collection;
+  if (status === 'loading') return '<li class="panel-placeholder">Loading the community collection…</li>';
+  if (status === 'unavailable') return '<li class="panel-placeholder">Collection browsing isn’t enabled on this server.</li>';
+  if (status === 'error') return '<li class="panel-placeholder">Couldn’t reach the community collection. Try again in a moment.</li>';
+  if (status === 'degraded' && state.collection.elements.length === 0) {
+    return `<li class="panel-placeholder">${escapeHtml(detail || 'The community collection is temporarily unavailable.')}</li>`;
+  }
+  return null;
 }
 
 function renderComponentSummary(el) {
@@ -269,7 +379,12 @@ function wireControls() {
   host.querySelector('#pf-search').addEventListener('input', (e) => { state.search = e.target.value; state.page = 1; render(); });
   host.querySelector('#pf-sort').addEventListener('change', (e) => { state.sort = e.target.value; render(); });
   host.querySelector('#pf-view').addEventListener('click', (e) => toggleGroup(e, '.view-btn', '#pf-view', v => { state.view = v; }));
-  host.querySelector('#pf-source').addEventListener('click', (e) => toggleGroup(e, '.source-btn', '#pf-source', v => { state.source = v; state.page = 1; }));
+  host.querySelector('#pf-source').addEventListener('click', (e) => toggleGroup(e, '.source-btn', '#pf-source', v => {
+    state.source = v; state.page = 1;
+    renderTypeFilters(); // counts follow the active source
+    // Lazy-load the catalog the first time the Collection tab is opened.
+    if (v === 'collection' && state.collection.status === 'idle') loadCollection();
+  }));
   host.querySelector('#pf-type-filters').addEventListener('click', (e) => {
     const btn = e.target.closest('.type-filter'); if (!btn) return;
     state.type = btn.dataset.key; state.page = 1;
@@ -282,6 +397,8 @@ function wireControls() {
     const list = visibleElements();
     const idx = list.findIndex(el => el.type === cardEl.dataset.key && el.name === cardEl.dataset.name);
     if (idx < 0) return;
+    const installBtn = e.target.closest('[data-action="install"]');
+    if (installBtn) { e.stopPropagation(); installCard(list[idx], installBtn); return; }   // install without opening
     const dlBtn = e.target.closest('[data-action="download"]');
     if (dlBtn) { e.stopPropagation(); downloadCard(list[idx], dlBtn); return; }   // download without opening
     openModal(list, idx);
@@ -312,6 +429,7 @@ function ensureModal() {
         <button class="modal-close" id="pf-modal-close" aria-label="Close">&#x2715;</button>
       </header>
       <div class="modal-toolbar">
+        <button class="modal-action-btn modal-install-btn" data-act="install" hidden>&#8681; Install</button>
         <button class="modal-action-btn" data-act="render">&#8644; Raw</button>
         <button class="modal-action-btn" data-act="copy">&#9112; Copy</button>
         <button class="modal-action-btn" data-act="download">&#10515; Download</button>
@@ -347,7 +465,8 @@ async function openModal(list, idx) {
   body.focus();
 
   // Fetch the full element (metadata + content) — the legacy did the same on open.
-  const res = await get(`/me/portfolio/elements/${encodeURIComponent(modalEl.type)}/${encodeURIComponent(modalEl.name)}`);
+  // Collection elements come from the catalog endpoint; portfolio from /me.
+  const res = await get(detailPath(modalEl));
   if (res.status !== 200 || !res.body) {
     body.innerHTML = `<p class="panel-placeholder">Couldn't load this element (status ${res.status}).</p>`;
     return;
@@ -365,8 +484,19 @@ function setHeader(el) {
   dlg.querySelector('#pf-modal-title').textContent = title(el);
   dlg.querySelector('#pf-modal-type').textContent = label;
   dlg.querySelector('#pf-modal-author').textContent = el.author || el.metadata?.author ? `by ${el.author || el.metadata.author}` : '';
-  dlg.querySelector('#pf-modal-version').textContent = typeof el.version === 'number' ? `v${el.version}` : '';
+  dlg.querySelector('#pf-modal-version').textContent = versionText(el.version);
   dlg.querySelector('#pf-modal-date').textContent = el.updated_at ? formatDate(el.updated_at) : '';
+
+  // The Install action shows only for collection elements, and reflects whether
+  // this session has already installed it.
+  const installBtn = dlg.querySelector('.modal-install-btn');
+  const isCollection = el.source === 'collection';
+  installBtn.hidden = !isCollection;
+  if (isCollection) {
+    const done = state.installed.has(el.path);
+    installBtn.disabled = done;
+    installBtn.textContent = done ? 'Installed ✓' : '⭳ Install';
+  }
 }
 
 function renderModalBody() {
@@ -447,6 +577,72 @@ async function downloadCard(el, btn) {
   }
 }
 
+/* ── Install (collection → portfolio) ───────────────────────────────────── */
+
+// Core install: POST /me/portfolio/from-collection (api.js attaches CSRF +
+// Idempotency-Key). A 201 (created) or 409 (already present) both leave the user
+// with the element, so both count as "installed"; on either, refresh the
+// portfolio in the background so the Portfolio tab reflects it. Returns true when
+// the element is now in the portfolio.
+async function performInstall(el) {
+  const res = await post('/me/portfolio/from-collection', { body: { path: el.path } });
+  if (res.status === 201 || res.status === 409) {
+    state.installed.add(el.path);
+    notify(res.status === 409
+      ? `“${title(el)}” is already in your portfolio.`
+      : `Installed “${title(el)}” into your portfolio.`, 'success');
+    refreshPortfolio();
+    return true;
+  }
+  const detail = res.body && typeof res.body.detail === 'string' ? res.body.detail : `status ${res.status}`;
+  notify(`Couldn't install “${title(el)}” — ${detail}`, 'error');
+  return false;
+}
+
+// Install from a collection card's button.
+async function installCard(el, btn) {
+  if (btn.disabled) return;
+  const prev = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = 'Installing…';
+  const ok = await performInstall(el);
+  if (ok) {
+    btn.textContent = 'Installed ✓';
+    btn.setAttribute('aria-disabled', 'true');
+  } else {
+    btn.disabled = false;
+    btn.textContent = prev;
+  }
+}
+
+// Install from the detail modal's toolbar button; also flips the underlying
+// card (which is still in the grid behind the modal).
+async function installFromModal(btn) {
+  if (btn.disabled || !modalEl?.path) return;
+  btn.disabled = true;
+  btn.textContent = 'Installing…';
+  const ok = await performInstall(modalEl);
+  if (ok) {
+    btn.textContent = 'Installed ✓';
+    if (state.source === 'collection') render();
+  } else {
+    btn.disabled = false;
+    btn.textContent = '⭳ Install';
+  }
+}
+
+// Quiet background refresh of the portfolio after an install, so switching to
+// the Portfolio tab shows the new element without a jarring full "Loading…".
+async function refreshPortfolio() {
+  try {
+    const list = await get('/me/portfolio/elements');
+    if (list.status !== 200) return;
+    state.elements = (list.body?.elements ?? []).filter(Boolean).map(el => ({ ...el, _local: true }));
+    if (state.source !== 'collection') paint();
+    hydrateDetails();
+  } catch { /* leave the current portfolio view; the next full load will catch up */ }
+}
+
 function onToolbar(e) {
   const btn = e.target.closest('[data-act]'); if (!btn) return;
   const act = btn.dataset.act;
@@ -458,6 +654,8 @@ function onToolbar(e) {
     navigator.clipboard?.writeText(rawSource(modalEl)).then(() => notify('Copied to clipboard.', 'success'));
   } else if (act === 'download') {
     downloadElement(modalEl);
+  } else if (act === 'install') {
+    installFromModal(btn);
   } else if (act === 'prev' && modalIdx > 0) {
     openModal(modalList, modalIdx - 1);
   } else if (act === 'next' && modalIdx < modalList.length - 1) {
@@ -479,6 +677,15 @@ function toggleGroup(e, btnSel, groupSel, apply) {
 
 function title(el) { return el.display_name || el.name || '(unnamed)'; }
 function capitalize(s) { return s ? s.charAt(0).toUpperCase() + s.slice(1) : s; }
+// Detail endpoint for an element — the public catalog for collection elements,
+// the user's portfolio otherwise.
+function detailPath(el) {
+  const type = encodeURIComponent(el.type);
+  const name = encodeURIComponent(el.name);
+  return el.source === 'collection'
+    ? `/collection/elements/${type}/${name}`
+    : `/me/portfolio/elements/${type}/${name}`;
+}
 function escapeHtml(s) {
   return String(s ?? '').replaceAll(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 }

--- a/src/web-console/ui/styles.css
+++ b/src/web-console/ui/styles.css
@@ -424,6 +424,18 @@ p, li { max-width: 69ch; }
   border-color: color-mix(in srgb, #fcd34d 35%, transparent);
 }
 
+/* COLLECTION badge — shown on catalog (not-yet-installed) elements */
+.source-badge-collection {
+  background: color-mix(in srgb, var(--signal) 20%, var(--paper-strong));
+  color: color-mix(in srgb, var(--signal) 88%, var(--ink-800));
+  border-color: color-mix(in srgb, var(--signal) 45%, transparent);
+}
+[data-theme="dark"] .source-badge-collection {
+  background: color-mix(in srgb, var(--signal) 16%, var(--paper-strong));
+  color: color-mix(in srgb, var(--signal) 92%, white);
+  border-color: color-mix(in srgb, var(--signal) 38%, transparent);
+}
+
 /* Portfolio button in browse controls */
 .portfolio-btn {
   appearance: none;
@@ -911,6 +923,34 @@ p, li { max-width: 69ch; }
   border-color: color-mix(in srgb, var(--signal) 30%, var(--line));
 }
 .card-download-btn:focus-visible { outline: 2px solid var(--signal); outline-offset: 2px; }
+
+/* Install action — always visible on collection cards (installing is the
+   primary collection interaction, unlike the list-only download). */
+.card-install-wrap { flex-shrink: 0; }
+.card-install-btn {
+  appearance: none;
+  border: 1px solid color-mix(in srgb, var(--signal) 40%, var(--line));
+  border-radius: 0.28rem;
+  background: color-mix(in srgb, var(--signal-2) 18%, var(--paper-strong));
+  color: color-mix(in srgb, var(--signal) 92%, var(--ink-800));
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  padding: 0.24rem 0.62rem;
+  cursor: pointer;
+  transition: background 100ms ease, color 100ms ease, border-color 100ms ease;
+}
+.card-install-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--signal-2) 32%, var(--paper-strong));
+  border-color: color-mix(in srgb, var(--signal) 60%, var(--line));
+}
+.card-install-btn:focus-visible { outline: 2px solid var(--signal); outline-offset: 2px; }
+.card-install-btn:disabled {
+  cursor: default;
+  color: var(--ink-500);
+  background: color-mix(in srgb, var(--surface-1) 40%, var(--paper-strong));
+  border-color: color-mix(in srgb, var(--line) 80%, transparent);
+}
 
 /* List view — inline expand */
 .card-inline-detail {

--- a/tests/integration/element-installation-priority.test.ts
+++ b/tests/integration/element-installation-priority.test.ts
@@ -84,7 +84,8 @@ describe('Element Installation Priority Integration Tests', () => {
     // Initialize element installer
     elementInstaller = new ElementInstaller(githubClient, {
       portfolioManager,
-      unifiedIndexManager
+      unifiedIndexManager,
+      fileOperations
     });
   });
 

--- a/tests/unit/GitHubClient.test.ts
+++ b/tests/unit/GitHubClient.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { GitHubClient } from '../../src/collection/GitHubClient.js';
-import { APICache } from '../../src/cache/APICache.js';
+import type { APICache } from '../../src/cache/APICache.js';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { SECURITY_LIMITS } from '../../src/security/constants.js';
 import { createMockTokenManager } from '../helpers/di-mocks.js';
 
 // Create a properly typed mock for fetch
 const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
-global.fetch = mockFetch;
+globalThis.fetch = mockFetch;
 
 // Mock SecurityMonitor to avoid security event logging in tests
 jest.mock('../../src/security/securityMonitor.js', () => ({
@@ -15,6 +15,9 @@ jest.mock('../../src/security/securityMonitor.js', () => ({
     logSecurityEvent: jest.fn()
   }
 }));
+
+const GITHUB_API_RATE_KEY = 'github_api';
+const GITHUB_TEST_URL = 'https://api.github.com/test';
 
 describe('GitHubClient', () => {
   let githubClient: GitHubClient;
@@ -68,13 +71,13 @@ describe('GitHubClient', () => {
       const result = await githubClient.fetchFromGitHub(testUrl);
 
       expect(result).toEqual(cachedData);
-      expect(global.fetch).not.toHaveBeenCalled();
+      expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 
     it('should enforce rate limiting', async () => {
       // Fill up rate limit
       const requests = new Array(SECURITY_LIMITS.RATE_LIMIT_REQUESTS).fill(Date.now());
-      rateLimitTracker.set('github_api', requests);
+      rateLimitTracker.set(GITHUB_API_RATE_KEY, requests);
 
       await expect(githubClient.fetchFromGitHub(testUrl))
         .rejects.toThrow('Rate limit exceeded');
@@ -151,10 +154,10 @@ describe('GitHubClient', () => {
       await githubClient.fetchFromGitHub(testUrl);
 
       // Check that only the API call was made (no separate token validation call)
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
 
       // Call should be to the actual URL with the validated token
-      expect(global.fetch).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
         testUrl,
         expect.objectContaining({
           headers: expect.objectContaining({
@@ -181,11 +184,55 @@ describe('GitHubClient', () => {
     });
   });
 
+  describe('SSRF guards', () => {
+    it('rejects a URL whose host is not on the allowlist', async () => {
+      await expect(
+        githubClient.fetchFromGitHub('https://evil.example.com/repos/x')
+      ).rejects.toThrow(/non-allowed URL/);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects a path-traversal URL that would normalize to a different endpoint', async () => {
+      // Would collapse to https://api.github.com/orgs/DollhouseMCP — a different
+      // endpoint that still passes a hostname-only allowlist. Must be blocked
+      // BEFORE the URL constructor normalizes the `..` segments.
+      await expect(
+        githubClient.fetchFromGitHub(
+          'https://api.github.com/repos/DollhouseMCP/collection/contents/library/../../../orgs/DollhouseMCP'
+        )
+      ).rejects.toThrow(/path-traversal/);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects a single-dot path segment', async () => {
+      await expect(
+        githubClient.fetchFromGitHub('https://api.github.com/repos/./collection')
+      ).rejects.toThrow(/path-traversal/);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('allows a search URL whose query string contains dots', async () => {
+      // Dots in the ?q= query must NOT trip the path-traversal check — only
+      // path segments are inspected.
+      const mockResponse = {
+        ok: true,
+        json: (jest.fn() as any).mockResolvedValue({ items: [] })
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+      mockApiCache.get.mockReturnValue(null);
+
+      await expect(
+        githubClient.fetchFromGitHub('https://api.github.com/search/code?q=a..b+repo:DollhouseMCP/collection')
+      ).resolves.toEqual({ items: [] });
+      expect(mockFetch).toHaveBeenCalled();
+    });
+  });
+
   describe('Rate Limiting', () => {
     it('should clean up old rate limit entries', async () => {
       // Add old entries (outside window)
       const oldTime = Date.now() - SECURITY_LIMITS.RATE_LIMIT_WINDOW_MS - 1000;
-      rateLimitTracker.set('github_api', [oldTime, oldTime, oldTime]);
+      rateLimitTracker.set(GITHUB_API_RATE_KEY, [oldTime, oldTime, oldTime]);
 
       const mockResponse = {
         ok: true,
@@ -195,10 +242,10 @@ describe('GitHubClient', () => {
       mockApiCache.get.mockReturnValue(null);
 
       // Should not throw rate limit error
-      await githubClient.fetchFromGitHub('https://api.github.com/test');
+      await githubClient.fetchFromGitHub(GITHUB_TEST_URL);
 
       // Old entries should be cleaned up
-      const requests = rateLimitTracker.get('github_api') || [];
+      const requests = rateLimitTracker.get(GITHUB_API_RATE_KEY) || [];
       expect(requests.every(time => time > oldTime)).toBe(true);
     });
 
@@ -214,7 +261,7 @@ describe('GitHubClient', () => {
       await githubClient.fetchFromGitHub('https://api.github.com/test1');
       await githubClient.fetchFromGitHub('https://api.github.com/test2');
 
-      const requests = rateLimitTracker.get('github_api') || [];
+      const requests = rateLimitTracker.get(GITHUB_API_RATE_KEY) || [];
       expect(requests).toHaveLength(2);
     });
   });
@@ -229,7 +276,7 @@ describe('GitHubClient', () => {
       mockFetch.mockResolvedValue(mockResponse);
       mockApiCache.get.mockReturnValue(null);
 
-      await expect(githubClient.fetchFromGitHub('https://api.github.com/test'))
+      await expect(githubClient.fetchFromGitHub(GITHUB_TEST_URL))
         .rejects.toThrow('Invalid JSON');
       
       // Verify cache was not updated with bad data
@@ -245,11 +292,11 @@ describe('GitHubClient', () => {
       mockFetch.mockResolvedValue(mockResponse);
       mockApiCache.get.mockReturnValue(null);
 
-      const result = await githubClient.fetchFromGitHub('https://api.github.com/test');
+      const result = await githubClient.fetchFromGitHub(GITHUB_TEST_URL);
       expect(result).toBe('not an object');
       
       // Even non-object JSON should be cached
-      expect(mockApiCache.set).toHaveBeenCalledWith('https://api.github.com/test', 'not an object');
+      expect(mockApiCache.set).toHaveBeenCalledWith(GITHUB_TEST_URL, 'not an object');
     });
 
     it('should handle 404 responses', async () => {
@@ -262,7 +309,7 @@ describe('GitHubClient', () => {
       mockFetch.mockResolvedValue(mockResponse);
       mockApiCache.get.mockReturnValue(null);
 
-      await expect(githubClient.fetchFromGitHub('https://api.github.com/test'))
+      await expect(githubClient.fetchFromGitHub(GITHUB_TEST_URL))
         .rejects.toThrow('Failed to fetch from GitHub: File not found in collection');
     });
 
@@ -278,7 +325,7 @@ describe('GitHubClient', () => {
       mockApiCache.get.mockReturnValue(null);
 
       try {
-        await githubClient.fetchFromGitHub('https://api.github.com/test');
+        await githubClient.fetchFromGitHub(GITHUB_TEST_URL);
         throw new Error('Should have thrown an error');
       } catch (error) {
         expect(error).toBeInstanceOf(McpError);
@@ -306,11 +353,11 @@ describe('GitHubClient', () => {
       mockApiCache.get.mockReturnValue(null);
 
       // First call should fail
-      await expect(githubClient.fetchFromGitHub('https://api.github.com/test'))
+      await expect(githubClient.fetchFromGitHub(GITHUB_TEST_URL))
         .rejects.toThrow('ECONNRESET');
       
       // Second call should succeed
-      const result = await githubClient.fetchFromGitHub('https://api.github.com/test');
+      const result = await githubClient.fetchFromGitHub(GITHUB_TEST_URL);
       expect(result).toEqual({ success: true });
       expect(callCount).toBe(2);
     });
@@ -346,7 +393,7 @@ describe('GitHubClient', () => {
       const testUrl = 'https://api.github.com/test-cache-corruption';
       
       // Simulate corrupted cache returning undefined
-      mockApiCache.get.mockReturnValue(undefined);
+      mockApiCache.get.mockReturnValue();
       
       const mockData = { fresh: 'data' };
       mockFetch.mockResolvedValue({

--- a/tests/unit/GitHubClient.test.ts
+++ b/tests/unit/GitHubClient.test.ts
@@ -211,6 +211,34 @@ describe('GitHubClient', () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
+    it('rejects percent-encoded traversal that the URL parser would collapse', async () => {
+      // new URL(...) decodes %2e%2e and collapses it to /repos/DollhouseMCP/orgs/evil,
+      // reaching a token-authenticated endpoint. The decoded raw-path check must
+      // catch it despite there being no literal ".." segment.
+      await expect(
+        githubClient.fetchFromGitHub(
+          'https://api.github.com/repos/DollhouseMCP/collection/contents/library/%2e%2e/%2e%2e/%2e%2e/orgs/evil'
+        )
+      ).rejects.toThrow(/path-traversal/);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects backslash-encoded traversal segments', async () => {
+      await expect(
+        githubClient.fetchFromGitHub(
+          String.raw`https://api.github.com/repos/DollhouseMCP/collection/contents/library/..\..\..\orgs/evil`
+        )
+      ).rejects.toThrow(/path-traversal/);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects a URL with malformed percent-encoding', async () => {
+      await expect(
+        githubClient.fetchFromGitHub('https://api.github.com/repos/DollhouseMCP/collection/contents/%zz')
+      ).rejects.toThrow(/malformed percent-encoding/);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
     it('allows a search URL whose query string contains dots', async () => {
       // Dots in the ?q= query must NOT trip the path-traversal check — only
       // path segments are inspected.

--- a/tests/unit/GitHubClient.test.ts
+++ b/tests/unit/GitHubClient.test.ts
@@ -192,43 +192,40 @@ describe('GitHubClient', () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it('rejects a path-traversal URL that would normalize to a different endpoint', async () => {
-      // Would collapse to https://api.github.com/orgs/DollhouseMCP — a different
-      // endpoint that still passes a hostname-only allowlist. Must be blocked
-      // BEFORE the URL constructor normalizes the `..` segments.
-      await expect(
-        githubClient.fetchFromGitHub(
-          'https://api.github.com/repos/DollhouseMCP/collection/contents/library/../../../orgs/DollhouseMCP'
-        )
-      ).rejects.toThrow(/path-traversal/);
+    // Each traversal shape must be blocked BEFORE the URL constructor
+    // normalizes it: raw `..` would collapse to a different (still-allowlisted)
+    // endpoint, `%2e%2e` decodes to `..` during parsing with no literal dot-dot
+    // segment in the raw string, and single-dot / backslash variants are the
+    // parser-collapse equivalents.
+    it.each([
+      [
+        'raw dot-dot segments that would normalize to a different endpoint',
+        'https://api.github.com/repos/DollhouseMCP/collection/contents/library/../../../orgs/DollhouseMCP',
+      ],
+      [
+        'a single-dot path segment',
+        'https://api.github.com/repos/./collection',
+      ],
+      [
+        'percent-encoded traversal that the URL parser would collapse',
+        'https://api.github.com/repos/DollhouseMCP/collection/contents/library/%2e%2e/%2e%2e/%2e%2e/orgs/evil',
+      ],
+      [
+        'backslash-encoded traversal segments',
+        String.raw`https://api.github.com/repos/DollhouseMCP/collection/contents/library/..\..\..\orgs/evil`,
+      ],
+    ])('rejects %s', async (_case, url) => {
+      await expect(githubClient.fetchFromGitHub(url)).rejects.toThrow(/path-traversal/);
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it('rejects a single-dot path segment', async () => {
+    it('rejects a percent-encoded non-allowlisted hostname', async () => {
+      // `evil%2ecom` decodes to `evil.com` during URL parsing — the allowlist
+      // check runs on the parsed hostname, so an attacker cannot smuggle a
+      // disallowed host past it with percent-encoding.
       await expect(
-        githubClient.fetchFromGitHub('https://api.github.com/repos/./collection')
-      ).rejects.toThrow(/path-traversal/);
-      expect(mockFetch).not.toHaveBeenCalled();
-    });
-
-    it('rejects percent-encoded traversal that the URL parser would collapse', async () => {
-      // new URL(...) decodes %2e%2e and collapses it to /repos/DollhouseMCP/orgs/evil,
-      // reaching a token-authenticated endpoint. The decoded raw-path check must
-      // catch it despite there being no literal ".." segment.
-      await expect(
-        githubClient.fetchFromGitHub(
-          'https://api.github.com/repos/DollhouseMCP/collection/contents/library/%2e%2e/%2e%2e/%2e%2e/orgs/evil'
-        )
-      ).rejects.toThrow(/path-traversal/);
-      expect(mockFetch).not.toHaveBeenCalled();
-    });
-
-    it('rejects backslash-encoded traversal segments', async () => {
-      await expect(
-        githubClient.fetchFromGitHub(
-          String.raw`https://api.github.com/repos/DollhouseMCP/collection/contents/library/..\..\..\orgs/evil`
-        )
-      ).rejects.toThrow(/path-traversal/);
+        githubClient.fetchFromGitHub('https://evil%2ecom/repos/DollhouseMCP/collection/contents/library/x.md')
+      ).rejects.toThrow(/non-allowed URL/);
       expect(mockFetch).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/cache/CollectionCache.test.ts
+++ b/tests/unit/cache/CollectionCache.test.ts
@@ -1,38 +1,64 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
 import * as path from 'path';
 import * as os from 'os';
+import type { CollectionItem } from '../../../src/cache/CollectionCache.js';
 import { CollectionCache } from '../../../src/cache/CollectionCache.js';
+import type { IFileOperationsService } from '../../../src/services/FileOperationsService.js';
+import { InMemorySharedCacheStore } from '../../../src/storage/sharedCache/InMemorySharedCacheStore.js';
 
 /**
  * Unit tests for CollectionCache - pure logic tests
  *
- * These tests verify the core logic of CollectionCache without filesystem operations.
- * For filesystem integration tests, see tests/integration/cache/CollectionCache.integration.test.ts
+ * These tests verify the core logic of CollectionCache without real filesystem
+ * operations. For filesystem integration tests, see
+ * tests/integration/cache/CollectionCache.integration.test.ts
  *
  * Tests cover:
  * - Constructor initialization
  * - TTL constant values
  * - Search term normalization logic
+ * - Shared-cache-store backend (backend-honesty seam)
  */
+
+const BROWSE_CACHE_KEY = 'collection-browse-cache';
+const NORMALIZED_PERSONA = 'test persona';
+
+// Minimal file-operations stub — the logic tests below never touch the
+// filesystem path, so the methods only need to exist.
+function createFileOperationsStub(): IFileOperationsService {
+  return {
+    readFile: () => Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })),
+    writeFile: () => Promise.resolve(),
+    deleteFile: () => Promise.resolve(),
+    createDirectory: () => Promise.resolve(),
+  } as unknown as IFileOperationsService;
+}
+
+const SAMPLE_ITEMS: CollectionItem[] = [
+  { name: 'test-persona.md', path: 'library/personas/test-persona.md', sha: 'abc123' },
+  { name: 'skill-example.md', path: 'library/skills/skill-example.md', sha: 'def456' },
+];
 
 describe('CollectionCache', () => {
   let cache: CollectionCache;
   let testBaseDir: string;
+  let fileOperations: IFileOperationsService;
 
   beforeEach(() => {
     // Setup test directory path (not created on filesystem)
     testBaseDir = path.join(os.tmpdir(), 'test-collection-cache-' + Date.now());
-    cache = new CollectionCache(testBaseDir);
+    fileOperations = createFileOperationsStub();
+    cache = new CollectionCache(fileOperations, testBaseDir);
   });
 
   describe('constructor', () => {
     it('should initialize with default base directory', () => {
-      const defaultCache = new CollectionCache();
+      const defaultCache = new CollectionCache(fileOperations);
       expect(defaultCache).toBeInstanceOf(CollectionCache);
     });
 
     it('should initialize with custom base directory', () => {
-      const customCache = new CollectionCache('/custom/path');
+      const customCache = new CollectionCache(fileOperations, '/custom/path');
       expect(customCache).toBeInstanceOf(CollectionCache);
     });
   });
@@ -49,11 +75,11 @@ describe('CollectionCache', () => {
       // Access private method through type assertion
       const normalizeMethod = (cache as any).normalizeSearchTerm.bind(cache);
 
-      expect(normalizeMethod('test-persona')).toBe('test persona');
-      expect(normalizeMethod('Test_Persona')).toBe('test persona');
-      expect(normalizeMethod('TEST PERSONA')).toBe('test persona');
-      expect(normalizeMethod('test-persona.md')).toBe('test persona');
-      expect(normalizeMethod('  test-persona  ')).toBe('test persona');
+      expect(normalizeMethod('test-persona')).toBe(NORMALIZED_PERSONA);
+      expect(normalizeMethod('Test_Persona')).toBe(NORMALIZED_PERSONA);
+      expect(normalizeMethod('TEST PERSONA')).toBe(NORMALIZED_PERSONA);
+      expect(normalizeMethod('test-persona.md')).toBe(NORMALIZED_PERSONA);
+      expect(normalizeMethod('  test-persona  ')).toBe(NORMALIZED_PERSONA);
       expect(normalizeMethod('test---persona___name')).toBe('test persona name');
     });
 
@@ -64,6 +90,69 @@ describe('CollectionCache', () => {
       expect(normalizeMethod('   ')).toBe('');
       expect(normalizeMethod('a')).toBe('a');
       expect(normalizeMethod('a.md')).toBe('a');
+    });
+  });
+
+  describe('shared cache store backend (backend honesty)', () => {
+    let store: InMemorySharedCacheStore;
+    let sharedCache: CollectionCache;
+
+    beforeEach(() => {
+      store = new InMemorySharedCacheStore();
+      // fileOperations that FAIL loudly — proves the shared-store path never
+      // falls back to the filesystem when a store is injected.
+      const failMessage = 'filesystem must not be touched in shared-store mode';
+      const fail = () => Promise.reject(new Error(failMessage));
+      const failingFileOps = {
+        readFile: fail,
+        writeFile: fail,
+        deleteFile: fail,
+        createDirectory: fail,
+      } as unknown as IFileOperationsService;
+      sharedCache = new CollectionCache(failingFileOps, testBaseDir, store);
+    });
+
+    it('round-trips items through the store without touching the filesystem', async () => {
+      await sharedCache.saveCache(SAMPLE_ITEMS, 'etag-1');
+      const loaded = await sharedCache.loadCache();
+
+      if (!loaded) throw new Error('expected a cache entry');
+      expect(loaded.items).toHaveLength(2);
+      expect(loaded.items.map(i => i.name)).toEqual(['test-persona.md', 'skill-example.md']);
+      expect(loaded.etag).toBe('etag-1');
+    });
+
+    it('writes to the store under the dedicated browse-cache key', async () => {
+      await sharedCache.saveCache(SAMPLE_ITEMS);
+      const raw = await store.get(BROWSE_CACHE_KEY);
+      if (!raw) throw new Error('expected a stored entry');
+      expect((raw.payload as { items: CollectionItem[] }).items).toHaveLength(2);
+    });
+
+    it('returns null when the store has no entry', async () => {
+      expect(await sharedCache.loadCache()).toBeNull();
+    });
+
+    it('treats an expired store entry as a miss', async () => {
+      await store.set({
+        cacheKey: BROWSE_CACHE_KEY,
+        payload: { items: SAMPLE_ITEMS },
+        expiresAt: Date.now() - 1000, // already expired
+      });
+      expect(await sharedCache.loadCache()).toBeNull();
+    });
+
+    it('clearCache deletes the store entry', async () => {
+      await sharedCache.saveCache(SAMPLE_ITEMS);
+      await sharedCache.clearCache();
+      expect(await store.get(BROWSE_CACHE_KEY)).toBeNull();
+    });
+
+    it('searchCache filters store-backed items', async () => {
+      await sharedCache.saveCache(SAMPLE_ITEMS);
+      const results = await sharedCache.searchCache('persona');
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('test-persona.md');
     });
   });
 });

--- a/tests/unit/collection/CollectionBrowser.mcp-filtering.test.ts
+++ b/tests/unit/collection/CollectionBrowser.mcp-filtering.test.ts
@@ -4,9 +4,9 @@
  */
 
 import { CollectionBrowser } from '../../../src/collection/CollectionBrowser.js';
-import { GitHubClient } from '../../../src/collection/GitHubClient.js';
-import { CollectionCache, CollectionItem } from '../../../src/cache/CollectionCache.js';
-import { CollectionIndexManager } from '../../../src/collection/CollectionIndexManager.js';
+import type { GitHubClient } from '../../../src/collection/GitHubClient.js';
+import type { CollectionCache, CollectionItem } from '../../../src/cache/CollectionCache.js';
+import type { CollectionIndexManager } from '../../../src/collection/CollectionIndexManager.js';
 import { ElementType } from '../../../src/portfolio/types.js';
 import { DollhouseContainer } from '../../../src/di/Container.js';
 import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
@@ -15,6 +15,9 @@ import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals
 jest.mock('../../../src/collection/GitHubClient.js');
 jest.mock('../../../src/cache/CollectionCache.js');
 jest.mock('../../../src/collection/CollectionIndexManager.js');
+
+const INVALID_TYPE = 'invalid-type';
+const PERSONA1_MD = 'persona1.md';
 
 describe('CollectionBrowser MCP Filtering', () => {
   let collectionBrowser: InstanceType<typeof CollectionBrowser>;
@@ -31,12 +34,12 @@ describe('CollectionBrowser MCP Filtering', () => {
     { name: 'templates', type: 'dir', path: 'library/templates' },
     { name: 'memories', type: 'dir', path: 'library/memories' }, // Valid MCP type
     { name: 'ensembles', type: 'dir', path: 'library/ensembles' }, // Should be filtered out
-    { name: 'invalid-type', type: 'dir', path: 'library/invalid-type' }, // Should be filtered out
+    { name: INVALID_TYPE, type: 'dir', path: 'library/invalid-type' }, // Should be filtered out
     { name: 'readme.md', type: 'file', path: 'library/readme.md' } // Should be ignored (not a directory)
   ];
 
   const mockCacheItems: CollectionItem[] = [
-    { name: 'persona1.md', path: 'library/personas/persona1.md', sha: 'sha1' },
+    { name: PERSONA1_MD, path: 'library/personas/persona1.md', sha: 'sha1' },
     { name: 'persona2.md', path: 'library/personas/persona2.md', sha: 'sha2' },
     { name: 'skill1.md', path: 'library/skills/skill1.md', sha: 'sha3' },
     { name: 'agent1.md', path: 'library/agents/agent1.md', sha: 'sha4' },
@@ -100,7 +103,7 @@ describe('CollectionBrowser MCP Filtering', () => {
       
       // Should NOT contain unsupported types
       expect(categoryNames).not.toContain('ensembles');
-      expect(categoryNames).not.toContain('invalid-type');
+      expect(categoryNames).not.toContain(INVALID_TYPE);
     });
 
     it('should handle empty directory response', async () => {
@@ -115,7 +118,7 @@ describe('CollectionBrowser MCP Filtering', () => {
     it('should handle response with no valid content types', async () => {
       const invalidResponse = [
         { name: 'ensembles', type: 'dir', path: 'library/ensembles' },
-        { name: 'invalid-type', type: 'dir', path: 'library/invalid-type' },
+        { name: INVALID_TYPE, type: 'dir', path: 'library/invalid-type' },
         { name: 'tools', type: 'dir', path: 'library/tools' },
         { name: 'readme.md', type: 'file', path: 'library/readme.md' }
       ];
@@ -129,7 +132,7 @@ describe('CollectionBrowser MCP Filtering', () => {
 
     it('should not filter when browsing specific content types', async () => {
       const personaFiles = [
-        { name: 'persona1.md', type: 'file', path: 'library/personas/persona1.md' },
+        { name: PERSONA1_MD, type: 'file', path: 'library/personas/persona1.md' },
         { name: 'persona2.md', type: 'file', path: 'library/personas/persona2.md' }
       ];
       
@@ -185,7 +188,7 @@ describe('CollectionBrowser MCP Filtering', () => {
       
       // Should NOT contain unsupported types
       expect(categoryNames).not.toContain('ensembles');
-      expect(categoryNames).not.toContain('invalid-type');
+      expect(categoryNames).not.toContain(INVALID_TYPE);
     });
 
     it('should handle empty cache gracefully', async () => {
@@ -210,7 +213,7 @@ describe('CollectionBrowser MCP Filtering', () => {
 
       expect(result.items).toHaveLength(2); // Only persona items
       const itemNames = result.items.map((item: any) => item.name);
-      expect(itemNames).toContain('persona1.md');
+      expect(itemNames).toContain(PERSONA1_MD);
       expect(itemNames).toContain('persona2.md');
       
       // Should not contain items from other types
@@ -220,7 +223,7 @@ describe('CollectionBrowser MCP Filtering', () => {
   });
 
   describe('getContentTypesFromItems - type safety', () => {
-    it('should only return supported content types from cache items', async () => {
+    it('should only return supported content types from cache items', () => {
       // Access private method via any cast for testing
       const browser = collectionBrowser as any;
       
@@ -237,7 +240,7 @@ describe('CollectionBrowser MCP Filtering', () => {
 
       // Should NOT contain unsupported types
       expect(typeNames).not.toContain('ensembles');
-      expect(typeNames).not.toContain('invalid-type');
+      expect(typeNames).not.toContain(INVALID_TYPE);
       
       // All returned items should have correct structure
       contentTypes.forEach((type: any) => {
@@ -246,13 +249,13 @@ describe('CollectionBrowser MCP Filtering', () => {
       });
     });
 
-    it('should handle items with invalid paths gracefully', async () => {
+    it('should handle items with invalid paths gracefully', () => {
       const browser = collectionBrowser as any;
       
       const invalidItems: CollectionItem[] = [
         { name: 'invalid.md', path: 'invalid', sha: 'sha1' }, // No library prefix
         { name: 'invalid2.md', path: 'library', sha: 'sha2' }, // No type specified
-        { name: 'persona1.md', path: 'library/personas/persona1.md', sha: 'sha3' } // Valid
+        { name: PERSONA1_MD, path: 'library/personas/persona1.md', sha: 'sha3' } // Valid
       ];
       
       const contentTypes = browser.getContentTypesFromItems(invalidItems);
@@ -261,11 +264,11 @@ describe('CollectionBrowser MCP Filtering', () => {
       expect(contentTypes[0].name).toBe('personas');
     });
 
-    it('should deduplicate content types from multiple items', async () => {
+    it('should deduplicate content types from multiple items', () => {
       const browser = collectionBrowser as any;
       
       const duplicateItems: CollectionItem[] = [
-        { name: 'persona1.md', path: 'library/personas/persona1.md', sha: 'sha1' },
+        { name: PERSONA1_MD, path: 'library/personas/persona1.md', sha: 'sha1' },
         { name: 'persona2.md', path: 'library/personas/persona2.md', sha: 'sha2' },
         { name: 'persona3.md', path: 'library/personas/persona3.md', sha: 'sha3' },
         { name: 'skill1.md', path: 'library/skills/skill1.md', sha: 'sha4' }
@@ -382,6 +385,34 @@ describe('CollectionBrowser MCP Filtering', () => {
       const cacheTypes = new Set(cacheResult.categories.map((cat: any) => cat.name));
       
       expect(apiTypes).toEqual(cacheTypes);
+    });
+  });
+
+  describe('browseCollection - SSRF input guards', () => {
+    it('rejects an unknown section without any GitHub fetch', async () => {
+      const result = await collectionBrowser.browseCollection('../../../orgs/DollhouseMCP');
+
+      expect(result).toEqual({ items: [], categories: [] });
+      expect(mockGitHubClient.fetchFromGitHub).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown/path-traversal type without any GitHub fetch', async () => {
+      const result = await collectionBrowser.browseCollection('library', '../../../orgs/DollhouseMCP');
+
+      expect(result).toEqual({ items: [], categories: [] });
+      expect(mockGitHubClient.fetchFromGitHub).not.toHaveBeenCalled();
+    });
+
+    it('accepts the known sections (library/showcase/catalog)', async () => {
+      // getIndex rejects in this suite, so browse falls through to the GitHub
+      // fallback — proving the section passed validation and was allowed through.
+      mockGitHubClient.fetchFromGitHub.mockResolvedValue([]);
+
+      for (const section of ['library', 'showcase', 'catalog']) {
+        mockGitHubClient.fetchFromGitHub.mockClear();
+        await collectionBrowser.browseCollection(section);
+        expect(mockGitHubClient.fetchFromGitHub).toHaveBeenCalled();
+      }
     });
   });
 });

--- a/tests/unit/collection/ElementInstaller-fetchAndValidate.test.ts
+++ b/tests/unit/collection/ElementInstaller-fetchAndValidate.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { describe, it, expect, afterEach, beforeEach, jest } from '@jest/globals';
+import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { ElementInstaller } from '../../../src/collection/ElementInstaller.js';
@@ -8,6 +9,49 @@ import { ElementType } from '../../../src/portfolio/PortfolioManager.js';
 import { createTestFileOperationsService } from '../../helpers/di-mocks.js';
 
 const TEST_PORTFOLIO_DIR = path.join(os.tmpdir(), 'fetch-and-validate-portfolio');
+
+const MARKDOWN_SKILL = `---
+name: Code Review
+description: Reviews pull requests
+version: 1.2.0
+author: dollhousemcp
+tags:
+  - review
+  - code
+---
+
+# Code Review
+Body instructions here.
+`;
+
+const MEMORY_YAML = `metadata:
+  name: Welcome Guide
+  description: Onboarding notes
+  version: 1.0.0
+entries:
+  - id: e1
+    content: hello world
+    timestamp: 2026-01-01T00:00:00Z
+`;
+
+const ENSEMBLE_MARKDOWN = `---
+name: Review Team
+description: A code review ensemble
+version: 1.0.0
+---
+
+# Review Team
+Members and activation notes.
+`;
+
+// Stub a GitHub file response on a mocked client (shared across both suites).
+function stubGithubFile(mockGitHubClient: jest.Mocked<GitHubClient>, text: string): void {
+  mockGitHubClient.fetchFromGitHub.mockResolvedValue({
+    type: 'file',
+    size: Buffer.byteLength(text),
+    content: Buffer.from(text, 'utf-8').toString('base64'),
+  });
+}
 
 /**
  * Tests for the no-write ElementInstaller.fetchAndValidate seam used by the web
@@ -29,36 +73,8 @@ describe('ElementInstaller.fetchAndValidate', () => {
   });
 
   function githubFileResponse(text: string): void {
-    mockGitHubClient.fetchFromGitHub.mockResolvedValue({
-      type: 'file',
-      size: Buffer.byteLength(text),
-      content: Buffer.from(text, 'utf-8').toString('base64'),
-    });
+    stubGithubFile(mockGitHubClient, text);
   }
-
-  const MARKDOWN_SKILL = `---
-name: Code Review
-description: Reviews pull requests
-version: 1.2.0
-author: dollhousemcp
-tags:
-  - review
-  - code
----
-
-# Code Review
-Body instructions here.
-`;
-
-  const MEMORY_YAML = `metadata:
-  name: Welcome Guide
-  description: Onboarding notes
-  version: 1.0.0
-entries:
-  - id: e1
-    content: hello world
-    timestamp: 2026-01-01T00:00:00Z
-`;
 
   it('fetches and validates a markdown skill, returning the frontmatter-stripped body', async () => {
     githubFileResponse(MARKDOWN_SKILL);
@@ -156,5 +172,79 @@ entries:
     mockGitHubClient.fetchFromGitHub.mockResolvedValue({ type: 'dir' });
     await expect(installer.fetchAndValidate('library/skills/adir.md'))
       .rejects.toThrow(/does not point to a file/);
+  });
+});
+
+/**
+ * The MCP-tool install path (installContent -> installFromCollection) must
+ * support the SAME six element types as the web-console seam — a catalog
+ * element installable from the console but not from the MCP tools would make
+ * the "all six types" claim false on one of its two surfaces.
+ */
+describe('ElementInstaller.installContent (all six element types)', () => {
+  let installer: ElementInstaller;
+  let mockGitHubClient: jest.Mocked<GitHubClient>;
+  let portfolioDir: string;
+
+  beforeEach(async () => {
+    portfolioDir = await fs.mkdtemp(path.join(os.tmpdir(), 'install-content-'));
+    mockGitHubClient = { fetchFromGitHub: jest.fn() } as any;
+    const mockPortfolioManager = { getElementDir: jest.fn(() => portfolioDir) } as any;
+    installer = new ElementInstaller(mockGitHubClient, {
+      portfolioManager: mockPortfolioManager,
+      unifiedIndexManager: { search: jest.fn() } as unknown as UnifiedIndexManager,
+      fileOperations: createTestFileOperationsService(),
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(portfolioDir, { recursive: true, force: true });
+  });
+
+  it('installs a pure-YAML memory with its .yaml filename', async () => {
+    stubGithubFile(mockGitHubClient, MEMORY_YAML);
+    const result = await installer.installContent('library/memories/welcome-guide.yaml');
+
+    expect(result.success).toBe(true);
+    expect(result.elementType).toBe(ElementType.MEMORY);
+    expect(result.filename).toBe('welcome-guide.yaml');
+    const written = await fs.readFile(path.join(portfolioDir, 'welcome-guide.yaml'), 'utf-8');
+    expect(written).toContain('entries:');
+    expect(written).toContain('hello world');
+  });
+
+  it('installs an ensemble through the markdown pipeline', async () => {
+    stubGithubFile(mockGitHubClient, ENSEMBLE_MARKDOWN);
+    const result = await installer.installContent('library/ensembles/review-team.md');
+
+    expect(result.success).toBe(true);
+    expect(result.elementType).toBe(ElementType.ENSEMBLE);
+    expect(result.filename).toBe('review-team.md');
+  });
+
+  it('installs a markdown skill (regression: existing types still work)', async () => {
+    stubGithubFile(mockGitHubClient, MARKDOWN_SKILL);
+    const result = await installer.installContent('library/skills/code-review.md');
+
+    expect(result.success).toBe(true);
+    expect(result.elementType).toBe(ElementType.SKILL);
+  });
+
+  it('rejects a markdown extension for a memory type', async () => {
+    stubGithubFile(mockGitHubClient, MEMORY_YAML);
+    await expect(installer.installContent('library/memories/welcome-guide.md'))
+      .rejects.toThrow(/Expected \.yaml/);
+  });
+
+  it('rejects a yaml extension for a markdown type', async () => {
+    stubGithubFile(mockGitHubClient, MARKDOWN_SKILL);
+    await expect(installer.installContent('library/ensembles/review-team.yaml'))
+      .rejects.toThrow(/Expected \.md/);
+  });
+
+  it('still rejects an unknown element type segment', async () => {
+    await expect(installer.installContent('library/gadgets/thing.md'))
+      .rejects.toThrow(/Unknown element type/);
+    expect(mockGitHubClient.fetchFromGitHub).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/collection/ElementInstaller-fetchAndValidate.test.ts
+++ b/tests/unit/collection/ElementInstaller-fetchAndValidate.test.ts
@@ -132,6 +132,20 @@ entries:
       .rejects.toThrow(/missing required name or description/);
   });
 
+  it('rejects a memory document whose name is not a string', async () => {
+    // parseRawYaml yields `name: 2024` as a number; letting it escape typed as
+    // string would TypeError deep in the portfolio store instead of 422ing.
+    githubFileResponse(`metadata:\n  name: 2024\n  description: Year notes\nentries: []\n`);
+    await expect(installer.fetchAndValidate('library/memories/year.yaml'))
+      .rejects.toThrow(/missing required name or description/);
+  });
+
+  it('rejects a memory document whose description is not a string', async () => {
+    githubFileResponse(`metadata:\n  name: Guide\n  description: true\nentries: []\n`);
+    await expect(installer.fetchAndValidate('library/memories/guide.yaml'))
+      .rejects.toThrow(/missing required name or description/);
+  });
+
   it('propagates a not-found error from the GitHub client', async () => {
     mockGitHubClient.fetchFromGitHub.mockRejectedValue(new Error('File not found in collection. Try search.'));
     await expect(installer.fetchAndValidate('library/skills/missing.md'))

--- a/tests/unit/collection/ElementInstaller-fetchAndValidate.test.ts
+++ b/tests/unit/collection/ElementInstaller-fetchAndValidate.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { ElementInstaller } from '../../../src/collection/ElementInstaller.js';
+import type { GitHubClient } from '../../../src/collection/GitHubClient.js';
+import type { UnifiedIndexManager } from '../../../src/portfolio/UnifiedIndexManager.js';
+import { ElementType } from '../../../src/portfolio/PortfolioManager.js';
+import { createTestFileOperationsService } from '../../helpers/di-mocks.js';
+
+const TEST_PORTFOLIO_DIR = path.join(os.tmpdir(), 'fetch-and-validate-portfolio');
+
+/**
+ * Tests for the no-write ElementInstaller.fetchAndValidate seam used by the web
+ * console to fetch + validate a collection element before routing the write
+ * through its own backend-honest portfolio path.
+ */
+describe('ElementInstaller.fetchAndValidate', () => {
+  let installer: ElementInstaller;
+  let mockGitHubClient: jest.Mocked<GitHubClient>;
+
+  beforeEach(() => {
+    mockGitHubClient = { fetchFromGitHub: jest.fn() } as any;
+    const mockPortfolioManager = { getElementDir: jest.fn(() => TEST_PORTFOLIO_DIR) } as any;
+    installer = new ElementInstaller(mockGitHubClient, {
+      portfolioManager: mockPortfolioManager,
+      unifiedIndexManager: { search: jest.fn() } as unknown as UnifiedIndexManager,
+      fileOperations: createTestFileOperationsService(),
+    });
+  });
+
+  function githubFileResponse(text: string): void {
+    mockGitHubClient.fetchFromGitHub.mockResolvedValue({
+      type: 'file',
+      size: Buffer.byteLength(text),
+      content: Buffer.from(text, 'utf-8').toString('base64'),
+    });
+  }
+
+  const MARKDOWN_SKILL = `---
+name: Code Review
+description: Reviews pull requests
+version: 1.2.0
+author: dollhousemcp
+tags:
+  - review
+  - code
+---
+
+# Code Review
+Body instructions here.
+`;
+
+  const MEMORY_YAML = `metadata:
+  name: Welcome Guide
+  description: Onboarding notes
+  version: 1.0.0
+entries:
+  - id: e1
+    content: hello world
+    timestamp: 2026-01-01T00:00:00Z
+`;
+
+  it('fetches and validates a markdown skill, returning the frontmatter-stripped body', async () => {
+    githubFileResponse(MARKDOWN_SKILL);
+    const result = await installer.fetchAndValidate('library/skills/code-review.md');
+
+    expect(result.elementType).toBe(ElementType.SKILL);
+    expect(result.name).toBe('Code Review');
+    expect(result.metadata.description).toBe('Reviews pull requests');
+    expect(result.content).toContain('# Code Review');
+    expect(result.content).not.toContain('name: Code Review'); // frontmatter stripped
+  });
+
+  it('fetches and validates a pure-YAML memory, returning the whole document', async () => {
+    githubFileResponse(MEMORY_YAML);
+    const result = await installer.fetchAndValidate('library/memories/welcome-guide.yaml');
+
+    expect(result.elementType).toBe(ElementType.MEMORY);
+    expect(result.name).toBe('Welcome Guide');
+    expect(result.metadata.description).toBe('Onboarding notes');
+    // Memories are written as a whole YAML document (the store parses entries).
+    expect(result.content).toContain('entries:');
+    expect(result.content).toContain('hello world');
+  });
+
+  it('accepts memory .yml extension', async () => {
+    githubFileResponse(MEMORY_YAML);
+    await expect(installer.fetchAndValidate('library/memories/welcome-guide.yml')).resolves.toMatchObject({
+      elementType: ElementType.MEMORY,
+    });
+  });
+
+  it('rejects a markdown extension for a memory type', async () => {
+    githubFileResponse(MEMORY_YAML);
+    await expect(installer.fetchAndValidate('library/memories/welcome-guide.md'))
+      .rejects.toThrow(/Expected \.yaml/);
+  });
+
+  it('rejects a yaml extension for a markdown type', async () => {
+    githubFileResponse(MARKDOWN_SKILL);
+    await expect(installer.fetchAndValidate('library/skills/code-review.yaml'))
+      .rejects.toThrow(/Expected \.md/);
+  });
+
+  it('rejects an unknown element type segment', async () => {
+    await expect(installer.fetchAndValidate('library/gadgets/thing.md'))
+      .rejects.toThrow(/Unknown element type/);
+    expect(mockGitHubClient.fetchFromGitHub).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-library path', async () => {
+    await expect(installer.fetchAndValidate('showcase/skills/thing.md'))
+      .rejects.toThrow(/Invalid collection path format/);
+    expect(mockGitHubClient.fetchFromGitHub).not.toHaveBeenCalled();
+  });
+
+  it('rejects a path-traversal path before any fetch', async () => {
+    await expect(installer.fetchAndValidate('library/skills/../../../etc/passwd'))
+      .rejects.toThrow();
+    expect(mockGitHubClient.fetchFromGitHub).not.toHaveBeenCalled();
+  });
+
+  it('rejects content missing required name/description', async () => {
+    githubFileResponse(`---\nversion: 1.0.0\n---\n\nbody\n`);
+    await expect(installer.fetchAndValidate('library/skills/broken.md'))
+      .rejects.toThrow(/missing required name or description/);
+  });
+
+  it('rejects a memory document missing required fields', async () => {
+    githubFileResponse(`metadata:\n  version: 1.0.0\nentries: []\n`);
+    await expect(installer.fetchAndValidate('library/memories/broken.yaml'))
+      .rejects.toThrow(/missing required name or description/);
+  });
+
+  it('propagates a not-found error from the GitHub client', async () => {
+    mockGitHubClient.fetchFromGitHub.mockRejectedValue(new Error('File not found in collection. Try search.'));
+    await expect(installer.fetchAndValidate('library/skills/missing.md'))
+      .rejects.toThrow(/File not found in collection/);
+  });
+
+  it('rejects a response that is not a file', async () => {
+    mockGitHubClient.fetchFromGitHub.mockResolvedValue({ type: 'dir' });
+    await expect(installer.fetchAndValidate('library/skills/adir.md'))
+      .rejects.toThrow(/does not point to a file/);
+  });
+});

--- a/tests/unit/web-console/WebConsoleHttpBootstrap.test.ts
+++ b/tests/unit/web-console/WebConsoleHttpBootstrap.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -14,6 +14,7 @@ import {
   WEB_CONSOLE_REPLACEMENT_REQUIRED_ROUTE_MODULE_IDS,
   type WebConsoleReplacementLiveCheckId,
 } from '../../../src/web-console/WebConsoleReplacementReadiness.js';
+import { logger } from '../../../src/utils/logger.js';
 
 const KEY_1 = Buffer.alloc(32, 1).toString('base64');
 const KEY_2 = Buffer.alloc(32, 2).toString('base64');
@@ -27,6 +28,8 @@ function env(overrides: Partial<WebConsoleHttpBootstrapEnv> = {}): WebConsoleHtt
     DOLLHOUSE_HTTP_HOST: '0.0.0.0',
     DOLLHOUSE_AUTH_METHODS: ['local-password'],
     GITHUB_REPOSITORY: 'custom-portfolio',
+    GITHUB_TOKEN: undefined,
+    DOLLHOUSE_WEB_CONSOLE_COLLECTION_ENABLED: false,
     DOLLHOUSE_WEB_CONSOLE_PRODUCTION_DATABASE_NAME: 'dollhouse_prod',
     DOLLHOUSE_WEB_CONSOLE_PRODUCTION_DATABASE_USER: 'dollhouse_admin',
     DOLLHOUSE_WEB_CONSOLE_OPAQUE_HMAC_KEY: KEY_1,
@@ -102,6 +105,58 @@ describe('WebConsoleHttpBootstrap', () => {
     expect(() => resolveWebConsoleHttpBootstrapOptions(env({
       DOLLHOUSE_WEB_CONSOLE_SECRET_ENCRYPTION_KEY: undefined,
     }))).toThrow('DOLLHOUSE_WEB_CONSOLE_SECRET_ENCRYPTION_KEY must be set');
+  });
+
+  describe('collection browse GITHUB_TOKEN warning', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('warns when collection browse is enabled on a non-loopback bind without GITHUB_TOKEN', () => {
+      const warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      resolveWebConsoleHttpBootstrapOptions(env({
+        DOLLHOUSE_WEB_CONSOLE_COLLECTION_ENABLED: true,
+      }));
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      const message = warn.mock.calls[0][0];
+      expect(message).toContain('DOLLHOUSE_WEB_CONSOLE_COLLECTION_ENABLED=true');
+      expect(message).toContain('GITHUB_TOKEN');
+      expect(message).toContain('zero-scope');
+    });
+
+    it('stays silent when GITHUB_TOKEN is configured', () => {
+      const warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      resolveWebConsoleHttpBootstrapOptions(env({
+        DOLLHOUSE_WEB_CONSOLE_COLLECTION_ENABLED: true,
+        GITHUB_TOKEN: 'ghp_zero_scope_token',
+      }));
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('stays silent on a loopback bind', () => {
+      const warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      resolveWebConsoleHttpBootstrapOptions(env({
+        DOLLHOUSE_WEB_CONSOLE_COLLECTION_ENABLED: true,
+        DOLLHOUSE_HTTP_HOST: '127.0.0.1',
+      }));
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('stays silent when collection browse is disabled', () => {
+      const warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      resolveWebConsoleHttpBootstrapOptions(env({
+        DOLLHOUSE_WEB_CONSOLE_COLLECTION_ENABLED: false,
+      }));
+
+      expect(warn).not.toHaveBeenCalled();
+    });
   });
 
   it('requires selected-deployment replacement evidence to pass before activation', async () => {

--- a/tests/unit/web-console/WebConsoleRegistrar.test.ts
+++ b/tests/unit/web-console/WebConsoleRegistrar.test.ts
@@ -395,6 +395,7 @@ describe('WebConsoleRegistrar', () => {
 
     const collectionRoutes = composition.registry.createRouteManifest().routes
       .filter(route => route.moduleId === 'collection');
+    // Browse-only: portfolio write flag is off, so no install route.
     expect(collectionRoutes.map(route => route.path)).toEqual([
       '/api/v1/collection/elements',
       '/api/v1/collection/elements/:type/:name',
@@ -404,6 +405,29 @@ describe('WebConsoleRegistrar', () => {
       expect(route.privacyClass).toBe('public_catalog');
       expect(route.rateLimit).toBe('collection_fetch');
     }
+  });
+
+  it('adds the install route only when collection AND portfolio write flags are both enabled', async () => {
+    const container = new TestContainer();
+    container.seed('CollectionIndexManager', { getIndex: jest.fn() });
+    container.seed('CollectionSearch', { searchCollectionWithOptions: jest.fn() });
+    container.seed('PersonaDetails', { getCollectionContent: jest.fn() });
+    container.seed('ElementInstaller', { fetchAndValidate: jest.fn() });
+    const { WebConsoleRegistrar } = await import('../../../src/web-console/index.js');
+
+    const composition = await new WebConsoleRegistrar({
+      opaqueValueHmacKey: Buffer.alloc(32, 24),
+      enableCollectionRoutes: true,
+      enablePortfolioWriteRoutes: true,
+      registerCleanup: false,
+    }).bootstrapAndRegister(container);
+
+    const install = composition.registry.createRouteManifest().routes
+      .find(route => route.moduleId === 'collection' && route.method === 'POST');
+    expect(install?.path).toBe('/api/v1/me/portfolio/from-collection');
+    expect(install?.privacyClass).toBe('self_private');
+    expect(install?.idempotency).toBe('required');
+    expect(install?.rateLimit).toBe('collection_fetch');
   });
 
   it('fails fast when collection routes are enabled without the collection engine services', async () => {

--- a/tests/unit/web-console/WebConsoleRegistrar.test.ts
+++ b/tests/unit/web-console/WebConsoleRegistrar.test.ts
@@ -407,6 +407,51 @@ describe('WebConsoleRegistrar', () => {
     }
   });
 
+  it('warns when collection routes are enabled with a process-local rate-limit backend', async () => {
+    // Default DOLLHOUSE_RATE_LIMIT_BACKEND is "memory" (process-local), so the
+    // collection-fetch deployment budget is per-replica — the registrar must
+    // warn operators to switch to a shared backend.
+    const { logger } = await import('../../../src/utils/logger.js');
+    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      const container = new TestContainer();
+      container.seed('CollectionIndexManager', { getIndex: jest.fn() });
+      container.seed('CollectionSearch', { searchCollectionWithOptions: jest.fn() });
+      container.seed('PersonaDetails', { getCollectionContent: jest.fn() });
+      const { WebConsoleRegistrar } = await import('../../../src/web-console/index.js');
+
+      await new WebConsoleRegistrar({
+        opaqueValueHmacKey: Buffer.alloc(32, 23),
+        enableCollectionRoutes: true,
+        registerCleanup: false,
+      }).bootstrapAndRegister(container);
+
+      const warned = warn.mock.calls.some(call =>
+        typeof call[0] === 'string' && call[0].includes('DOLLHOUSE_RATE_LIMIT_BACKEND'));
+      expect(warned).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not emit the rate-limit-backend warning when collection routes are disabled', async () => {
+    const { logger } = await import('../../../src/utils/logger.js');
+    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      const { WebConsoleRegistrar } = await import('../../../src/web-console/index.js');
+      await new WebConsoleRegistrar({
+        opaqueValueHmacKey: Buffer.alloc(32, 25),
+        registerCleanup: false,
+      }).bootstrapAndRegister(new TestContainer());
+
+      const warned = warn.mock.calls.some(call =>
+        typeof call[0] === 'string' && call[0].includes('DOLLHOUSE_RATE_LIMIT_BACKEND'));
+      expect(warned).toBe(false);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it('adds the install route only when collection AND portfolio write flags are both enabled', async () => {
     const container = new TestContainer();
     container.seed('CollectionIndexManager', { getIndex: jest.fn() });

--- a/tests/unit/web-console/WebConsoleRegistrar.test.ts
+++ b/tests/unit/web-console/WebConsoleRegistrar.test.ts
@@ -366,6 +366,57 @@ describe('WebConsoleRegistrar', () => {
     expect(composition.portfolioStore).toBe(portfolioStore);
   });
 
+  it('omits the collection catalog module unless collection routes are enabled', async () => {
+    const container = new TestContainer();
+    const { WebConsoleRegistrar } = await import('../../../src/web-console/index.js');
+
+    const composition = await new WebConsoleRegistrar({
+      opaqueValueHmacKey: Buffer.alloc(32, 21),
+      registerCleanup: false,
+    }).bootstrapAndRegister(container);
+
+    expect(
+      composition.registry.createRouteManifest().routes.some(route => route.moduleId === 'collection'),
+    ).toBe(false);
+  });
+
+  it('registers the collection catalog module from the collection engine services when enabled', async () => {
+    const container = new TestContainer();
+    container.seed('CollectionIndexManager', { getIndex: jest.fn() });
+    container.seed('CollectionSearch', { searchCollectionWithOptions: jest.fn() });
+    container.seed('PersonaDetails', { getCollectionContent: jest.fn() });
+    const { WebConsoleRegistrar } = await import('../../../src/web-console/index.js');
+
+    const composition = await new WebConsoleRegistrar({
+      opaqueValueHmacKey: Buffer.alloc(32, 22),
+      enableCollectionRoutes: true,
+      registerCleanup: false,
+    }).bootstrapAndRegister(container);
+
+    const collectionRoutes = composition.registry.createRouteManifest().routes
+      .filter(route => route.moduleId === 'collection');
+    expect(collectionRoutes.map(route => route.path)).toEqual([
+      '/api/v1/collection/elements',
+      '/api/v1/collection/elements/:type/:name',
+    ]);
+    for (const route of collectionRoutes) {
+      expect(route.requiredCapability).toBe(CONSOLE_SELF_CAPABILITY);
+      expect(route.privacyClass).toBe('public_catalog');
+      expect(route.rateLimit).toBe('collection_fetch');
+    }
+  });
+
+  it('fails fast when collection routes are enabled without the collection engine services', async () => {
+    const container = new TestContainer();
+    const { WebConsoleRegistrar } = await import('../../../src/web-console/index.js');
+
+    await expect(new WebConsoleRegistrar({
+      opaqueValueHmacKey: Buffer.alloc(32, 23),
+      enableCollectionRoutes: true,
+      registerCleanup: false,
+    }).bootstrapAndRegister(container)).rejects.toThrow(/CollectionIndexManager/);
+  });
+
   it('registers protected correlation rate limiting only with explicit shared dependencies', async () => {
     const container = new TestContainer();
     const { InMemoryRateLimitStore } = await import('../../../src/auth/embedded-as/storage/InMemoryRateLimitStore.js');
@@ -1129,6 +1180,7 @@ describe('WebConsoleRegistrar', () => {
       createAccountAdminModule,
       createActivationModule,
       createAuditModule,
+      createCollectionModule,
       createExecutionModule,
       createIntegrationModule,
       createOperationsModule,
@@ -1220,6 +1272,11 @@ describe('WebConsoleRegistrar', () => {
       integrationStore: productionAdapter(),
       syncJobStore: new InMemoryPortfolioSyncJobStore(),
     }));
+    registry.register(createCollectionModule({
+      index: productionAdapter(),
+      search: productionAdapter(),
+      details: productionAdapter(),
+    }));
     registry.register(createSessionTelemetryModule({
       runtimeStore,
       ownedActivityQuery: new InMemoryOwnedActivityQuery(),
@@ -1246,6 +1303,7 @@ describe('WebConsoleRegistrar', () => {
         oauthGrantRevocationService: productionAdapter(),
         protectedCorrelationRateLimiter: productionAdapter(),
         protectedCorrelationRateLimitStore: productionAdapter(),
+        collectionFetchRateLimiter: productionAdapter(),
         adminAuditQuery: productionAdapter(),
         approvalAuditQuery: productionAdapter(),
         authenticationAuditQuery: productionAdapter(),

--- a/tests/unit/web-console/WebConsoleReplacementReadiness.test.ts
+++ b/tests/unit/web-console/WebConsoleReplacementReadiness.test.ts
@@ -9,11 +9,13 @@ import {
   type WebConsoleReplacementLiveCheck,
 } from '../../../src/web-console/index.js';
 
+const PRE_REPLACEMENT = 'pre-replacement';
+
 describe('WebConsoleReplacementReadiness', () => {
   it('passes only when local composition and every selected-deployment check are ready', () => {
     const result = verifyWebConsoleReplacementReadiness({
       composition: composition(),
-      phase: 'pre-replacement',
+      phase: PRE_REPLACEMENT,
       liveChecks: readyLiveChecks(),
     });
 
@@ -32,7 +34,7 @@ describe('WebConsoleReplacementReadiness', () => {
   it('fails closed for missing or failed selected-deployment checks', () => {
     const result = verifyWebConsoleReplacementReadiness({
       composition: composition(),
-      phase: 'pre-replacement',
+      phase: PRE_REPLACEMENT,
       liveChecks: readyLiveChecks({
         omit: 'portfolio_sync_live_repository',
         fail: 'security_invalidation_multi_replica',
@@ -55,7 +57,7 @@ describe('WebConsoleReplacementReadiness', () => {
   it('distinguishes pre-replacement and active replacement route state', () => {
     const preReplacement = verifyWebConsoleReplacementReadiness({
       composition: composition({ routesMounted: true }),
-      phase: 'pre-replacement',
+      phase: PRE_REPLACEMENT,
       liveChecks: readyLiveChecks(),
     });
     const activeReplacement = verifyWebConsoleReplacementReadiness({
@@ -74,7 +76,7 @@ describe('WebConsoleReplacementReadiness', () => {
   it('requires the complete v1 route surface registered for M7 replacement', () => {
     const result = verifyWebConsoleReplacementReadiness({
       composition: composition({ registeredModules: WEB_CONSOLE_REPLACEMENT_REQUIRED_ROUTE_MODULE_IDS.slice(1) }),
-      phase: 'pre-replacement',
+      phase: PRE_REPLACEMENT,
       liveChecks: readyLiveChecks(),
     });
 
@@ -82,6 +84,21 @@ describe('WebConsoleReplacementReadiness', () => {
     expect(result.failures).toEqual(expect.arrayContaining([
       expect.objectContaining({ id: 'complete_v1_route_surface_registered' }),
     ]));
+  });
+
+  it('does not require optional default-off modules (collection) for replacement', () => {
+    // Regression: collection is a default-off feature module. A console that
+    // leaves it off must still be a valid, ready replacement — so it must never
+    // appear in the required-for-replacement set (or the app fails to start in a
+    // production deployment that hasn't opted into it).
+    expect(WEB_CONSOLE_REPLACEMENT_REQUIRED_ROUTE_MODULE_IDS).not.toContain('collection');
+
+    const result = verifyWebConsoleReplacementReadiness({
+      composition: composition(), // default registered modules: baseline, no collection
+      phase: PRE_REPLACEMENT,
+      liveChecks: readyLiveChecks(),
+    });
+    expect(result.ready).toBe(true);
   });
 });
 

--- a/tests/unit/web-console/middleware/ConsoleRateLimit.test.ts
+++ b/tests/unit/web-console/middleware/ConsoleRateLimit.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import type { Response } from 'express';
+
+import { createConsoleRateLimitMiddleware } from '../../../../src/web-console/middleware/ConsoleRateLimit.js';
+import {
+  ConsoleCollectionFetchRateLimitDependencyError,
+  type ConsoleCollectionFetchRateLimiter,
+  type ConsoleCollectionFetchRateLimitResult,
+} from '../../../../src/web-console/services/rate-limit/ConsoleCollectionFetchRateLimiter.js';
+import type { ConsoleRequest, ConsoleRouteDefinition } from '../../../../src/web-console/platform/ConsolePlatformTypes.js';
+
+const RESET_AT = new Date('2026-07-03T12:01:00.000Z');
+const TEST_IP = '198.51.100.7';
+
+function collectionRoute(rateLimit?: ConsoleRouteDefinition['rateLimit']): ConsoleRouteDefinition {
+  return {
+    method: 'GET',
+    path: '/api/v1/collection/elements',
+    audience: 'self',
+    requiredCapability: 'console:self',
+    ownership: 'authenticated_user',
+    elevation: 'none',
+    privacyClass: 'public_catalog',
+    idempotency: 'not_applicable',
+    rateLimit,
+    handler: () => ({ status: 200 }),
+  };
+}
+
+function consoleRequest(): ConsoleRequest {
+  return {
+    ip: TEST_IP,
+    params: {},
+    query: {},
+    headers: {},
+    consoleContext: {
+      correlationId: '3e0a4c1e-6f5b-4a52-9d5f-59a1c1de0b11',
+      receivedAt: new Date('2026-07-03T12:00:00.000Z'),
+    },
+    consoleAuthentication: {
+      sessionIdHash: Buffer.alloc(32, 7),
+      userId: '018f3d47-73ae-7f10-a0de-0742618d4fb1',
+      authSub: 'github_user-7',
+      authzVersion: 1,
+      grantedCapabilities: ['console:self'],
+      elevation: null,
+    },
+  } as unknown as ConsoleRequest;
+}
+
+interface FakeResponse extends Response {
+  readonly statusCode: number;
+  readonly headers: Record<string, string>;
+  readonly jsonBody: unknown;
+}
+
+function fakeResponse(): FakeResponse {
+  const state = {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    jsonBody: undefined as unknown,
+    headersSent: false,
+  };
+  const res = {
+    get statusCode() { return state.statusCode; },
+    get headers() { return state.headers; },
+    get jsonBody() { return state.jsonBody; },
+    get headersSent() { return state.headersSent; },
+    setHeader(name: string, value: string) {
+      state.headers[name] = value;
+      return res;
+    },
+    status(code: number) {
+      state.statusCode = code;
+      return res;
+    },
+    type() { return res; },
+    json(body: unknown) {
+      state.jsonBody = body;
+      state.headersSent = true;
+      return res;
+    },
+  };
+  return res as unknown as FakeResponse;
+}
+
+function limiterReturning(result: ConsoleCollectionFetchRateLimitResult): ConsoleCollectionFetchRateLimiter {
+  return { consume: () => Promise.resolve(result) } as unknown as ConsoleCollectionFetchRateLimiter;
+}
+
+async function run(
+  middleware: ReturnType<typeof createConsoleRateLimitMiddleware>,
+  req: ConsoleRequest,
+  res: FakeResponse,
+): Promise<{ nextError: unknown; nextCalled: boolean }> {
+  return await new Promise(resolve => {
+    let settled = false;
+    const finish = (value: { nextError: unknown; nextCalled: boolean }) => {
+      if (!settled) {
+        settled = true;
+        resolve(value);
+      }
+    };
+    const originalJson = res.json.bind(res);
+    (res as { json: (body: unknown) => unknown }).json = (body: unknown) => {
+      const out = originalJson(body);
+      queueMicrotask(() => finish({ nextError: undefined, nextCalled: false }));
+      return out;
+    };
+    middleware(req, res, (error?: unknown) => finish({ nextError: error, nextCalled: true }));
+  });
+}
+
+describe('createConsoleRateLimitMiddleware (collection_fetch)', () => {
+  it('passes allowed requests through to next()', async () => {
+    const middleware = createConsoleRateLimitMiddleware(collectionRoute('collection_fetch'), {
+      collectionFetchRateLimiter: limiterReturning({
+        allowed: true,
+        windowResetsAt: RESET_AT,
+        retryAfterSeconds: null,
+        exceededScopes: [],
+      }),
+    });
+    const outcome = await run(middleware, consoleRequest(), fakeResponse());
+    expect(outcome.nextCalled).toBe(true);
+    expect(outcome.nextError).toBeUndefined();
+  });
+
+  it('sends 429 with Retry-After when the budget is exceeded', async () => {
+    const middleware = createConsoleRateLimitMiddleware(collectionRoute('collection_fetch'), {
+      collectionFetchRateLimiter: limiterReturning({
+        allowed: false,
+        windowResetsAt: RESET_AT,
+        retryAfterSeconds: 42,
+        exceededScopes: ['session'],
+      }),
+    });
+    const res = fakeResponse();
+    const outcome = await run(middleware, consoleRequest(), res);
+    expect(outcome.nextCalled).toBe(false);
+    expect(res.statusCode).toBe(429);
+    expect(res.headers['Retry-After']).toBe('42');
+    expect(res.jsonBody).toMatchObject({
+      code: 'rate_limited',
+      exceeded_scopes: ['session'],
+    });
+  });
+
+  it('sends 503 when the rate-limit store is unavailable', async () => {
+    const failingLimiter = {
+      consume: () => Promise.reject(new ConsoleCollectionFetchRateLimitDependencyError('store offline')),
+    } as unknown as ConsoleCollectionFetchRateLimiter;
+    const middleware = createConsoleRateLimitMiddleware(collectionRoute('collection_fetch'), {
+      collectionFetchRateLimiter: failingLimiter,
+    });
+    const res = fakeResponse();
+    const outcome = await run(middleware, consoleRequest(), res);
+    expect(outcome.nextCalled).toBe(false);
+    expect(res.statusCode).toBe(503);
+    expect(res.jsonBody).toMatchObject({ code: 'service_unavailable' });
+  });
+
+  it('fails at construction when the limiter is missing', () => {
+    expect(() => createConsoleRateLimitMiddleware(collectionRoute('collection_fetch'), {}))
+      .toThrow(/collection fetch rate limiter/);
+  });
+
+  it('is a no-op for routes without a rate-limit policy', () => {
+    const middleware = createConsoleRateLimitMiddleware(collectionRoute(), {});
+    const next = jest.fn();
+    middleware(consoleRequest(), fakeResponse(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/web-console/modules/CollectionInstallService.test.ts
+++ b/tests/unit/web-console/modules/CollectionInstallService.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import {
+  CollectionInstallService,
+  type CollectionInstallPort,
+  type CollectionValidatedElement,
+  InMemoryPortfolioElementStore,
+  PortfolioElementAlreadyExistsError,
+  type ConsoleHandlerResult,
+  type ConsoleRequest,
+  type IPortfolioElementStore,
+} from '../../../../src/web-console/index.js';
+
+const USER_ID = '018f3d47-73ae-7f10-a0de-0742618d4fb1';
+const NOW = new Date('2026-07-03T12:00:00.000Z');
+const CODE_REVIEW_NAME = 'Code Review';
+
+function consoleRequest(body: unknown): ConsoleRequest {
+  return {
+    params: {},
+    query: {},
+    body,
+    headers: {},
+    consoleAuthentication: {
+      sessionIdHash: Buffer.alloc(32, 7),
+      userId: USER_ID,
+      authSub: 'github_user-7',
+      authzVersion: 1,
+      grantedCapabilities: ['console:self'],
+      elevation: null,
+    },
+  } as unknown as ConsoleRequest;
+}
+
+function validatedSkill(overrides: Partial<CollectionValidatedElement> = {}): CollectionValidatedElement {
+  return {
+    elementType: 'skills',
+    name: CODE_REVIEW_NAME,
+    metadata: { name: CODE_REVIEW_NAME, description: 'Reviews PRs', tags: ['review'] },
+    content: '# Code Review\nBody.',
+    ...overrides,
+  };
+}
+
+function installerReturning(element: CollectionValidatedElement): CollectionInstallPort {
+  return { fetchAndValidate: jest.fn<CollectionInstallPort['fetchAndValidate']>().mockResolvedValue(element) };
+}
+
+function installerThrowing(error: unknown): CollectionInstallPort {
+  return { fetchAndValidate: jest.fn<CollectionInstallPort['fetchAndValidate']>().mockRejectedValue(error) };
+}
+
+function serviceWith(installer: CollectionInstallPort, store: IPortfolioElementStore = new InMemoryPortfolioElementStore()): CollectionInstallService {
+  return new CollectionInstallService({ installer, portfolioStore: store, now: () => NOW });
+}
+
+async function run(service: CollectionInstallService, body: unknown): Promise<ConsoleHandlerResult> {
+  return await service.install(consoleRequest(body));
+}
+
+describe('CollectionInstallService', () => {
+  it('installs a validated element into the portfolio and returns 201', async () => {
+    const store = new InMemoryPortfolioElementStore();
+    const service = serviceWith(installerReturning(validatedSkill()), store);
+    const result = await run(service, { path: 'library/skills/code-review.md' });
+
+    expect(result.status).toBe(201);
+    expect(result.headers?.ETag).toBeDefined();
+    // The element is now in the user's portfolio (end-to-end through the store).
+    const listed = await store.listByUser(USER_ID, { type: 'skills' });
+    expect(listed).toHaveLength(1);
+  });
+
+  it('passes the validated element straight to the store create input', async () => {
+    const store = { create: jest.fn<IPortfolioElementStore['create']>().mockResolvedValue({
+      userId: USER_ID, type: 'skills', name: CODE_REVIEW_NAME, canonicalName: 'code-review',
+      displayName: CODE_REVIEW_NAME, version: 1, updatedAt: NOW, validationStatus: 'valid',
+      tags: ['review'], metadata: {}, content: 'x',
+    }) } as unknown as IPortfolioElementStore;
+    const service = serviceWith(installerReturning(validatedSkill()), store);
+    await run(service, { path: 'library/skills/code-review.md' });
+
+    expect(store.create).toHaveBeenCalledWith(expect.objectContaining({
+      userId: USER_ID,
+      type: 'skills',
+      name: CODE_REVIEW_NAME,
+      content: '# Code Review\nBody.',
+      tags: ['review'],
+      now: NOW,
+    }));
+  });
+
+  it('installs a memory element (type routed through, whole document as content)', async () => {
+    const store = { create: jest.fn<IPortfolioElementStore['create']>().mockResolvedValue({
+      userId: USER_ID, type: 'memories', name: 'Guide', canonicalName: 'guide',
+      displayName: 'Guide', version: 1, updatedAt: NOW, validationStatus: 'valid',
+      tags: [], metadata: {}, content: 'x',
+    }) } as unknown as IPortfolioElementStore;
+    const service = serviceWith(installerReturning(validatedSkill({
+      elementType: 'memories', name: 'Guide', metadata: { name: 'Guide', description: 'd' },
+      content: 'metadata:\n  name: Guide\nentries: []\n',
+    })), store);
+    const result = await run(service, { path: 'library/memories/guide.yaml' });
+
+    expect(result.status).toBe(201);
+    expect(store.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'memories' }));
+  });
+
+  it('rejects a missing/empty path with 400', async () => {
+    const service = serviceWith(installerReturning(validatedSkill()));
+    expect((await run(service, {})).status).toBe(400);
+    expect((await run(service, { path: '' })).status).toBe(400);
+    expect((await run(service, { path: 42 })).status).toBe(400);
+    expect((await run(service, null)).status).toBe(400);
+  });
+
+  it('rejects a non-library path with 400 before fetching', async () => {
+    const installer = installerReturning(validatedSkill());
+    const service = serviceWith(installer);
+    const result = await run(service, { path: 'showcase/skills/x.md' });
+    expect(result.status).toBe(400);
+    expect(installer.fetchAndValidate).not.toHaveBeenCalled();
+  });
+
+  it('maps a not-found fetch error to 404', async () => {
+    const service = serviceWith(installerThrowing(new Error('File not found in collection. Try search.')));
+    const result = await run(service, { path: 'library/skills/missing.md' });
+    expect(result.status).toBe(404);
+    expect((result.body as { code: string }).code).toBe('collection_element_not_found');
+  });
+
+  it('maps an invalid-path fetch error to 400', async () => {
+    const service = serviceWith(installerThrowing(new Error('Unknown element type: gadgets.')));
+    expect((await run(service, { path: 'library/gadgets/x.md' })).status).toBe(400);
+  });
+
+  it('maps a security/validation fetch error to 422', async () => {
+    const service = serviceWith(installerThrowing(new Error('Security threat in content: bad')));
+    const result = await run(service, { path: 'library/skills/evil.md' });
+    expect(result.status).toBe(422);
+    expect((result.body as { code: string }).code).toBe('collection_element_invalid');
+  });
+
+  it('maps an unexpected fetch error to 503', async () => {
+    const service = serviceWith(installerThrowing(new Error('GitHub API error: 500')));
+    const result = await run(service, { path: 'library/skills/x.md' });
+    expect(result.status).toBe(503);
+    expect((result.body as { code: string }).code).toBe('collection_unavailable');
+  });
+
+  it('rejects an element whose type is not a supported portfolio type with 422', async () => {
+    const service = serviceWith(installerReturning(validatedSkill({ elementType: 'tools' })));
+    const result = await run(service, { path: 'library/skills/x.md' });
+    expect(result.status).toBe(422);
+    expect((result.body as { code: string }).code).toBe('collection_element_unsupported');
+  });
+
+  it('maps a duplicate element to 409', async () => {
+    const store = {
+      create: jest.fn<IPortfolioElementStore['create']>().mockRejectedValue(new PortfolioElementAlreadyExistsError()),
+    } as unknown as IPortfolioElementStore;
+    const service = serviceWith(installerReturning(validatedSkill()), store);
+    const result = await run(service, { path: 'library/skills/code-review.md' });
+    expect(result.status).toBe(409);
+    expect((result.body as { code: string }).code).toBe('portfolio_element_exists');
+  });
+});

--- a/tests/unit/web-console/modules/CollectionInstallService.test.ts
+++ b/tests/unit/web-console/modules/CollectionInstallService.test.ts
@@ -134,6 +134,20 @@ describe('CollectionInstallService', () => {
     expect((await run(service, { path: 'library/gadgets/x.md' })).status).toBe(400);
   });
 
+  it('maps a too-deep path fetch error to 400, not a retryable 503', async () => {
+    const service = serviceWith(installerThrowing(new Error('Path too deep (max 10 levels)')));
+    const result = await run(service, { path: 'library/skills/a/b/c/d/e/f/g/h/i/x.md' });
+    expect(result.status).toBe(400);
+    expect((result.body as { code: string }).code).toBe('invalid_request');
+  });
+
+  it('maps missing inline content (oversized upstream file) to 422, not 503', async () => {
+    const service = serviceWith(installerThrowing(new Error('Content must be a non-empty string')));
+    const result = await run(service, { path: 'library/skills/huge.md' });
+    expect(result.status).toBe(422);
+    expect((result.body as { code: string }).code).toBe('collection_element_invalid');
+  });
+
   it('maps a security/validation fetch error to 422', async () => {
     const service = serviceWith(installerThrowing(new Error('Security threat in content: bad')));
     const result = await run(service, { path: 'library/skills/evil.md' });
@@ -153,6 +167,33 @@ describe('CollectionInstallService', () => {
     const result = await run(service, { path: 'library/skills/x.md' });
     expect(result.status).toBe(422);
     expect((result.body as { code: string }).code).toBe('collection_element_unsupported');
+  });
+
+  it('rejects an element violating the portfolio record contract with 422 before any store write', async () => {
+    const store = { create: jest.fn<IPortfolioElementStore['create']>() } as unknown as IPortfolioElementStore;
+    const tooManyTags = Array.from({ length: 51 }, (_, i) => `tag-${i}`);
+    const service = serviceWith(installerReturning(validatedSkill({
+      metadata: { name: CODE_REVIEW_NAME, description: 'Reviews PRs', tags: tooManyTags },
+    })), store);
+    const result = await run(service, { path: 'library/skills/code-review.md' });
+
+    expect(result.status).toBe(422);
+    expect((result.body as { code: string }).code).toBe('collection_element_invalid');
+    expect((result.body as { issues: unknown[] }).issues.length).toBeGreaterThan(0);
+    expect(store.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects an over-long element name with 422 before any store write', async () => {
+    const store = { create: jest.fn<IPortfolioElementStore['create']>() } as unknown as IPortfolioElementStore;
+    const longName = 'n'.repeat(201);
+    const service = serviceWith(installerReturning(validatedSkill({
+      name: longName,
+      metadata: { name: longName, description: 'd' },
+    })), store);
+    const result = await run(service, { path: 'library/skills/long.md' });
+
+    expect(result.status).toBe(422);
+    expect(store.create).not.toHaveBeenCalled();
   });
 
   it('maps a duplicate element to 409', async () => {

--- a/tests/unit/web-console/modules/CollectionInstallService.test.ts
+++ b/tests/unit/web-console/modules/CollectionInstallService.test.ts
@@ -10,6 +10,13 @@ import {
   type ConsoleRequest,
   type IPortfolioElementStore,
 } from '../../../../src/web-console/index.js';
+import {
+  CollectionContentInvalidError,
+  CollectionElementNotFoundError,
+  CollectionPathInvalidError,
+} from '../../../../src/collection/CollectionErrors.js';
+import { ApplicationError, ErrorCategory } from '../../../../src/utils/ErrorHandler.js';
+import { ValidationErrorCodes } from '../../../../src/utils/errorCodes.js';
 
 const USER_ID = '018f3d47-73ae-7f10-a0de-0742618d4fb1';
 const NOW = new Date('2026-07-03T12:00:00.000Z');
@@ -122,44 +129,39 @@ describe('CollectionInstallService', () => {
     expect(installer.fetchAndValidate).not.toHaveBeenCalled();
   });
 
-  it('maps a not-found fetch error to 404', async () => {
-    const service = serviceWith(installerThrowing(new Error('File not found in collection. Try search.')));
-    const result = await run(service, { path: 'library/skills/missing.md' });
-    expect(result.status).toBe(404);
-    expect((result.body as { code: string }).code).toBe('collection_element_not_found');
-  });
-
-  it('maps an invalid-path fetch error to 400', async () => {
-    const service = serviceWith(installerThrowing(new Error('Unknown element type: gadgets.')));
-    expect((await run(service, { path: 'library/gadgets/x.md' })).status).toBe(400);
-  });
-
-  it('maps a too-deep path fetch error to 400, not a retryable 503', async () => {
-    const service = serviceWith(installerThrowing(new Error('Path too deep (max 10 levels)')));
-    const result = await run(service, { path: 'library/skills/a/b/c/d/e/f/g/h/i/x.md' });
-    expect(result.status).toBe(400);
-    expect((result.body as { code: string }).code).toBe('invalid_request');
-  });
-
-  it('maps missing inline content (oversized upstream file) to 422, not 503', async () => {
-    const service = serviceWith(installerThrowing(new Error('Content must be a non-empty string')));
-    const result = await run(service, { path: 'library/skills/huge.md' });
-    expect(result.status).toBe(422);
-    expect((result.body as { code: string }).code).toBe('collection_element_invalid');
-  });
-
-  it('maps a security/validation fetch error to 422', async () => {
-    const service = serviceWith(installerThrowing(new Error('Security threat in content: bad')));
-    const result = await run(service, { path: 'library/skills/evil.md' });
-    expect(result.status).toBe(422);
-    expect((result.body as { code: string }).code).toBe('collection_element_invalid');
-  });
-
-  it('maps an unexpected fetch error to 503', async () => {
-    const service = serviceWith(installerThrowing(new Error('GitHub API error: 500')));
+  // Exhaustive fetch-error classification: typed errors from the installer /
+  // GitHub client, ApplicationErrors from the shared input validators, and the
+  // message-based fallbacks for errors that crossed a wrapping boundary.
+  it.each([
+    ['typed not-found', new CollectionElementNotFoundError('File not found in collection. Try search.'), 404, 'collection_element_not_found'],
+    ['typed not-a-file', new CollectionElementNotFoundError('Path does not point to a file'), 404, 'collection_element_not_found'],
+    ['typed invalid path', new CollectionPathInvalidError('Unknown element type: gadgets. Valid types: personas'), 400, 'invalid_request'],
+    ['typed wrong extension', new CollectionPathInvalidError('Invalid file type for memories. Expected .yaml/.yml.'), 400, 'invalid_request'],
+    ['typed invalid content', new CollectionContentInvalidError('Security threat in content: bad'), 422, 'collection_element_invalid'],
+    ['typed missing fields', new CollectionContentInvalidError('Invalid content: missing required name or description'), 422, 'collection_element_invalid'],
+    ['typed oversized file', new CollectionContentInvalidError('File too large (3000000 bytes, max 2097152 bytes)'), 422, 'collection_element_invalid'],
+    ['validator path too deep', new ApplicationError('Path too deep (max 10 levels)', ErrorCategory.VALIDATION_ERROR, ValidationErrorCodes.INVALID_PATH), 400, 'invalid_request'],
+    ['validator traversal', new ApplicationError('Path traversal attempt detected', ErrorCategory.VALIDATION_ERROR, ValidationErrorCodes.INVALID_PATH), 400, 'invalid_request'],
+    ['validator missing inline content', new ApplicationError('Content must be a non-empty string', ErrorCategory.VALIDATION_ERROR, ValidationErrorCodes.REQUIRED_FIELD), 422, 'collection_element_invalid'],
+    // The GitHub client wraps everything in an McpError whose message may be
+    // redacted — the typed original survives as `cause` and must classify even
+    // when the wrapper message matches no fallback string.
+    ['wrapped typed not-found via cause chain', (() => {
+      const wrapper = new Error('Failed to fetch from GitHub: [REDACTED]');
+      wrapper.cause = new CollectionElementNotFoundError('File not found in collection.');
+      return wrapper;
+    })(), 404, 'collection_element_not_found'],
+    ['fallback not-found message', new Error('File not found in collection. Try search.'), 404, 'collection_element_not_found'],
+    ['fallback invalid-path message', new Error('Unknown element type: gadgets.'), 400, 'invalid_request'],
+    ['fallback path-too-deep message', new Error('Path too deep (max 10 levels)'), 400, 'invalid_request'],
+    ['fallback security message', new Error('Security threat in content: bad'), 422, 'collection_element_invalid'],
+    ['fallback missing-content message', new Error('Content must be a non-empty string'), 422, 'collection_element_invalid'],
+    ['unclassified upstream failure', new Error('GitHub API error: 500'), 503, 'collection_unavailable'],
+  ])('maps %s to the right status', async (_case, error, status, code) => {
+    const service = serviceWith(installerThrowing(error));
     const result = await run(service, { path: 'library/skills/x.md' });
-    expect(result.status).toBe(503);
-    expect((result.body as { code: string }).code).toBe('collection_unavailable');
+    expect(result.status).toBe(status);
+    expect((result.body as { code: string }).code).toBe(code);
   });
 
   it('rejects an element whose type is not a supported portfolio type with 422', async () => {

--- a/tests/unit/web-console/modules/CollectionModule.test.ts
+++ b/tests/unit/web-console/modules/CollectionModule.test.ts
@@ -11,6 +11,7 @@ import {
   type ConsoleHandlerResult,
   type ConsoleRequest,
   type ConsoleRouteDefinition,
+  type IPortfolioElementStore,
 } from '../../../../src/web-console/index.js';
 import type { CollectionIndexManager } from '../../../../src/collection/CollectionIndexManager.js';
 import type { CollectionSearch } from '../../../../src/collection/CollectionSearch.js';
@@ -150,6 +151,29 @@ describe('CollectionModule', () => {
         expect(definition.elevation).toBe('none');
         expect(definition.privacyProjector).toBeDefined();
       }
+    });
+
+    it('omits the install route unless install options are provided', () => {
+      const module = createCollectionModule(fakePorts());
+      expect(module.routes.some(r => r.method === 'POST')).toBe(false);
+    });
+
+    it('adds a self-private install route under the portfolio path when install is enabled', () => {
+      const module = createCollectionModule({
+        ...fakePorts(),
+        install: {
+          installer: { fetchAndValidate: () => Promise.reject(new Error('unused')) },
+          portfolioStore: {} as unknown as IPortfolioElementStore,
+        },
+      });
+      const install = module.routes.find(r => r.method === 'POST');
+      expect(install).toBeDefined();
+      expect(install?.path).toBe('/api/v1/me/portfolio/from-collection');
+      // Install writes per-user data: self_private, NOT the catalog class.
+      expect(install?.privacyClass).toBe('self_private');
+      expect(install?.idempotency).toBe('required');
+      expect(install?.rateLimit).toBe('collection_fetch');
+      expect(install?.ownership).toBe('authenticated_user');
     });
   });
 

--- a/tests/unit/web-console/modules/CollectionModule.test.ts
+++ b/tests/unit/web-console/modules/CollectionModule.test.ts
@@ -178,6 +178,23 @@ describe('CollectionModule', () => {
       expect(body.elements[0].type).toBe('skills');
     });
 
+    it('strips the .yaml extension from memory element names', async () => {
+      const definition = routeWith(LIST_PATH, fakePorts({
+        index: {
+          getIndex: () => Promise.resolve(collectionIndex({
+            memories: [indexEntry({
+              path: 'library/memories/welcome-to-dollhouse-guide.yaml',
+              type: 'memories',
+              name: 'Welcome Guide',
+            })],
+          })),
+        },
+      }));
+      const body = (await invoke(definition, consoleRequest({ query: { type: 'memories' } } as Partial<ConsoleRequest>))).body as CollectionElementListDto;
+      expect(body.elements[0].name).toBe('welcome-to-dollhouse-guide');
+      expect(body.elements[0].path).toBe('library/memories/welcome-to-dollhouse-guide.yaml');
+    });
+
     it('rejects an unsupported type with a clean 400', async () => {
       const result = await invoke(route(LIST_PATH), consoleRequest({ query: { type: '../../../orgs/x' } } as Partial<ConsoleRequest>));
       expect(result.status).toBe(400);
@@ -229,6 +246,31 @@ describe('CollectionModule', () => {
       expect(result.status).toBe(400);
     });
 
+    it('derives has_more from the engine, not the (unfiltered) total', async () => {
+      // Engine reports a large total but says this is the last page. Non-console
+      // hits get filtered out; has_more must follow the engine's hasMore=false,
+      // not page*page_size<total (which would wrongly advertise another page).
+      const definition = routeWith(LIST_PATH, fakePorts({
+        search: {
+          searchCollectionWithOptions: (query, options) => Promise.resolve({
+            items: [
+              indexEntry(),
+              indexEntry({ path: 'library/tools/foo.md', type: 'tools', name: 'Foo' }),
+            ],
+            total: 100,
+            page: options.page ?? 1,
+            pageSize: options.pageSize ?? 50,
+            hasMore: false,
+            query,
+            searchTime: 1,
+          } satisfies SearchResults),
+        },
+      }));
+      const body = (await invoke(definition, consoleRequest({ query: { q: 'review' } } as Partial<ConsoleRequest>))).body as CollectionElementListDto;
+      expect(body.elements).toHaveLength(1); // non-console 'tools' hit filtered out
+      expect(body.has_more).toBe(false);
+    });
+
     it('degrades cleanly when search fails', async () => {
       const definition = routeWith(LIST_PATH, fakePorts({
         search: { searchCollectionWithOptions: () => Promise.reject(new Error('search backend down')) },
@@ -270,6 +312,25 @@ describe('CollectionModule', () => {
         params: { type: 'skills', name: 'my-skill_v2.1' },
       } as Partial<ConsoleRequest>));
       expect(paths).toEqual(['library/skills/my-skill_v2.1.md']);
+    });
+
+    it('fetches memories with a .yaml extension, not .md', async () => {
+      // Memories are stored as YAML in the collection; a hardcoded .md would
+      // 404 every memory detail. The path must carry the per-type extension.
+      const paths: string[] = [];
+      const definition = routeWith(DETAIL_PATH, fakePorts({
+        details: {
+          getCollectionContent: path => {
+            paths.push(path);
+            return Promise.resolve({ metadata: { name: 'Guide' }, content: 'body' });
+          },
+        },
+      }));
+      const result = await invoke(definition, consoleRequest({
+        params: { type: 'memories', name: 'welcome-to-dollhouse-guide' },
+      } as Partial<ConsoleRequest>));
+      expect(paths).toEqual(['library/memories/welcome-to-dollhouse-guide.yaml']);
+      expect(result.status).toBe(200);
     });
 
     it('rejects traversal-shaped names without fetching', async () => {

--- a/tests/unit/web-console/modules/CollectionModule.test.ts
+++ b/tests/unit/web-console/modules/CollectionModule.test.ts
@@ -13,6 +13,7 @@ import {
   type ConsoleRouteDefinition,
   type IPortfolioElementStore,
 } from '../../../../src/web-console/index.js';
+import { collectionElementNameFromPath } from '../../../../src/web-console/modules/collection/CollectionDtos.js';
 import type { CollectionIndexManager } from '../../../../src/collection/CollectionIndexManager.js';
 import type { CollectionSearch } from '../../../../src/collection/CollectionSearch.js';
 import type { PersonaDetails } from '../../../../src/collection/PersonaDetails.js';
@@ -200,6 +201,19 @@ describe('CollectionModule', () => {
       const body = result.body as CollectionElementListDto;
       expect(body.total).toBe(1);
       expect(body.elements[0].type).toBe('skills');
+    });
+
+    // The stem IS the element's install/detail name: only the final catalog
+    // extension is stripped, inner dots survive (a `guide.yaml.md` file lists
+    // as `guide.yaml` and round-trips through the detail route unchanged).
+    it.each([
+      ['library/personas/code-review.md', 'code-review'],
+      ['library/memories/guide.yaml', 'guide'],
+      ['library/memories/guide.yml', 'guide'],
+      ['library/personas/guide.yaml.md', 'guide.yaml'],
+      ['library/personas/no-extension', 'no-extension'],
+    ])('derives the element name from catalog path %s as %s', (catalogPath, expected) => {
+      expect(collectionElementNameFromPath(catalogPath, 'fallback')).toBe(expected);
     });
 
     it('strips the .yaml extension from memory element names', async () => {

--- a/tests/unit/web-console/modules/CollectionModule.test.ts
+++ b/tests/unit/web-console/modules/CollectionModule.test.ts
@@ -241,6 +241,21 @@ describe('CollectionModule', () => {
       expect(body.has_more).toBe(false);
     });
 
+    it('advertises install_enabled=false on a browse-only module and true when install is wired', async () => {
+      const browseOnly = (await invoke(route(LIST_PATH), consoleRequest())).body as CollectionElementListDto;
+      expect(browseOnly.install_enabled).toBe(false);
+
+      const listRoute = routeWith(LIST_PATH, {
+        ...fakePorts(),
+        install: {
+          installer: { fetchAndValidate: () => Promise.reject(new Error('unused')) },
+          portfolioStore: {} as unknown as IPortfolioElementStore,
+        },
+      });
+      const body = (await invoke(listRoute, consoleRequest())).body as CollectionElementListDto;
+      expect(body.install_enabled).toBe(true);
+    });
+
     it('returns the degraded state when the index is unavailable', async () => {
       const errors: unknown[] = [];
       const definition = routeWith(LIST_PATH, fakePorts({

--- a/tests/unit/web-console/modules/CollectionModule.test.ts
+++ b/tests/unit/web-console/modules/CollectionModule.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  createCollectionModule,
+  type CollectionDetailPort,
+  type CollectionElementDetailDto,
+  type CollectionElementListDto,
+  type CollectionIndexPort,
+  type CollectionModuleOptions,
+  type CollectionSearchPort,
+  type ConsoleHandlerResult,
+  type ConsoleRequest,
+  type ConsoleRouteDefinition,
+} from '../../../../src/web-console/index.js';
+import type { CollectionIndexManager } from '../../../../src/collection/CollectionIndexManager.js';
+import type { CollectionSearch } from '../../../../src/collection/CollectionSearch.js';
+import type { PersonaDetails } from '../../../../src/collection/PersonaDetails.js';
+import type { CollectionIndex, IndexEntry, SearchResults } from '../../../../src/types/collection.js';
+
+// Compile-time proof that the real collection engine classes satisfy the
+// module's structural ports (the registrar resolves them via untyped DI).
+const _indexPortCheck: CollectionIndexPort = {} as CollectionIndexManager;
+const _searchPortCheck: CollectionSearchPort = {} as CollectionSearch;
+const _detailPortCheck: CollectionDetailPort = {} as PersonaDetails;
+void _indexPortCheck;
+void _searchPortCheck;
+void _detailPortCheck;
+
+const USER_ID = '018f3d47-73ae-7f10-a0de-0742618d4fb1';
+const SELF_CAPABILITY = 'console:self';
+const LIST_PATH = '/api/v1/collection/elements';
+const DETAIL_PATH = '/api/v1/collection/elements/:type/:name';
+const CODE_REVIEW_NAME = 'code-review';
+
+function indexEntry(overrides: Partial<IndexEntry> = {}): IndexEntry {
+  return {
+    path: 'library/personas/code-review.md',
+    type: 'personas',
+    name: 'Code Review',
+    description: 'Reviews pull requests',
+    version: '1.2.0',
+    author: 'dollhousemcp',
+    tags: ['review', 'code'],
+    sha: 'abc123',
+    created: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function collectionIndex(entries: Readonly<Record<string, IndexEntry[]>>): CollectionIndex {
+  return {
+    version: '2.0.0',
+    generated: '2026-07-01T00:00:00.000Z',
+    total_elements: Object.values(entries).reduce((sum, list) => sum + list.length, 0),
+    index: { ...entries },
+    metadata: { build_time_ms: 10, file_count: 3, skipped_files: 0 },
+  } as CollectionIndex;
+}
+
+function fakePorts(overrides: Partial<CollectionModuleOptions> = {}): CollectionModuleOptions {
+  return {
+    index: {
+      getIndex: () => Promise.resolve(collectionIndex({
+        personas: [indexEntry()],
+        skills: [indexEntry({
+          path: 'library/skills/linter.md',
+          type: 'skills',
+          name: 'Linter',
+          description: 'Lints code',
+        })],
+      })),
+    },
+    search: {
+      searchCollectionWithOptions: (query, options) => Promise.resolve({
+        items: [indexEntry()],
+        total: 1,
+        page: options.page ?? 1,
+        pageSize: options.pageSize ?? 50,
+        hasMore: false,
+        query,
+        searchTime: 1,
+      } satisfies SearchResults),
+    },
+    details: {
+      getCollectionContent: () => Promise.resolve({
+        metadata: {
+          name: 'Code Review',
+          description: 'Reviews pull requests',
+          version: '1.2.0',
+          author: 'dollhousemcp',
+          tags: ['review'],
+        },
+        content: '# Code Review\nInstructions.',
+      }),
+    },
+    ...overrides,
+  };
+}
+
+function consoleRequest(overrides: Partial<ConsoleRequest> = {}): ConsoleRequest {
+  return {
+    params: {},
+    query: {},
+    body: {},
+    headers: {},
+    consoleAuthentication: {
+      sessionIdHash: Buffer.alloc(32, 7),
+      userId: USER_ID,
+      authSub: 'github_user-7',
+      authzVersion: 3,
+      grantedCapabilities: [SELF_CAPABILITY],
+      elevation: null,
+    },
+    ...overrides,
+  } as ConsoleRequest;
+}
+
+function route(path: string): ConsoleRouteDefinition {
+  const module = createCollectionModule(fakePorts());
+  const match = module.routes.find(candidate => candidate.path === path);
+  if (!match) throw new Error(`route ${path} not found`);
+  return match;
+}
+
+function routeWith(path: string, options: CollectionModuleOptions): ConsoleRouteDefinition {
+  const module = createCollectionModule(options);
+  const match = module.routes.find(candidate => candidate.path === path);
+  if (!match) throw new Error(`route ${path} not found`);
+  return match;
+}
+
+async function invoke(definition: ConsoleRouteDefinition, req: ConsoleRequest): Promise<ConsoleHandlerResult> {
+  return await definition.handler(req);
+}
+
+describe('CollectionModule', () => {
+  describe('route surface', () => {
+    it('declares exactly the two session-gated, rate-limited catalog routes', () => {
+      const module = createCollectionModule(fakePorts());
+      expect(module.id).toBe('collection');
+      expect(module.routes.map(definition => `${definition.method} ${definition.path}`)).toEqual([
+        `GET ${LIST_PATH}`,
+        `GET ${DETAIL_PATH}`,
+      ]);
+      for (const definition of module.routes) {
+        expect(definition.audience).toBe('self');
+        expect(definition.requiredCapability).toBe(SELF_CAPABILITY);
+        expect(definition.privacyClass).toBe('public_catalog');
+        expect(definition.rateLimit).toBe('collection_fetch');
+        expect(definition.elevation).toBe('none');
+        expect(definition.privacyProjector).toBeDefined();
+      }
+    });
+  });
+
+  describe('list', () => {
+    it('lists all catalog elements across types', async () => {
+      const result = await invoke(route(LIST_PATH), consoleRequest());
+      expect(result.status).toBe(200);
+      const body = result.body as CollectionElementListDto;
+      expect(body.total).toBe(2);
+      expect(body.source_status).toBe('ok');
+      expect(body.elements.map(element => element.name)).toEqual([CODE_REVIEW_NAME, 'linter']);
+      expect(body.elements[0]).toMatchObject({
+        type: 'personas',
+        name: CODE_REVIEW_NAME,
+        display_name: 'Code Review',
+        description: 'Reviews pull requests',
+        path: 'library/personas/code-review.md',
+        source: 'collection',
+      });
+    });
+
+    it('filters by type', async () => {
+      const result = await invoke(route(LIST_PATH), consoleRequest({ query: { type: 'skills' } } as Partial<ConsoleRequest>));
+      const body = result.body as CollectionElementListDto;
+      expect(body.total).toBe(1);
+      expect(body.elements[0].type).toBe('skills');
+    });
+
+    it('rejects an unsupported type with a clean 400', async () => {
+      const result = await invoke(route(LIST_PATH), consoleRequest({ query: { type: '../../../orgs/x' } } as Partial<ConsoleRequest>));
+      expect(result.status).toBe(400);
+      expect((result.body as { code: string }).code).toBe('invalid_request');
+    });
+
+    it('rejects invalid pagination parameters', async () => {
+      const badPage = await invoke(route(LIST_PATH), consoleRequest({ query: { page: '0' } } as Partial<ConsoleRequest>));
+      expect(badPage.status).toBe(400);
+      const badSize = await invoke(route(LIST_PATH), consoleRequest({ query: { page_size: '101' } } as Partial<ConsoleRequest>));
+      expect(badSize.status).toBe(400);
+    });
+
+    it('paginates browse results', async () => {
+      const result = await invoke(route(LIST_PATH), consoleRequest({ query: { page: '2', page_size: '1' } } as Partial<ConsoleRequest>));
+      const body = result.body as CollectionElementListDto;
+      expect(body.total).toBe(2);
+      expect(body.page).toBe(2);
+      expect(body.elements).toHaveLength(1);
+      expect(body.has_more).toBe(false);
+    });
+
+    it('returns the degraded state when the index is unavailable', async () => {
+      const errors: unknown[] = [];
+      const definition = routeWith(LIST_PATH, fakePorts({
+        index: { getIndex: () => Promise.reject(new Error('index fetch failed')) },
+        reportSourceError: error => { errors.push(error); },
+      }));
+      const result = await invoke(definition, consoleRequest());
+      expect(result.status).toBe(200);
+      const body = result.body as CollectionElementListDto;
+      expect(body.source_status).toBe('degraded');
+      expect(body.source_detail).toContain('unavailable');
+      expect(body.elements).toHaveLength(0);
+      expect(errors).toHaveLength(1);
+    });
+  });
+
+  describe('search', () => {
+    it('routes q queries through the search engine', async () => {
+      const result = await invoke(route(LIST_PATH), consoleRequest({ query: { q: 'review' } } as Partial<ConsoleRequest>));
+      const body = result.body as CollectionElementListDto;
+      expect(body.total).toBe(1);
+      expect(body.elements[0].name).toBe(CODE_REVIEW_NAME);
+    });
+
+    it('rejects an oversized query', async () => {
+      const result = await invoke(route(LIST_PATH), consoleRequest({ query: { q: 'a'.repeat(201) } } as Partial<ConsoleRequest>));
+      expect(result.status).toBe(400);
+    });
+
+    it('degrades cleanly when search fails', async () => {
+      const definition = routeWith(LIST_PATH, fakePorts({
+        search: { searchCollectionWithOptions: () => Promise.reject(new Error('search backend down')) },
+      }));
+      const result = await invoke(definition, consoleRequest({ query: { q: 'review' } } as Partial<ConsoleRequest>));
+      expect(result.status).toBe(200);
+      expect((result.body as CollectionElementListDto).source_status).toBe('degraded');
+    });
+  });
+
+  describe('detail', () => {
+    it('returns metadata and content for a catalog element', async () => {
+      const result = await invoke(route(DETAIL_PATH), consoleRequest({
+        params: { type: 'personas', name: CODE_REVIEW_NAME },
+      } as Partial<ConsoleRequest>));
+      expect(result.status).toBe(200);
+      const body = result.body as CollectionElementDetailDto;
+      expect(body).toMatchObject({
+        type: 'personas',
+        name: CODE_REVIEW_NAME,
+        display_name: 'Code Review',
+        path: 'library/personas/code-review.md',
+        content: '# Code Review\nInstructions.',
+      });
+      expect(body.metadata.description).toBe('Reviews pull requests');
+    });
+
+    it('constructs the fetch path only from validated components', async () => {
+      const paths: string[] = [];
+      const definition = routeWith(DETAIL_PATH, fakePorts({
+        details: {
+          getCollectionContent: path => {
+            paths.push(path);
+            return Promise.resolve({ metadata: {}, content: '' });
+          },
+        },
+      }));
+      await invoke(definition, consoleRequest({
+        params: { type: 'skills', name: 'my-skill_v2.1' },
+      } as Partial<ConsoleRequest>));
+      expect(paths).toEqual(['library/skills/my-skill_v2.1.md']);
+    });
+
+    it('rejects traversal-shaped names without fetching', async () => {
+      const paths: string[] = [];
+      const definition = routeWith(DETAIL_PATH, fakePorts({
+        details: {
+          getCollectionContent: path => {
+            paths.push(path);
+            return Promise.resolve({ metadata: {}, content: '' });
+          },
+        },
+      }));
+      for (const name of ['../secrets', 'a/b', '.hidden', '']) {
+        const result = await invoke(definition, consoleRequest({
+          params: { type: 'personas', name },
+        } as Partial<ConsoleRequest>));
+        expect(result.status).toBe(400);
+      }
+      expect(paths).toHaveLength(0);
+    });
+
+    it('maps a missing catalog file to 404', async () => {
+      const definition = routeWith(DETAIL_PATH, fakePorts({
+        details: {
+          getCollectionContent: () => Promise.reject(
+            new Error('File not found in collection. Try using search to get the correct path: search_collection_enhanced "your-search-term"'),
+          ),
+        },
+      }));
+      const result = await invoke(definition, consoleRequest({
+        params: { type: 'personas', name: 'missing' },
+      } as Partial<ConsoleRequest>));
+      expect(result.status).toBe(404);
+      expect((result.body as { code: string }).code).toBe('collection_element_not_found');
+    });
+
+    it('maps other fetch failures to 503 collection_unavailable', async () => {
+      const definition = routeWith(DETAIL_PATH, fakePorts({
+        details: { getCollectionContent: () => Promise.reject(new Error('GitHub API error: 500')) },
+      }));
+      const result = await invoke(definition, consoleRequest({
+        params: { type: 'personas', name: CODE_REVIEW_NAME },
+      } as Partial<ConsoleRequest>));
+      expect(result.status).toBe(503);
+      expect((result.body as { code: string }).code).toBe('collection_unavailable');
+    });
+  });
+});

--- a/tests/unit/web-console/modules/PortfolioModule.test.ts
+++ b/tests/unit/web-console/modules/PortfolioModule.test.ts
@@ -503,6 +503,37 @@ describe('PortfolioModule', () => {
         issues: [expect.objectContaining({ path: 'tags', code: 'too_many' })],
       },
     });
+    // Store record contract mirrored pre-write: name/tag caps 422 here instead
+    // of the store persisting the element and only then throwing on toRecord.
+    await expect(create.handler(consoleRequest({
+      params: { type: 'skills' },
+      body: {
+        name: 'n'.repeat(201),
+        metadata: {},
+        content: '# Long name',
+      },
+    }))).resolves.toMatchObject({
+      status: 422,
+      body: {
+        code: 'validation_failed',
+        issues: [expect.objectContaining({ path: 'name', code: 'invalid' })],
+      },
+    });
+    await expect(create.handler(consoleRequest({
+      params: { type: 'skills' },
+      body: {
+        name: 'long-tag',
+        metadata: {},
+        content: '# Long tag',
+        tags: ['t'.repeat(81)],
+      },
+    }))).resolves.toMatchObject({
+      status: 422,
+      body: {
+        code: 'validation_failed',
+        issues: [expect.objectContaining({ path: 'tags.0', code: 'invalid' })],
+      },
+    });
   });
 
   it('updates portfolio elements only with the current element ETag', async () => {

--- a/tests/unit/web-console/platform/ConsoleModuleRegistry.test.ts
+++ b/tests/unit/web-console/platform/ConsoleModuleRegistry.test.ts
@@ -414,6 +414,30 @@ describe('ConsoleModuleRegistry', () => {
     }))).toThrow(/duplicates schema/);
   });
 
+  it('accepts a public_catalog route under /api/v1/collection', () => {
+    const registry = new ConsoleModuleRegistry();
+    expect(() => registry.register(selfModule({
+      id: 'collection',
+      routes: [selfRoute({ path: '/api/v1/collection/elements', privacyClass: 'public_catalog' })],
+    }))).not.toThrow();
+  });
+
+  it('rejects a personal route that claims the public_catalog privacy class', () => {
+    const registry = new ConsoleModuleRegistry();
+    // Laundering per-user data through the non-personal catalog class must fail.
+    expect(() => registry.register(selfModule({
+      routes: [selfRoute({ path: '/api/v1/me/example', privacyClass: 'public_catalog' })],
+    }))).toThrow(/public_catalog/);
+  });
+
+  it('rejects a /api/v1/collection route that claims a personal privacy class', () => {
+    const registry = new ConsoleModuleRegistry();
+    expect(() => registry.register(selfModule({
+      id: 'collection',
+      routes: [selfRoute({ path: '/api/v1/collection/elements', privacyClass: 'self_private' })],
+    }))).toThrow(/public_catalog/);
+  });
+
   it('rejects event and schema identifier collisions across modules', () => {
     const registry = new ConsoleModuleRegistry();
     registry.register(selfModule({

--- a/tests/unit/web-console/services/ConsoleCollectionFetchRateLimiter.test.ts
+++ b/tests/unit/web-console/services/ConsoleCollectionFetchRateLimiter.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { InMemoryRateLimitStore } from '../../../../src/auth/embedded-as/storage/InMemoryRateLimitStore.js';
+import type { IRateLimitStore } from '../../../../src/auth/embedded-as/storage/IRateLimitStore.js';
+import {
+  ConsoleCollectionFetchRateLimitDependencyError,
+  ConsoleCollectionFetchRateLimiter,
+} from '../../../../src/web-console/services/rate-limit/ConsoleCollectionFetchRateLimiter.js';
+
+jest.mock('../../../../src/security/securityMonitor.js', () => ({
+  SecurityMonitor: {
+    logSecurityEvent: jest.fn(),
+  },
+}));
+
+const SESSION_LIMIT = 30;
+const KEY = Buffer.alloc(32, 1);
+const TEST_IP = '198.51.100.7';
+// InMemoryRateLimitStore expires entries against the REAL clock, so the
+// injected test clock must be anchored to Date.now() or every write is
+// already expired on the next read.
+const START = new Date(Date.now());
+
+function sessionHash(fill: number): Buffer {
+  return Buffer.alloc(32, fill);
+}
+
+function createLimiter(now: () => Date, store: IRateLimitStore = new InMemoryRateLimitStore()) {
+  return new ConsoleCollectionFetchRateLimiter({ store, selectorHmacKey: KEY, now });
+}
+
+describe('ConsoleCollectionFetchRateLimiter', () => {
+  it('allows requests under the session budget', async () => {
+    const limiter = createLimiter(() => START);
+    for (let i = 0; i < SESSION_LIMIT; i++) {
+      const result = await limiter.consume({ consoleSessionIdHash: sessionHash(1), ip: TEST_IP });
+      expect(result.allowed).toBe(true);
+      expect(result.retryAfterSeconds).toBeNull();
+    }
+  });
+
+  it('denies the request past the session budget with a Retry-After hint', async () => {
+    const limiter = createLimiter(() => START);
+    for (let i = 0; i < SESSION_LIMIT; i++) {
+      await limiter.consume({ consoleSessionIdHash: sessionHash(1), ip: TEST_IP });
+    }
+    const denied = await limiter.consume({ consoleSessionIdHash: sessionHash(1), ip: TEST_IP });
+    expect(denied.allowed).toBe(false);
+    expect(denied.exceededScopes).toEqual(['session']);
+    expect(denied.retryAfterSeconds).toBeGreaterThan(0);
+    expect(denied.retryAfterSeconds).toBeLessThanOrEqual(60);
+  });
+
+  it('isolates budgets per session', async () => {
+    const limiter = createLimiter(() => START);
+    for (let i = 0; i <= SESSION_LIMIT; i++) {
+      await limiter.consume({ consoleSessionIdHash: sessionHash(1), ip: TEST_IP });
+    }
+    const otherSession = await limiter.consume({ consoleSessionIdHash: sessionHash(2), ip: TEST_IP });
+    expect(otherSession.allowed).toBe(true);
+  });
+
+  it('resets the budget after the window elapses', async () => {
+    let now = START;
+    const limiter = createLimiter(() => now);
+    for (let i = 0; i <= SESSION_LIMIT; i++) {
+      await limiter.consume({ consoleSessionIdHash: sessionHash(1), ip: TEST_IP });
+    }
+    now = new Date(START.getTime() + 61_000);
+    const afterWindow = await limiter.consume({ consoleSessionIdHash: sessionHash(1), ip: TEST_IP });
+    expect(afterWindow.allowed).toBe(true);
+  });
+
+  it('wraps store failures in a dependency error', async () => {
+    const failingStore: IRateLimitStore = {
+      update: () => Promise.reject(new Error('store offline')),
+    } as unknown as IRateLimitStore;
+    const limiter = createLimiter(() => START, failingStore);
+    await expect(
+      limiter.consume({ consoleSessionIdHash: sessionHash(1), ip: TEST_IP }),
+    ).rejects.toThrow(ConsoleCollectionFetchRateLimitDependencyError);
+  });
+
+  it('rejects a malformed session hash', async () => {
+    const limiter = createLimiter(() => START);
+    await expect(
+      limiter.consume({ consoleSessionIdHash: Buffer.alloc(8, 1), ip: TEST_IP }),
+    ).rejects.toThrow(/consoleSessionIdHash/);
+  });
+});

--- a/tests/unit/web-console/services/ConsoleCollectionFetchRateLimiter.test.ts
+++ b/tests/unit/web-console/services/ConsoleCollectionFetchRateLimiter.test.ts
@@ -14,6 +14,7 @@ jest.mock('../../../../src/security/securityMonitor.js', () => ({
 }));
 
 const SESSION_LIMIT = 30;
+const DEPLOYMENT_LIMIT = 300;
 const KEY = Buffer.alloc(32, 1);
 const TEST_IP = '198.51.100.7';
 // InMemoryRateLimitStore expires entries against the REAL clock, so the
@@ -58,6 +59,39 @@ describe('ConsoleCollectionFetchRateLimiter', () => {
     }
     const otherSession = await limiter.consume({ consoleSessionIdHash: sessionHash(2), ip: TEST_IP });
     expect(otherSession.allowed).toBe(true);
+  });
+
+  it('does not charge the shared deployment budget for session-rejected requests', async () => {
+    const limiter = createLimiter(() => START);
+    // A single session floods far past the deployment limit. Only its first 30
+    // are allowed; the rest are session-rejected and must NOT reach GitHub, so
+    // they must not consume the deployment budget.
+    for (let i = 0; i < DEPLOYMENT_LIMIT + 50; i++) {
+      const result = await limiter.consume({ consoleSessionIdHash: sessionHash(1), ip: TEST_IP });
+      if (i >= SESSION_LIMIT) {
+        expect(result.exceededScopes).toEqual(['session']);
+      }
+    }
+    // A different session must still be served — the deployment budget was only
+    // charged for this session's 30 allowed requests, nowhere near 300.
+    const otherSession = await limiter.consume({ consoleSessionIdHash: sessionHash(9), ip: TEST_IP });
+    expect(otherSession.allowed).toBe(true);
+    expect(otherSession.exceededScopes).toEqual([]);
+  });
+
+  it('trips the deployment scope when allowed requests across sessions exceed the budget', async () => {
+    const limiter = createLimiter(() => START);
+    // Spread allowed requests across many sessions so no single session budget
+    // trips; the shared deployment budget must still cap the aggregate.
+    let denied: Awaited<ReturnType<typeof limiter.consume>> | null = null;
+    for (let session = 0; session < DEPLOYMENT_LIMIT + 5 && !denied; session++) {
+      const result = await limiter.consume({ consoleSessionIdHash: sessionHash(session % 200), ip: TEST_IP });
+      if (!result.allowed) denied = result;
+    }
+    // With distinct sessions each spending 1, the deployment budget (300) trips
+    // before any per-session budget (30) does.
+    expect(denied).not.toBeNull();
+    expect(denied?.exceededScopes).toEqual(['deployment']);
   });
 
   it('resets the budget after the window elapses', async () => {


### PR DESCRIPTION
Closes #2317

Adds the community collection to the web console: browse/search the public catalog from the Portfolio tab and install elements into the signed-in user's portfolio, wiring the hosted Portfolio tab to the collection.dollhousemcp source.

## What's here

**Browse surface** — `GET /api/v1/collection/elements` (browse + search) and `GET /api/v1/collection/elements/:type/:name` (detail), served by a new `collection` BFF module over the existing collection engine (`CollectionIndexManager`, `CollectionSearch`, `PersonaDetails`). The catalog is public data, but the routes stay session-gated because every request can drive server-funded outbound GitHub traffic. A new `public_catalog` privacy class and a dedicated `collection_fetch` rate policy (per-session and per-user, store-backed) cover the surface, and the module registry refuses `public_catalog` routes outside `/api/v1/collection`.

**Install** — `POST /api/v1/me/portfolio/from-collection` (self-private, idempotency required). It lives under the portfolio path rather than `/collection` because installing creates a private copy of a catalog element. Fetch + validation happen through a new no-write seam on the shared installer (`ElementInstaller.fetchAndValidate`), and the write goes through the same manager-backed store the portfolio CRUD routes use — DB-mode deployments persist to Postgres with per-user scoping and no filesystem fallback. Installs apply the same pre-write payload validation as direct portfolio creates, so an out-of-contract catalog element is rejected with a 422 before anything persists. All six element types are supported, including pure-YAML memories with their own secure validation branch.

**UI** — the Portfolio tab's Collection source is now live: lazy-loaded catalog, COLLECTION badges, always-visible Install buttons (hidden on browse-only deployments via a new `install_enabled` list field), a detail modal for both sources, and distinct not-enabled / degraded / error states with retry.

**Security hardening** — SSRF guards reject raw and percent-encoded traversal in collection paths before URL normalization; the browse cache is store-backed when a cache store is configured (filesystem only as the no-store fallback); collection section/type inputs validate against allowlists.

## Deployment

Everything is behind `DOLLHOUSE_WEB_CONSOLE_COLLECTION_ENABLED` (default **off**) — browse spends the deployment's shared GitHub API budget, so operators opt in deliberately. The install route additionally requires the portfolio-write flag. The replacement-readiness check treats `collection` as an optional module, so default deployments boot with the flag off. Hosted deployments should set a **zero-scope** `GITHUB_TOKEN` (public catalog reads need no scopes; `public_repo` would grant public-repo write) to raise the GitHub budget from 60 to 5,000 requests/hour — startup logs a warning on non-loopback binds without one.

## Testing

Unit coverage for the module, install service, installer seam (all six types, extension enforcement, traversal and security rejections), rate limiter, registrar gating, and readiness matrix; full unit/integration/e2e suites green. Browse → install → persisted-to-Postgres → visible-in-portfolio verified end-to-end in a browser against a production-mode boot.
