### PR TITLE
feat(web-console): API contract conformance — error envelope, profile fields, pagination

### DIFF
--- a/src/web-console/WebConsoleRegistrar.ts
+++ b/src/web-console/WebConsoleRegistrar.ts
@@ -500,6 +500,7 @@ export class WebConsoleRegistrar {
         loginTransactions: stores.loginTransactionStore,
         sessionStore: stores.sessionStore,
         identityResolver: stores.identityResolver,
+        accountAdminStore: stores.accountAdminStore,
         opaqueValues,
         secretEncryption,
         publicBaseUrl: integrationPublicBaseUrl,

--- a/src/web-console/auth/ConsoleBffAuthModule.ts
+++ b/src/web-console/auth/ConsoleBffAuthModule.ts
@@ -502,6 +502,9 @@ function invalidCapability(): ConsoleHandlerResult {
   return {
     status: 400,
     body: {
+      type: 'about:blank',
+      title: 'Invalid request',
+      status: 400,
       code: 'invalid_capability',
       detail: 'Step-up requires a valid administrative console capability.',
     },

--- a/src/web-console/auth/ConsoleBffAuthModule.ts
+++ b/src/web-console/auth/ConsoleBffAuthModule.ts
@@ -11,6 +11,7 @@ import {
 } from '../middleware/ConsoleCookies.js';
 import type { IConsoleOpaqueValueService } from '../security/ConsoleOpaqueValues.js';
 import type { ISecretEncryptionService } from '../security/SecretEncryption.js';
+import type { IConsoleAccountAdminStore } from '../stores/IConsoleAccountAdminStore.js';
 import type { IConsoleSessionStore } from '../stores/IConsoleSessionStore.js';
 import type { ILoginTransactionStore } from '../stores/ILoginTransactionStore.js';
 import type {
@@ -43,6 +44,8 @@ export interface ConsoleBffAuthModuleOptions {
   readonly loginTransactions: ILoginTransactionStore;
   readonly sessionStore: IConsoleSessionStore;
   readonly identityResolver: IConsoleIdentityResolver;
+  /** Profile-field source for /auth/me — the same store /me/profile reads. */
+  readonly accountAdminStore: IConsoleAccountAdminStore;
   readonly opaqueValues: IConsoleOpaqueValueService;
   readonly secretEncryption: ISecretEncryptionService;
   readonly publicBaseUrl: string;
@@ -413,11 +416,18 @@ class ConsoleBffAuthService {
     // failure (disabled/removed principal) falls back to none.
     const principal = await this.options.identityResolver.resolveEnabledPrincipal(authentication.authSub);
     const availableAdminCapabilities = principal ? capabilitiesForRoles(principal.roles ?? []) : [];
+    // Profile fields for the SPA header, from the same store /me/profile
+    // serves. Null-safe: a session can briefly outlive a deleted principal,
+    // and /auth/me must keep answering (the SPA uses it to decide sign-out).
+    const profile = await this.options.accountAdminStore.findPrincipal(authentication.userId);
     return {
       status: 200,
       body: {
         user_id: authentication.userId,
         auth_sub: authentication.authSub,
+        display_name: profile?.displayName ?? null,
+        email: profile?.email ?? null,
+        auth_methods: profile ? [...profile.authMethods] : [],
         granted_capabilities: authentication.grantedCapabilities,
         available_admin_capabilities: availableAdminCapabilities,
         elevation: authentication.elevation

--- a/src/web-console/modules/me-logs/MeLogsModule.ts
+++ b/src/web-console/modules/me-logs/MeLogsModule.ts
@@ -12,6 +12,7 @@ import {
   stringField,
 } from '../../platform/ConsoleProjectorHelpers.js';
 import { offsetConsoleCursor, offsetFromConsoleCursor } from '../../platform/ConsoleCursor.js';
+import { boundedLimit, boundedString, firstString } from '../../platform/ConsoleQueryParams.js';
 
 const SELF_CAPABILITY = 'console:self';
 
@@ -107,7 +108,7 @@ function parseLogQuery(req: ConsoleRequest, userId: string): ConsoleLogQueryOpti
     correlationId: boundedString(firstString(req.query.correlation_id), 128),
     sessionId: boundedString(firstString(req.query.session_id), 200),
     since: boundedString(firstString(req.query.since), 64),
-    limit: boundedLimit(firstString(req.query.limit), 200),
+    limit: boundedLimit(firstString(req.query.limit), 200, 1000),
     offset: offsetFromConsoleCursor(boundedString(firstString(req.query.cursor), 512)),
   };
 }
@@ -150,20 +151,3 @@ function projectConsoleLogEntry(value: unknown): ConsoleLogEntry {
   };
 }
 
-function boundedLimit(value: string | null, fallback: number): number {
-  const parsed = value ? Number.parseInt(value, 10) : Number.NaN;
-  if (!Number.isSafeInteger(parsed) || parsed < 1) return fallback;
-  return Math.min(parsed, 1000);
-}
-
-function boundedString(value: string | null, maxLength: number): string | null {
-  if (value === null) return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 && trimmed.length <= maxLength ? trimmed : null;
-}
-
-function firstString(value: ConsoleRequest['query'][string] | undefined): string | null {
-  if (typeof value === 'string') return value;
-  if (Array.isArray(value) && typeof value[0] === 'string') return value[0];
-  return null;
-}

--- a/src/web-console/modules/me-logs/MeLogsModule.ts
+++ b/src/web-console/modules/me-logs/MeLogsModule.ts
@@ -11,6 +11,7 @@ import {
   objectValue,
   stringField,
 } from '../../platform/ConsoleProjectorHelpers.js';
+import { offsetConsoleCursor, offsetFromConsoleCursor } from '../../platform/ConsoleCursor.js';
 
 const SELF_CAPABILITY = 'console:self';
 
@@ -29,6 +30,8 @@ export interface ConsoleLogQueryOptions {
   readonly sessionId: string | null;
   readonly since: string | null;
   readonly limit: number;
+  /** Continuation position within the filtered result set (0 = first page). */
+  readonly offset: number;
 }
 
 export interface ConsoleLogEntry {
@@ -44,8 +47,17 @@ export interface ConsoleLogEntry {
 
 export interface ConsoleLogPage {
   readonly entries: readonly ConsoleLogEntry[];
-  readonly total: number;
   readonly has_more: boolean;
+}
+
+/** Cursor-family response envelope (`{items, page:{limit, cursor, next_cursor}}`). */
+export interface ConsoleLogPageDto {
+  readonly items: readonly ConsoleLogEntry[];
+  readonly page: {
+    readonly limit: number;
+    readonly cursor: string | null;
+    readonly next_cursor: string | null;
+  };
 }
 
 export interface IConsoleLogSource {
@@ -74,11 +86,12 @@ export function createMeLogsModule(options: MeLogsModuleOptions): ConsoleModuleD
         elevation: 'none',
         privacyClass: 'self_private',
         idempotency: 'not_applicable',
-        privacyProjector: projectConsoleLogPage,
+        privacyProjector: projectConsoleLogPageDto,
         handler: (req): ConsoleHandlerResult => {
           const actor = requireConsoleAuthentication(req);
-          const page = logSource.queryUserLogs(parseLogQuery(req, actor.userId));
-          return { status: 200, body: projectConsoleLogPage(page) };
+          const query = parseLogQuery(req, actor.userId);
+          const page = logSource.queryUserLogs(query);
+          return { status: 200, body: serializeConsoleLogPage(page, query) };
         },
       },
     ],
@@ -95,15 +108,31 @@ function parseLogQuery(req: ConsoleRequest, userId: string): ConsoleLogQueryOpti
     sessionId: boundedString(firstString(req.query.session_id), 200),
     since: boundedString(firstString(req.query.since), 64),
     limit: boundedLimit(firstString(req.query.limit), 200),
+    offset: offsetFromConsoleCursor(boundedString(firstString(req.query.cursor), 512)),
   };
 }
 
-function projectConsoleLogPage(value: unknown): ConsoleLogPage {
-  const record = objectValue(value);
+function serializeConsoleLogPage(page: ConsoleLogPage, query: ConsoleLogQueryOptions): ConsoleLogPageDto {
   return {
-    entries: arrayValue(record.entries).map(projectConsoleLogEntry),
-    total: numberField(record, 'total'),
-    has_more: record.has_more === true,
+    items: page.entries,
+    page: {
+      limit: query.limit,
+      cursor: query.offset > 0 ? offsetConsoleCursor(query.offset) : null,
+      next_cursor: page.has_more ? offsetConsoleCursor(query.offset + page.entries.length) : null,
+    },
+  };
+}
+
+function projectConsoleLogPageDto(value: unknown): ConsoleLogPageDto {
+  const record = objectValue(value);
+  const page = objectValue(record.page);
+  return {
+    items: arrayValue(record.items).map(projectConsoleLogEntry),
+    page: {
+      limit: numberField(page, 'limit'),
+      cursor: nullableStringField(page, 'cursor'),
+      next_cursor: nullableStringField(page, 'next_cursor'),
+    },
   };
 }
 

--- a/src/web-console/modules/me-logs/MemoryConsoleLogSource.ts
+++ b/src/web-console/modules/me-logs/MemoryConsoleLogSource.ts
@@ -23,6 +23,7 @@ export function createMemoryConsoleLogSource(sink: QueryableLogSink): IConsoleLo
         sessionId: options.sessionId ?? undefined,
         since: options.since ?? undefined,
         limit: options.limit,
+        offset: options.offset,
       });
       return {
         entries: result.entries.map(entry => ({
@@ -35,7 +36,6 @@ export function createMemoryConsoleLogSource(sink: QueryableLogSink): IConsoleLo
           correlation_id: entry.correlationId ?? null,
           session_id: entry.sessionId ?? null,
         })),
-        total: result.total,
         has_more: result.hasMore,
       };
     },

--- a/src/web-console/modules/operations/OperationsDtos.ts
+++ b/src/web-console/modules/operations/OperationsDtos.ts
@@ -136,12 +136,18 @@ export interface SystemMetricSnapshotDto {
   readonly errors: readonly string[];
 }
 
+/**
+ * Cursor-family envelope (`{items, page:{limit, cursor, next_cursor}}`).
+ * `oldest_available`/`newest_available` are ring-buffer anchors — domain
+ * metadata, not pagination — so they stay at the top level.
+ */
 export interface SystemMetricsResponseDto {
-  readonly snapshots: readonly SystemMetricSnapshotDto[];
-  readonly total: number;
-  readonly has_more: boolean;
-  readonly limit: number;
-  readonly offset: number;
+  readonly items: readonly SystemMetricSnapshotDto[];
+  readonly page: {
+    readonly limit: number;
+    readonly cursor: string | null;
+    readonly next_cursor: string | null;
+  };
   readonly oldest_available: string;
   readonly newest_available: string;
 }

--- a/src/web-console/modules/operations/OperationsModule.ts
+++ b/src/web-console/modules/operations/OperationsModule.ts
@@ -4,6 +4,7 @@ import type {
   ConsoleRequest,
 } from '../../platform/ConsolePlatformTypes.js';
 import { projectConsoleStreamEndStatus } from '../../platform/ConsoleProjectorHelpers.js';
+import { offsetConsoleCursor, offsetFromConsoleCursor } from '../../platform/ConsoleCursor.js';
 import { parseConsoleLastEventId } from '../../platform/ConsoleSseStream.js';
 import type { IOperatorConfigStore } from '../../../storage/operatorConfig/IOperatorConfigStore.js';
 import { ConsoleStoreValidationError } from '../../stores/ConsoleStoreValidation.js';
@@ -290,8 +291,24 @@ function querySystemMetrics(
   query: MetricQueryOptions,
   now: () => Date,
 ): ConsoleHandlerResult {
-  if (!source) return { status: 200, body: emptySystemMetrics(now()) };
-  return { status: 200, body: source.query(query) };
+  const result = source ? source.query(query) : emptySystemMetrics(now());
+  return { status: 200, body: serializeSystemMetrics(result) };
+}
+
+// Cursor-family envelope over the offset-backed ring buffer: the offset is
+// carried in an opaque cursor, never exposed raw. The ring-buffer anchors
+// (oldest/newest available) are domain metadata and stay top-level.
+function serializeSystemMetrics(result: MetricQueryResult): Record<string, unknown> {
+  return {
+    items: result.snapshots,
+    page: {
+      limit: result.limit,
+      cursor: result.offset > 0 ? offsetConsoleCursor(result.offset) : null,
+      next_cursor: result.hasMore ? offsetConsoleCursor(result.offset + result.snapshots.length) : null,
+    },
+    oldestAvailable: result.oldestAvailable,
+    newestAvailable: result.newestAvailable,
+  };
 }
 
 function emptySystemMetrics(at: Date): MetricQueryResult {
@@ -399,8 +416,10 @@ function parseSystemMetricQuery(req: ConsoleRequest): MetricQueryOptions {
   if (latest !== null) options.latest = latest !== 'false';
   const limit = boundedNonNegativeInt(firstString(req.query.limit), 1, 1000);
   if (limit !== null) options.limit = limit;
-  const offset = boundedNonNegativeInt(firstString(req.query.offset), 0, Number.MAX_SAFE_INTEGER);
-  if (offset !== null) options.offset = offset;
+  // Continuation position arrives as an opaque cursor (cursor family), never
+  // as a raw offset parameter.
+  const cursor = boundedString(firstString(req.query.cursor), 512);
+  if (cursor) options.offset = offsetFromConsoleCursor(cursor);
   return options;
 }
 

--- a/src/web-console/modules/operations/OperationsModule.ts
+++ b/src/web-console/modules/operations/OperationsModule.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../platform/ConsolePlatformTypes.js';
 import { projectConsoleStreamEndStatus } from '../../platform/ConsoleProjectorHelpers.js';
 import { offsetConsoleCursor, offsetFromConsoleCursor } from '../../platform/ConsoleCursor.js';
+import { boundedLimit, boundedString, firstString } from '../../platform/ConsoleQueryParams.js';
 import { parseConsoleLastEventId } from '../../platform/ConsoleSseStream.js';
 import type { IOperatorConfigStore } from '../../../storage/operatorConfig/IOperatorConfigStore.js';
 import { ConsoleStoreValidationError } from '../../stores/ConsoleStoreValidation.js';
@@ -297,7 +298,9 @@ function querySystemMetrics(
 
 // Cursor-family envelope over the offset-backed ring buffer: the offset is
 // carried in an opaque cursor, never exposed raw. The ring-buffer anchors
-// (oldest/newest available) are domain metadata and stay top-level.
+// (oldest/newest available) are domain metadata and stay top-level. Keys here
+// are the camelCase internal model — projectSystemMetrics maps them to the
+// snake_case DTO (oldestAvailable → oldest_available) at the trust boundary.
 function serializeSystemMetrics(result: MetricQueryResult): Record<string, unknown> {
   return {
     items: result.snapshots,
@@ -385,7 +388,7 @@ function projectMetricStreamFilters(value: unknown): Record<string, string | nul
 
 function parseLogQuery(req: ConsoleRequest): OperationalLogQuery {
   return {
-    limit: boundedLimit(firstString(req.query.limit), 100),
+    limit: boundedLimit(firstString(req.query.limit), 100, 100),
     cursor: boundedString(firstString(req.query.cursor), 256),
     level: boundedString(firstString(req.query.level), 16),
     subsystem: boundedString(firstString(req.query.subsystem), 64),
@@ -414,8 +417,9 @@ function parseSystemMetricQuery(req: ConsoleRequest): MetricQueryOptions {
   if (until) options.until = until;
   const latest = firstString(req.query.latest);
   if (latest !== null) options.latest = latest !== 'false';
-  const limit = boundedNonNegativeInt(firstString(req.query.limit), 1, 1000);
-  if (limit !== null) options.limit = limit;
+  // 0 sentinel = absent/invalid, so the sink's own default page size applies.
+  const limit = boundedLimit(firstString(req.query.limit), 0, 1000);
+  if (limit > 0) options.limit = limit;
   // Continuation position arrives as an opaque cursor (cursor family), never
   // as a raw offset parameter.
   const cursor = boundedString(firstString(req.query.cursor), 512);
@@ -423,33 +427,6 @@ function parseSystemMetricQuery(req: ConsoleRequest): MetricQueryOptions {
   return options;
 }
 
-function boundedNonNegativeInt(value: string | null, min: number, max: number): number | null {
-  if (value === null) return null;
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isSafeInteger(parsed)) return null;
-  return Math.min(Math.max(parsed, min), max);
-}
-
-function boundedLimit(value: string | null, fallback: number): number {
-  const parsed = value ? Number.parseInt(value, 10) : fallback;
-  if (!Number.isSafeInteger(parsed)) return fallback;
-  return Math.min(Math.max(parsed, 1), 100);
-}
-
-function boundedString(value: string | null, maxLength: number): string | null {
-  if (!value) return null;
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-  return trimmed.slice(0, maxLength);
-}
-
-function firstString(value: ConsoleRequest['query'][string] | string | readonly string[] | undefined): string | null {
-  if (Array.isArray(value)) {
-    const first = value[0];
-    return typeof first === 'string' ? first : null;
-  }
-  return typeof value === 'string' ? value : null;
-}
 
 export function operationalProblem(status: number, code: string, detail: string): ConsoleHandlerResult {
   return {

--- a/src/web-console/modules/operations/OperationsModule.ts
+++ b/src/web-console/modules/operations/OperationsModule.ts
@@ -5,7 +5,7 @@ import type {
 } from '../../platform/ConsolePlatformTypes.js';
 import { projectConsoleStreamEndStatus } from '../../platform/ConsoleProjectorHelpers.js';
 import { offsetConsoleCursor, offsetFromConsoleCursor } from '../../platform/ConsoleCursor.js';
-import { boundedLimit, boundedString, firstString } from '../../platform/ConsoleQueryParams.js';
+import { boundedLimit, boundedString, firstString, optionalLimit } from '../../platform/ConsoleQueryParams.js';
 import { parseConsoleLastEventId } from '../../platform/ConsoleSseStream.js';
 import type { IOperatorConfigStore } from '../../../storage/operatorConfig/IOperatorConfigStore.js';
 import { ConsoleStoreValidationError } from '../../stores/ConsoleStoreValidation.js';
@@ -417,9 +417,9 @@ function parseSystemMetricQuery(req: ConsoleRequest): MetricQueryOptions {
   if (until) options.until = until;
   const latest = firstString(req.query.latest);
   if (latest !== null) options.latest = latest !== 'false';
-  // 0 sentinel = absent/invalid, so the sink's own default page size applies.
-  const limit = boundedLimit(firstString(req.query.limit), 0, 1000);
-  if (limit > 0) options.limit = limit;
+  // Absent/invalid limit → omit the option so the sink's default applies.
+  const limit = optionalLimit(firstString(req.query.limit), 1000);
+  if (limit !== null) options.limit = limit;
   // Continuation position arrives as an opaque cursor (cursor family), never
   // as a raw offset parameter.
   const cursor = boundedString(firstString(req.query.cursor), 512);

--- a/src/web-console/modules/operations/OperationsPrivacyProjectors.ts
+++ b/src/web-console/modules/operations/OperationsPrivacyProjectors.ts
@@ -218,12 +218,14 @@ function cloneAllowedValue(value: unknown): unknown {
 // is forwarded.
 export function projectSystemMetrics(value: unknown): SystemMetricsResponseDto {
   const record = objectValue(value);
+  const page = objectValue(record.page);
   return {
-    snapshots: arrayValue(record.snapshots).map(projectSystemMetricSnapshot),
-    total: numberField(record, 'total'),
-    has_more: record.hasMore === true,
-    limit: numberField(record, 'limit'),
-    offset: numberField(record, 'offset'),
+    items: arrayValue(record.items).map(projectSystemMetricSnapshot),
+    page: {
+      limit: numberField(page, 'limit'),
+      cursor: nullableStringField(page, 'cursor'),
+      next_cursor: nullableStringField(page, 'next_cursor'),
+    },
     oldest_available: stringField(record, 'oldestAvailable'),
     newest_available: stringField(record, 'newestAvailable'),
   };

--- a/src/web-console/modules/portfolio/PortfolioService.ts
+++ b/src/web-console/modules/portfolio/PortfolioService.ts
@@ -569,6 +569,7 @@ function validationFailed(issues: readonly PortfolioElementValidationIssueDto[])
       title: 'Validation failed',
       status: 422,
       code: 'validation_failed',
+      detail: 'The request failed validation; see issues.',
       issues,
     },
   };

--- a/src/web-console/modules/runtime-sessions/RuntimeSessionModule.ts
+++ b/src/web-console/modules/runtime-sessions/RuntimeSessionModule.ts
@@ -45,6 +45,7 @@ export function createRuntimeSessionModule(options: RuntimeSessionModuleOptions)
       elevation: 'none',
       privacyClass: 'self_private',
       idempotency: 'not_applicable',
+      privacyProjector: projectRuntimeSessionSelfList,
       handler: req => listSelfSessions(req, service),
     },
     {
@@ -130,7 +131,7 @@ export function createRuntimeSessionModule(options: RuntimeSessionModuleOptions)
       idempotency: 'not_applicable',
       auditOperation: 'operate.sessions.list',
       privacyProjector: projectRuntimeSessionOperationalList,
-      handler: () => service.listOperationalSessions().then(body => ({ status: 200, body })),
+      handler: () => service.listOperationalSessions().then(sessions => ({ status: 200, body: { sessions } })),
     },
     {
       method: 'GET',
@@ -171,7 +172,8 @@ export function createRuntimeSessionModule(options: RuntimeSessionModuleOptions)
 
 async function listSelfSessions(req: ConsoleRequest, service: RuntimeSessionService): Promise<ConsoleHandlerResult> {
   const actor = requireConsoleAuthentication(req);
-  return { status: 200, body: projectRuntimeSessionSelfList(await service.listSelfSessions(actor.userId)) };
+  // Snapshot-family envelope; the kernel applies the declared projector.
+  return { status: 200, body: { sessions: await service.listSelfSessions(actor.userId) } };
 }
 
 async function getSelfSession(req: ConsoleRequest, service: RuntimeSessionService): Promise<ConsoleHandlerResult> {
@@ -199,8 +201,8 @@ async function revokeAllSelfSessions(req: ConsoleRequest, service: RuntimeSessio
 async function listAccountSessions(req: ConsoleRequest, service: RuntimeSessionService): Promise<ConsoleHandlerResult> {
   const userId = requiredParam(req, 'user_id');
   if (!userId) return invalidParam('user_id');
-  const body = await service.listAccountSessions(userId);
-  return body ? { status: 200, body } : notFound('User principal was not found.');
+  const sessions = await service.listAccountSessions(userId);
+  return sessions ? { status: 200, body: { sessions } } : notFound('User principal was not found.');
 }
 
 async function terminateAccountSession(req: ConsoleRequest, service: RuntimeSessionService): Promise<ConsoleHandlerResult> {

--- a/src/web-console/modules/runtime-sessions/RuntimeSessionModule.ts
+++ b/src/web-console/modules/runtime-sessions/RuntimeSessionModule.ts
@@ -57,6 +57,7 @@ export function createRuntimeSessionModule(options: RuntimeSessionModuleOptions)
       elevation: 'none',
       privacyClass: 'self_private',
       idempotency: 'not_applicable',
+      privacyProjector: projectRuntimeSessionSelf,
       handler: req => getSelfSession(req, service),
     },
     {
@@ -68,6 +69,7 @@ export function createRuntimeSessionModule(options: RuntimeSessionModuleOptions)
       elevation: 'none',
       privacyClass: 'self_private',
       idempotency: 'required',
+      privacyProjector: projectRuntimeTermination,
       // Self termination provenance is retained in runtime_control_commands; admin_audit remains admin-scoped.
       handler: req => terminateSelfSession(req, service),
     },
@@ -181,7 +183,8 @@ async function getSelfSession(req: ConsoleRequest, service: RuntimeSessionServic
   const sessionId = requiredParam(req, SESSION_ID_PARAM);
   if (!sessionId) return invalidParam(SESSION_ID_PARAM);
   const body = await service.getSelfSession(actor.userId, sessionId);
-  return body ? { status: 200, body: projectRuntimeSessionSelf(body) } : notFound(RUNTIME_SESSION_NOT_FOUND_DETAIL);
+  // The route-declared projector runs in the kernel; no inline projection.
+  return body ? { status: 200, body } : notFound(RUNTIME_SESSION_NOT_FOUND_DETAIL);
 }
 
 async function terminateSelfSession(req: ConsoleRequest, service: RuntimeSessionService): Promise<ConsoleHandlerResult> {
@@ -189,7 +192,7 @@ async function terminateSelfSession(req: ConsoleRequest, service: RuntimeSession
   const sessionId = requiredParam(req, SESSION_ID_PARAM);
   if (!sessionId) return invalidParam(SESSION_ID_PARAM);
   const body = await service.terminateSelfSession(actor.userId, sessionId);
-  return body ? { status: 202, body: projectRuntimeTermination(body) } : notFound(RUNTIME_SESSION_NOT_FOUND_DETAIL);
+  return body ? { status: 202, body } : notFound(RUNTIME_SESSION_NOT_FOUND_DETAIL);
 }
 
 async function revokeAllSelfSessions(req: ConsoleRequest, service: RuntimeSessionService): Promise<ConsoleHandlerResult> {

--- a/src/web-console/modules/runtime-sessions/RuntimeSessionPrivacyProjectors.ts
+++ b/src/web-console/modules/runtime-sessions/RuntimeSessionPrivacyProjectors.ts
@@ -21,8 +21,11 @@ export function projectRuntimeSessionSelf(value: unknown): RuntimeSessionSelfDto
   };
 }
 
-export function projectRuntimeSessionSelfList(value: unknown): RuntimeSessionSelfDto[] {
-  return arrayValue(value).map(item => projectRuntimeSessionSelf(item));
+// List envelopes: the snapshot family (`{sessions: [...]}`) — never a bare
+// array, so the shape can grow (e.g. a reserved `pagination` member) without
+// breaking consumers.
+export function projectRuntimeSessionSelfList(value: unknown): { sessions: RuntimeSessionSelfDto[] } {
+  return { sessions: arrayValue(objectValue(value).sessions).map(item => projectRuntimeSessionSelf(item)) };
 }
 
 export function projectRuntimeSessionAccount(value: unknown): RuntimeSessionAccountDto {
@@ -36,8 +39,8 @@ export function projectRuntimeSessionAccount(value: unknown): RuntimeSessionAcco
   };
 }
 
-export function projectRuntimeSessionAccountList(value: unknown): RuntimeSessionAccountDto[] {
-  return arrayValue(value).map(item => projectRuntimeSessionAccount(item));
+export function projectRuntimeSessionAccountList(value: unknown): { sessions: RuntimeSessionAccountDto[] } {
+  return { sessions: arrayValue(objectValue(value).sessions).map(item => projectRuntimeSessionAccount(item)) };
 }
 
 export function projectRuntimeSessionOperational(value: unknown): RuntimeSessionOperationalDto {
@@ -53,8 +56,8 @@ export function projectRuntimeSessionOperational(value: unknown): RuntimeSession
   };
 }
 
-export function projectRuntimeSessionOperationalList(value: unknown): RuntimeSessionOperationalDto[] {
-  return arrayValue(value).map(item => projectRuntimeSessionOperational(item));
+export function projectRuntimeSessionOperationalList(value: unknown): { sessions: RuntimeSessionOperationalDto[] } {
+  return { sessions: arrayValue(objectValue(value).sessions).map(item => projectRuntimeSessionOperational(item)) };
 }
 
 export function projectRuntimeTermination(value: unknown): RuntimeTerminationAcceptedDto {

--- a/src/web-console/platform/ConsoleCursor.ts
+++ b/src/web-console/platform/ConsoleCursor.ts
@@ -1,0 +1,45 @@
+/**
+ * Opaque pagination cursors for the console's cursor list family
+ * (`{items, page:{limit, cursor, next_cursor}}`).
+ *
+ * The contract guarantees cursors are opaque strings: clients never parse or
+ * construct them, and the payload shape is a server implementation detail a
+ * module can change freely. There is no server-side state and therefore no
+ * TTL — a cursor pointing at data that has since been retained away simply
+ * yields an empty page with `next_cursor: null`, which clients treat as the
+ * terminal condition.
+ */
+
+const CURSOR_ENCODING = 'base64url';
+
+export function encodeConsoleCursor(payload: Readonly<Record<string, unknown>>): string {
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString(CURSOR_ENCODING);
+}
+
+/** Returns null for anything that is not a cursor this server issued. */
+export function decodeConsoleCursor(token: string): Record<string, unknown> | null {
+  if (typeof token !== 'string' || token.length === 0 || token.length > 512) return null;
+  try {
+    const parsed: unknown = JSON.parse(Buffer.from(token, CURSOR_ENCODING).toString('utf8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Convenience for the offset-backed sources (in-memory ring buffers): decode
+ * a cursor carrying `{o: <offset>}` to a non-negative integer offset, treating
+ * absent/garbage cursors as offset 0 (first page).
+ */
+export function offsetFromConsoleCursor(token: string | null): number {
+  if (!token) return 0;
+  const payload = decodeConsoleCursor(token);
+  const offset = payload?.o;
+  return typeof offset === 'number' && Number.isSafeInteger(offset) && offset >= 0 ? offset : 0;
+}
+
+export function offsetConsoleCursor(offset: number): string {
+  return encodeConsoleCursor({ o: offset });
+}

--- a/src/web-console/platform/ConsoleQueryParams.ts
+++ b/src/web-console/platform/ConsoleQueryParams.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared query/param string readers for console route modules, so every
+ * module parses request inputs with ONE set of semantics instead of drifting
+ * per-module copies.
+ */
+
+/** First string out of an Express query/param value (string | string[] | undefined). */
+export function firstString(value: unknown): string | null {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value) && typeof value[0] === 'string') return value[0];
+  return null;
+}
+
+/**
+ * Trimmed non-empty string within the length bound, else null. Over-length
+ * input is rejected (treated as absent), never truncated — a silently
+ * truncated filter would match different data than the client asked for.
+ */
+export function boundedString(value: string | null, maxLength: number): string | null {
+  if (value === null) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 && trimmed.length <= maxLength ? trimmed : null;
+}
+
+/**
+ * Positive integer limit capped at `max`; anything absent, unparsable, or
+ * below 1 yields the endpoint's fallback.
+ */
+export function boundedLimit(value: string | null, fallback: number, max: number): number {
+  const parsed = value ? Number.parseInt(value, 10) : Number.NaN;
+  if (!Number.isSafeInteger(parsed) || parsed < 1) return fallback;
+  return Math.min(parsed, max);
+}

--- a/src/web-console/platform/ConsoleQueryParams.ts
+++ b/src/web-console/platform/ConsoleQueryParams.ts
@@ -27,7 +27,16 @@ export function boundedString(value: string | null, maxLength: number): string |
  * below 1 yields the endpoint's fallback.
  */
 export function boundedLimit(value: string | null, fallback: number, max: number): number {
+  return optionalLimit(value, max) ?? fallback;
+}
+
+/**
+ * Like boundedLimit, but with no endpoint-level fallback: absent/invalid
+ * input yields null so the caller can omit the option entirely and let the
+ * underlying source apply its own default.
+ */
+export function optionalLimit(value: string | null, max: number): number | null {
   const parsed = value ? Number.parseInt(value, 10) : Number.NaN;
-  if (!Number.isSafeInteger(parsed) || parsed < 1) return fallback;
+  if (!Number.isSafeInteger(parsed) || parsed < 1) return null;
   return Math.min(parsed, max);
 }

--- a/src/web-console/platform/ConsoleRouteExecution.ts
+++ b/src/web-console/platform/ConsoleRouteExecution.ts
@@ -9,6 +9,7 @@ import type {
 } from './ConsolePlatformTypes.js';
 import { serializeConsoleCookie, validateConsoleCookieDirectives } from '../middleware/ConsoleCookies.js';
 import { sendConsoleSseStream } from './ConsoleSseStream.js';
+import { problemInputFromHandlerBody, sendProblemResponse } from './ProblemResponses.js';
 import { renderAuthErrorPage, requestPrefersHtml } from '../../auth/embedded-as/browserErrorPage.js';
 
 const ALLOWED_HANDLER_HEADERS = new Set<keyof ConsoleResponseHeaders>([
@@ -120,6 +121,21 @@ export function sendConsoleHandlerResult(response: Response, result: ConsoleHand
     if (problem) {
       response.status(result.status).type('text/html')
         .send(renderAuthErrorPage(result.status, problem.code, problem.detail, '/ui'));
+      return;
+    }
+  }
+  // Handler-returned error bodies are lifted into RFC 9457 problem documents
+  // here — one enforcement point for every module, present and future — so
+  // API clients get the contract's `application/problem+json` with a typed
+  // `type` URI and an `instance` correlation id, matching the middleware
+  // errors. `code`/`title`/`detail` and extension members (e.g. `issues`)
+  // pass through unchanged. Requires the request-context middleware for the
+  // correlation id; without it (bare test harnesses) the body ships as-is.
+  if (result.status >= 400) {
+    const problem = problemInputFromHandlerBody(result.body, result.status);
+    const correlationId = request?.consoleContext?.correlationId;
+    if (problem && correlationId) {
+      sendProblemResponse(response, problem, correlationId);
       return;
     }
   }

--- a/src/web-console/platform/ProblemResponses.ts
+++ b/src/web-console/platform/ProblemResponses.ts
@@ -100,6 +100,11 @@ export function problemInputFromHandlerBody(body: unknown, status: number): Cons
   const extensions: Record<string, ConsoleProblemExtension> = {};
   for (const [member, value] of Object.entries(record)) {
     if (!RESERVED_PROBLEM_MEMBERS.has(member)) {
+      // Extension values arrive from handler-authored JSON response bodies, so
+      // they are JSON-serializable by construction — a non-serializable value
+      // (Buffer, class instance) would have misbehaved identically in the
+      // pre-lift res.json() path. The cast records that provenance; it is not
+      // a validation point.
       extensions[member] = value as ConsoleProblemExtension;
     }
   }

--- a/src/web-console/platform/ProblemResponses.ts
+++ b/src/web-console/platform/ProblemResponses.ts
@@ -11,7 +11,16 @@ const RESERVED_PROBLEM_MEMBERS = new Set([
   'code',
 ]);
 
-export type ConsoleProblemExtension = string | number | boolean | null | readonly string[];
+export type ConsoleProblemExtension =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly string[]
+  // Structured extension members (e.g. a validation `issues` array) — RFC 9457
+  // permits arbitrary JSON extension members alongside the required ones.
+  | readonly Readonly<Record<string, unknown>>[]
+  | Readonly<Record<string, unknown>>;
 
 export interface ConsoleProblemInput {
   readonly status: number;
@@ -66,6 +75,41 @@ export function sendProblemResponse(
     .status(problem.status)
     .type('application/problem+json')
     .json(createProblemDetails(problem, correlationId));
+}
+
+/**
+ * Recognize a handler-returned problem body and lift it into a
+ * ConsoleProblemInput so the kernel can emit it as a real RFC 9457 problem
+ * document (typed `type` URI, `instance` correlation id,
+ * `application/problem+json`) instead of the handlers' plain-JSON
+ * `type: "about:blank"` shape. Non-problem bodies return null and are sent
+ * unchanged. Extension members (e.g. validation `issues`) are carried over;
+ * the reserved members are re-derived, never copied.
+ */
+export function problemInputFromHandlerBody(body: unknown, status: number): ConsoleProblemInput | null {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return null;
+  const record = body as Record<string, unknown>;
+  if (
+    typeof record.code !== 'string' ||
+    typeof record.title !== 'string' ||
+    typeof record.detail !== 'string' ||
+    record.status !== status
+  ) {
+    return null;
+  }
+  const extensions: Record<string, ConsoleProblemExtension> = {};
+  for (const [member, value] of Object.entries(record)) {
+    if (!RESERVED_PROBLEM_MEMBERS.has(member)) {
+      extensions[member] = value as ConsoleProblemExtension;
+    }
+  }
+  return {
+    status,
+    code: record.code,
+    title: record.title,
+    detail: record.detail,
+    extensions: Object.keys(extensions).length > 0 ? extensions : undefined,
+  };
 }
 
 export function problemForConsoleError(error: unknown): ConsoleProblemInput | null {

--- a/src/web-console/ui/logs.js
+++ b/src/web-console/ui/logs.js
@@ -381,7 +381,7 @@ async function reload() {
   updateSelectionUI();
   // The endpoint returns newest-first; the buffer is oldest→newest (newest at
   // the bottom, like the legacy stream).
-  const entries = (res.body.entries || []).slice().reverse();
+  const entries = (res.body.items || []).slice().reverse();
   for (const entry of entries) buffer.push(entry);
   newestTs = entries.length ? entries[entries.length - 1].ts : newestTs;
   noteSessions(entries);
@@ -438,7 +438,7 @@ async function poll() {
     }
     if (lastPollFailed) setStatus(paused ? 'paused' : 'live');
     lastPollFailed = false;
-    applyFreshEntries((res.body.entries || []).slice().reverse()); // oldest→newest
+    applyFreshEntries((res.body.items || []).slice().reverse()); // oldest→newest
   } catch {
     markPollFailed();
   } finally {

--- a/src/web-console/ui/sessions.js
+++ b/src/web-console/ui/sessions.js
@@ -41,7 +41,7 @@ async function load() {
     get('/me/sessions').catch(() => null),
   ]);
   state.console = sec?.status === 200 && Array.isArray(sec.body?.sessions) ? sec.body?.sessions : [];
-  state.mcp = mcp?.status === 200 && Array.isArray(mcp.body) ? mcp.body : [];
+  state.mcp = mcp?.status === 200 && Array.isArray(mcp.body?.sessions) ? mcp.body.sessions : [];
   state.error = sec?.status !== 200;
   state.loading = false;
   renderBody();

--- a/tests/integration/web-console-e2e/specs/health-and-auth.e2e-spec.ts
+++ b/tests/integration/web-console-e2e/specs/health-and-auth.e2e-spec.ts
@@ -37,6 +37,17 @@ describe('authentication gate', () => {
     expect(res.body).toBeTruthy();
   });
 
+  it('GET /auth/me carries the profile header fields', async () => {
+    const res = await world.clients.userA.get('/api/v1/auth/me');
+    expect(res.status).toBe(200);
+    const body = res.body as Record<string, unknown>;
+    // The SPA profile header reads these; they mirror /me/profile's source.
+    expect(body).toHaveProperty('display_name');
+    expect(body).toHaveProperty('email');
+    expect(Array.isArray(body.auth_methods)).toBe(true);
+    expect(Array.isArray(body.granted_capabilities)).toBe(true);
+  });
+
   it('an elevated admin can list users', async () => {
     const res = await world.clients.admin.get('/api/v1/admin/accounts/users');
     expect(res.status).toBe(200);

--- a/tests/integration/web-console-e2e/specs/health-and-auth.e2e-spec.ts
+++ b/tests/integration/web-console-e2e/specs/health-and-auth.e2e-spec.ts
@@ -37,15 +37,18 @@ describe('authentication gate', () => {
     expect(res.body).toBeTruthy();
   });
 
-  it('GET /auth/me carries the profile header fields', async () => {
+  it('GET /auth/me carries the profile header fields with contract types', async () => {
     const res = await world.clients.userA.get('/api/v1/auth/me');
     expect(res.status).toBe(200);
     const body = res.body as Record<string, unknown>;
     // The SPA profile header reads these; they mirror /me/profile's source.
-    expect(body).toHaveProperty('display_name');
-    expect(body).toHaveProperty('email');
+    // Types are the contract: string-or-null scalars, string arrays.
+    expect(body.display_name === null || typeof body.display_name === 'string').toBe(true);
+    expect(body.email === null || typeof body.email === 'string').toBe(true);
     expect(Array.isArray(body.auth_methods)).toBe(true);
+    expect((body.auth_methods as unknown[]).every(m => typeof m === 'string')).toBe(true);
     expect(Array.isArray(body.granted_capabilities)).toBe(true);
+    expect((body.granted_capabilities as unknown[]).every(c => typeof c === 'string')).toBe(true);
   });
 
   it('an elevated admin can list users', async () => {

--- a/tests/integration/web-console-e2e/specs/health-and-auth.e2e-spec.ts
+++ b/tests/integration/web-console-e2e/specs/health-and-auth.e2e-spec.ts
@@ -37,18 +37,17 @@ describe('authentication gate', () => {
     expect(res.body).toBeTruthy();
   });
 
-  it('GET /auth/me carries the profile header fields with contract types', async () => {
+  it('GET /auth/me carries the profile header fields with the seeded values', async () => {
     const res = await world.clients.userA.get('/api/v1/auth/me');
     expect(res.status).toBe(200);
     const body = res.body as Record<string, unknown>;
     // The SPA profile header reads these; they mirror /me/profile's source.
-    // Types are the contract: string-or-null scalars, string arrays.
-    expect(body.display_name === null || typeof body.display_name === 'string').toBe(true);
-    expect(body.email === null || typeof body.email === 'string').toBe(true);
-    expect(Array.isArray(body.auth_methods)).toBe(true);
-    expect((body.auth_methods as unknown[]).every(m => typeof m === 'string')).toBe(true);
-    expect(Array.isArray(body.granted_capabilities)).toBe(true);
-    expect((body.granted_capabilities as unknown[]).every(c => typeof c === 'string')).toBe(true);
+    // Pin the seeded user's actual values, not just the field types — a
+    // regression to null/[] for an existing principal must fail here.
+    expect(body.display_name).toBe(world.userA.username);
+    expect(body.email).toBe(world.userA.email);
+    expect(body.auth_methods).toEqual(['local']);
+    expect(body.granted_capabilities).toEqual(['console:self']);
   });
 
   it('an elevated admin can list users', async () => {

--- a/tests/integration/web-console-e2e/specs/me-logs.e2e-spec.ts
+++ b/tests/integration/web-console-e2e/specs/me-logs.e2e-spec.ts
@@ -1,0 +1,23 @@
+import { setupWorld, type World } from '../harness/world.js';
+
+let world: World;
+beforeAll(async () => { world = await setupWorld(); });
+
+describe('/me/logs', () => {
+  it('serves the cursor-family envelope', async () => {
+    const res = await world.clients.userA.get('/api/v1/me/logs?limit=5');
+    expect(res.status).toBe(200);
+    const body = res.body as { items: unknown[]; page: { limit: number; cursor: unknown; next_cursor: unknown } };
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(body.page.limit).toBe(5);
+    // First page: cursor null; next_cursor is either null or an opaque string.
+    expect(body.page.cursor).toBeNull();
+    expect(body.page.next_cursor === null || typeof body.page.next_cursor === 'string').toBe(true);
+  });
+
+  it('treats a garbage cursor as the first page rather than erroring', async () => {
+    const res = await world.clients.userA.get('/api/v1/me/logs?limit=5&cursor=not-a-real-cursor');
+    expect(res.status).toBe(200);
+    expect((res.body as { page: { cursor: unknown } }).page.cursor).toBeNull();
+  });
+});

--- a/tests/integration/web-console-e2e/specs/me-logs.e2e-spec.ts
+++ b/tests/integration/web-console-e2e/specs/me-logs.e2e-spec.ts
@@ -20,4 +20,28 @@ describe('/me/logs', () => {
     expect(res.status).toBe(200);
     expect((res.body as { page: { cursor: unknown } }).page.cursor).toBeNull();
   });
+
+  it('walks a second page through the opaque cursor over real HTTP', async () => {
+    // Guarantee user-scoped log entries: portfolio mutations run inside the
+    // per-user context bridge, so the element managers' logging is attributed
+    // to this user (plain reads are not reliably attributed).
+    for (const name of ['Log-Walk-A', 'Log-Walk-B']) {
+      await world.clients.userA.post('/api/v1/me/portfolio/elements/personas', {
+        body: { name, content: `You are ${name}.`, metadata: {}, tags: [] },
+      });
+    }
+
+    type Page = { items: { id: string }[]; page: { cursor: string | null; next_cursor: string | null } };
+    const first = (await world.clients.userA.get('/api/v1/me/logs?limit=1')).body as Page;
+    expect(first.items).toHaveLength(1);
+    expect(first.page.next_cursor).not.toBeNull();
+
+    const second = (await world.clients.userA.get(
+      `/api/v1/me/logs?limit=1&cursor=${encodeURIComponent(first.page.next_cursor ?? '')}`,
+    )).body as Page;
+    expect(second.items).toHaveLength(1);
+    expect(second.page.cursor).toBe(first.page.next_cursor);
+    // The walk continues, and it never repeats the first page's entry.
+    expect(second.items[0].id).not.toBe(first.items[0].id);
+  });
 });

--- a/tests/integration/web-console-e2e/specs/me-portfolio.e2e-spec.ts
+++ b/tests/integration/web-console-e2e/specs/me-portfolio.e2e-spec.ts
@@ -22,9 +22,16 @@ describe('/me/portfolio reads', () => {
     expect(res.status).toBe(200);
   });
 
-  it('404s an unknown element', async () => {
+  it('404s an unknown element as an RFC 9457 problem document', async () => {
     const res = await world.clients.userA.get(`${base}/does-not-exist`);
     expect(res.status).toBe(404);
+    // Handler errors must ship the same problem+json envelope as middleware
+    // errors: typed `type` URI, `instance` echoing the request correlation id.
+    expect(res.headers.get('content-type')).toContain('application/problem+json');
+    const problem = res.body as Record<string, unknown>;
+    expect(problem.type).toBe('https://dollhousemcp.com/errors/portfolio_element_not_found');
+    expect(problem.code).toBe('portfolio_element_not_found');
+    expect(problem.instance).toBe(res.headers.get('x-correlation-id'));
   });
 });
 

--- a/tests/integration/web-console-e2e/specs/me-runtime-sessions.e2e-spec.ts
+++ b/tests/integration/web-console-e2e/specs/me-runtime-sessions.e2e-spec.ts
@@ -6,10 +6,11 @@ beforeAll(async () => { world = await setupWorld(); });
 const UNKNOWN = '00000000-0000-4000-8000-000000000000';
 
 describe('/me/sessions (MCP runtime sessions)', () => {
-  it('lists the caller runtime sessions', async () => {
+  it('lists the caller runtime sessions in the snapshot envelope', async () => {
     const res = await world.clients.userA.get('/api/v1/me/sessions');
     expect(res.status).toBe(200);
-    expect(res.body).toBeTruthy();
+    // Snapshot family: noun-keyed envelope, never a bare array.
+    expect(Array.isArray((res.body as { sessions: unknown[] }).sessions)).toBe(true);
   });
 
   it('an unknown session detail is 404', async () => {

--- a/tests/unit/web-console/auth/ConsoleBffAuthModule.test.ts
+++ b/tests/unit/web-console/auth/ConsoleBffAuthModule.test.ts
@@ -504,6 +504,23 @@ describe('ConsoleBffAuthModule', () => {
     expect(redirect.searchParams.get('redirect_uri')).toBe(`${ORIGIN}${STEP_UP_CALLBACK_PATH}`);
   });
 
+  it('rejects an invalid step-up capability as an RFC 9457 problem document', async () => {
+    const fixture = buildFixture();
+    const session = await loginSession(fixture);
+
+    const response = await request(fixture.app)
+      .get(`${STEP_UP_PATH}?capability=not-a-capability`)
+      .set('Cookie', session.sessionCookie);
+
+    expect(response.status).toBe(400);
+    // The handler error must ride the kernel's problem lift like every other
+    // module error: typed type URI, instance = correlation id, problem+json.
+    expect(response.headers['content-type']).toContain('application/problem+json');
+    expect(response.body.type).toBe('https://dollhousemcp.com/errors/invalid_capability');
+    expect(response.body.code).toBe('invalid_capability');
+    expect(response.body.instance).toBe(response.headers['x-correlation-id']);
+  });
+
   it('completes step-up once and attaches TOTP-backed elevation to the current session', async () => {
     const fixture = buildFixture();
     fixture.oauthClient.claims = {
@@ -723,9 +740,14 @@ describe('ConsoleBffAuthModule', () => {
       .set('Cookie', session.sessionCookie);
 
     expect(response.status).toBe(400);
+    // Full RFC 9457 problem document via the kernel lift.
     expect(response.body).toEqual({
+      type: 'https://dollhousemcp.com/errors/invalid_capability',
+      title: 'Invalid request',
+      status: 400,
       code: 'invalid_capability',
       detail: 'Step-up requires a valid administrative console capability.',
+      instance: response.headers['x-correlation-id'],
     });
     expect(response.headers['set-cookie']).toBeUndefined();
   });

--- a/tests/unit/web-console/auth/ConsoleBffAuthModule.test.ts
+++ b/tests/unit/web-console/auth/ConsoleBffAuthModule.test.ts
@@ -9,6 +9,7 @@ import {
   createConsoleBffAuthModule,
   HmacConsoleOpaqueValueService,
   InMemoryAdminAuditWriter,
+  InMemoryConsoleAccountAdminStore,
   InMemoryConsoleIdentityResolver,
   InMemoryConsoleSessionStore,
   InMemoryIdempotencyStore,
@@ -16,6 +17,7 @@ import {
   InMemoryRuntimeSessionControlStore,
   type ConsoleLoginFlowKind,
   type ConsolePrincipalSecurityState,
+  type ConsolePrincipalSummary,
   type ConsoleOAuthCodeExchangeRequest,
   type ConsoleOAuthIdentityClaims,
   type ConsoleAuthorizationUrlRequest,
@@ -80,7 +82,28 @@ class FakeConsoleOAuthClient implements IConsoleOAuthClient {
 interface FixtureOptions {
   readonly now?: () => Date;
   readonly principals?: readonly ConsolePrincipalSecurityState[];
+  readonly accountPrincipals?: readonly ConsolePrincipalSummary[];
   readonly secretEncryption?: ISecretEncryptionService;
+}
+
+function accountPrincipal(overrides: Partial<ConsolePrincipalSummary> = {}): ConsolePrincipalSummary {
+  return {
+    userId: USER_ID,
+    primarySub: AUTH_SUB,
+    username: 'alice',
+    displayName: 'Alice Example',
+    email: 'alice@example.test',
+    emailVerified: true,
+    authMethods: ['github'],
+    roles: [],
+    disabledAt: null,
+    createdAt: NOW,
+    lastLoginAt: null,
+    adminFactorEnrolled: false,
+    accountCorrelationId: '7f0a2f6e-9be2-4d5f-8a4e-1c2b3d4e5f60',
+    authzVersion: 3,
+    ...overrides,
+  };
 }
 
 function buildFixture(options: FixtureOptions = {}): {
@@ -101,6 +124,9 @@ function buildFixture(options: FixtureOptions = {}): {
     authzVersion: 3,
   }];
   const identityResolver = new InMemoryConsoleIdentityResolver(principals);
+  const accountAdminStore = new InMemoryConsoleAccountAdminStore(
+    options.accountPrincipals ?? [accountPrincipal()],
+  );
   const secretEncryption = options.secretEncryption ?? new AeadSecretEncryptionService({
     keyId: 'test-key',
     key: SECRET_KEY,
@@ -111,6 +137,7 @@ function buildFixture(options: FixtureOptions = {}): {
     loginTransactions,
     sessionStore,
     identityResolver,
+    accountAdminStore,
     opaqueValues,
     secretEncryption,
     publicBaseUrl: ORIGIN,
@@ -180,10 +207,30 @@ describe('ConsoleBffAuthModule', () => {
     expect(me.body).toEqual({
       user_id: USER_ID,
       auth_sub: AUTH_SUB,
+      display_name: 'Alice Example',
+      email: 'alice@example.test',
+      auth_methods: ['github'],
       granted_capabilities: [SELF_CAPABILITY],
       available_admin_capabilities: [],
       elevation: { active: false, expires_at: null, acr: null },
     });
+  });
+
+  it('serves /auth/me with null profile fields when the principal row is gone', async () => {
+    const { app } = buildFixture({ accountPrincipals: [] });
+    const login = await request(app).get(LOGIN_PATH);
+    const state = new URL(login.headers.location).searchParams.get('state');
+    const loginCookie = cookieHeader(login.headers['set-cookie'], CONSOLE_LOGIN_STATE_COOKIE);
+    const callback = await request(app)
+      .get(`${CALLBACK_PATH}?code=${AUTH_CODE}&state=${encodeURIComponent(state ?? '')}`)
+      .set('Cookie', loginCookie);
+    const sessionCookie = cookieHeader(callback.headers['set-cookie'], CONSOLE_SESSION_COOKIE);
+
+    const me = await request(app).get(ME_PATH).set('Cookie', sessionCookie);
+    expect(me.status).toBe(200);
+    expect(me.body.display_name).toBeNull();
+    expect(me.body.email).toBeNull();
+    expect(me.body.auth_methods).toEqual([]);
   });
 
   it('reports the role-entitled admin capabilities a principal can step up into', async () => {

--- a/tests/unit/web-console/modules/MeLogsModule.test.ts
+++ b/tests/unit/web-console/modules/MeLogsModule.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  createMeLogsModule,
+  type ConsoleLogEntry,
+  type ConsoleLogQueryOptions,
+  type IConsoleLogSource,
+} from '../../../../src/web-console/modules/me-logs/index.js';
+import type { ConsoleRequest } from '../../../../src/web-console/index.js';
+
+const USER_ID = '018f3d47-73ae-7f10-a0de-0742618d4fb1';
+
+function entry(id: number): ConsoleLogEntry {
+  return {
+    id: `log-${id}`,
+    ts: '2026-07-06T12:00:00.000Z',
+    level: 'info',
+    category: 'app',
+    source: 'test',
+    message: `message ${id}`,
+    correlation_id: null,
+    session_id: null,
+  };
+}
+
+/** A source over a fixed set of entries honoring limit/offset like the sink. */
+function sourceOver(total: number): { source: IConsoleLogSource; seen: ConsoleLogQueryOptions[] } {
+  const seen: ConsoleLogQueryOptions[] = [];
+  return {
+    seen,
+    source: {
+      queryUserLogs(options) {
+        seen.push(options);
+        const all = Array.from({ length: total }, (_, i) => entry(i + 1));
+        const slice = all.slice(options.offset, options.offset + options.limit);
+        return { entries: slice, has_more: options.offset + slice.length < total };
+      },
+    },
+  };
+}
+
+function request(query: Record<string, string> = {}): ConsoleRequest {
+  return {
+    params: {},
+    query,
+    body: {},
+    headers: {},
+    consoleAuthentication: {
+      sessionIdHash: Buffer.alloc(32, 7),
+      userId: USER_ID,
+      authSub: 'github_user-7',
+      authzVersion: 1,
+      grantedCapabilities: ['console:self'],
+      elevation: null,
+    },
+  } as unknown as ConsoleRequest;
+}
+
+function route(source: IConsoleLogSource) {
+  const module = createMeLogsModule({ logSource: source });
+  const match = module.routes.find(candidate => candidate.path === '/api/v1/me/logs');
+  if (!match) throw new Error('me/logs route not found');
+  return match;
+}
+
+describe('MeLogsModule', () => {
+  it('serves the cursor-family envelope with a null cursor on the first page', async () => {
+    const { source } = sourceOver(2);
+    const result = await route(source).handler(request({ limit: '10' }));
+
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({
+      items: [entry(1), entry(2)],
+      page: { limit: 10, cursor: null, next_cursor: null },
+    });
+  });
+
+  it('walks pages through opaque cursors, never exposing an offset parameter', async () => {
+    const { source, seen } = sourceOver(3);
+    const handler = route(source).handler;
+
+    const first = await handler(request({ limit: '2' }));
+    const firstBody = first.body as { items: unknown[]; page: { next_cursor: string | null } };
+    expect(firstBody.items).toHaveLength(2);
+    expect(firstBody.page.next_cursor).not.toBeNull();
+    expect(firstBody.page.next_cursor).not.toContain('2'); // opaque, not a raw offset
+
+    const second = await handler(request({ limit: '2', cursor: firstBody.page.next_cursor ?? '' }));
+    const secondBody = second.body as {
+      items: readonly ConsoleLogEntry[];
+      page: { cursor: string | null; next_cursor: string | null };
+    };
+    expect(secondBody.items).toEqual([entry(3)]);
+    expect(secondBody.page.cursor).toBe(firstBody.page.next_cursor);
+    expect(secondBody.page.next_cursor).toBeNull();
+    expect(seen.map(options => options.offset)).toEqual([0, 2]);
+  });
+
+  it('treats a garbage cursor as the first page', async () => {
+    const { source, seen } = sourceOver(1);
+    await route(source).handler(request({ cursor: 'not-a-cursor' }));
+    expect(seen[0].offset).toBe(0);
+  });
+
+  it('passes filters through to the source alongside the cursor', async () => {
+    const { source, seen } = sourceOver(1);
+    await route(source).handler(request({ level: 'error', session_id: 'sess-1' }));
+    expect(seen[0]).toMatchObject({ userId: USER_ID, level: 'error', sessionId: 'sess-1', offset: 0 });
+  });
+});

--- a/tests/unit/web-console/modules/OperationsModule.test.ts
+++ b/tests/unit/web-console/modules/OperationsModule.test.ts
@@ -751,8 +751,9 @@ describe('OperationsModule', () => {
     const result = await route.handler({ query: {}, params: {} } as never);
 
     expect(result.status).toBe(200);
+    // Cursor-family envelope; ring-buffer anchors stay top-level.
     expect(projectSystemMetrics(result.body)).toEqual({
-      snapshots: [{
+      items: [{
         id: 'snap-1',
         timestamp: NOW.toISOString(),
         duration_ms: 5,
@@ -762,13 +763,49 @@ describe('OperationsModule', () => {
           { name: 'op.latency', source: 'perf', unit: 'ms', type: 'histogram', value: { count: 3, sum: 30, min: 5, p95: 20 } },
         ],
       }],
-      total: 1,
-      has_more: false,
-      limit: 50,
-      offset: 0,
+      page: { limit: 50, cursor: null, next_cursor: null },
       oldest_available: NOW.toISOString(),
       newest_available: NOW.toISOString(),
     });
+  });
+
+  it('walks System A pages through opaque cursors, never raw offsets', async () => {
+    const source: ISystemMetricsSource = {
+      query: (options) => ({
+        snapshots: [{
+          id: `snap-${(options?.offset ?? 0) + 1}`,
+          timestamp: NOW.toISOString(),
+          durationMs: 5,
+          errors: [],
+          metrics: [],
+        }],
+        total: 2,
+        hasMore: (options?.offset ?? 0) === 0,
+        limit: 1,
+        offset: options?.offset ?? 0,
+        oldestAvailable: NOW.toISOString(),
+        newestAvailable: NOW.toISOString(),
+      }),
+    };
+    const route = findRoute(createOperationsModule({
+      healthChecks: HEALTH_CHECKS,
+      telemetry: createTelemetry(),
+      operatorConfigStore: new InMemoryOperatorConfigStore(),
+      systemMetrics: source,
+      now: () => NOW,
+    }).routes, 'GET', SYSTEM_METRICS_PATH);
+
+    const first = projectSystemMetrics((await route.handler({ query: { limit: '1' }, params: {} } as never)).body);
+    expect(first.items[0].id).toBe('snap-1');
+    expect(first.page.next_cursor).not.toBeNull();
+    // The cursor is opaque — the raw offset never appears as a query param.
+    const second = projectSystemMetrics((await route.handler({
+      query: { limit: '1', cursor: first.page.next_cursor },
+      params: {},
+    } as never)).body);
+    expect(second.items[0].id).toBe('snap-2');
+    expect(second.page.cursor).toBe(first.page.next_cursor);
+    expect(second.page.next_cursor).toBeNull();
   });
 
   it('returns an empty System A result when metrics collection is disabled (no sink)', async () => {
@@ -777,7 +814,10 @@ describe('OperationsModule', () => {
     const result = await route.handler({ query: {}, params: {} } as never);
 
     expect(result.status).toBe(200);
-    expect(projectSystemMetrics(result.body)).toMatchObject({ snapshots: [], total: 0, has_more: false });
+    expect(projectSystemMetrics(result.body)).toMatchObject({
+      items: [],
+      page: { cursor: null, next_cursor: null },
+    });
   });
 
   it('streams operational metrics through SSE update events with allowlisted payloads', async () => {

--- a/tests/unit/web-console/modules/OperationsModule.test.ts
+++ b/tests/unit/web-console/modules/OperationsModule.test.ts
@@ -589,10 +589,12 @@ describe('OperationsModule', () => {
   it('bounds operational log limits for invalid and extreme requests', async () => {
     const route = findRoute(createModule(HEALTH_CHECKS, createTelemetry(150)).routes, 'GET', OPERATE_LOGS_PATH);
 
+    // Sub-1 and unparsable limits are invalid input → the endpoint default
+    // (shared ConsoleQueryParams semantics), not a clamp to 1.
     await expect(route.handler({ query: { limit: '0' }, params: {} } as never))
-      .resolves.toMatchObject({ body: { items: expect.arrayContaining([expect.any(Object)]), page: { limit: 1 } } });
+      .resolves.toMatchObject({ body: { items: expect.arrayContaining([expect.any(Object)]), page: { limit: 100 } } });
     await expect(route.handler({ query: { limit: '-10' }, params: {} } as never))
-      .resolves.toMatchObject({ body: { page: { limit: 1 } } });
+      .resolves.toMatchObject({ body: { page: { limit: 100 } } });
     await expect(route.handler({ query: { limit: '1000' }, params: {} } as never))
       .resolves.toMatchObject({ body: { items: expect.any(Array), page: { limit: 100 } } });
     await expect(route.handler({ query: { limit: 'not-a-number' }, params: {} } as never))

--- a/tests/unit/web-console/modules/RuntimeSessionModule.test.ts
+++ b/tests/unit/web-console/modules/RuntimeSessionModule.test.ts
@@ -204,10 +204,13 @@ describe('RuntimeSessionModule', () => {
 
     await expect(listRoute.handler(request())).resolves.toMatchObject({
       status: 200,
-      body: [{
-        session_id: SESSION_ID,
-        client_info: { name: 'Dollhouse CLI', version: '1.0.0' },
-      }],
+      // Snapshot-family envelope: noun-keyed, never a bare array.
+      body: {
+        sessions: [{
+          session_id: SESSION_ID,
+          client_info: { name: 'Dollhouse CLI', version: '1.0.0' },
+        }],
+      },
     });
     const result = await showRoute.handler(request({ params: { session_id: SESSION_ID } }));
     expect(result.body).not.toHaveProperty('account_correlation_id');
@@ -239,7 +242,8 @@ describe('RuntimeSessionModule', () => {
     const route = findRoute(module.routes, 'GET', '/api/v1/admin/accounts/users/:user_id/sessions');
 
     const result = await route.handler(request({ params: { user_id: USER_ID } }));
-    const projected = projectRuntimeSessionAccount((result.body as unknown[])[0]);
+    const sessions = (result.body as { sessions: unknown[] }).sessions;
+    const projected = projectRuntimeSessionAccount(sessions[0]);
 
     expect(projected).toEqual({
       session_id: SESSION_ID,
@@ -318,7 +322,7 @@ describe('RuntimeSessionModule', () => {
     const deleteRoute = findRoute(module.routes, 'DELETE', '/api/v1/admin/operate/sessions/:session_id');
 
     const list = await listRoute.handler(request());
-    const projected = projectRuntimeSessionOperational((list.body as unknown[])[0]);
+    const projected = projectRuntimeSessionOperational((list.body as { sessions: unknown[] }).sessions[0]);
     expect(projected).toMatchObject({
       session_id: SESSION_ID,
       account_correlation_id: ACCOUNT_CORRELATION_ID,

--- a/tests/unit/web-console/platform/ConsoleCursor.test.ts
+++ b/tests/unit/web-console/platform/ConsoleCursor.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  decodeConsoleCursor,
+  encodeConsoleCursor,
+  offsetConsoleCursor,
+  offsetFromConsoleCursor,
+} from '../../../../src/web-console/platform/ConsoleCursor.js';
+
+describe('ConsoleCursor', () => {
+  it('round-trips a payload through an opaque token', () => {
+    const token = encodeConsoleCursor({ o: 42, k: 'seq' });
+    expect(token).not.toContain('42');
+    expect(decodeConsoleCursor(token)).toEqual({ o: 42, k: 'seq' });
+  });
+
+  it.each([
+    ['empty string', ''],
+    ['not base64 json', 'garbage!!!'],
+    ['json but not an object', Buffer.from('[1,2]').toString('base64url')],
+    ['oversized token', 'a'.repeat(513)],
+  ])('rejects %s as null', (_case, token) => {
+    expect(decodeConsoleCursor(token)).toBeNull();
+  });
+
+  it('maps offset cursors both ways, treating garbage as the first page', () => {
+    expect(offsetFromConsoleCursor(null)).toBe(0);
+    expect(offsetFromConsoleCursor('not-a-cursor')).toBe(0);
+    expect(offsetFromConsoleCursor(offsetConsoleCursor(250))).toBe(250);
+    expect(offsetFromConsoleCursor(encodeConsoleCursor({ o: -5 }))).toBe(0);
+    expect(offsetFromConsoleCursor(encodeConsoleCursor({ o: 1.5 }))).toBe(0);
+  });
+});

--- a/tests/unit/web-console/platform/ConsolePolicyExecution.test.ts
+++ b/tests/unit/web-console/platform/ConsolePolicyExecution.test.ts
@@ -17,6 +17,9 @@ import {
   serializeConsoleCookie,
 } from '../../../../src/web-console/middleware/ConsoleCookies.js';
 
+const ABOUT_BLANK = 'about:blank';
+const TEST_ACTOR_USER_ID = '018f3d47-73ae-7f10-a0de-0742618d4fb1';
+
 function route(overrides: Partial<ConsoleRouteDefinition> = {}): ConsoleRouteDefinition {
   return {
     method: 'GET',
@@ -35,7 +38,7 @@ function route(overrides: Partial<ConsoleRouteDefinition> = {}): ConsoleRouteDef
 function auditEvent(): ConsoleAdminAuditEvent {
   return {
     occurredAt: new Date('2026-05-26T12:00:00.000Z'),
-    actorUserId: '018f3d47-73ae-7f10-a0de-0742618d4fb1',
+    actorUserId: TEST_ACTOR_USER_ID,
     actorSub: 'github_user-7',
     actorRole: null,
     actorCapabilityRole: 'auditor',
@@ -78,7 +81,7 @@ describe('console route policy execution', () => {
   it('leaves administrative problem bodies unprojected', async () => {
     const projector = jest.fn(value => ({ visible: (value as { visible: boolean }).visible }));
     const problem = {
-      type: 'about:blank',
+      type: ABOUT_BLANK,
       title: 'Not found',
       status: 404,
       code: 'not_found',
@@ -115,7 +118,7 @@ describe('console route policy execution', () => {
   it('leaves self-service problem bodies unprojected', async () => {
     const projector = jest.fn(value => ({ visible: (value as { visible: boolean }).visible }));
     const problem = {
-      type: 'about:blank',
+      type: ABOUT_BLANK,
       title: 'Validation failed',
       status: 422,
       code: 'validation_failed',
@@ -288,6 +291,116 @@ describe('console route policy execution', () => {
     sendConsoleHandlerResult(response, { status: 200, body: { ok: true } });
     expect(response.status).toHaveBeenCalledWith(200);
     expect(json).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it('lifts handler problem bodies into RFC 9457 problem documents', () => {
+    const json = jest.fn();
+    const type = jest.fn().mockReturnThis();
+    const response = {
+      status: jest.fn().mockReturnThis(),
+      type,
+      json,
+      end: jest.fn(),
+    } as unknown as Response;
+    const request = {
+      headers: {},
+      consoleContext: { correlationId: TEST_ACTOR_USER_ID, receivedAt: new Date() },
+    } as unknown as Parameters<typeof sendConsoleHandlerResult>[2];
+
+    sendConsoleHandlerResult(response, {
+      status: 422,
+      body: {
+        type: ABOUT_BLANK,
+        title: 'Validation failed',
+        status: 422,
+        code: 'validation_failed',
+        detail: 'content is required.',
+        issues: [{ path: 'content', code: 'required', message: 'content is required.' }],
+      },
+    }, request);
+
+    expect(response.status).toHaveBeenCalledWith(422);
+    expect(type).toHaveBeenCalledWith('application/problem+json');
+    expect(json).toHaveBeenCalledWith({
+      type: 'https://dollhousemcp.com/errors/validation_failed',
+      title: 'Validation failed',
+      status: 422,
+      detail: 'content is required.',
+      instance: TEST_ACTOR_USER_ID,
+      code: 'validation_failed',
+      issues: [{ path: 'content', code: 'required', message: 'content is required.' }],
+    });
+  });
+
+  it('sends non-problem error bodies and status-mismatched bodies unchanged', () => {
+    const json = jest.fn();
+    const type = jest.fn().mockReturnThis();
+    const response = {
+      status: jest.fn().mockReturnThis(),
+      type,
+      json,
+      end: jest.fn(),
+    } as unknown as Response;
+    const request = {
+      headers: {},
+      consoleContext: { correlationId: TEST_ACTOR_USER_ID, receivedAt: new Date() },
+    } as unknown as Parameters<typeof sendConsoleHandlerResult>[2];
+
+    // Not a problem document at all.
+    sendConsoleHandlerResult(response, { status: 400, body: { message: 'nope' } }, request);
+    expect(json).toHaveBeenLastCalledWith({ message: 'nope' });
+
+    // Problem-shaped but self-identifying as a different status: not lifted.
+    sendConsoleHandlerResult(response, {
+      status: 400,
+      body: { type: ABOUT_BLANK, title: 'Not found', status: 404, code: 'not_found', detail: 'x' },
+    }, request);
+    expect(json).toHaveBeenLastCalledWith({ type: ABOUT_BLANK, title: 'Not found', status: 404, code: 'not_found', detail: 'x' });
+    expect(type).not.toHaveBeenCalledWith('application/problem+json');
+  });
+
+  it('ships the plain body when no request context is available', () => {
+    const json = jest.fn();
+    const type = jest.fn().mockReturnThis();
+    const response = {
+      status: jest.fn().mockReturnThis(),
+      type,
+      json,
+      end: jest.fn(),
+    } as unknown as Response;
+
+    sendConsoleHandlerResult(response, {
+      status: 404,
+      body: { type: ABOUT_BLANK, title: 'Not found', status: 404, code: 'not_found', detail: 'x' },
+    });
+
+    expect(json).toHaveBeenCalledWith({ type: ABOUT_BLANK, title: 'Not found', status: 404, code: 'not_found', detail: 'x' });
+    expect(type).not.toHaveBeenCalledWith('application/problem+json');
+  });
+
+  it('prefers the browser HTML error page over problem+json for document navigations', () => {
+    const send = jest.fn();
+    const type = jest.fn().mockReturnThis();
+    const response = {
+      status: jest.fn().mockReturnThis(),
+      type,
+      send,
+      json: jest.fn(),
+      end: jest.fn(),
+    } as unknown as Response;
+    const request = {
+      headers: { accept: 'text/html' },
+      consoleContext: { correlationId: TEST_ACTOR_USER_ID, receivedAt: new Date() },
+    } as unknown as Parameters<typeof sendConsoleHandlerResult>[2];
+
+    sendConsoleHandlerResult(response, {
+      status: 401,
+      body: { type: ABOUT_BLANK, title: 'Step-up required', status: 401, code: 'step_up_required', detail: 'x' },
+    }, request);
+
+    expect(type).toHaveBeenCalledWith('text/html');
+    expect(type).not.toHaveBeenCalledWith('application/problem+json');
+    expect(send).toHaveBeenCalledTimes(1);
   });
 
   it('emits platform-controlled cookie directives before completing a response', () => {

--- a/tests/unit/web-console/platform/ConsoleQueryParams.test.ts
+++ b/tests/unit/web-console/platform/ConsoleQueryParams.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  boundedLimit,
+  boundedString,
+  firstString,
+  optionalLimit,
+} from '../../../../src/web-console/platform/ConsoleQueryParams.js';
+
+describe('ConsoleQueryParams', () => {
+  describe('firstString', () => {
+    it.each([
+      ['a plain string', 'value', 'value'],
+      ['the first array element', ['first', 'second'], 'first'],
+      ['undefined', undefined, null],
+      ['a non-string array head', [42, 'second'], null],
+      ['a number', 7, null],
+    ])('reads %s', (_case, input, expected) => {
+      expect(firstString(input)).toBe(expected);
+    });
+  });
+
+  describe('boundedString', () => {
+    it('trims and accepts in-bound strings', () => {
+      expect(boundedString('  hello  ', 10)).toBe('hello');
+    });
+
+    it('rejects over-length input as null — never truncates', () => {
+      // A silently truncated filter would match different data than the
+      // client asked for; over-length is treated as absent.
+      expect(boundedString('a'.repeat(11), 10)).toBeNull();
+      expect(boundedString('a'.repeat(10), 10)).toBe('a'.repeat(10));
+    });
+
+    it.each([
+      ['null', null],
+      ['empty', ''],
+      ['whitespace only', '   '],
+    ])('treats %s as absent', (_case, input) => {
+      expect(boundedString(input, 10)).toBeNull();
+    });
+  });
+
+  describe('boundedLimit / optionalLimit', () => {
+    it('accepts positive integers up to the cap', () => {
+      expect(boundedLimit('5', 100, 1000)).toBe(5);
+      expect(boundedLimit('5000', 100, 1000)).toBe(1000);
+      expect(optionalLimit('5', 1000)).toBe(5);
+      expect(optionalLimit('5000', 1000)).toBe(1000);
+    });
+
+    it.each([
+      ['absent', null],
+      ['zero', '0'],
+      ['negative', '-3'],
+      ['garbage', 'lots'],
+    ])('%s input falls back / yields null', (_case, input) => {
+      expect(boundedLimit(input, 100, 1000)).toBe(100);
+      expect(optionalLimit(input, 1000)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Locks down the three response-shape contracts a production UI (and any future API client) builds against, while the `/api/v1` surface still has a single first-party consumer and shape changes are free.

## Error envelope

Errors returned from inside route handlers previously shipped as plain `application/json` with `type: "about:blank"` and no correlation id, while middleware errors (authentication, CSRF, authorization) correctly used RFC 9457 `problem+json`. The route-execution kernel now lifts handler error bodies through the same problem builder — typed `type` URI derived from the error `code`, `instance` populated with the request correlation id, extension members such as validation `issues` preserved. One enforcement point covers every module, present and future; the module-level error helpers are unchanged. The browser-navigation HTML error page keeps precedence for document requests.

## `GET /auth/me` profile fields

The response now carries `display_name`, `email`, and `auth_methods`, served from the same account store `/me/profile` reads — no parallel profile path. Null-safe when the principal row is gone, so a session that outlives its principal can still resolve and sign out. The field is the `auth_methods` array (the account's linked methods, matching `/me/profile`) rather than a singular `auth_method`: the session record carries no per-session method attribution, so a singular value would be fabricated.

## Pagination: two list families

List endpoints previously spanned five envelope shapes, including two broken ones — `/me/logs` reported `has_more` with no token to fetch more, and the system-metrics endpoint exposed its pagination as a raw integer `offset`. The surface now uses exactly two families:

- **Cursor** — `{items, page: {limit, cursor, next_cursor}}` for unbounded/append-only surfaces. Cursors are opaque and filter-bound; `next_cursor: null` is the exhaustion signal; there is no `total` (counting an unbounded set is either unaffordable or meaningless). `/me/logs` and `/admin/operate/metrics/system` converge into this family via a shared cursor codec.
- **Snapshot** — `{<noun>: [...]}` for bounded sets, never a bare array, with the envelope key reserved for future evolution. The three runtime-session lists (which returned bare, unevolvable JSON arrays) converge here; the self-session list also gains its previously missing privacy-projector declaration.

The collection catalog's page-number form is grandfathered as a documented exception (a cached remote snapshot where `total` is free and the interaction model is browse-then-filter). The never-implemented page-based + `Link`-header model is withdrawn from the contract. Consuming UI modules are updated in the same change, so the bundled console is never off-contract.

## Testing

Unit coverage for the kernel problem lift, the cursor codec, cursor page-walks on both converged endpoints, and the envelope shapes; new end-to-end assertions pin the problem envelope (including `instance` = `X-Correlation-Id`) and both list families over real HTTP against a production-mode boot. Full unit/integration/e2e suites green; Logs and Sessions tabs verified live in a browser.
