### PR TITLE
web-console: hardening sweep, deletion auditing, retention, and account erasure

### DIFF
--- a/src/database/migrations/0043_drop_portfolio_sync_cancelled_status.sql
+++ b/src/database/migrations/0043_drop_portfolio_sync_cancelled_status.sql
@@ -1,0 +1,49 @@
+-- Remove the never-produced 'cancelled' portfolio-sync job status.
+-- No cancel operation exists to emit it (the store exposes only create/claim/renew/
+-- complete/fail), so the value is dropped from both status CHECK constraints. Nothing
+-- ever wrote 'cancelled', so no rows carry it and no data migration is required. If a
+-- real cancel path is added later, re-introduce the value together with its transition.
+
+ALTER TABLE "portfolio_sync_jobs"
+  DROP CONSTRAINT IF EXISTS "portfolio_sync_jobs_status_check";
+ALTER TABLE "portfolio_sync_jobs"
+  ADD CONSTRAINT "portfolio_sync_jobs_status_check"
+    CHECK ("status" IN ('queued', 'running', 'succeeded', 'failed'));
+
+ALTER TABLE "portfolio_sync_jobs"
+  DROP CONSTRAINT IF EXISTS "portfolio_sync_jobs_shape_check";
+ALTER TABLE "portfolio_sync_jobs"
+  ADD CONSTRAINT "portfolio_sync_jobs_shape_check"
+    CHECK (
+      "claim_version" >= 0
+      AND "attempt_count" >= 0
+      AND ("claimed_by_worker_id" IS NULL OR (
+        btrim("claimed_by_worker_id") <> ''
+        AND char_length("claimed_by_worker_id") <= 128
+      ))
+      AND ("operational_error_code" IS NULL OR (
+        btrim("operational_error_code") <> ''
+        AND char_length("operational_error_code") <= 100
+      ))
+      AND ("result_summary" IS NULL OR (
+        jsonb_typeof("result_summary") = 'object'
+        AND char_length("result_summary"::text) <= 4096
+      ))
+      AND (
+        ("status" = 'running'
+          AND "claimed_by_worker_id" IS NOT NULL
+          AND "lease_until" IS NOT NULL
+          AND "completed_at" IS NULL)
+        OR ("status" <> 'running'
+          AND "claimed_by_worker_id" IS NULL
+          AND "lease_until" IS NULL)
+      )
+      AND (
+        ("status" IN ('succeeded', 'failed') AND "completed_at" IS NOT NULL)
+        OR ("status" NOT IN ('succeeded', 'failed') AND "completed_at" IS NULL)
+      )
+      AND (
+        ("status" = 'failed' AND "operational_error_code" IS NOT NULL)
+        OR ("status" <> 'failed' AND "operational_error_code" IS NULL)
+      )
+    );

--- a/src/database/migrations/meta/_journal.json
+++ b/src/database/migrations/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1779085000000,
       "tag": "0042_web_console_integration_token_refresh",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1779085100000,
+      "tag": "0043_drop_portfolio_sync_cancelled_status",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/schema/webConsole.ts
+++ b/src/database/schema/webConsole.ts
@@ -337,7 +337,7 @@ export const integrationOpenApiSpecs = pgTable('integration_openapi_specs', {
 
 export type PortfolioSyncDirection = 'pull' | 'push' | 'bidirectional';
 export type PortfolioSyncConflictPolicy = 'fail' | 'prefer_local' | 'prefer_remote';
-export type PortfolioSyncJobStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+export type PortfolioSyncJobStatus = 'queued' | 'running' | 'succeeded' | 'failed';
 export const portfolioSyncJobs = pgTable('portfolio_sync_jobs', {
   id: uuid('id').primaryKey().defaultRandom(),
   userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
@@ -357,7 +357,7 @@ export const portfolioSyncJobs = pgTable('portfolio_sync_jobs', {
 }, (table) => [
   check('portfolio_sync_jobs_direction_check', sql`${table.direction} IN ('pull', 'push', 'bidirectional')`),
   check('portfolio_sync_jobs_conflict_policy_check', sql`${table.conflictPolicy} IN ('fail', 'prefer_local', 'prefer_remote')`),
-  check('portfolio_sync_jobs_status_check', sql`${table.status} IN ('queued', 'running', 'succeeded', 'failed', 'cancelled')`),
+  check('portfolio_sync_jobs_status_check', sql`${table.status} IN ('queued', 'running', 'succeeded', 'failed')`),
   check('portfolio_sync_jobs_shape_check', sql`
     ${table.claimVersion} >= 0
     AND ${table.attemptCount} >= 0
@@ -383,8 +383,8 @@ export const portfolioSyncJobs = pgTable('portfolio_sync_jobs', {
         AND ${table.leaseUntil} IS NULL)
     )
     AND (
-      (${table.status} IN ('succeeded', 'failed', 'cancelled') AND ${table.completedAt} IS NOT NULL)
-      OR (${table.status} NOT IN ('succeeded', 'failed', 'cancelled') AND ${table.completedAt} IS NULL)
+      (${table.status} IN ('succeeded', 'failed') AND ${table.completedAt} IS NOT NULL)
+      OR (${table.status} NOT IN ('succeeded', 'failed') AND ${table.completedAt} IS NULL)
     )
     AND (
       (${table.status} = 'failed' AND ${table.operationalErrorCode} IS NOT NULL)

--- a/src/database/userDataPurge.ts
+++ b/src/database/userDataPurge.ts
@@ -156,7 +156,9 @@ export function collectDeletionIdentity(
  */
 export async function purgeNonCascadeUserIdentity(tx: DrizzleTx, identity: DeletionIdentity): Promise<void> {
   for (const sub of identity.subs) {
-    // OIDC grants/tokens: model rows carry the subject in payload->>'accountId'.
+    // OIDC grants/tokens: account-linked model rows (Grant, Session, AccessToken, RefreshToken,
+    // …) carry the subject in payload->>'accountId'. Pre-auth Interaction rows have no accountId
+    // and self-expire. Looped rather than batched: an account has one or two subjects.
     await tx.delete(authKv).where(sql`${authKv.payload}->>'accountId' = ${sub}`);
   }
   if (identity.subs.length > 0) {

--- a/src/database/userDataPurge.ts
+++ b/src/database/userDataPurge.ts
@@ -1,0 +1,179 @@
+import { and, eq, inArray, or, sql } from 'drizzle-orm';
+import {
+  approvalAuditEvents,
+  authAllowlist,
+  authIdentityEvents,
+  authKv,
+  consoleLoginTransactions,
+  consoleSessions,
+  elements,
+  integrationProviderDescriptors,
+  portfolioSyncJobs,
+  runtimeSessionPresence,
+  securityInvalidationEvents,
+  sessionActivationEvents,
+  sessionActivityEvents,
+  sessions,
+  userIntegrations,
+  userOauthTokens,
+  userSettings,
+} from './schema/index.js';
+import type { DrizzleTx } from './db-utils.js';
+
+/**
+ * The complete set of user-owned tables that `ON DELETE CASCADE` off `users.id`, expressed
+ * as the top-level deletes that also sweep their own cascade children. A hard `DELETE FROM
+ * users` removes all of this through the DB cascade; when the `users` row is retained
+ * (anonymize-tombstone) the cascade never fires, so this function replays it explicitly.
+ *
+ * This list must stay in lockstep with the schema — the drift-guard test in
+ * `userDataPurge.drift.test.ts` fails if any table that cascades off `users.id` is neither
+ * purged here nor removed transitively (see {@link USER_SCOPED_CASCADE_VIA_PARENT}).
+ */
+export async function purgeUserScopedData(tx: DrizzleTx, userId: string): Promise<void> {
+  // portfolio_sync_jobs RESTRICT-references user_integrations, so it must precede it.
+  await tx.delete(sessionActivityEvents).where(eq(sessionActivityEvents.userId, userId));
+  await tx.delete(portfolioSyncJobs).where(eq(portfolioSyncJobs.userId, userId));
+  await tx.delete(userIntegrations).where(eq(userIntegrations.userId, userId));
+  await tx.delete(userOauthTokens).where(eq(userOauthTokens.userId, userId));
+  await tx.delete(integrationProviderDescriptors).where(eq(integrationProviderDescriptors.ownerUserId, userId));
+  await tx.delete(securityInvalidationEvents).where(eq(securityInvalidationEvents.userId, userId));
+  await tx.delete(runtimeSessionPresence).where(eq(runtimeSessionPresence.userId, userId));
+  await tx.delete(sessionActivationEvents).where(eq(sessionActivationEvents.userId, userId));
+  await tx.delete(approvalAuditEvents).where(eq(approvalAuditEvents.userId, userId));
+  await tx.delete(consoleLoginTransactions).where(eq(consoleLoginTransactions.userId, userId));
+  await tx.delete(consoleSessions).where(eq(consoleSessions.userId, userId));
+  await tx.delete(sessions).where(eq(sessions.userId, userId));
+  await tx.delete(userSettings).where(eq(userSettings.userId, userId));
+  // elements last: cascades element_tags, element_relationships, memory_entries,
+  // agent_states, ensemble_members, and element_provenance via elements.id.
+  await tx.delete(elements).where(eq(elements.userId, userId));
+}
+
+/** Physical table names purged directly by {@link purgeUserScopedData}. */
+export const USER_SCOPED_CASCADE_PURGE_TABLES: readonly string[] = [
+  'session_activity_events',
+  'portfolio_sync_jobs',
+  'user_integrations',
+  'user_oauth_tokens',
+  'integration_provider_descriptors',
+  'security_invalidation_events',
+  'runtime_session_presence',
+  'session_activation_events',
+  'approval_audit_events',
+  'console_login_transactions',
+  'console_sessions',
+  'sessions',
+  'user_settings',
+  'elements',
+];
+
+/**
+ * Tables that also cascade off `users.id` but are removed transitively when a table in
+ * {@link USER_SCOPED_CASCADE_PURGE_TABLES} above them is deleted (children of `elements`,
+ * `runtime_session_presence`, etc.), so they need no explicit delete.
+ */
+export const USER_SCOPED_CASCADE_VIA_PARENT: readonly string[] = [
+  'element_tags',
+  'element_relationships',
+  'memory_entries',
+  'agent_states',
+  'ensemble_members',
+  'element_provenance',
+  'session_activation_records',
+  'security_invalidation_acks',
+  'account_factor_backup_codes',
+];
+
+/**
+ * Cascade-off-`users` tables purged in the pre-savepoint detach of `deleteConsolePrincipalWithTx`
+ * (on both the hard-delete and anonymize paths, so the login stops working immediately) rather
+ * than in {@link purgeUserScopedData}.
+ */
+export const USER_SCOPED_CASCADE_PURGED_ON_DETACH: readonly string[] = [
+  'account_factors',
+  'user_admin_roles',
+];
+
+/** One federated login of the account being deleted. */
+export interface DeletionIdentityAccount {
+  readonly sub: string;
+  readonly provider: string;
+  readonly externalSub: string;
+  readonly email: string | null;
+  readonly rawProfile: unknown;
+}
+
+/** The identity values needed to purge the non-FK identity/credential tables. */
+export interface DeletionIdentity {
+  readonly subs: readonly string[];
+  readonly emails: readonly string[];
+  readonly githubIds: readonly string[];
+  readonly githubLogins: readonly string[];
+}
+
+function githubLogin(account: DeletionIdentityAccount): string | null {
+  if (account.provider !== 'github' || !account.rawProfile || typeof account.rawProfile !== 'object') {
+    return null;
+  }
+  const login = (account.rawProfile as { readonly login?: unknown }).login;
+  return typeof login === 'string' && login.trim() !== '' ? login.toLowerCase() : null;
+}
+
+/** Collect the identity match values from the account's own row + its federated logins. */
+export function collectDeletionIdentity(
+  userEmail: string | null,
+  accounts: readonly DeletionIdentityAccount[],
+): DeletionIdentity {
+  const emails = new Set<string>();
+  if (userEmail) emails.add(userEmail.toLowerCase());
+  const subs = new Set<string>();
+  const githubIds = new Set<string>();
+  const githubLogins = new Set<string>();
+  for (const account of accounts) {
+    subs.add(account.sub);
+    if (account.email) emails.add(account.email.toLowerCase());
+    if (account.provider === 'github' && account.externalSub) githubIds.add(account.externalSub);
+    const login = githubLogin(account);
+    if (login) githubLogins.add(login);
+  }
+  return {
+    subs: [...subs],
+    emails: [...emails],
+    githubIds: [...githubIds],
+    githubLogins: [...githubLogins],
+  };
+}
+
+/**
+ * Purge the account's personal data from tables that have NO foreign key to `users` and are
+ * therefore reached by neither the hard-delete cascade nor {@link purgeUserScopedData}. Called
+ * on BOTH deletion paths. `auth_kv` holds the OIDC grants/tokens (email/profile in the payload,
+ * keyed by the subject as `accountId`); `auth_identity_events` is the account's own auth-event
+ * log; `auth_allowlist` is the pre-approval entry (a direct identifier + re-onboarding vector).
+ * `security_audit_events` is intentionally NOT purged here — it is the operator security-audit
+ * sink and is retained (see docs).
+ */
+export async function purgeNonCascadeUserIdentity(tx: DrizzleTx, identity: DeletionIdentity): Promise<void> {
+  for (const sub of identity.subs) {
+    // OIDC grants/tokens: model rows carry the subject in payload->>'accountId'.
+    await tx.delete(authKv).where(sql`${authKv.payload}->>'accountId' = ${sub}`);
+  }
+  if (identity.subs.length > 0) {
+    await tx.delete(authIdentityEvents).where(inArray(authIdentityEvents.sub, [...identity.subs]));
+  }
+  const allowlistMatches = [
+    identity.emails.length > 0
+      ? and(eq(authAllowlist.kind, 'email'), inArray(authAllowlist.value, [...identity.emails]))
+      : undefined,
+    identity.githubIds.length > 0
+      ? and(eq(authAllowlist.kind, 'github_id'), inArray(authAllowlist.value, [...identity.githubIds]))
+      : undefined,
+    identity.githubLogins.length > 0
+      ? and(eq(authAllowlist.kind, 'github_username'), inArray(authAllowlist.value, [...identity.githubLogins]))
+      : undefined,
+  ].filter((clause): clause is NonNullable<typeof clause> => clause !== undefined);
+  if (allowlistMatches.length > 0) {
+    await tx.delete(authAllowlist).where(or(...allowlistMatches));
+  }
+}

--- a/src/database/userDataPurge.ts
+++ b/src/database/userDataPurge.ts
@@ -40,6 +40,8 @@ export async function purgeUserScopedData(tx: DrizzleTx, userId: string): Promis
   await tx.delete(securityInvalidationEvents).where(eq(securityInvalidationEvents.userId, userId));
   await tx.delete(runtimeSessionPresence).where(eq(runtimeSessionPresence.userId, userId));
   await tx.delete(sessionActivationEvents).where(eq(sessionActivationEvents.userId, userId));
+  // approval_audit_events is the user's OWN gatekeeper approval decisions (cascade-off-users), not
+  // the retained tamper-evident admin_audit chain — so it is erased with the account.
   await tx.delete(approvalAuditEvents).where(eq(approvalAuditEvents.userId, userId));
   await tx.delete(consoleLoginTransactions).where(eq(consoleLoginTransactions.userId, userId));
   await tx.delete(consoleSessions).where(eq(consoleSessions.userId, userId));
@@ -156,9 +158,16 @@ export function collectDeletionIdentity(
  */
 export async function purgeNonCascadeUserIdentity(tx: DrizzleTx, identity: DeletionIdentity): Promise<void> {
   for (const sub of identity.subs) {
-    // OIDC grants/tokens: account-linked model rows (Grant, Session, AccessToken, RefreshToken,
-    // …) carry the subject in payload->>'accountId'. Pre-auth Interaction rows have no accountId
-    // and self-expire. Looped rather than batched: an account has one or two subjects.
+    // OIDC storage: a Grant carries the subject as payload.accountId, while tokens/sessions/codes
+    // are linked to it via payload.grantId (this mirrors the adapter's own revokeByGrantId). Purge
+    // both, so no token or session survives even if it does not itself carry accountId. Pre-auth
+    // Interaction rows have no account linkage and self-expire. Looped: an account has one or two
+    // subjects, each with a handful of grants.
+    const grants = await tx.select({ id: authKv.id }).from(authKv)
+      .where(and(eq(authKv.model, 'Grant'), sql`${authKv.payload}->>'accountId' = ${sub}`));
+    for (const grant of grants) {
+      await tx.delete(authKv).where(sql`${authKv.payload}->>'grantId' = ${grant.id}`);
+    }
     await tx.delete(authKv).where(sql`${authKv.payload}->>'accountId' = ${sub}`);
   }
   if (identity.subs.length > 0) {

--- a/src/web-console/WebConsoleRegistrar.ts
+++ b/src/web-console/WebConsoleRegistrar.ts
@@ -153,6 +153,12 @@ import {
   type CollectionSearchPort,
 } from './modules/collection/index.js';
 import { createPortfolioModule } from './modules/portfolio/PortfolioModule.js';
+import {
+  InMemoryPortfolioActivityEventSink,
+  PostgresPortfolioActivityEventSink,
+  type IPortfolioActivityEventSink,
+} from './modules/portfolio/PortfolioActivityEvents.js';
+import { PostgresConsoleSessionActivityStore } from './stores/IConsoleSessionActivityStore.js';
 import { createRuntimeSessionModule } from './modules/runtime-sessions/RuntimeSessionModule.js';
 import { createSelfServiceModule } from './modules/self-service/SelfServiceModule.js';
 import { createSelfSecurityModule } from './modules/self-security/SelfSecurityModule.js';
@@ -216,6 +222,7 @@ export const WEB_CONSOLE_SERVICE_NAMES = {
   integrationDescriptorStore: 'WebConsoleIntegrationDescriptorStore',
   integrationOpenApiSpecStore: 'WebConsoleIntegrationOpenApiSpecStore',
   portfolioStore: 'WebConsolePortfolioStore',
+  portfolioActivityEventSink: 'WebConsolePortfolioActivityEventSink',
   portfolioSyncJobStore: 'WebConsolePortfolioSyncJobStore',
   securityInvalidationStore: 'WebConsoleSecurityInvalidationStore',
   runtimeSessionControlStore: 'WebConsoleRuntimeSessionControlStore',
@@ -287,6 +294,7 @@ export interface WebConsoleRegistrarOptions {
   /** Directory of curated integration descriptor seed files, loaded at bootstrap. */
   readonly integrationDescriptorSeedDir?: string;
   readonly portfolioStore?: IPortfolioElementStore | null;
+  readonly portfolioActivityEventSink?: IPortfolioActivityEventSink | null;
   readonly enableManagerBackedPortfolioStore?: boolean;
   readonly enablePortfolioWriteRoutes?: boolean;
   /**
@@ -612,6 +620,7 @@ export class WebConsoleRegistrar {
       syncJobStore: stores.portfolioSyncJobStore,
       enablePortfolioWriteRoutes: this.options.enablePortfolioWriteRoutes === true,
       now: this.options.now,
+      activityEventSink: resolvePortfolioActivityEventSink(container, database, this.options),
     }));
     // Whole-module gate (not per-route like portfolio writes): when the flag is
     // off, the catalog surface is absent from the manifest entirely. The install
@@ -721,7 +730,7 @@ export class WebConsoleRegistrar {
       apiV1MountState,
       userContext: resolveConsoleUserContext(container),
     });
-    const cleanupScheduler = this.createCleanupScheduler(stores, container);
+    const cleanupScheduler = this.createCleanupScheduler(stores, database, container);
     const composition: WebConsoleComposition = {
       activationProfile,
       registry,
@@ -772,6 +781,7 @@ export class WebConsoleRegistrar {
     stores: Pick<WebConsoleComposition,
       'sessionStore' | 'loginTransactionStore' | 'idempotencyStore' | 'runtimeSessionControlStore'
     >,
+    database: DatabaseInstance | undefined,
     container: DiContainerFacade,
   ): ConsoleStoreCleanupScheduler | null {
     if (this.options.registerCleanup === false) return null;
@@ -783,7 +793,12 @@ export class WebConsoleRegistrar {
       throw new Error('Web console cleanup registration requires LifecycleService');
     }
     const scheduler = new ConsoleStoreCleanupScheduler({
-      stores,
+      stores: {
+        ...stores,
+        sessionActivityStore: database
+          ? markProductionAdapter(new PostgresConsoleSessionActivityStore(database), 'PostgresConsoleSessionActivityStore')
+          : undefined,
+      },
       intervalMs: this.options.cleanupIntervalMs,
       now: this.options.now,
       reportError,
@@ -1620,6 +1635,23 @@ function resolveSessionApprovalEventSink(
   }
   if (database) return markProductionAdapter(new PostgresSessionApprovalEventSink(database), 'PostgresSessionApprovalEventSink');
   return new InMemorySessionApprovalEventSink();
+}
+
+function resolvePortfolioActivityEventSink(
+  container: DiContainerFacade,
+  database: DatabaseInstance | undefined,
+  options: WebConsoleRegistrarOptions,
+): IPortfolioActivityEventSink {
+  if (options.portfolioActivityEventSink !== undefined) {
+    return options.portfolioActivityEventSink ?? new InMemoryPortfolioActivityEventSink();
+  }
+  if (container.hasRegistration(WEB_CONSOLE_SERVICE_NAMES.portfolioActivityEventSink)) {
+    return container.resolve<IPortfolioActivityEventSink>(WEB_CONSOLE_SERVICE_NAMES.portfolioActivityEventSink);
+  }
+  if (database) {
+    return markProductionAdapter(new PostgresPortfolioActivityEventSink(database), 'PostgresPortfolioActivityEventSink');
+  }
+  return new InMemoryPortfolioActivityEventSink();
 }
 
 function resolveSessionExecutionReader(

--- a/src/web-console/WebConsoleRegistrar.ts
+++ b/src/web-console/WebConsoleRegistrar.ts
@@ -476,22 +476,16 @@ export class WebConsoleRegistrar {
       database,
     );
     const apiV1MountState = createApiV1MountState();
-    const operationHealthChecks = createOperationHealthChecks({
+    const healthProbes = createConsoleHealthProbes({
       database,
       stores,
       authStorage,
-      container,
       securityInvalidationReadiness,
       routesMounted: apiV1MountState.mounted,
     });
+    const operationHealthChecks = createOperationHealthChecks(healthProbes, container);
     registry.register(createHealthModule({
-      readiness: createHealthReadinessInputs({
-        database,
-        stores,
-        authStorage,
-        securityInvalidationReadiness,
-        routesMounted: apiV1MountState.mounted,
-      }),
+      readiness: createHealthReadinessInputs(healthProbes, stores),
       now: this.options.now,
     }));
     if (consoleOAuthClient && secretEncryption && integrationPublicBaseUrl) {
@@ -1190,41 +1184,62 @@ interface ConsoleStoreSet {
   readonly identityResolver: IConsoleIdentityResolver;
 }
 
-function createHealthReadinessInputs(options: {
+type ConsoleSecurityInvalidationSnapshot = Awaited<ReturnType<IConsoleSecurityInvalidationReadiness['getReadiness']>>;
+
+interface ConsoleHealthProbes {
+  readonly databaseAvailable: () => boolean;
+  readonly authServerAvailable: () => boolean;
+  readonly runtimeControlAvailable: () => boolean;
+  readonly apiV1Mounted: () => boolean;
+  readonly securityInvalidationReadiness: () => Promise<ConsoleSecurityInvalidationSnapshot>;
+}
+
+// Single source for the dependency probes shared by both the public readiness surface
+// and the admin operations health surface, so a new or changed probe is defined once.
+function createConsoleHealthProbes(options: {
   readonly database: DatabaseInstance | undefined;
   readonly stores: ConsoleStoreSet;
   readonly authStorage: IAuthStorageLayer | null;
   readonly securityInvalidationReadiness: IConsoleSecurityInvalidationReadiness;
   readonly routesMounted: () => boolean;
-}): HealthReadinessChecks {
+}): ConsoleHealthProbes {
   return {
-    sessionStorageAvailable: () => Boolean(options.stores.sessionStore),
-    identityResolutionAvailable: () => Boolean(options.stores.identityResolver),
-    securityInvalidationReady: async () => (await options.securityInvalidationReadiness.getReadiness()).ready,
-    runtimeControlAvailable: () => Boolean(options.stores.runtimeSessionControlStore),
     databaseAvailable: () => Boolean(options.database),
     authServerAvailable: () => Boolean(options.authStorage),
+    runtimeControlAvailable: () => Boolean(options.stores.runtimeSessionControlStore),
     apiV1Mounted: () => options.routesMounted(),
+    securityInvalidationReadiness: () => options.securityInvalidationReadiness.getReadiness(),
   };
 }
 
-function createOperationHealthChecks(options: {
-  readonly database: DatabaseInstance | undefined;
-  readonly stores: ConsoleStoreSet;
-  readonly authStorage: IAuthStorageLayer | null;
-  readonly container: DiContainerFacade;
-  readonly securityInvalidationReadiness: IConsoleSecurityInvalidationReadiness;
-  readonly routesMounted: () => boolean;
-}): OperationsHealthChecks {
+function createHealthReadinessInputs(
+  probes: ConsoleHealthProbes,
+  stores: ConsoleStoreSet,
+): HealthReadinessChecks {
   return {
-    database: () => Boolean(options.database),
-    authServer: () => Boolean(options.authStorage),
-    gatekeeper: () => options.container.hasRegistration('gatekeeper'),
-    runtimeControl: () => Boolean(options.stores.runtimeSessionControlStore),
+    sessionStorageAvailable: () => Boolean(stores.sessionStore),
+    identityResolutionAvailable: () => Boolean(stores.identityResolver),
+    securityInvalidationReady: async () => (await probes.securityInvalidationReadiness()).ready,
+    runtimeControlAvailable: probes.runtimeControlAvailable,
+    databaseAvailable: probes.databaseAvailable,
+    authServerAvailable: probes.authServerAvailable,
+    apiV1Mounted: probes.apiV1Mounted,
+  };
+}
+
+function createOperationHealthChecks(
+  probes: ConsoleHealthProbes,
+  container: DiContainerFacade,
+): OperationsHealthChecks {
+  return {
+    database: probes.databaseAvailable,
+    authServer: probes.authServerAvailable,
+    gatekeeper: () => container.hasRegistration('gatekeeper'),
+    runtimeControl: probes.runtimeControlAvailable,
     securityInvalidation: async () => operationHealthFromInvalidationReadiness(
-      await options.securityInvalidationReadiness.getReadiness(),
+      await probes.securityInvalidationReadiness(),
     ),
-    apiMount: () => options.routesMounted()
+    apiMount: () => probes.apiV1Mounted()
       ? {
         component: 'api_mount',
         status: 'ok',
@@ -1240,7 +1255,7 @@ function createOperationHealthChecks(options: {
   };
 }
 
-function operationHealthFromInvalidationReadiness(snapshot: Awaited<ReturnType<IConsoleSecurityInvalidationReadiness['getReadiness']>>) {
+function operationHealthFromInvalidationReadiness(snapshot: ConsoleSecurityInvalidationSnapshot) {
   return {
     component: 'security_invalidation' as const,
     status: snapshot.status,
@@ -1249,6 +1264,14 @@ function operationHealthFromInvalidationReadiness(snapshot: Awaited<ReturnType<I
   };
 }
 
+// Console stores support exactly two backend families: Postgres-backed (durable,
+// per-user, RLS-enforced) when a database is configured, and in-memory otherwise.
+// In-memory is development/loopback only — it loses all session, approval, and audit
+// state on restart — so there is deliberately no file-backed durable family (a file
+// store for security-relevant state would lack RLS, transactional CAS, and tamper
+// evidence). Shared-hosted production activation fails loud on a memory backend (see
+// WebConsoleProductionActivation's database_required check), so a no-DB production
+// deployment is refused rather than left silently volatile.
 async function createConsoleStores(database: DatabaseInstance | undefined): Promise<ConsoleStoreSet> {
   if (database) {
     const [

--- a/src/web-console/lifecycle/ConsoleStoreCleanupScheduler.ts
+++ b/src/web-console/lifecycle/ConsoleStoreCleanupScheduler.ts
@@ -1,6 +1,7 @@
 import type { IConsoleSessionStore } from '../stores/IConsoleSessionStore.js';
 import type { IIdempotencyStore } from '../stores/IIdempotencyStore.js';
 import type { ILoginTransactionStore } from '../stores/ILoginTransactionStore.js';
+import type { IConsoleSessionActivityStore } from '../stores/IConsoleSessionActivityStore.js';
 import type { IRuntimeSessionControlStore } from '../services/runtime/IRuntimeSessionControlStore.js';
 
 export const DEFAULT_CONSOLE_STORE_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
@@ -11,6 +12,7 @@ export interface ConsoleStoreCleanupStores {
   readonly loginTransactionStore: Pick<ILoginTransactionStore, 'sweepExpired'>;
   readonly idempotencyStore: Pick<IIdempotencyStore, 'sweepExpired'>;
   readonly runtimeSessionControlStore?: Pick<IRuntimeSessionControlStore, 'sweepStalePresence'>;
+  readonly sessionActivityStore?: Pick<IConsoleSessionActivityStore, 'sweepExpired'>;
   // account_factors is intentionally excluded; disabled factor rows remain for status history and audit context.
 }
 
@@ -40,7 +42,8 @@ type ConsoleStoreCleanupStoreName =
   | 'consoleSessions'
   | 'loginTransactions'
   | 'idempotencyRecords'
-  | 'runtimeSessionPresence';
+  | 'runtimeSessionPresence'
+  | 'sessionActivityEvents';
 
 type SweepStore = Pick<IConsoleSessionStore, 'sweepExpired'>;
 type RuntimePresenceSweepStore = Pick<IRuntimeSessionControlStore, 'sweepStalePresence'>;
@@ -82,6 +85,7 @@ export class ConsoleStoreCleanupScheduler {
       loginTransactions: 0,
       idempotencyRecords: 0,
       runtimeSessionPresence: 0,
+      sessionActivityEvents: 0,
     };
     const errors: ConsoleStoreCleanupError[] = [];
 
@@ -89,6 +93,14 @@ export class ConsoleStoreCleanupScheduler {
       removed.consoleSessions = await this.sweep('consoleSessions', this.stores.sessionStore, before, errors);
       removed.loginTransactions = await this.sweep('loginTransactions', this.stores.loginTransactionStore, before, errors);
       removed.idempotencyRecords = await this.sweep('idempotencyRecords', this.stores.idempotencyStore, before, errors);
+      if (this.stores.sessionActivityStore) {
+        removed.sessionActivityEvents = await this.sweep(
+          'sessionActivityEvents',
+          this.stores.sessionActivityStore,
+          before,
+          errors,
+        );
+      }
       if (this.stores.runtimeSessionControlStore) {
         removed.runtimeSessionPresence = await this.sweepRuntimePresence(
           this.stores.runtimeSessionControlStore,

--- a/src/web-console/modules/approvals/ApprovalService.ts
+++ b/src/web-console/modules/approvals/ApprovalService.ts
@@ -1,11 +1,10 @@
-import type { CliApprovalRecord } from '../../../handlers/mcp-aql/GatekeeperTypes.js';
 import type { ConsoleHandlerResult, ConsoleRequest } from '../../platform/ConsolePlatformTypes.js';
 import { requireConsoleRequestContext } from '../../platform/ConsoleRequestContext.js';
 import { requireConsoleAuthentication } from '../../middleware/ConsoleAuthentication.js';
 import type { IRuntimeSessionControlStore } from '../../services/runtime/IRuntimeSessionControlStore.js';
 import type { ConsoleApprovalScope, ConsoleApprovalStatus, SessionApprovalDto, SessionApprovalListDto } from './ApprovalDtos.js';
 import type { ISessionApprovalEventSink } from './ApprovalEvents.js';
-import type { SessionApprovalStore } from './ApprovalStore.js';
+import type { ConsoleApprovalRecord, SessionApprovalStore } from './ApprovalStore.js';
 import { toCliApprovalScope } from './ApprovalStore.js';
 
 const DEFAULT_APPROVAL_TTL_MS = 300_000;
@@ -48,7 +47,7 @@ export class ApprovalService {
     }
 
     const decidedAt = this.now().toISOString();
-    const updated: CliApprovalRecord = decision === 'approved'
+    const updated: ConsoleApprovalRecord = decision === 'approved'
       ? {
         ...record,
         approvedAt: decidedAt,
@@ -68,7 +67,7 @@ export class ApprovalService {
     return session?.userId === userId;
   }
 
-  private statusOf(record: CliApprovalRecord): ConsoleApprovalStatus {
+  private statusOf(record: ConsoleApprovalRecord): ConsoleApprovalStatus {
     if (record.cancelledAt) return 'cancelled_session_terminated';
     if (record.deniedAt) return 'denied';
     if (record.approvedAt) return 'approved';
@@ -77,7 +76,7 @@ export class ApprovalService {
     return 'pending';
   }
 
-  private toDto(sessionId: string, record: CliApprovalRecord): SessionApprovalDto {
+  private toDto(sessionId: string, record: ConsoleApprovalRecord): SessionApprovalDto {
     const status = this.statusOf(record);
     return {
       approval_id: record.requestId,
@@ -98,14 +97,14 @@ export class ApprovalService {
     };
   }
 
-  private expiresAt(record: CliApprovalRecord): Date {
+  private expiresAt(record: ConsoleApprovalRecord): Date {
     return new Date(new Date(record.requestedAt).getTime() + (record.ttlMs ?? DEFAULT_APPROVAL_TTL_MS));
   }
 
   private async recordEvent(
     userId: string,
     sessionId: string,
-    record: CliApprovalRecord,
+    record: ConsoleApprovalRecord,
     decision: 'approved' | 'denied',
     scope: ConsoleApprovalScope,
     correlationId: string,

--- a/src/web-console/modules/approvals/ApprovalStore.ts
+++ b/src/web-console/modules/approvals/ApprovalStore.ts
@@ -2,7 +2,71 @@ import type { CliApprovalRecord, CliApprovalScope } from '../../../handlers/mcp-
 import type { Gatekeeper } from '../../../handlers/mcp-aql/Gatekeeper.js';
 import type { IConfirmationStore } from '../../../state/IConfirmationStore.js';
 
-export type ConsoleApprovalRecord = CliApprovalRecord;
+/**
+ * Console-owned approval record. Structurally mirrors the gatekeeper-internal
+ * {@link CliApprovalRecord} but is owned by the console so an internal gatekeeper
+ * change surfaces as a mapper compile error here rather than silently altering the
+ * console contract. `scope` intentionally reuses the shared {@link CliApprovalScope}
+ * value vocabulary.
+ */
+export interface ConsoleApprovalRecord {
+  readonly requestId: string;
+  readonly toolName: string;
+  readonly toolInputDigest: Record<string, unknown>;
+  readonly toolInputHash: string;
+  readonly toolInputDetail?: Record<string, unknown>;
+  readonly riskLevel: string;
+  readonly riskScore: number;
+  readonly irreversible: boolean;
+  readonly requestedAt: string;
+  readonly approvedAt?: string;
+  readonly deniedAt?: string;
+  readonly expiredAt?: string;
+  readonly cancelledAt?: string;
+  readonly consumed: boolean;
+  readonly scope: CliApprovalScope;
+  readonly denyReason: string;
+  readonly policySource?: string;
+  readonly ttlMs?: number;
+}
+
+// Single explicit field copy shared by both mapping directions. The console and
+// gatekeeper record shapes are structurally identical today; enumerating every field
+// here (rather than spreading) keeps a compile-time tripwire — if the gatekeeper-internal
+// CliApprovalRecord gains or renames a required field, toCliApprovalRecord stops compiling
+// until the console shape and this mapping are consciously updated.
+function copyApprovalRecordFields(record: ConsoleApprovalRecord | CliApprovalRecord): ConsoleApprovalRecord {
+  return {
+    requestId: record.requestId,
+    toolName: record.toolName,
+    toolInputDigest: record.toolInputDigest,
+    toolInputHash: record.toolInputHash,
+    toolInputDetail: record.toolInputDetail,
+    riskLevel: record.riskLevel,
+    riskScore: record.riskScore,
+    irreversible: record.irreversible,
+    requestedAt: record.requestedAt,
+    approvedAt: record.approvedAt,
+    deniedAt: record.deniedAt,
+    expiredAt: record.expiredAt,
+    cancelledAt: record.cancelledAt,
+    consumed: record.consumed,
+    scope: record.scope,
+    denyReason: record.denyReason,
+    policySource: record.policySource,
+    ttlMs: record.ttlMs,
+  };
+}
+
+/** Map a gatekeeper-internal CLI approval record into the console-owned shape. */
+export function toConsoleApprovalRecord(record: CliApprovalRecord): ConsoleApprovalRecord {
+  return copyApprovalRecordFields(record);
+}
+
+/** Map a console-owned approval record back into the gatekeeper-internal shape for persistence. */
+export function toCliApprovalRecord(record: ConsoleApprovalRecord): CliApprovalRecord {
+  return copyApprovalRecordFields(record);
+}
 
 export interface SessionApprovalStore {
   list(userId: string, sessionId: string): Promise<readonly ConsoleApprovalRecord[]>;
@@ -20,12 +84,13 @@ export class ConfirmationSessionApprovalStore implements SessionApprovalStore {
 
   async list(userId: string, sessionId: string): Promise<readonly ConsoleApprovalRecord[]> {
     const store = await this.openStore(userId, sessionId);
-    return store.getAllCliApprovals();
+    return store.getAllCliApprovals().map(toConsoleApprovalRecord);
   }
 
   async find(userId: string, sessionId: string, approvalId: string): Promise<ConsoleApprovalRecord | null> {
     const store = await this.openStore(userId, sessionId);
-    return store.getCliApproval(approvalId) ?? null;
+    const record = store.getCliApproval(approvalId);
+    return record ? toConsoleApprovalRecord(record) : null;
   }
 
   async save(
@@ -35,9 +100,10 @@ export class ConfirmationSessionApprovalStore implements SessionApprovalStore {
     record: ConsoleApprovalRecord,
   ): Promise<void> {
     const store = await this.openStore(userId, sessionId);
-    store.saveCliApproval(approvalId, record);
+    const cliRecord = toCliApprovalRecord(record);
+    store.saveCliApproval(approvalId, cliRecord);
     if (record.scope === 'tool_session' && record.approvedAt) {
-      store.saveCliSessionApproval(record.toolName, record);
+      store.saveCliSessionApproval(record.toolName, cliRecord);
     }
     await store.persist();
   }
@@ -89,11 +155,13 @@ export class GatekeeperSessionApprovalStore implements SessionApprovalStore {
   constructor(private readonly gatekeeper: Gatekeeper) {}
 
   list(_userId: string, sessionId: string): Promise<readonly ConsoleApprovalRecord[]> {
-    return Promise.resolve(this.gatekeeper.getRegisteredSession(sessionId)?.getAllCliApprovals() ?? []);
+    const records = this.gatekeeper.getRegisteredSession(sessionId)?.getAllCliApprovals() ?? [];
+    return Promise.resolve(records.map(toConsoleApprovalRecord));
   }
 
   find(_userId: string, sessionId: string, approvalId: string): Promise<ConsoleApprovalRecord | null> {
-    return Promise.resolve(this.gatekeeper.getRegisteredSession(sessionId)?.getCliApproval(approvalId) ?? null);
+    const record = this.gatekeeper.getRegisteredSession(sessionId)?.getCliApproval(approvalId);
+    return Promise.resolve(record ? toConsoleApprovalRecord(record) : null);
   }
 
   async save(

--- a/src/web-console/modules/audit/PostgresProductionAuditQueries.ts
+++ b/src/web-console/modules/audit/PostgresProductionAuditQueries.ts
@@ -119,6 +119,45 @@ function page<TSource, TItem>(
   };
 }
 
+export type ApprovalAuditVerification =
+  | { readonly available: false }
+  | {
+    readonly available: true;
+    readonly verified: boolean;
+    readonly chainKeyId: string;
+    readonly chainPrev: string | null;
+    readonly chainHmac: string;
+  };
+
+/**
+ * Map a verification result to the integrity block. A `verified` status is only ever
+ * produced by a real verification returning `available && verified`; every other case is
+ * honestly `not_available`. This is the single place the integrity block is built, so a
+ * `verified` status cannot be hand-written at a call site.
+ */
+export function integrityFromApprovalAuditVerification(
+  verification: ApprovalAuditVerification,
+): ApprovalAuditEventDto['integrity'] {
+  if (verification.available && verification.verified) {
+    return {
+      status: 'verified',
+      chain_key_id: verification.chainKeyId,
+      chain_prev: verification.chainPrev,
+      chain_hmac: verification.chainHmac,
+    };
+  }
+  return { status: 'not_available', chain_key_id: null, chain_prev: null, chain_hmac: null };
+}
+
+/**
+ * approval_audit_events (migration 0036) stores no hash-chain material, so verification is
+ * unavailable for every row today. When a durable hash-chained approval-audit backend is
+ * wired, compute the chain HMAC here and return `{ available: true, verified: <hmac check>, ... }`.
+ */
+function verifyApprovalAuditRow(_row: ApprovalAuditDbRow): ApprovalAuditVerification {
+  return { available: false };
+}
+
 function toApprovalAuditDto(row: ApprovalAuditDbRow): ApprovalAuditEventDto {
   return {
     id: row.id,
@@ -130,12 +169,7 @@ function toApprovalAuditDto(row: ApprovalAuditDbRow): ApprovalAuditEventDto {
     result: row.result,
     decision_source: row.decision_source,
     correlation_id: row.correlation_id,
-    integrity: {
-      status: 'not_available',
-      chain_key_id: null,
-      chain_prev: null,
-      chain_hmac: null,
-    },
+    integrity: integrityFromApprovalAuditVerification(verifyApprovalAuditRow(row)),
   };
 }
 

--- a/src/web-console/modules/operations/OperationsPrivacyProjectors.ts
+++ b/src/web-console/modules/operations/OperationsPrivacyProjectors.ts
@@ -23,6 +23,7 @@ import {
   stringField,
   type UnknownRecord,
 } from '../../platform/ConsoleProjectorHelpers.js';
+import { OPERATION_HEALTH_COMPONENTS } from './OperationsHealth.js';
 
 export function projectOperationHealthSummary(value: unknown): OperationHealthSummaryDto {
   const record = objectValue(value);
@@ -181,15 +182,10 @@ function optionalStableCode(record: UnknownRecord, key: string): Record<string, 
 
 function componentField(record: UnknownRecord, key: string): OperationHealthComponentDto['component'] {
   const value = record[key];
-  if (
-    value === 'database' ||
-    value === 'auth_server' ||
-    value === 'gatekeeper' ||
-    value === 'runtime_control' ||
-    value === 'security_invalidation' ||
-    value === 'api_mount'
-  ) {
-    return value;
+  // Derive the allowlist from the single source of truth so a new component added to the health
+  // builder can't silently coerce to the fallback (see OperationsHealth.OPERATION_HEALTH_COMPONENTS).
+  if (typeof value === 'string' && (OPERATION_HEALTH_COMPONENTS as readonly string[]).includes(value)) {
+    return value as OperationHealthComponentDto['component'];
   }
   return 'api_mount';
 }

--- a/src/web-console/modules/operations/OperationsPrivacyProjectors.ts
+++ b/src/web-console/modules/operations/OperationsPrivacyProjectors.ts
@@ -39,7 +39,7 @@ export function projectOperationHealthComponent(value: unknown): OperationHealth
     component: componentField(record, 'component'),
     status: healthStatusField(record, 'status'),
     checked_at: stringField(record, 'checked_at'),
-    failure_codes: arrayValue(record.failure_codes).filter((item): item is string => typeof item === 'string'),
+    failure_codes: arrayValue(record.failure_codes).filter(isStableCode),
   };
 }
 
@@ -101,15 +101,15 @@ export function projectOperationalLog(value: unknown): OperationalLogDto {
   return {
     ts: stringField(record, 'ts'),
     level: logLevelField(record, 'level'),
-    subsystem: stringField(record, 'subsystem'),
-    event: stringField(record, 'event'),
+    subsystem: stableCodeField(record, 'subsystem'),
+    event: stableCodeField(record, 'event'),
     correlation_id: nullableStringField(record, 'correlation_id'),
     account_correlation_id: nullableStringField(record, 'account_correlation_id'),
     session_id: nullableStringField(record, 'session_id'),
-    replica: stringField(record, 'replica'),
+    replica: stableCodeField(record, 'replica'),
     duration_ms: nullableNumberField(record, 'duration_ms'),
     status_code: nullableNumberField(record, 'status_code'),
-    error_code: nullableStringField(record, 'error_code'),
+    error_code: nullableStableCodeField(record, 'error_code'),
   };
 }
 
@@ -122,13 +122,13 @@ export function projectOperationalMetric(value: unknown): OperationalMetricDto {
     value: numberField(record, 'value'),
     unit: stringField(record, 'unit'),
     dimensions: {
-      ...optionalString(dimensions, 'subsystem'),
-      ...optionalString(dimensions, 'event'),
-      ...optionalString(dimensions, 'status_family'),
-      ...optionalString(dimensions, 'error_code'),
-      ...optionalString(dimensions, 'replica'),
-      ...optionalString(dimensions, 'transport'),
-      ...optionalString(dimensions, 'latency_bucket'),
+      ...optionalStableCode(dimensions, 'subsystem'),
+      ...optionalStableCode(dimensions, 'event'),
+      ...optionalStableCode(dimensions, 'status_family'),
+      ...optionalStableCode(dimensions, 'error_code'),
+      ...optionalStableCode(dimensions, 'replica'),
+      ...optionalStableCode(dimensions, 'transport'),
+      ...optionalStableCode(dimensions, 'latency_bucket'),
       ...optionalString(dimensions, 'account_correlation_id'),
     },
   };
@@ -152,6 +152,31 @@ function optionalString(record: UnknownRecord, key: string): Record<string, stri
 function optionalNumber(record: UnknownRecord, key: string): Record<string, number> {
   const value = record[key];
   return typeof value === 'number' && Number.isFinite(value) ? { [key]: value } : {};
+}
+
+// Stable-code contract for operator-facing telemetry codes. Operator surfaces forward
+// these free-string fields to admins, so a value that isn't a bounded, well-formed
+// identifier is treated as absent (fail-closed) rather than passed through — a future
+// telemetry producer must not be able to leak user content or PII through them.
+const STABLE_CODE_PATTERN = /^[A-Za-z0-9][\w.:/-]{0,63}$/u;
+
+function isStableCode(value: unknown): value is string {
+  return typeof value === 'string' && STABLE_CODE_PATTERN.test(value);
+}
+
+function stableCodeField(record: UnknownRecord, key: string): string {
+  const value = record[key];
+  return isStableCode(value) ? value : '';
+}
+
+function nullableStableCodeField(record: UnknownRecord, key: string): string | null {
+  const value = record[key];
+  return isStableCode(value) ? value : null;
+}
+
+function optionalStableCode(record: UnknownRecord, key: string): Record<string, string> {
+  const value = record[key];
+  return isStableCode(value) ? { [key]: value } : {};
 }
 
 function componentField(record: UnknownRecord, key: string): OperationHealthComponentDto['component'] {

--- a/src/web-console/modules/portfolio/PortfolioActivityEvents.ts
+++ b/src/web-console/modules/portfolio/PortfolioActivityEvents.ts
@@ -26,7 +26,10 @@ export interface IPortfolioActivityEventSink {
   recordElementDeleted(event: PortfolioElementDeletedEvent): Promise<void>;
 }
 
-/** Metadata-only, content-free summary line for the activity log. */
+/**
+ * Metadata-only, content-free summary line for the activity log. `contentHash` is the portfolio
+ * store's SHA-256 hex digest (validated as 64 lowercase hex), so the `sha256:` prefix is accurate.
+ */
 export function portfolioDeletionActivityMessage(event: PortfolioElementDeletedEvent): string {
   const target = `${event.elementType}/${event.canonicalName}`;
   return event.contentHash ? `Deleted ${target} (sha256:${event.contentHash})` : `Deleted ${target}`;

--- a/src/web-console/modules/portfolio/PortfolioActivityEvents.ts
+++ b/src/web-console/modules/portfolio/PortfolioActivityEvents.ts
@@ -17,6 +17,11 @@ export interface PortfolioElementDeletedEvent {
   readonly consoleSessionId: string;
   readonly elementType: ConsolePortfolioElementType;
   readonly canonicalName: string;
+  /**
+   * The deleted element's SHA-256 content digest (64 lowercase hex), or null. The activity message
+   * renders it with a `sha256:` prefix, so a store that changes the digest algorithm must update
+   * {@link portfolioDeletionActivityMessage} accordingly.
+   */
   readonly contentHash: string | null;
   readonly correlationId: string | null;
   readonly occurredAt: Date;

--- a/src/web-console/modules/portfolio/PortfolioActivityEvents.ts
+++ b/src/web-console/modules/portfolio/PortfolioActivityEvents.ts
@@ -1,0 +1,66 @@
+import { sessionActivityEvents } from '../../../database/schema/index.js';
+import type { DatabaseInstance } from '../../../database/connection.js';
+import { withSystemContext } from '../../../database/admin.js';
+import type { ConsolePortfolioElementType } from '../../stores/IPortfolioElementStore.js';
+
+/**
+ * Metadata-only record that a portfolio element was deleted through the console.
+ * Console portfolio deletion is an intentional hard delete (it mirrors the canonical
+ * `delete_element` semantics — see PortfolioService.deleteElement), so this event is the
+ * forensic trail of what was removed. It carries the element's `contentHash`, never its
+ * content, so no user-authored content is retained.
+ */
+export interface PortfolioElementDeletedEvent {
+  readonly type: 'console.portfolio.element.deleted.v1';
+  readonly userId: string;
+  /** Stable, non-PII per-console-session handle (hex of the session id hash). */
+  readonly consoleSessionId: string;
+  readonly elementType: ConsolePortfolioElementType;
+  readonly canonicalName: string;
+  readonly contentHash: string | null;
+  readonly correlationId: string | null;
+  readonly occurredAt: Date;
+}
+
+export interface IPortfolioActivityEventSink {
+  recordElementDeleted(event: PortfolioElementDeletedEvent): Promise<void>;
+}
+
+/** Metadata-only, content-free summary line for the activity log. */
+export function portfolioDeletionActivityMessage(event: PortfolioElementDeletedEvent): string {
+  const target = `${event.elementType}/${event.canonicalName}`;
+  return event.contentHash ? `Deleted ${target} (sha256:${event.contentHash})` : `Deleted ${target}`;
+}
+
+export class InMemoryPortfolioActivityEventSink implements IPortfolioActivityEventSink {
+  private readonly events: PortfolioElementDeletedEvent[] = [];
+
+  recordElementDeleted(event: PortfolioElementDeletedEvent): Promise<void> {
+    this.events.push(event);
+    return Promise.resolve();
+  }
+
+  listEvents(): readonly PortfolioElementDeletedEvent[] {
+    return [...this.events];
+  }
+}
+
+export class PostgresPortfolioActivityEventSink implements IPortfolioActivityEventSink {
+  constructor(private readonly db: DatabaseInstance) {}
+
+  async recordElementDeleted(event: PortfolioElementDeletedEvent): Promise<void> {
+    await withSystemContext(this.db, async (tx) => {
+      await tx.insert(sessionActivityEvents).values({
+        userId: event.userId,
+        sessionId: event.consoleSessionId,
+        occurredAt: event.occurredAt,
+        level: 'info',
+        subsystem: 'portfolio',
+        event: event.type,
+        message: portfolioDeletionActivityMessage(event),
+        correlationId: event.correlationId,
+        stableErrorCode: null,
+      });
+    });
+  }
+}

--- a/src/web-console/modules/portfolio/PortfolioModule.ts
+++ b/src/web-console/modules/portfolio/PortfolioModule.ts
@@ -6,6 +6,7 @@ import type {
 import type { IPortfolioElementStore } from '../../stores/IPortfolioElementStore.js';
 import type { IUserIntegrationStore } from '../../stores/IUserIntegrationStore.js';
 import type { IPortfolioSyncJobStore } from '../../stores/IPortfolioSyncJobStore.js';
+import type { IPortfolioActivityEventSink } from './PortfolioActivityEvents.js';
 import {
   projectPortfolioElementDelete,
   projectPortfolioElementDetail,
@@ -25,10 +26,17 @@ export interface PortfolioModuleOptions {
   readonly syncJobStore: IPortfolioSyncJobStore;
   readonly enablePortfolioWriteRoutes?: boolean;
   readonly now?: () => Date;
+  readonly activityEventSink?: IPortfolioActivityEventSink | null;
 }
 
 export function createPortfolioModule(options: PortfolioModuleOptions): ConsoleModuleDescriptor {
-  const service = new PortfolioService(options.portfolioStore, options.integrationStore, options.syncJobStore, options.now);
+  const service = new PortfolioService(
+    options.portfolioStore,
+    options.integrationStore,
+    options.syncJobStore,
+    options.now,
+    options.activityEventSink ?? null,
+  );
   const routes: ConsoleModuleDescriptor['routes'] = [
     ...(options.enablePortfolioWriteRoutes === true ? writeRoutes(service) : []),
     {

--- a/src/web-console/modules/portfolio/PortfolioPrivacyProjectors.ts
+++ b/src/web-console/modules/portfolio/PortfolioPrivacyProjectors.ts
@@ -144,7 +144,7 @@ function validationStatus(value: unknown): ConsolePortfolioValidationStatus {
 }
 
 function syncJobStatus(value: unknown): PortfolioSyncJobDto['status'] {
-  if (value === 'running' || value === 'succeeded' || value === 'failed' || value === 'cancelled') return value;
+  if (value === 'running' || value === 'succeeded' || value === 'failed') return value;
   return 'queued';
 }
 

--- a/src/web-console/modules/portfolio/PortfolioService.ts
+++ b/src/web-console/modules/portfolio/PortfolioService.ts
@@ -3,6 +3,8 @@ import type {
   ConsoleRequest,
 } from '../../platform/ConsolePlatformTypes.js';
 import { requireConsoleAuthentication } from '../../middleware/ConsoleAuthentication.js';
+import { requireConsoleRequestContext } from '../../platform/ConsoleRequestContext.js';
+import type { IPortfolioActivityEventSink } from './PortfolioActivityEvents.js';
 import {
   canonicalizePortfolioElementName,
   isConsolePortfolioElementType,
@@ -53,6 +55,7 @@ export class PortfolioService {
     private readonly integrationStore: IUserIntegrationStore,
     private readonly syncJobStore: IPortfolioSyncJobStore,
     private readonly now: () => Date = () => new Date(),
+    private readonly activityEventSink: IPortfolioActivityEventSink | null = null,
   ) {}
 
   async getSummary(req: ConsoleRequest): Promise<ConsoleHandlerResult> {
@@ -206,6 +209,10 @@ export class PortfolioService {
     }
   }
 
+  // Console deletion is an intentional HARD delete, mirroring the canonical `delete_element`
+  // semantics the manager-backed store delegates to — there is deliberately no recycle bin.
+  // The metadata-only activity event below is the forensic trail of what was removed
+  // (it records the contentHash, never the content).
   async deleteElement(
     req: ConsoleRequest,
     type: string,
@@ -228,6 +235,16 @@ export class PortfolioService {
         now: this.now(),
       });
       if (!deleted) return notFound();
+      await this.activityEventSink?.recordElementDeleted({
+        type: 'console.portfolio.element.deleted.v1',
+        userId: auth.userId,
+        consoleSessionId: auth.sessionIdHash.toString('hex'),
+        elementType: deleted.type,
+        canonicalName: deleted.canonicalName,
+        contentHash: deleted.contentHash ?? null,
+        correlationId: requireConsoleRequestContext(req).correlationId,
+        occurredAt: this.now(),
+      });
       return {
         status: 200,
         body: {

--- a/src/web-console/modules/portfolio/index.ts
+++ b/src/web-console/modules/portfolio/index.ts
@@ -1,3 +1,4 @@
+export * from './PortfolioActivityEvents.js';
 export * from './PortfolioDtos.js';
 export * from './PortfolioModule.js';
 export * from './PortfolioPrivacyProjectors.js';

--- a/src/web-console/stores/IConsoleSessionActivityStore.ts
+++ b/src/web-console/stores/IConsoleSessionActivityStore.ts
@@ -1,0 +1,57 @@
+import { lt } from 'drizzle-orm';
+import { sessionActivityEvents } from '../../database/schema/index.js';
+import type { DatabaseInstance } from '../../database/connection.js';
+import { withSystemContext } from '../../database/admin.js';
+
+/**
+ * Retention sweeper for `session_activity_events`. The table has no per-row expiry, so
+ * rows are pruned by age relative to the sweep time. This bounds an otherwise unbounded,
+ * PII-bearing (message) telemetry table — the cascade on user deletion cannot be relied on
+ * because account deletion is anonymize-tombstone, so the row is never actually removed.
+ */
+export const DEFAULT_SESSION_ACTIVITY_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+
+export interface IConsoleSessionActivityStore {
+  /** Delete activity rows older than the retention window relative to `before`. Returns rows removed. */
+  sweepExpired(before: Date): Promise<number>;
+}
+
+export class InMemoryConsoleSessionActivityStore implements IConsoleSessionActivityStore {
+  private readonly rows: { readonly userId: string; readonly occurredAt: Date }[] = [];
+
+  constructor(private readonly retentionMs: number = DEFAULT_SESSION_ACTIVITY_RETENTION_MS) {}
+
+  seed(userId: string, occurredAt: Date): void {
+    this.rows.push({ userId, occurredAt });
+  }
+
+  size(): number {
+    return this.rows.length;
+  }
+
+  sweepExpired(before: Date): Promise<number> {
+    const cutoff = before.getTime() - this.retentionMs;
+    const kept = this.rows.filter(row => row.occurredAt.getTime() >= cutoff);
+    const removed = this.rows.length - kept.length;
+    this.rows.length = 0;
+    this.rows.push(...kept);
+    return Promise.resolve(removed);
+  }
+}
+
+export class PostgresConsoleSessionActivityStore implements IConsoleSessionActivityStore {
+  constructor(
+    private readonly db: DatabaseInstance,
+    private readonly retentionMs: number = DEFAULT_SESSION_ACTIVITY_RETENTION_MS,
+  ) {}
+
+  async sweepExpired(before: Date): Promise<number> {
+    const cutoff = new Date(before.getTime() - this.retentionMs);
+    const rows = await withSystemContext(this.db, tx =>
+      tx.delete(sessionActivityEvents)
+        .where(lt(sessionActivityEvents.occurredAt, cutoff))
+        .returning({ id: sessionActivityEvents.id }),
+    );
+    return rows.length;
+  }
+}

--- a/src/web-console/stores/IPortfolioSyncJobStore.ts
+++ b/src/web-console/stores/IPortfolioSyncJobStore.ts
@@ -8,7 +8,7 @@ import {
 export type PortfolioSyncProvider = 'github';
 export type PortfolioSyncJobDirection = 'pull' | 'push' | 'bidirectional';
 export type PortfolioSyncJobConflictPolicy = 'fail' | 'prefer_local' | 'prefer_remote';
-export type PortfolioSyncJobStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+export type PortfolioSyncJobStatus = 'queued' | 'running' | 'succeeded' | 'failed';
 
 export interface PortfolioSyncJobRecord {
   readonly id: string;
@@ -134,8 +134,7 @@ function isPortfolioSyncJobStatus(value: string): value is PortfolioSyncJobStatu
   return value === 'queued' ||
     value === 'running' ||
     value === 'succeeded' ||
-    value === 'failed' ||
-    value === 'cancelled';
+    value === 'failed';
 }
 
 function validateLeaseShape(record: PortfolioSyncJobRecord): void {
@@ -148,7 +147,7 @@ function validateLeaseShape(record: PortfolioSyncJobRecord): void {
 }
 
 function validateTerminalShape(record: PortfolioSyncJobRecord): void {
-  if (['succeeded', 'failed', 'cancelled'].includes(record.status) && !record.completedAt) {
+  if (['succeeded', 'failed'].includes(record.status) && !record.completedAt) {
     throw new ConsoleStoreValidationError('terminal sync job requires completedAt');
   }
   if (record.status === 'failed' && !record.operationalErrorCode) {

--- a/src/web-console/stores/PostgresConsoleAccountAdminStore.ts
+++ b/src/web-console/stores/PostgresConsoleAccountAdminStore.ts
@@ -3,16 +3,12 @@ import { and, eq, isNull, sql } from 'drizzle-orm';
 import { withSystemContext } from '../../database/admin.js';
 import type { DatabaseInstance } from '../../database/connection.js';
 import type { DrizzleTx } from '../../database/db-utils.js';
+import { accountFactors, authAccounts, userAdminRoles, users } from '../../database/schema/index.js';
 import {
-  accountFactors,
-  authAccounts,
-  portfolioSyncJobs,
-  sessionActivityEvents,
-  userAdminRoles,
-  userIntegrations,
-  userOauthTokens,
-  users,
-} from '../../database/schema/index.js';
+  collectDeletionIdentity,
+  purgeNonCascadeUserIdentity,
+  purgeUserScopedData,
+} from '../../database/userDataPurge.js';
 import type {
   ConsoleAdminRole,
   ConsolePrincipalSummary,
@@ -379,9 +375,22 @@ export async function deleteConsolePrincipalWithTx(
   input: PrincipalDeletionInput,
 ): Promise<PrincipalDeletionOutcome | null> {
   validatePrincipalDeletionInput(input);
-  const existing = await tx.select({ id: users.id }).from(users)
+  const existing = await tx.select({ id: users.id, email: users.email }).from(users)
     .where(and(eq(users.id, input.userId), isNull(users.deletedAt))).limit(1).for('update');
   if (existing.length === 0) return null;
+
+  // Capture the account's federated identity BEFORE deleting auth_accounts, then purge the
+  // non-FK identity/credential tables (auth_kv OIDC grants/tokens, auth_identity_events, and the
+  // auth_allowlist pre-approval) that no cascade reaches. Runs on BOTH paths — a hard delete
+  // does not reach these either.
+  const accounts = await tx.select({
+    sub: authAccounts.sub,
+    provider: authAccounts.provider,
+    externalSub: authAccounts.externalSub,
+    email: authAccounts.email,
+    rawProfile: authAccounts.rawProfile,
+  }).from(authAccounts).where(eq(authAccounts.userId, input.userId));
+  await purgeNonCascadeUserIdentity(tx, collectDeletionIdentity(existing[0]?.email ?? null, accounts));
 
   // Detach the account's own identity/credential/role surface first, so the
   // login stops working on either branch and so these rows don't themselves
@@ -401,16 +410,10 @@ export async function deleteConsolePrincipalWithTx(
     return { userId: input.userId, outcome: 'deleted', authzVersion: null };
   } catch (error) {
     if (!isForeignKeyViolation(error)) throw error;
-    // Anonymize-tombstone: the users row is kept, so ON DELETE CASCADE never fires. Explicitly
-    // purge the account's credentials and personal data so nothing sensitive survives under the
-    // tombstone. Order matters: portfolio_sync_jobs RESTRICT-references user_integrations, so it
-    // must be deleted before the integrations (which hold the OAuth access/refresh token
-    // ciphertext). Non-credential user content (elements, settings) is out of scope here and
-    // tracked separately for a full-erasure pass.
-    await tx.delete(sessionActivityEvents).where(eq(sessionActivityEvents.userId, input.userId));
-    await tx.delete(portfolioSyncJobs).where(eq(portfolioSyncJobs.userId, input.userId));
-    await tx.delete(userIntegrations).where(eq(userIntegrations.userId, input.userId));
-    await tx.delete(userOauthTokens).where(eq(userOauthTokens.userId, input.userId));
+    // Anonymize-tombstone: the users row is kept, so ON DELETE CASCADE never fires. Replay the
+    // cascade explicitly so no personal data survives under the tombstone; only the retained
+    // RESTRICT-anchored audit chain (and this user's actions on others) remain.
+    await purgeUserScopedData(tx, input.userId);
     const rows = await tx.update(users).set({
       // Username is NOT NULL + unique; the id guarantees a unique tombstone.
       username: `deleted-${input.userId}`,

--- a/src/web-console/stores/PostgresConsoleAccountAdminStore.ts
+++ b/src/web-console/stores/PostgresConsoleAccountAdminStore.ts
@@ -3,7 +3,16 @@ import { and, eq, isNull, sql } from 'drizzle-orm';
 import { withSystemContext } from '../../database/admin.js';
 import type { DatabaseInstance } from '../../database/connection.js';
 import type { DrizzleTx } from '../../database/db-utils.js';
-import { accountFactors, authAccounts, sessionActivityEvents, userAdminRoles, users } from '../../database/schema/index.js';
+import {
+  accountFactors,
+  authAccounts,
+  portfolioSyncJobs,
+  sessionActivityEvents,
+  userAdminRoles,
+  userIntegrations,
+  userOauthTokens,
+  users,
+} from '../../database/schema/index.js';
 import type {
   ConsoleAdminRole,
   ConsolePrincipalSummary,
@@ -392,10 +401,16 @@ export async function deleteConsolePrincipalWithTx(
     return { userId: input.userId, outcome: 'deleted', authzVersion: null };
   } catch (error) {
     if (!isForeignKeyViolation(error)) throw error;
-    // Anonymize-tombstone: the users row is kept, so ON DELETE CASCADE never fires.
-    // Explicitly purge the user's activity telemetry (its message can hold PII) so the
-    // account's personal data is erased rather than surviving under the tombstone.
+    // Anonymize-tombstone: the users row is kept, so ON DELETE CASCADE never fires. Explicitly
+    // purge the account's credentials and personal data so nothing sensitive survives under the
+    // tombstone. Order matters: portfolio_sync_jobs RESTRICT-references user_integrations, so it
+    // must be deleted before the integrations (which hold the OAuth access/refresh token
+    // ciphertext). Non-credential user content (elements, settings) is out of scope here and
+    // tracked separately for a full-erasure pass.
     await tx.delete(sessionActivityEvents).where(eq(sessionActivityEvents.userId, input.userId));
+    await tx.delete(portfolioSyncJobs).where(eq(portfolioSyncJobs.userId, input.userId));
+    await tx.delete(userIntegrations).where(eq(userIntegrations.userId, input.userId));
+    await tx.delete(userOauthTokens).where(eq(userOauthTokens.userId, input.userId));
     const rows = await tx.update(users).set({
       // Username is NOT NULL + unique; the id guarantees a unique tombstone.
       username: `deleted-${input.userId}`,

--- a/src/web-console/stores/PostgresConsoleAccountAdminStore.ts
+++ b/src/web-console/stores/PostgresConsoleAccountAdminStore.ts
@@ -3,7 +3,7 @@ import { and, eq, isNull, sql } from 'drizzle-orm';
 import { withSystemContext } from '../../database/admin.js';
 import type { DatabaseInstance } from '../../database/connection.js';
 import type { DrizzleTx } from '../../database/db-utils.js';
-import { accountFactors, authAccounts, userAdminRoles, users } from '../../database/schema/index.js';
+import { accountFactors, authAccounts, sessionActivityEvents, userAdminRoles, users } from '../../database/schema/index.js';
 import type {
   ConsoleAdminRole,
   ConsolePrincipalSummary,
@@ -147,7 +147,7 @@ export class PostgresConsoleAccountAdminStore implements IConsoleAccountAdminSto
     return rows.map(row => {
       assertAdminRole(row.role, 'role');
       return row.role;
-    }).sort();
+    }).sort((a, b) => a.localeCompare(b));
   }
 
   async grantRole(input: RoleGrantInput): Promise<ConsoleRoleAssignment> {
@@ -392,6 +392,10 @@ export async function deleteConsolePrincipalWithTx(
     return { userId: input.userId, outcome: 'deleted', authzVersion: null };
   } catch (error) {
     if (!isForeignKeyViolation(error)) throw error;
+    // Anonymize-tombstone: the users row is kept, so ON DELETE CASCADE never fires.
+    // Explicitly purge the user's activity telemetry (its message can hold PII) so the
+    // account's personal data is erased rather than surviving under the tombstone.
+    await tx.delete(sessionActivityEvents).where(eq(sessionActivityEvents.userId, input.userId));
     const rows = await tx.update(users).set({
       // Username is NOT NULL + unique; the id guarantees a unique tombstone.
       username: `deleted-${input.userId}`,

--- a/src/web-console/stores/PostgresConsoleAccountAdminStore.ts
+++ b/src/web-console/stores/PostgresConsoleAccountAdminStore.ts
@@ -379,6 +379,10 @@ export async function deleteConsolePrincipalWithTx(
     .where(and(eq(users.id, input.userId), isNull(users.deletedAt))).limit(1).for('update');
   if (existing.length === 0) return null;
 
+  // Everything below runs in the caller's single `withSystemContext` transaction, so any thrown
+  // error (the FK violation on the hard delete, or any other DB failure) rolls back every delete
+  // here atomically — there is no partially-erased intermediate state.
+
   // Capture the account's federated identity BEFORE deleting auth_accounts, then purge the
   // non-FK identity/credential tables (auth_kv OIDC grants/tokens, auth_identity_events, and the
   // auth_allowlist pre-approval) that no cascade reaches. Runs on BOTH paths — a hard delete

--- a/tests/unit/database/userDataPurge.drift.test.ts
+++ b/tests/unit/database/userDataPurge.drift.test.ts
@@ -1,27 +1,41 @@
 import { describe, expect, it } from '@jest/globals';
-import { readdirSync, readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { getTableConfig, PgTable } from 'drizzle-orm/pg-core';
+import { getTableName, is } from 'drizzle-orm';
 
+import * as schema from '../../../src/database/schema/index.js';
+import { users } from '../../../src/database/schema/index.js';
 import {
   USER_SCOPED_CASCADE_PURGE_TABLES,
   USER_SCOPED_CASCADE_PURGED_ON_DETACH,
   USER_SCOPED_CASCADE_VIA_PARENT,
 } from '../../../src/database/userDataPurge.js';
 
-const SCHEMA_DIR = join(dirname(fileURLToPath(import.meta.url)), '../../../src/database/schema');
+// Read the compiled FK metadata straight from Drizzle rather than parsing source — immune to
+// formatting/quoting and reflects exactly what the DB will enforce.
+function allTableConfigs() {
+  const configs: ReturnType<typeof getTableConfig>[] = [];
+  for (const value of Object.values(schema)) {
+    // Skip non-table exports (types, enum consts, helpers) via Drizzle's runtime guard.
+    if (is(value, PgTable)) configs.push(getTableConfig(value));
+  }
+  return configs;
+}
 
-// Every `pgTable('name', ...)` whose body declares references(() => users.id, {onDelete:'cascade'}).
-function cascadeOffUsersTables(): string[] {
-  const found: string[] = [];
-  for (const file of readdirSync(SCHEMA_DIR).filter(f => f.endsWith('.ts') && f !== 'index.ts')) {
-    const src = readFileSync(join(SCHEMA_DIR, file), 'utf8');
-    const decls = [...src.matchAll(/pgTable\(\s*['"]([a-z0-9_]+)['"]/g)]
-      .map(m => ({ name: m[1], index: m.index }));
-    for (let i = 0; i < decls.length; i += 1) {
-      const body = src.slice(decls[i].index, i + 1 < decls.length ? decls[i + 1].index : undefined);
-      if (/users\.id\s*,\s*\{[^}]*onDelete:\s*['"]cascade['"]/u.test(body)) {
-        found.push(decls[i].name);
+function cascadeOffUsersTables(): Set<string> {
+  const usersName = getTableName(users);
+  const found = new Set<string>();
+  for (const cfg of allTableConfigs()) {
+    for (const fk of cfg.foreignKeys) {
+      const ref = fk.reference();
+      let foreignTable = '';
+      try {
+        foreignTable = getTableName(ref.foreignTable);
+      } catch {
+        continue;
+      }
+      const referencesUserId = ref.foreignColumns.some((c: { readonly name: string }) => c.name === 'id');
+      if (foreignTable === usersName && referencesUserId && fk.onDelete === 'cascade') {
+        found.add(cfg.name);
       }
     }
   }
@@ -35,20 +49,26 @@ describe('user-data purge coverage (schema drift guard)', () => {
       ...USER_SCOPED_CASCADE_VIA_PARENT,
       ...USER_SCOPED_CASCADE_PURGED_ON_DETACH,
     ]);
-    const cascadeTables = cascadeOffUsersTables();
+    const cascade = cascadeOffUsersTables();
 
-    // Sanity: the parser actually found the cascade set (guards against a regex that silently matches nothing).
-    expect(cascadeTables.length).toBeGreaterThan(10);
+    // Sanity: introspection actually found the real cascade set.
+    expect(cascade.size).toBeGreaterThan(10);
+    expect(cascade.has('elements')).toBe(true);
 
-    const uncovered = [...new Set(cascadeTables)].filter(t => !covered.has(t)).sort((a, b) => a.localeCompare(b));
-    // If this fails, a new user-owned table was added that cascades off users.id but is not
-    // erased on account deletion — add it to purgeUserScopedData (or the via-parent list).
+    // If this fails, a new user-owned table cascades off users.id but is not erased on account
+    // deletion — add it to purgeUserScopedData (or the via-parent / detach list).
+    const uncovered = [...cascade].filter(t => !covered.has(t)).sort((a, b) => a.localeCompare(b));
     expect(uncovered).toEqual([]);
   });
 
-  it('does not list purge tables that are not actually user-owned cascade tables', () => {
-    const cascadeTables = new Set(cascadeOffUsersTables());
-    const stale = USER_SCOPED_CASCADE_PURGE_TABLES.filter(t => !cascadeTables.has(t));
+  it('lists no purge / via-parent / detach table that no longer exists in the schema', () => {
+    const allTables = new Set(allTableConfigs().map(c => c.name));
+    const listed = [
+      ...USER_SCOPED_CASCADE_PURGE_TABLES,
+      ...USER_SCOPED_CASCADE_VIA_PARENT,
+      ...USER_SCOPED_CASCADE_PURGED_ON_DETACH,
+    ];
+    const stale = listed.filter(t => !allTables.has(t)).sort((a, b) => a.localeCompare(b));
     expect(stale).toEqual([]);
   });
 });

--- a/tests/unit/database/userDataPurge.drift.test.ts
+++ b/tests/unit/database/userDataPurge.drift.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from '@jest/globals';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  USER_SCOPED_CASCADE_PURGE_TABLES,
+  USER_SCOPED_CASCADE_PURGED_ON_DETACH,
+  USER_SCOPED_CASCADE_VIA_PARENT,
+} from '../../../src/database/userDataPurge.js';
+
+const SCHEMA_DIR = join(dirname(fileURLToPath(import.meta.url)), '../../../src/database/schema');
+
+// Every `pgTable('name', ...)` whose body declares references(() => users.id, {onDelete:'cascade'}).
+function cascadeOffUsersTables(): string[] {
+  const found: string[] = [];
+  for (const file of readdirSync(SCHEMA_DIR).filter(f => f.endsWith('.ts') && f !== 'index.ts')) {
+    const src = readFileSync(join(SCHEMA_DIR, file), 'utf8');
+    const decls = [...src.matchAll(/pgTable\(\s*['"]([a-z0-9_]+)['"]/g)]
+      .map(m => ({ name: m[1], index: m.index }));
+    for (let i = 0; i < decls.length; i += 1) {
+      const body = src.slice(decls[i].index, i + 1 < decls.length ? decls[i + 1].index : undefined);
+      if (/users\.id\s*,\s*\{[^}]*onDelete:\s*['"]cascade['"]/u.test(body)) {
+        found.push(decls[i].name);
+      }
+    }
+  }
+  return found;
+}
+
+describe('user-data purge coverage (schema drift guard)', () => {
+  it('covers every table that cascades off users.id', () => {
+    const covered = new Set([
+      ...USER_SCOPED_CASCADE_PURGE_TABLES,
+      ...USER_SCOPED_CASCADE_VIA_PARENT,
+      ...USER_SCOPED_CASCADE_PURGED_ON_DETACH,
+    ]);
+    const cascadeTables = cascadeOffUsersTables();
+
+    // Sanity: the parser actually found the cascade set (guards against a regex that silently matches nothing).
+    expect(cascadeTables.length).toBeGreaterThan(10);
+
+    const uncovered = [...new Set(cascadeTables)].filter(t => !covered.has(t)).sort((a, b) => a.localeCompare(b));
+    // If this fails, a new user-owned table was added that cascades off users.id but is not
+    // erased on account deletion — add it to purgeUserScopedData (or the via-parent list).
+    expect(uncovered).toEqual([]);
+  });
+
+  it('does not list purge tables that are not actually user-owned cascade tables', () => {
+    const cascadeTables = new Set(cascadeOffUsersTables());
+    const stale = USER_SCOPED_CASCADE_PURGE_TABLES.filter(t => !cascadeTables.has(t));
+    expect(stale).toEqual([]);
+  });
+});

--- a/tests/unit/database/userDataPurge.test.ts
+++ b/tests/unit/database/userDataPurge.test.ts
@@ -29,9 +29,10 @@ import type { DrizzleTx } from '../../../src/database/db-utils.js';
 
 const USER_ID = '018f3d47-73ae-7f10-a0de-0742618d4fb1';
 
-function captureTx() {
+function captureTx(grantRows: readonly { id: string }[] = []) {
   const deletes: { readonly table: unknown; readonly predicate: unknown }[] = [];
   const tx = {
+    select: () => ({ from: () => ({ where: () => Promise.resolve(grantRows) }) }),
     delete: (table: unknown) => ({
       where: (predicate: unknown) => {
         deletes.push({ table, predicate });
@@ -98,9 +99,18 @@ describe('purgeNonCascadeUserIdentity', () => {
       githubLogins: ['octo'],
     });
 
-    expect(deletes.filter(d => d.table === authKv)).toHaveLength(2); // one per sub
+    expect(deletes.filter(d => d.table === authKv)).toHaveLength(2); // one accountId delete per sub (no grants)
     expect(deletes.filter(d => d.table === authIdentityEvents)).toHaveLength(1);
     expect(deletes.filter(d => d.table === authAllowlist)).toHaveLength(1);
+  });
+
+  it('also purges auth_kv rows linked to the account\'s grants by grantId', async () => {
+    const { tx, deletes } = captureTx([{ id: 'grant-1' }, { id: 'grant-2' }]);
+
+    await purgeNonCascadeUserIdentity(tx, { subs: ['sub-1'], emails: [], githubIds: [], githubLogins: [] });
+
+    // one subject → two grant-linked deletes (by grantId) + one accountId delete.
+    expect(deletes.filter(d => d.table === authKv)).toHaveLength(3);
   });
 
   it('deletes nothing when the account has no resolvable identity', async () => {

--- a/tests/unit/database/userDataPurge.test.ts
+++ b/tests/unit/database/userDataPurge.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from '@jest/globals';
+import { eq } from 'drizzle-orm';
+
+import {
+  collectDeletionIdentity,
+  purgeNonCascadeUserIdentity,
+  purgeUserScopedData,
+} from '../../../src/database/userDataPurge.js';
+import {
+  approvalAuditEvents,
+  authAllowlist,
+  authIdentityEvents,
+  authKv,
+  consoleLoginTransactions,
+  consoleSessions,
+  elements,
+  integrationProviderDescriptors,
+  portfolioSyncJobs,
+  runtimeSessionPresence,
+  securityInvalidationEvents,
+  sessionActivationEvents,
+  sessionActivityEvents,
+  sessions,
+  userIntegrations,
+  userOauthTokens,
+  userSettings,
+} from '../../../src/database/schema/index.js';
+import type { DrizzleTx } from '../../../src/database/db-utils.js';
+
+const USER_ID = '018f3d47-73ae-7f10-a0de-0742618d4fb1';
+
+function captureTx() {
+  const deletes: { readonly table: unknown; readonly predicate: unknown }[] = [];
+  const tx = {
+    delete: (table: unknown) => ({
+      where: (predicate: unknown) => {
+        deletes.push({ table, predicate });
+        return Promise.resolve();
+      },
+    }),
+  };
+  return { tx: tx as unknown as DrizzleTx, deletes };
+}
+
+describe('collectDeletionIdentity', () => {
+  it('gathers deduped, lowercased identity values from the account and its logins', () => {
+    const identity = collectDeletionIdentity('User@Example.com', [
+      { sub: 'sub-1', provider: 'github', externalSub: '42', email: 'GH@x.com', rawProfile: { login: 'OctoCat' } },
+      { sub: 'sub-2', provider: 'google', externalSub: 'g-1', email: null, rawProfile: null },
+    ]);
+
+    expect(identity.subs).toEqual(['sub-1', 'sub-2']);
+    expect([...identity.emails].sort((a, b) => a.localeCompare(b))).toEqual(['gh@x.com', 'user@example.com']);
+    expect(identity.githubIds).toEqual(['42']);
+    expect(identity.githubLogins).toEqual(['octocat']);
+  });
+
+  it('handles an account with no email or github login', () => {
+    const identity = collectDeletionIdentity(null, [
+      { sub: 's', provider: 'local', externalSub: 'x', email: null, rawProfile: null },
+    ]);
+    expect(identity).toEqual({ subs: ['s'], emails: [], githubIds: [], githubLogins: [] });
+  });
+});
+
+describe('purgeUserScopedData', () => {
+  it('purges the whole user-owned cascade closure, scoped to the user, sync-jobs before integrations', async () => {
+    const { tx, deletes } = captureTx();
+
+    await purgeUserScopedData(tx, USER_ID);
+
+    const tables = deletes.map(d => d.table);
+    for (const table of [
+      sessionActivityEvents, portfolioSyncJobs, userIntegrations, userOauthTokens,
+      integrationProviderDescriptors, securityInvalidationEvents, runtimeSessionPresence,
+      sessionActivationEvents, approvalAuditEvents, consoleLoginTransactions, consoleSessions,
+      sessions, userSettings, elements,
+    ]) {
+      expect(tables).toContain(table);
+    }
+    // Scope: each purge targets exactly this user.
+    expect(deletes.find(d => d.table === elements)?.predicate).toEqual(eq(elements.userId, USER_ID));
+    expect(deletes.find(d => d.table === integrationProviderDescriptors)?.predicate)
+      .toEqual(eq(integrationProviderDescriptors.ownerUserId, USER_ID));
+    // Ordering: RESTRICT dependency.
+    expect(tables.indexOf(portfolioSyncJobs)).toBeLessThan(tables.indexOf(userIntegrations));
+  });
+});
+
+describe('purgeNonCascadeUserIdentity', () => {
+  it('purges auth_kv per subject, identity events by sub, and allowlist by matched identity', async () => {
+    const { tx, deletes } = captureTx();
+
+    await purgeNonCascadeUserIdentity(tx, {
+      subs: ['sub-1', 'sub-2'],
+      emails: ['a@b.com'],
+      githubIds: ['42'],
+      githubLogins: ['octo'],
+    });
+
+    expect(deletes.filter(d => d.table === authKv)).toHaveLength(2); // one per sub
+    expect(deletes.filter(d => d.table === authIdentityEvents)).toHaveLength(1);
+    expect(deletes.filter(d => d.table === authAllowlist)).toHaveLength(1);
+  });
+
+  it('deletes nothing when the account has no resolvable identity', async () => {
+    const { tx, deletes } = captureTx();
+    await purgeNonCascadeUserIdentity(tx, { subs: [], emails: [], githubIds: [], githubLogins: [] });
+    expect(deletes).toHaveLength(0);
+  });
+});

--- a/tests/unit/web-console/lifecycle/ConsoleStoreCleanupScheduler.test.ts
+++ b/tests/unit/web-console/lifecycle/ConsoleStoreCleanupScheduler.test.ts
@@ -18,12 +18,14 @@ function stores(overrides: {
   readonly login?: jest.Mock<(before?: Date) => Promise<number>>;
   readonly idempotency?: jest.Mock<(before?: Date) => Promise<number>>;
   readonly runtime?: jest.Mock<(before?: Date) => Promise<number>>;
+  readonly activity?: jest.Mock<(before?: Date) => Promise<number>>;
 } = {}) {
   return {
     sessionStore: { sweepExpired: overrides.sessions ?? jest.fn(() => Promise.resolve(1)) },
     loginTransactionStore: { sweepExpired: overrides.login ?? jest.fn(() => Promise.resolve(2)) },
     idempotencyStore: { sweepExpired: overrides.idempotency ?? jest.fn(() => Promise.resolve(3)) },
     ...(overrides.runtime ? { runtimeSessionControlStore: { sweepStalePresence: overrides.runtime } } : {}),
+    ...(overrides.activity ? { sessionActivityStore: { sweepExpired: overrides.activity } } : {}),
   };
 }
 
@@ -66,6 +68,7 @@ describe('ConsoleStoreCleanupScheduler', () => {
         loginTransactions: 2,
         idempotencyRecords: 3,
         runtimeSessionPresence: 0,
+        sessionActivityEvents: 0,
       },
       errors: [],
     });
@@ -117,6 +120,7 @@ describe('ConsoleStoreCleanupScheduler', () => {
         loginTransactions: 2,
         idempotencyRecords: 3,
         runtimeSessionPresence: 0,
+        sessionActivityEvents: 0,
       },
       errors: [{ store: 'consoleSessions', error: failure }],
     });
@@ -146,6 +150,7 @@ describe('ConsoleStoreCleanupScheduler', () => {
         loginTransactions: 2,
         idempotencyRecords: 0,
         runtimeSessionPresence: 0,
+        sessionActivityEvents: 0,
       },
       errors: [
         { store: 'consoleSessions', error: sessionFailure },
@@ -153,6 +158,20 @@ describe('ConsoleStoreCleanupScheduler', () => {
       ],
     });
     expect(cleanupStores.loginTransactionStore.sweepExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it('sweeps session activity retention when an activity store is configured', async () => {
+    const activity = jest.fn(() => Promise.resolve(5));
+    const cleanupStores = stores({ activity });
+    const scheduler = new ConsoleStoreCleanupScheduler({
+      stores: cleanupStores,
+      now: () => NOW,
+    });
+
+    const result = await scheduler.runOnce();
+
+    expect(result?.removed.sessionActivityEvents).toBe(5);
+    expect(activity).toHaveBeenCalledWith(NOW);
   });
 
   it('sweeps stale runtime session presence when a runtime store is configured', async () => {

--- a/tests/unit/web-console/modules/OperationsModule.test.ts
+++ b/tests/unit/web-console/modules/OperationsModule.test.ts
@@ -17,6 +17,7 @@ import {
   type ISystemMetricsSource,
   type OperationsHealthChecks,
 } from '../../../../src/web-console/index.js';
+import { OPERATION_HEALTH_COMPONENTS } from '../../../../src/web-console/modules/operations/OperationsHealth.js';
 
 const NOW = new Date('2026-05-29T10:30:00.000Z');
 const MUST_NOT_LEAK = 'must-not-leak';
@@ -998,6 +999,27 @@ describe('OperationsModule', () => {
       transport: 'tcp/secure',
       account_correlation_id: 'account-4',
     });
+  });
+
+  it('accepts every health component the builder can emit (no silent drift to the fallback)', () => {
+    for (const component of OPERATION_HEALTH_COMPONENTS) {
+      const projected = projectOperationHealthComponent({
+        component,
+        status: 'ok',
+        checked_at: NOW.toISOString(),
+        failure_codes: [],
+      });
+      expect(projected.component).toBe(component);
+    }
+    // A component the builder never emits is coerced to a valid member (defensive), not passed through.
+    const coerced = projectOperationHealthComponent({
+      component: 'queue_processor',
+      status: 'ok',
+      checked_at: NOW.toISOString(),
+      failure_codes: [],
+    });
+    expect(OPERATION_HEALTH_COMPONENTS).toContain(coerced.component);
+    expect(coerced.component).not.toBe('queue_processor');
   });
 
   it('projects health by allowlist rather than source object shape', () => {

--- a/tests/unit/web-console/modules/OperationsModule.test.ts
+++ b/tests/unit/web-console/modules/OperationsModule.test.ts
@@ -949,6 +949,57 @@ describe('OperationsModule', () => {
     });
   });
 
+  it('drops telemetry codes that are not well-formed stable identifiers (fail-closed)', () => {
+    const projected = projectOperationalLogs({
+      items: [{
+        ts: NOW.toISOString(),
+        level: 'error',
+        subsystem: 'user report: crash in payment flow',
+        event: 'evt@example.com',
+        correlation_id: 'correlation-9',
+        account_correlation_id: 'account-9',
+        session_id: 'session-9',
+        replica: 'replica-a',
+        duration_ms: 3,
+        status_code: 500,
+        error_code: `contains spaces ${'x'.repeat(80)}`,
+      }],
+      page: { limit: 1, cursor: null, next_cursor: null },
+    });
+    expect(projected.items[0]).toMatchObject({
+      subsystem: '',
+      event: '',
+      replica: 'replica-a',
+      error_code: null,
+      correlation_id: 'correlation-9',
+      session_id: 'session-9',
+    });
+
+    const metrics = projectOperationalMetrics({
+      checked_at: NOW.toISOString(),
+      metrics: [{
+        name: RUNTIME_ERRORS_METRIC,
+        kind: 'counter',
+        value: 1,
+        unit: 'count',
+        dimensions: {
+          subsystem: 'runtime',
+          event: 'has space',
+          error_code: 'ok_code',
+          transport: 'tcp/secure',
+          latency_bucket: 'not a bucket!!',
+          account_correlation_id: 'account-4',
+        },
+      }],
+    });
+    expect(metrics.metrics[0].dimensions).toEqual({
+      subsystem: 'runtime',
+      error_code: 'ok_code',
+      transport: 'tcp/secure',
+      account_correlation_id: 'account-4',
+    });
+  });
+
   it('projects health by allowlist rather than source object shape', () => {
     expect(projectOperationHealthSummary({
       status: 'ok',

--- a/tests/unit/web-console/modules/PortfolioModule.test.ts
+++ b/tests/unit/web-console/modules/PortfolioModule.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from '@jest/globals';
 import {
   createPortfolioModule,
   InMemoryPortfolioActivityEventSink,
+  portfolioDeletionActivityMessage,
   InMemoryPortfolioElementStore,
   InMemoryPortfolioSyncJobStore,
   InMemoryUserIntegrationStore,
@@ -36,6 +37,7 @@ const REVIEW_HELPER_NAME = 'review-helper';
 const REVIEW_HELPER_V3_ETAG = 'W/"portfolio:skills:review-helper:v3"';
 const INTEGRATION_ID = '35e22a52-dc56-4cd0-9d13-b2802524fbd3';
 const CORRELATION_ID = '22222222-2222-4222-8222-222222222222';
+const CONTENT_HASH = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
 function authenticatedContext(userId = USER_ID): NonNullable<ConsoleRequest['consoleAuthentication']> {
   return {
@@ -647,9 +649,9 @@ describe('PortfolioModule', () => {
     await expect(store.findByName(USER_ID, 'skills', REVIEW_HELPER_NAME)).resolves.toBeNull();
   });
 
-  it('records a metadata-only deletion activity event on delete', async () => {
+  it('records a metadata-only deletion activity event carrying the content hash, not the content', async () => {
     const sink = new InMemoryPortfolioActivityEventSink();
-    const store = new InMemoryPortfolioElementStore([portfolioElement()]);
+    const store = new InMemoryPortfolioElementStore([portfolioElement({ contentHash: CONTENT_HASH })]);
     const module = createPortfolioModule({
       portfolioStore: store,
       integrationStore: new InMemoryUserIntegrationStore(),
@@ -677,10 +679,30 @@ describe('PortfolioModule', () => {
       userId: USER_ID,
       elementType: 'skills',
       canonicalName: REVIEW_HELPER_NAME,
+      contentHash: CONTENT_HASH,
       correlationId: CORRELATION_ID,
     });
     expect(events[0].consoleSessionId).toMatch(/^[0-9a-f]{64}$/u);
-    expect(events[0]).not.toHaveProperty('content');
+    // The persisted activity message must carry the hash and never the element's content.
+    const message = portfolioDeletionActivityMessage(events[0]);
+    expect(message).toContain(CONTENT_HASH);
+    expect(message).not.toContain('Owner private content.');
+  });
+
+  it('builds a content-free deletion message with and without a content hash', () => {
+    const base = {
+      type: 'console.portfolio.element.deleted.v1' as const,
+      userId: USER_ID,
+      consoleSessionId: 'a'.repeat(64),
+      elementType: 'skills' as const,
+      canonicalName: REVIEW_HELPER_NAME,
+      correlationId: CORRELATION_ID,
+      occurredAt: NOW,
+    };
+    expect(portfolioDeletionActivityMessage({ ...base, contentHash: CONTENT_HASH }))
+      .toBe(`Deleted skills/${REVIEW_HELPER_NAME} (sha256:${CONTENT_HASH})`);
+    expect(portfolioDeletionActivityMessage({ ...base, contentHash: null }))
+      .toBe(`Deleted skills/${REVIEW_HELPER_NAME}`);
   });
 
   it('enforces delete preconditions before deleting owned elements', async () => {

--- a/tests/unit/web-console/modules/PortfolioModule.test.ts
+++ b/tests/unit/web-console/modules/PortfolioModule.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 
 import {
   createPortfolioModule,
+  InMemoryPortfolioActivityEventSink,
   InMemoryPortfolioElementStore,
   InMemoryPortfolioSyncJobStore,
   InMemoryUserIntegrationStore,
@@ -34,6 +35,7 @@ const SYNC_STATUS_PATH = '/api/v1/me/portfolio/sync/:job_id';
 const REVIEW_HELPER_NAME = 'review-helper';
 const REVIEW_HELPER_V3_ETAG = 'W/"portfolio:skills:review-helper:v3"';
 const INTEGRATION_ID = '35e22a52-dc56-4cd0-9d13-b2802524fbd3';
+const CORRELATION_ID = '22222222-2222-4222-8222-222222222222';
 
 function authenticatedContext(userId = USER_ID): NonNullable<ConsoleRequest['consoleAuthentication']> {
   return {
@@ -643,6 +645,42 @@ describe('PortfolioModule', () => {
       },
     });
     await expect(store.findByName(USER_ID, 'skills', REVIEW_HELPER_NAME)).resolves.toBeNull();
+  });
+
+  it('records a metadata-only deletion activity event on delete', async () => {
+    const sink = new InMemoryPortfolioActivityEventSink();
+    const store = new InMemoryPortfolioElementStore([portfolioElement()]);
+    const module = createPortfolioModule({
+      portfolioStore: store,
+      integrationStore: new InMemoryUserIntegrationStore(),
+      syncJobStore: new InMemoryPortfolioSyncJobStore(),
+      enablePortfolioWriteRoutes: true,
+      now: () => NOW,
+      activityEventSink: sink,
+    });
+    const remove = findRoute(module.routes, ELEMENT_DETAIL_PATH, 'DELETE');
+    const detail = findRoute(module.routes, ELEMENT_DETAIL_PATH);
+    const current = await detail.handler(consoleRequest({
+      params: { type: 'skills', name: REVIEW_HELPER_NAME },
+    }));
+
+    await remove.handler(consoleRequest({
+      params: { type: 'skills', name: REVIEW_HELPER_NAME },
+      headers: { 'if-match': responseEtag(current) },
+      consoleContext: { correlationId: CORRELATION_ID, receivedAt: NOW },
+    }));
+
+    const events = sink.listEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'console.portfolio.element.deleted.v1',
+      userId: USER_ID,
+      elementType: 'skills',
+      canonicalName: REVIEW_HELPER_NAME,
+      correlationId: CORRELATION_ID,
+    });
+    expect(events[0].consoleSessionId).toMatch(/^[0-9a-f]{64}$/u);
+    expect(events[0]).not.toHaveProperty('content');
   });
 
   it('enforces delete preconditions before deleting owned elements', async () => {

--- a/tests/unit/web-console/modules/ProductionAuditQueries.test.ts
+++ b/tests/unit/web-console/modules/ProductionAuditQueries.test.ts
@@ -14,6 +14,10 @@ const {
   PostgresAuthenticationAuditQuery,
 } = await import('../../../../src/web-console/modules/audit/index.js');
 
+const { integrityFromApprovalAuditVerification } = await import(
+  '../../../../src/web-console/modules/audit/PostgresProductionAuditQueries.js'
+);
+
 const NOW = new Date('2099-05-31T12:00:00.000Z');
 const APPROVAL_ID = 'cli-018f3d47-73ae-7f10-a0de-0742618d4fb1';
 const USER_ID = '018f3d47-73ae-7f10-a0de-0742618d4fb2';
@@ -72,6 +76,39 @@ describe('production audit query adapters', () => {
       },
     });
     expect(withSystemContextMock).toHaveBeenCalledWith(db, expect.any(Function));
+  });
+
+  it('only reports verified integrity when a real verification succeeds', () => {
+    expect(integrityFromApprovalAuditVerification({ available: false })).toEqual({
+      status: 'not_available',
+      chain_key_id: null,
+      chain_prev: null,
+      chain_hmac: null,
+    });
+    expect(integrityFromApprovalAuditVerification({
+      available: true,
+      verified: false,
+      chainKeyId: 'key-1',
+      chainPrev: null,
+      chainHmac: 'hmac-1',
+    })).toEqual({
+      status: 'not_available',
+      chain_key_id: null,
+      chain_prev: null,
+      chain_hmac: null,
+    });
+    expect(integrityFromApprovalAuditVerification({
+      available: true,
+      verified: true,
+      chainKeyId: 'key-1',
+      chainPrev: 'prev-0',
+      chainHmac: 'hmac-1',
+    })).toEqual({
+      status: 'verified',
+      chain_key_id: 'key-1',
+      chain_prev: 'prev-0',
+      chain_hmac: 'hmac-1',
+    });
   });
 
   it('returns a single approval audit row by id', async () => {

--- a/tests/unit/web-console/stores/ConsolePrincipalDeletion.test.ts
+++ b/tests/unit/web-console/stores/ConsolePrincipalDeletion.test.ts
@@ -26,7 +26,7 @@ interface SelectNode {
 
 // A tx where the hard `DELETE FROM users` raises a 23503 FK violation unless hardDelete is set,
 // forcing the anonymize-tombstone branch. Both selects (users, auth_accounts) are served.
-function txMock({ hardDelete = false } = {}) {
+function txMock({ hardDelete = false, transactionError }: { hardDelete?: boolean; transactionError?: unknown } = {}) {
   const deletes: { readonly table: unknown; readonly predicate: unknown }[] = [];
   const from = (table: unknown): SelectNode => {
     const rows = table === users ? [{ id: USER_ID, email: 'a@b.com' }] : ACCOUNTS;
@@ -46,7 +46,10 @@ function txMock({ hardDelete = false } = {}) {
         return Promise.resolve();
       },
     }),
-    transaction: () => (hardDelete ? Promise.resolve() : Promise.reject({ code: '23503' })),
+    transaction: () => {
+      if (hardDelete) return Promise.resolve();
+      return Promise.reject(transactionError ?? { code: '23503' });
+    },
     update: () => ({
       set: () => ({ where: () => ({ returning: () => Promise.resolve([{ authzVersion: 5 }]) }) }),
     }),
@@ -76,5 +79,12 @@ describe('deleteConsolePrincipalWithTx', () => {
     const outcome = await deleteConsolePrincipalWithTx(tx, { userId: USER_ID, deletedAt: DELETED_AT });
 
     expect(outcome).toMatchObject({ userId: USER_ID, outcome: 'deleted' });
+  });
+
+  it('propagates a non-FK error from the hard-delete attempt (the whole tx then rolls back)', async () => {
+    const { tx } = txMock({ transactionError: { code: '40001' } }); // serialization failure, not 23503
+
+    await expect(deleteConsolePrincipalWithTx(tx, { userId: USER_ID, deletedAt: DELETED_AT }))
+      .rejects.toMatchObject({ code: '40001' });
   });
 });

--- a/tests/unit/web-console/stores/ConsolePrincipalDeletion.test.ts
+++ b/tests/unit/web-console/stores/ConsolePrincipalDeletion.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from '@jest/globals';
 import { eq } from 'drizzle-orm';
 
 import { deleteConsolePrincipalWithTx } from '../../../../src/web-console/stores/PostgresConsoleAccountAdminStore.js';
-import { sessionActivityEvents } from '../../../../src/database/schema/index.js';
+import {
+  portfolioSyncJobs,
+  sessionActivityEvents,
+  userIntegrations,
+  userOauthTokens,
+} from '../../../../src/database/schema/index.js';
 import type { DrizzleTx } from '../../../../src/database/db-utils.js';
 
 const USER_ID = '018f3d47-73ae-7f10-a0de-0742618d4fb1';
@@ -38,16 +43,24 @@ function anonymizingTxMock() {
 }
 
 describe('deleteConsolePrincipalWithTx (anonymize path)', () => {
-  it('purges only the deleted user\'s session_activity_events when anonymize-tombstoned', async () => {
+  it('purges the deleted user\'s activity and credential data, scoped to that user, when anonymize-tombstoned', async () => {
     const { tx, deletes } = anonymizingTxMock();
 
     const outcome = await deleteConsolePrincipalWithTx(tx, { userId: USER_ID, deletedAt: DELETED_AT });
 
     expect(outcome).toMatchObject({ userId: USER_ID, outcome: 'anonymized' });
-    // The users row is retained, so ON DELETE CASCADE never fires — the activity purge must be explicit.
-    const activityPurge = deletes.find(entry => entry.table === sessionActivityEvents);
-    expect(activityPurge).toBeDefined();
-    // ...and it must be scoped to exactly this user, not a blanket delete of everyone's activity.
-    expect(activityPurge?.predicate).toEqual(eq(sessionActivityEvents.userId, USER_ID));
+    // The users row is retained, so ON DELETE CASCADE never fires — these purges must be explicit,
+    // and each must be scoped to exactly this user (not a blanket delete of everyone's rows).
+    // user_integrations / user_oauth_tokens hold OAuth token ciphertext; portfolio_sync_jobs must
+    // precede user_integrations because it RESTRICT-references it.
+    for (const table of [sessionActivityEvents, portfolioSyncJobs, userIntegrations, userOauthTokens]) {
+      const purge = deletes.find(entry => entry.table === table);
+      expect(purge).toBeDefined();
+      expect(purge?.predicate).toEqual(eq(table.userId, USER_ID));
+    }
+
+    // Sync jobs must be deleted before the integrations they RESTRICT-reference.
+    const order = (table: unknown) => deletes.findIndex(entry => entry.table === table);
+    expect(order(portfolioSyncJobs)).toBeLessThan(order(userIntegrations));
   });
 });

--- a/tests/unit/web-console/stores/ConsolePrincipalDeletion.test.ts
+++ b/tests/unit/web-console/stores/ConsolePrincipalDeletion.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { deleteConsolePrincipalWithTx } from '../../../../src/web-console/stores/PostgresConsoleAccountAdminStore.js';
+import { sessionActivityEvents } from '../../../../src/database/schema/index.js';
+import type { DrizzleTx } from '../../../../src/database/db-utils.js';
+
+const USER_ID = '018f3d47-73ae-7f10-a0de-0742618d4fb1';
+const DELETED_AT = new Date('2026-07-07T12:00:00.000Z');
+
+// A transaction whose hard `DELETE FROM users` raises a foreign-key violation (23503),
+// as an audit-chain RESTRICT reference would, forcing the anonymize-tombstone branch.
+function anonymizingTxMock() {
+  const deletedTables: unknown[] = [];
+  const tx = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => ({ for: () => Promise.resolve([{ id: USER_ID }]) }),
+        }),
+      }),
+    }),
+    delete: (table: unknown) => {
+      deletedTables.push(table);
+      return { where: () => Promise.resolve() };
+    },
+    transaction: () => Promise.reject({ code: '23503' }),
+    update: () => ({
+      set: () => ({
+        where: () => ({ returning: () => Promise.resolve([{ authzVersion: 5 }]) }),
+      }),
+    }),
+  };
+  return { tx: tx as unknown as DrizzleTx, deletedTables };
+}
+
+describe('deleteConsolePrincipalWithTx (anonymize path)', () => {
+  it('purges session_activity_events when the account is anonymize-tombstoned', async () => {
+    const { tx, deletedTables } = anonymizingTxMock();
+
+    const outcome = await deleteConsolePrincipalWithTx(tx, { userId: USER_ID, deletedAt: DELETED_AT });
+
+    expect(outcome).toMatchObject({ userId: USER_ID, outcome: 'anonymized' });
+    // The users row is retained, so ON DELETE CASCADE never fires — the activity purge must be explicit.
+    expect(deletedTables).toContain(sessionActivityEvents);
+  });
+});

--- a/tests/unit/web-console/stores/ConsolePrincipalDeletion.test.ts
+++ b/tests/unit/web-console/stores/ConsolePrincipalDeletion.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
+import { eq } from 'drizzle-orm';
 
 import { deleteConsolePrincipalWithTx } from '../../../../src/web-console/stores/PostgresConsoleAccountAdminStore.js';
 import { sessionActivityEvents } from '../../../../src/database/schema/index.js';
@@ -9,8 +10,9 @@ const DELETED_AT = new Date('2026-07-07T12:00:00.000Z');
 
 // A transaction whose hard `DELETE FROM users` raises a foreign-key violation (23503),
 // as an audit-chain RESTRICT reference would, forcing the anonymize-tombstone branch.
+// Every `delete(table).where(predicate)` is captured so the purge scope can be asserted.
 function anonymizingTxMock() {
-  const deletedTables: unknown[] = [];
+  const deletes: { readonly table: unknown; readonly predicate: unknown }[] = [];
   const tx = {
     select: () => ({
       from: () => ({
@@ -19,10 +21,12 @@ function anonymizingTxMock() {
         }),
       }),
     }),
-    delete: (table: unknown) => {
-      deletedTables.push(table);
-      return { where: () => Promise.resolve() };
-    },
+    delete: (table: unknown) => ({
+      where: (predicate: unknown) => {
+        deletes.push({ table, predicate });
+        return Promise.resolve();
+      },
+    }),
     transaction: () => Promise.reject({ code: '23503' }),
     update: () => ({
       set: () => ({
@@ -30,17 +34,20 @@ function anonymizingTxMock() {
       }),
     }),
   };
-  return { tx: tx as unknown as DrizzleTx, deletedTables };
+  return { tx: tx as unknown as DrizzleTx, deletes };
 }
 
 describe('deleteConsolePrincipalWithTx (anonymize path)', () => {
-  it('purges session_activity_events when the account is anonymize-tombstoned', async () => {
-    const { tx, deletedTables } = anonymizingTxMock();
+  it('purges only the deleted user\'s session_activity_events when anonymize-tombstoned', async () => {
+    const { tx, deletes } = anonymizingTxMock();
 
     const outcome = await deleteConsolePrincipalWithTx(tx, { userId: USER_ID, deletedAt: DELETED_AT });
 
     expect(outcome).toMatchObject({ userId: USER_ID, outcome: 'anonymized' });
     // The users row is retained, so ON DELETE CASCADE never fires — the activity purge must be explicit.
-    expect(deletedTables).toContain(sessionActivityEvents);
+    const activityPurge = deletes.find(entry => entry.table === sessionActivityEvents);
+    expect(activityPurge).toBeDefined();
+    // ...and it must be scoped to exactly this user, not a blanket delete of everyone's activity.
+    expect(activityPurge?.predicate).toEqual(eq(sessionActivityEvents.userId, USER_ID));
   });
 });

--- a/tests/unit/web-console/stores/ConsolePrincipalDeletion.test.ts
+++ b/tests/unit/web-console/stores/ConsolePrincipalDeletion.test.ts
@@ -3,64 +3,78 @@ import { eq } from 'drizzle-orm';
 
 import { deleteConsolePrincipalWithTx } from '../../../../src/web-console/stores/PostgresConsoleAccountAdminStore.js';
 import {
+  authKv,
+  elements,
   portfolioSyncJobs,
-  sessionActivityEvents,
   userIntegrations,
-  userOauthTokens,
+  users,
 } from '../../../../src/database/schema/index.js';
 import type { DrizzleTx } from '../../../../src/database/db-utils.js';
 
 const USER_ID = '018f3d47-73ae-7f10-a0de-0742618d4fb1';
 const DELETED_AT = new Date('2026-07-07T12:00:00.000Z');
+const ACCOUNTS = [
+  { sub: 'sub-1', provider: 'github', externalSub: '42', email: 'a@b.com', rawProfile: { login: 'octo' } },
+];
 
-// A transaction whose hard `DELETE FROM users` raises a foreign-key violation (23503),
-// as an audit-chain RESTRICT reference would, forcing the anonymize-tombstone branch.
-// Every `delete(table).where(predicate)` is captured so the purge scope can be asserted.
-function anonymizingTxMock() {
+interface SelectNode {
+  where(): SelectNode;
+  limit(): SelectNode;
+  for(): Promise<unknown>;
+  then(resolve: (value: unknown) => void, reject: (error: unknown) => void): Promise<unknown>;
+}
+
+// A tx where the hard `DELETE FROM users` raises a 23503 FK violation unless hardDelete is set,
+// forcing the anonymize-tombstone branch. Both selects (users, auth_accounts) are served.
+function txMock({ hardDelete = false } = {}) {
   const deletes: { readonly table: unknown; readonly predicate: unknown }[] = [];
+  const from = (table: unknown): SelectNode => {
+    const rows = table === users ? [{ id: USER_ID, email: 'a@b.com' }] : ACCOUNTS;
+    const node: SelectNode = {
+      where: () => node,
+      limit: () => node,
+      for: () => Promise.resolve(rows),
+      then: (resolve, reject) => Promise.resolve(rows).then(resolve, reject),
+    };
+    return node;
+  };
   const tx = {
-    select: () => ({
-      from: () => ({
-        where: () => ({
-          limit: () => ({ for: () => Promise.resolve([{ id: USER_ID }]) }),
-        }),
-      }),
-    }),
+    select: () => ({ from }),
     delete: (table: unknown) => ({
       where: (predicate: unknown) => {
         deletes.push({ table, predicate });
         return Promise.resolve();
       },
     }),
-    transaction: () => Promise.reject({ code: '23503' }),
+    transaction: () => (hardDelete ? Promise.resolve() : Promise.reject({ code: '23503' })),
     update: () => ({
-      set: () => ({
-        where: () => ({ returning: () => Promise.resolve([{ authzVersion: 5 }]) }),
-      }),
+      set: () => ({ where: () => ({ returning: () => Promise.resolve([{ authzVersion: 5 }]) }) }),
     }),
   };
   return { tx: tx as unknown as DrizzleTx, deletes };
 }
 
-describe('deleteConsolePrincipalWithTx (anonymize path)', () => {
-  it('purges the deleted user\'s activity and credential data, scoped to that user, when anonymize-tombstoned', async () => {
-    const { tx, deletes } = anonymizingTxMock();
+describe('deleteConsolePrincipalWithTx', () => {
+  it('anonymize-tombstones and erases the account content + non-FK identity, scoped to the user', async () => {
+    const { tx, deletes } = txMock();
 
     const outcome = await deleteConsolePrincipalWithTx(tx, { userId: USER_ID, deletedAt: DELETED_AT });
 
     expect(outcome).toMatchObject({ userId: USER_ID, outcome: 'anonymized' });
-    // The users row is retained, so ON DELETE CASCADE never fires — these purges must be explicit,
-    // and each must be scoped to exactly this user (not a blanket delete of everyone's rows).
-    // user_integrations / user_oauth_tokens hold OAuth token ciphertext; portfolio_sync_jobs must
-    // precede user_integrations because it RESTRICT-references it.
-    for (const table of [sessionActivityEvents, portfolioSyncJobs, userIntegrations, userOauthTokens]) {
-      const purge = deletes.find(entry => entry.table === table);
-      expect(purge).toBeDefined();
-      expect(purge?.predicate).toEqual(eq(table.userId, USER_ID));
-    }
+    const tables = deletes.map(d => d.table);
+    // Cascade-closure content is purged (via purgeUserScopedData), scoped to this user...
+    expect(tables).toContain(elements);
+    expect(deletes.find(d => d.table === elements)?.predicate).toEqual(eq(elements.userId, USER_ID));
+    expect(tables.indexOf(portfolioSyncJobs)).toBeLessThan(tables.indexOf(userIntegrations));
+    // ...and the non-FK identity/credential tables are purged too (via purgeNonCascadeUserIdentity).
+    expect(tables).toContain(authKv);
+  });
 
-    // Sync jobs must be deleted before the integrations they RESTRICT-reference.
-    const order = (table: unknown) => deletes.findIndex(entry => entry.table === table);
-    expect(order(portfolioSyncJobs)).toBeLessThan(order(userIntegrations));
+  it('hard-deletes (users row removed) when nothing RESTRICT-references the user', async () => {
+    const { tx } = txMock({ hardDelete: true });
+
+    const outcome = await deleteConsolePrincipalWithTx(tx, { userId: USER_ID, deletedAt: DELETED_AT });
+
+    expect(outcome).toMatchObject({ userId: USER_ID, outcome: 'deleted' });
   });
 });

--- a/tests/unit/web-console/stores/ConsoleSessionActivityStore.test.ts
+++ b/tests/unit/web-console/stores/ConsoleSessionActivityStore.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { InMemoryConsoleSessionActivityStore } from '../../../../src/web-console/stores/IConsoleSessionActivityStore.js';
+
+const NOW = new Date('2026-07-07T12:00:00.000Z');
+const USER = '018f3d47-73ae-7f10-a0de-0742618d4fb1';
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('InMemoryConsoleSessionActivityStore', () => {
+  it('sweeps rows older than the retention window and keeps newer ones', async () => {
+    const store = new InMemoryConsoleSessionActivityStore(30 * DAY_MS);
+    store.seed(USER, new Date(NOW.getTime() - 40 * DAY_MS));
+    store.seed(USER, new Date(NOW.getTime() - 31 * DAY_MS));
+    store.seed(USER, new Date(NOW.getTime() - 10 * DAY_MS));
+    store.seed(USER, NOW);
+
+    const removed = await store.sweepExpired(NOW);
+
+    expect(removed).toBe(2);
+    expect(store.size()).toBe(2);
+  });
+
+  it('keeps rows exactly at the retention boundary', async () => {
+    const store = new InMemoryConsoleSessionActivityStore(30 * DAY_MS);
+    store.seed(USER, new Date(NOW.getTime() - 30 * DAY_MS));
+
+    const removed = await store.sweepExpired(NOW);
+
+    expect(removed).toBe(0);
+    expect(store.size()).toBe(1);
+  });
+});

--- a/tests/unit/web-console/stores/ConsoleSessionActivityStore.test.ts
+++ b/tests/unit/web-console/stores/ConsoleSessionActivityStore.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { InMemoryConsoleSessionActivityStore } from '../../../../src/web-console/stores/IConsoleSessionActivityStore.js';
+import {
+  DEFAULT_SESSION_ACTIVITY_RETENTION_MS,
+  InMemoryConsoleSessionActivityStore,
+} from '../../../../src/web-console/stores/IConsoleSessionActivityStore.js';
 
 const NOW = new Date('2026-07-07T12:00:00.000Z');
 const USER = '018f3d47-73ae-7f10-a0de-0742618d4fb1';
@@ -27,6 +30,19 @@ describe('InMemoryConsoleSessionActivityStore', () => {
     const removed = await store.sweepExpired(NOW);
 
     expect(removed).toBe(0);
+    expect(store.size()).toBe(1);
+  });
+
+  it('ships a 90-day default retention window', async () => {
+    expect(DEFAULT_SESSION_ACTIVITY_RETENTION_MS).toBe(90 * DAY_MS);
+
+    const store = new InMemoryConsoleSessionActivityStore();
+    store.seed(USER, new Date(NOW.getTime() - 91 * DAY_MS));
+    store.seed(USER, new Date(NOW.getTime() - 89 * DAY_MS));
+
+    const removed = await store.sweepExpired(NOW);
+
+    expect(removed).toBe(1);
     expect(store.size()).toBe(1);
   });
 });

--- a/tests/unit/web-console/stores/PostgresActivityPersistence.test.ts
+++ b/tests/unit/web-console/stores/PostgresActivityPersistence.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { lt } from 'drizzle-orm';
+import { sessionActivityEvents } from '../../../../src/database/schema/index.js';
+import type { DatabaseInstance } from '../../../../src/database/connection.js';
+
+const withSystemContextMock = jest.fn((db: unknown, cb: (tx: unknown) => unknown) => cb(db));
+jest.unstable_mockModule('../../../../src/database/admin.js', () => ({
+  withSystemContext: withSystemContextMock,
+}));
+
+const { PostgresConsoleSessionActivityStore } = await import(
+  '../../../../src/web-console/stores/IConsoleSessionActivityStore.js'
+);
+const { PostgresPortfolioActivityEventSink } = await import(
+  '../../../../src/web-console/modules/portfolio/PortfolioActivityEvents.js'
+);
+
+const NOW = new Date('2026-07-07T12:00:00.000Z');
+const DAY_MS = 24 * 60 * 60 * 1000;
+const USER_ID = '018f3d47-73ae-7f10-a0de-0742618d4fb1';
+const CONTENT_HASH = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+const CORRELATION_ID = '22222222-2222-4222-8222-222222222222';
+
+describe('PostgresConsoleSessionActivityStore.sweepExpired', () => {
+  it('deletes rows strictly older than before-minus-retention and returns the removed count', async () => {
+    let captured: { table?: unknown; predicate?: unknown } = {};
+    const db = {
+      delete: (table: unknown) => ({
+        where: (predicate: unknown) => ({
+          returning: () => {
+            captured = { table, predicate };
+            return Promise.resolve([{ id: '1' }, { id: '2' }]);
+          },
+        }),
+      }),
+    };
+    const store = new PostgresConsoleSessionActivityStore(db as unknown as DatabaseInstance, 30 * DAY_MS);
+
+    const removed = await store.sweepExpired(NOW);
+
+    expect(removed).toBe(2);
+    expect(captured.table).toBe(sessionActivityEvents);
+    // Pins both the operator (strictly-less-than, not <=) and the cutoff math.
+    expect(captured.predicate).toEqual(
+      lt(sessionActivityEvents.occurredAt, new Date(NOW.getTime() - 30 * DAY_MS)),
+    );
+  });
+});
+
+describe('PostgresPortfolioActivityEventSink.recordElementDeleted', () => {
+  it('inserts a metadata-only activity row carrying the hash, never the content', async () => {
+    let inserted: { table?: unknown; row?: Record<string, unknown> } = {};
+    const db = {
+      insert: (table: unknown) => ({
+        values: (row: Record<string, unknown>) => {
+          inserted = { table, row };
+          return Promise.resolve();
+        },
+      }),
+    };
+    const sink = new PostgresPortfolioActivityEventSink(db as unknown as DatabaseInstance);
+
+    await sink.recordElementDeleted({
+      type: 'console.portfolio.element.deleted.v1',
+      userId: USER_ID,
+      consoleSessionId: 'a'.repeat(64),
+      elementType: 'skills',
+      canonicalName: 'review-helper',
+      contentHash: CONTENT_HASH,
+      correlationId: CORRELATION_ID,
+      occurredAt: NOW,
+    });
+
+    expect(inserted.table).toBe(sessionActivityEvents);
+    expect(inserted.row).toMatchObject({
+      userId: USER_ID,
+      sessionId: 'a'.repeat(64),
+      occurredAt: NOW,
+      level: 'info',
+      subsystem: 'portfolio',
+      event: 'console.portfolio.element.deleted.v1',
+      message: `Deleted skills/review-helper (sha256:${CONTENT_HASH})`,
+      correlationId: CORRELATION_ID,
+      stableErrorCode: null,
+    });
+    expect(JSON.stringify(inserted.row)).not.toContain('Owner private content');
+  });
+});


### PR DESCRIPTION
## Summary

A cleanup and hardening pass over the `/api/v1` web console, plus deletion auditing, activity retention, and completing account-deletion erasure. Console delete semantics are unchanged (still a hard delete).

## Changes

**Hardening & cleanup**
- Extracted a single source for the dependency health probes shared by the public readiness and admin operations surfaces, so a probe is defined once.
- Gave the console its own approval-record type instead of aliasing the gatekeeper-internal one, with explicit boundary mappers (a gatekeeper-internal change now surfaces as a compile error rather than silently altering the console contract).
- Fail-closed validation of operator-facing telemetry code fields: a value that isn't a bounded, well-formed identifier is dropped rather than forwarded, so a future producer can't leak user content into operator surfaces.
- Routed approval-audit integrity through a single verification result so a `verified` status can only originate from a real verification (never hand-written).
- Removed the never-produced `cancelled` portfolio-sync-job status from the type/validator/projector and the DB CHECK constraints (forward migration), so the schema no longer advertises an unreachable state.
- Documented the supported storage matrix (Postgres for durability, in-memory for dev/loopback only).

**Deletion auditing & retention**
- Portfolio element deletion now emits a metadata-only activity event (records the content hash, never the content). Console deletion remains an intentional hard delete mirroring the canonical element-manager semantics.
- Added a bounded retention sweep for `session_activity_events` (previously unbounded) via the existing store-cleanup scheduler.

**Account-deletion erasure**
- Account deletion has two outcomes: hard delete (row removed, cascade wipes everything) and anonymize-tombstone (the row is retained PII-scrubbed to anchor the tamper-evident audit chain). On the tombstone path the cascade never fires, so it is now replayed explicitly — the full user-owned cascade closure (elements and their content, settings, sessions, per-user telemetry, integrations + OAuth token ciphertext) is purged.
- Purges the non-FK identity/credential tables that survived **even a hard delete**: the OIDC grants/tokens (`auth_kv`), the account's auth-event log, and the allowlist pre-approval (a direct identifier and re-onboarding vector), on both deletion paths.
- A single `purgeUserScopedData` helper defines the erasure, backed by a schema drift-guard test that fails the build if any new table cascading off `users.id` is not covered — so this can't silently regress.

## For reviewers

Account deletion deliberately **retains** two things, so they aren't misread as an incomplete erasure: the tamper-evident admin-audit chain, and records of this user's actions on *other* users / shared platform state (roles they granted, allowlist entries they created). The one unavoidable residual is a set of audit-chain fields (client IP / user-agent) bound by the row's HMAC — they can't be scrubbed without breaking verification, so that is the single place personal data survives, by design.

Validation: full gate green (build, lint, Sonar, unit, integration, console-e2e). The new migration and erasure paths are exercised under the e2e provisioning path.
