### PR TITLE
feat(web-console): paginate admin lists and add UI discovery endpoints

### DIFF
--- a/src/database/migrations/0044_web_console_list_keyset_indexes.sql
+++ b/src/database/migrations/0044_web_console_list_keyset_indexes.sql
@@ -1,0 +1,20 @@
+-- Keyset-pagination indexes for the Family-B console list surfaces that scale with
+-- the tenant/session population (see API contract §5.3). Each index matches the exact
+-- ORDER BY + row-value cursor predicate of its query so pagination stays O(limit),
+-- independent of table size, instead of the prior full-scan + sort under a hard cap.
+
+-- Users directory: `ORDER BY created_at ASC, id ASC` over live accounts, cursor `(created_at, id) > ?`.
+CREATE INDEX IF NOT EXISTS "idx_users_created_at_id_active"
+  ON "users" ("created_at", "id")
+  WHERE "deleted_at" IS NULL;
+
+-- Cross-user operational sessions: `WHERE status=? ORDER BY last_active_at DESC, session_id DESC`,
+-- cursor `(last_active_at, session_id) < ?`. `lease_until > now()` stays a residual filter.
+CREATE INDEX IF NOT EXISTS "idx_runtime_session_presence_active_ordering"
+  ON "runtime_session_presence" ("status", "last_active_at" DESC, "session_id" DESC);
+
+-- Admin unlinked-logins directory: `WHERE user_id IS NULL ORDER BY created_at ASC, sub ASC`,
+-- cursor `(created_at, sub) > ?`. Backs the identity-link picker.
+CREATE INDEX IF NOT EXISTS "idx_auth_accounts_unlinked"
+  ON "auth_accounts" ("created_at", "sub")
+  WHERE "user_id" IS NULL;

--- a/src/database/migrations/meta/_journal.json
+++ b/src/database/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1779085100000,
       "tag": "0043_drop_portfolio_sync_cancelled_status",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1779085200000,
+      "tag": "0044_web_console_list_keyset_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/schema/auth.ts
+++ b/src/database/schema/auth.ts
@@ -72,6 +72,9 @@ export const authAccounts = pgTable('auth_accounts', {
   primaryKey({ columns: [table.provider, table.externalSub] }),
   uniqueIndex('idx_auth_accounts_sub').on(table.sub),
   index('idx_auth_accounts_user_id').on(table.userId),
+  // Keyset pagination for the admin unlinked-logins directory (Family B): `(created_at, sub)`
+  // over logins not yet attached to a user, backing the identity-link picker.
+  index('idx_auth_accounts_unlinked').on(table.createdAt, table.sub).where(sql`user_id IS NULL`),
 ]);
 
 /**

--- a/src/database/schema/users.ts
+++ b/src/database/schema/users.ts
@@ -8,7 +8,7 @@
  * @since v2.2.0 — Phase 4, Step 4.1
  */
 
-import { pgTable, uuid, varchar, timestamp, jsonb, bigint, uniqueIndex } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, varchar, timestamp, jsonb, bigint, index, uniqueIndex } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 
 export const users = pgTable('users', {
@@ -29,6 +29,9 @@ export const users = pgTable('users', {
 }, (table) => [
   uniqueIndex('idx_users_username').on(table.username),
   uniqueIndex('idx_users_account_correlation_id').on(table.accountCorrelationId),
+  // Keyset pagination for the cross-tenant users directory (Family B): `(created_at, id)`
+  // over live accounts only, matching `ORDER BY created_at ASC, id ASC` + `(created_at, id) > cursor`.
+  index('idx_users_created_at_id_active').on(table.createdAt, table.id).where(sql`deleted_at IS NULL`),
 ]);
 
 // Identity fields (username, email, displayName) live exclusively in the

--- a/src/database/schema/webConsole.ts
+++ b/src/database/schema/webConsole.ts
@@ -550,6 +550,10 @@ export const runtimeSessionPresence = pgTable('runtime_session_presence', {
   index('idx_runtime_session_presence_user').on(table.userId, table.status, table.leaseUntil),
   index('idx_runtime_session_presence_replica').on(table.replicaId, table.leaseUntil),
   index('idx_runtime_session_presence_correlation').on(table.accountCorrelationId),
+  // Keyset pagination for the cross-user operational sessions list (Family B): matches
+  // `WHERE status=? ORDER BY last_active_at DESC, session_id DESC` + `(last_active_at, session_id) < cursor`.
+  index('idx_runtime_session_presence_active_ordering')
+    .on(table.status, table.lastActiveAt.desc(), table.sessionId.desc()),
 ]);
 
 export type SessionActivationElementType =

--- a/src/web-console/WebConsoleProductionActivation.ts
+++ b/src/web-console/WebConsoleProductionActivation.ts
@@ -81,6 +81,9 @@ const ROUTE_MODULES_WITH_GLOBAL_PRODUCTION_DEPENDENCIES = new Set<string>([
   // me-logs reads the in-memory log sink (a backend-agnostic source), not a
   // production storage adapter — so it has no per-module readiness evidence.
   'me-logs',
+  // consoleMeta serves static route-manifest + role-catalog data with no external
+  // dependency (the registry reference is in-process), so it declares no adapters.
+  'consoleMeta',
 ]);
 
 const ADAPTER_METADATA = new WeakMap<object | ((...args: never[]) => unknown), WebConsoleProductionAdapterMetadata>();

--- a/src/web-console/WebConsoleRegistrar.ts
+++ b/src/web-console/WebConsoleRegistrar.ts
@@ -126,7 +126,9 @@ import {
 import { createAccountAdminModule } from './modules/account-admin/AccountAdminModule.js';
 import { createActivationModule } from './modules/activations/index.js';
 import { createMeLogsModule, createMemoryConsoleLogSource, type IConsoleLogSource } from './modules/me-logs/index.js';
+import { sql } from 'drizzle-orm';
 import { createHealthModule, type HealthReadinessChecks } from './modules/health/index.js';
+import { createConsoleMetaModule } from './modules/console-meta/ConsoleMetaModule.js';
 import {
   GitHubAppIntegrationProvider,
   type GitHubAppIntegrationProviderConfig,
@@ -495,6 +497,11 @@ export class WebConsoleRegistrar {
     registry.register(createHealthModule({
       readiness: createHealthReadinessInputs(healthProbes, stores),
       now: this.options.now,
+    }));
+    // Bootstrap metadata (route manifest + role catalog); the manifest is resolved
+    // lazily so it reflects every module registered after this point.
+    registry.register(createConsoleMetaModule({
+      getRouteManifest: () => registry.createRouteManifest(),
     }));
     if (consoleOAuthClient && secretEncryption && integrationPublicBaseUrl) {
       registry.register(createConsoleBffAuthModule({
@@ -1202,7 +1209,12 @@ interface ConsoleStoreSet {
 type ConsoleSecurityInvalidationSnapshot = Awaited<ReturnType<IConsoleSecurityInvalidationReadiness['getReadiness']>>;
 
 interface ConsoleHealthProbes {
-  readonly databaseAvailable: () => boolean;
+  // Real liveness: actually reaches the database, so a wired-but-unreachable
+  // backend reports degraded instead of a misleading green.
+  readonly databaseAvailable: () => Promise<boolean>;
+  // Presence probes. authServer is backed by the same Postgres in hosted mode, so
+  // databaseAvailable already covers its reachability; runtime control + api mount
+  // are in-process wiring where presence is liveness (no network hop to fail).
   readonly authServerAvailable: () => boolean;
   readonly runtimeControlAvailable: () => boolean;
   readonly apiV1Mounted: () => boolean;
@@ -1219,12 +1231,23 @@ function createConsoleHealthProbes(options: {
   readonly routesMounted: () => boolean;
 }): ConsoleHealthProbes {
   return {
-    databaseAvailable: () => Boolean(options.database),
+    databaseAvailable: () => probeDatabaseLiveness(options.database),
     authServerAvailable: () => Boolean(options.authStorage),
     runtimeControlAvailable: () => Boolean(options.stores.runtimeSessionControlStore),
     apiV1Mounted: () => options.routesMounted(),
     securityInvalidationReadiness: () => options.securityInvalidationReadiness.getReadiness(),
   };
+}
+
+/** True only if a trivial `SELECT 1` round-trips — not merely that a DB handle is wired. */
+async function probeDatabaseLiveness(database: DatabaseInstance | undefined): Promise<boolean> {
+  if (!database) return false;
+  try {
+    await database.execute(sql`SELECT 1`);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function createHealthReadinessInputs(

--- a/src/web-console/modules/account-admin/AccountAdminBootstrapService.ts
+++ b/src/web-console/modules/account-admin/AccountAdminBootstrapService.ts
@@ -24,7 +24,7 @@ export class AccountAdminBootstrapService {
         sub: state.adminSub,
         limit: 1,
       });
-      adminUserId = matches[0]?.userId ?? null;
+      adminUserId = matches.items[0]?.userId ?? null;
     }
     return {
       status: 200,

--- a/src/web-console/modules/account-admin/AccountAdminDtos.ts
+++ b/src/web-console/modules/account-admin/AccountAdminDtos.ts
@@ -1,3 +1,4 @@
+import type { ConsolePageDto, ConsolePageInfo } from '../../platform/ConsolePlatformTypes.js';
 import type {
   ConsoleAdminRole,
   ConsolePrincipalSummary,
@@ -18,9 +19,8 @@ export interface AccountPrincipalDto {
   readonly admin_factor_enrolled: boolean;
 }
 
-export interface AccountPrincipalListDto {
-  readonly users: readonly AccountPrincipalDto[];
-}
+/** Family-B cursor page of the cross-tenant users directory. */
+export type AccountPrincipalListDto = ConsolePageDto<AccountPrincipalDto>;
 
 export interface AccountRoleListDto {
   readonly user_id: string;
@@ -85,9 +85,11 @@ export function serializeAccountPrincipal(summary: ConsolePrincipalSummary): Acc
 
 export function serializeAccountPrincipalList(
   summaries: readonly ConsolePrincipalSummary[],
+  page: ConsolePageInfo,
 ): AccountPrincipalListDto {
   return {
-    users: summaries.map(summary => serializeAccountPrincipal(summary)),
+    items: summaries.map(summary => serializeAccountPrincipal(summary)),
+    page,
   };
 }
 

--- a/src/web-console/modules/account-admin/AccountAdminIdentityDtos.ts
+++ b/src/web-console/modules/account-admin/AccountAdminIdentityDtos.ts
@@ -1,3 +1,4 @@
+import type { ConsolePageDto, ConsolePageInfo } from '../../platform/ConsolePlatformTypes.js';
 import type { LinkedIdentity } from '../../stores/IConsoleAccountAdminStore.js';
 
 /**
@@ -59,4 +60,14 @@ export function serializeAccountIdentityMutation(
   linked: boolean,
 ): AccountIdentityMutationDto {
   return { user_id: userId, sub, linked };
+}
+
+/** Keyset-paged list of logins not yet attached to any user — the link picker's source. */
+export type AccountUnlinkedIdentityListDto = ConsolePageDto<AccountIdentityDto>;
+
+export function serializeAccountUnlinkedIdentityList(
+  identities: readonly LinkedIdentity[],
+  page: ConsolePageInfo,
+): AccountUnlinkedIdentityListDto {
+  return { items: identities.map(serializeAccountIdentity), page };
 }

--- a/src/web-console/modules/account-admin/AccountAdminModule.ts
+++ b/src/web-console/modules/account-admin/AccountAdminModule.ts
@@ -7,7 +7,9 @@ import type { IAuthStorageLayer } from '../../../auth/embedded-as/storage/IAuthS
 import type { IOAuthGrantRevocationService } from '../../services/oauth/IConsoleOAuthGrantRevocationService.js';
 import type { IRuntimeSessionControlStore } from '../../services/runtime/IRuntimeSessionControlStore.js';
 import type { IConsoleAccountAllowlistStore } from '../../stores/IConsoleAccountAllowlistStore.js';
-import type { IConsoleAccountAdminStore } from '../../stores/IConsoleAccountAdminStore.js';
+import type { ConsoleAdminRole, IConsoleAccountAdminStore } from '../../stores/IConsoleAccountAdminStore.js';
+import { CONSOLE_ADMIN_ROLES } from '../../stores/IConsoleAccountAdminStore.js';
+import { tupleIncludes } from '../../stores/ConsoleStoreValidation.js';
 import type { IConsoleSessionStore } from '../../stores/IConsoleSessionStore.js';
 import type { IAccountAdminMutationTransactionRunner } from './AccountAdminMutationTransaction.js';
 import { AccountAdminAllowlistService } from './AccountAdminAllowlistService.js';
@@ -20,7 +22,11 @@ import {
   type IConsoleAccountInviteIssuer,
 } from './AccountAdminInviteService.js';
 import { AccountAdminLifecycleMutationService } from './AccountAdminLifecycleMutationService.js';
-import { AccountAdminReadService } from './AccountAdminReadService.js';
+import {
+  AccountAdminReadService,
+  type AccountPrincipalListQuery,
+  type AccountUnlinkedIdentityListQuery,
+} from './AccountAdminReadService.js';
 import { AccountAdminRoleMutationService } from './AccountAdminRoleMutationService.js';
 import { AccountAdminRuntimeTerminationService } from './AccountAdminRuntimeTerminationService.js';
 import {
@@ -35,6 +41,7 @@ import {
   projectAccountPrincipalLifecycle,
   projectAccountPrincipalList,
   projectAccountRoleList,
+  projectAccountUnlinkedIdentityList,
 } from './AccountAdminPrivacyProjectors.js';
 
 const ACCOUNT_ADMIN_AUDIT = {
@@ -46,6 +53,7 @@ const ACCOUNT_ADMIN_AUDIT = {
   usersDelete: 'accounts.users.delete',
   usersCredentialsRevokeAll: 'accounts.users.credentials.revoke_all',
   identitiesList: 'accounts.identities.list',
+  identitiesUnlinkedList: 'accounts.identities.unlinked.list',
   identitiesLink: 'accounts.identities.link',
   identitiesUnlink: 'accounts.identities.unlink',
   rolesList: 'accounts.roles.list',
@@ -364,6 +372,18 @@ export function createAccountAdminModule(options: AccountAdminModuleOptions): Co
     },
     linkIdentityRoute,
     unlinkIdentityRoute,
+    {
+      method: 'GET',
+      path: '/api/v1/admin/accounts/identities/unlinked',
+      audience: 'admin',
+      requiredCapability: ACCOUNT_ADMIN_CAPABILITY,
+      elevation: 'admin_30m',
+      privacyClass: 'account_metadata',
+      idempotency: 'not_applicable',
+      auditOperation: ACCOUNT_ADMIN_AUDIT.identitiesUnlinkedList,
+      privacyProjector: projectAccountUnlinkedIdentityList,
+      handler: req => listUnlinkedIdentities(req, service),
+    },
     ...(options.enableAccountAllowlistRoutes === true ? [
       {
         method: 'GET',
@@ -432,6 +452,12 @@ function listUsers(req: ConsoleRequest, service: AccountAdminReadService): Promi
   const query = parseUserListQuery(req);
   if (query.kind === 'invalid') return Promise.resolve(problem(400, 'invalid_request', query.detail));
   return service.listUsers(query.value).then(body => ({ status: 200, body }));
+}
+
+function listUnlinkedIdentities(req: ConsoleRequest, service: AccountAdminReadService): Promise<ConsoleHandlerResult> {
+  const query = parseUnlinkedIdentityQuery(req);
+  if (query.kind === 'invalid') return Promise.resolve(problem(400, 'invalid_request', query.detail));
+  return service.listUnlinkedIdentities(query.value).then(body => ({ status: 200, body }));
 }
 
 async function getUser(req: ConsoleRequest, service: AccountAdminReadService): Promise<ConsoleHandlerResult> {
@@ -588,26 +614,82 @@ async function resolveCorrelation(
   return body ? { status: 200, body } : problem(404, 'not_found', 'Account correlation id was not found.');
 }
 
-function parseUserListQuery(
-  req: ConsoleRequest,
-): { readonly kind: 'valid'; readonly value: { readonly sub?: string; readonly limit?: number } }
-  | { readonly kind: 'invalid'; readonly detail: string } {
-  const query: { sub?: string; limit?: number } = {};
-  if (typeof req.query.sub === 'string') {
-    query.sub = req.query.sub;
-  } else if (req.query.sub !== undefined) {
-    return { kind: 'invalid', detail: 'sub must be a string.' };
+type QueryParse<T> =
+  | { readonly kind: 'valid'; readonly value: T }
+  | { readonly kind: 'invalid'; readonly detail: string };
+
+function parseUserListQuery(req: ConsoleRequest): QueryParse<AccountPrincipalListQuery> {
+  const sub = parseOptionalStringParam(req.query.sub, 'sub');
+  if (sub.kind === 'invalid') return sub;
+  const search = parseOptionalStringParam(req.query.search, 'search');
+  if (search.kind === 'invalid') return search;
+  const role = parseRoleParam(req.query.role);
+  if (role.kind === 'invalid') return role;
+  const enabled = parseEnabledParam(req.query.enabled);
+  if (enabled.kind === 'invalid') return enabled;
+  const limit = parseListLimit(req.query.limit);
+  if (limit.kind === 'invalid') return limit;
+  const cursor = parseOptionalStringParam(req.query.cursor, 'cursor');
+  if (cursor.kind === 'invalid') return cursor;
+  return {
+    kind: 'valid',
+    value: {
+      ...(sub.value === undefined ? {} : { sub: sub.value }),
+      ...(search.value === undefined ? {} : { search: search.value }),
+      ...(role.value === undefined ? {} : { role: role.value }),
+      ...(enabled.value === undefined ? {} : { enabled: enabled.value }),
+      ...(limit.value === undefined ? {} : { limit: limit.value }),
+      ...(cursor.value === undefined ? {} : { cursor: cursor.value }),
+    },
+  };
+}
+
+function parseOptionalStringParam(
+  raw: ConsoleRequest['query'][string],
+  name: string,
+): QueryParse<string | undefined> {
+  if (raw === undefined) return { kind: 'valid', value: undefined };
+  if (typeof raw !== 'string') return { kind: 'invalid', detail: `${name} must be a string.` };
+  return { kind: 'valid', value: raw };
+}
+
+function parseRoleParam(raw: ConsoleRequest['query'][string]): QueryParse<ConsoleAdminRole | undefined> {
+  if (raw === undefined) return { kind: 'valid', value: undefined };
+  if (typeof raw !== 'string') return { kind: 'invalid', detail: 'role must be a string.' };
+  if (!tupleIncludes(CONSOLE_ADMIN_ROLES, raw)) {
+    return { kind: 'invalid', detail: 'role must be a valid administrative role.' };
   }
-  if (typeof req.query.limit === 'string') {
-    const limit = Number(req.query.limit);
-    if (!Number.isInteger(limit)) {
-      return { kind: 'invalid', detail: 'limit must be an integer.' };
-    }
-    query.limit = limit;
-  } else if (req.query.limit !== undefined) {
-    return { kind: 'invalid', detail: 'limit must be a string integer.' };
+  return { kind: 'valid', value: raw };
+}
+
+function parseEnabledParam(raw: ConsoleRequest['query'][string]): QueryParse<boolean | undefined> {
+  if (raw === undefined) return { kind: 'valid', value: undefined };
+  if (raw !== 'true' && raw !== 'false') {
+    return { kind: 'invalid', detail: 'enabled must be "true" or "false".' };
   }
-  return { kind: 'valid', value: query };
+  return { kind: 'valid', value: raw === 'true' };
+}
+
+function parseUnlinkedIdentityQuery(req: ConsoleRequest): QueryParse<AccountUnlinkedIdentityListQuery> {
+  const limit = parseListLimit(req.query.limit);
+  if (limit.kind === 'invalid') return limit;
+  const cursor = parseOptionalStringParam(req.query.cursor, 'cursor');
+  if (cursor.kind === 'invalid') return cursor;
+  return {
+    kind: 'valid',
+    value: {
+      ...(limit.value === undefined ? {} : { limit: limit.value }),
+      ...(cursor.value === undefined ? {} : { cursor: cursor.value }),
+    },
+  };
+}
+
+function parseListLimit(raw: ConsoleRequest['query'][string]): QueryParse<number | undefined> {
+  if (raw === undefined) return { kind: 'valid', value: undefined };
+  if (typeof raw !== 'string') return { kind: 'invalid', detail: 'limit must be a string integer.' };
+  const limit = Number(raw);
+  if (!Number.isInteger(limit)) return { kind: 'invalid', detail: 'limit must be an integer.' };
+  return { kind: 'valid', value: limit };
 }
 
 function problem(status: number, code: string, detail: string): ConsoleHandlerResult {

--- a/src/web-console/modules/account-admin/AccountAdminPrivacyProjectors.ts
+++ b/src/web-console/modules/account-admin/AccountAdminPrivacyProjectors.ts
@@ -13,14 +13,17 @@ import type {
   AccountBootstrapStatusDto,
   AccountInviteDto,
 } from './AccountAdminOnboardingDtos.js';
+import type { ConsolePageInfo } from '../../platform/ConsolePlatformTypes.js';
 import type {
   AccountIdentityDto,
   AccountIdentityListDto,
   AccountIdentityMutationDto,
+  AccountUnlinkedIdentityListDto,
 } from './AccountAdminIdentityDtos.js';
 import {
   serializeAccountIdentityList,
   serializeAccountIdentityMutation,
+  serializeAccountUnlinkedIdentityList,
 } from './AccountAdminIdentityDtos.js';
 import {
   serializeAccountAllowlistEntry,
@@ -44,7 +47,21 @@ export function projectAccountPrincipal(value: unknown): AccountPrincipalDto {
 
 export function projectAccountPrincipalList(value: unknown): AccountPrincipalListDto {
   const list = value as AccountPrincipalListDto;
-  return serializeAccountPrincipalList(list.users.map(item => fromPrincipalDto(item)));
+  return serializeAccountPrincipalList(list.items.map(item => fromPrincipalDto(item)), projectConsolePageInfo(list.page));
+}
+
+export function projectAccountUnlinkedIdentityList(value: unknown): AccountUnlinkedIdentityListDto {
+  const list = value as AccountUnlinkedIdentityListDto;
+  return serializeAccountUnlinkedIdentityList(list.items.map(fromIdentityDto), projectConsolePageInfo(list.page));
+}
+
+/** Allowlist the Family-B page envelope so a projector can't leak a producer's extra fields. */
+function projectConsolePageInfo(page: ConsolePageInfo): ConsolePageInfo {
+  return {
+    limit: Number(page.limit),
+    cursor: typeof page.cursor === 'string' ? page.cursor : null,
+    next_cursor: typeof page.next_cursor === 'string' ? page.next_cursor : null,
+  };
 }
 
 export function projectAccountRoleList(value: unknown): AccountRoleListDto {

--- a/src/web-console/modules/account-admin/AccountAdminReadService.ts
+++ b/src/web-console/modules/account-admin/AccountAdminReadService.ts
@@ -1,6 +1,9 @@
+import { decodeConsoleCursor, encodeConsoleCursor } from '../../platform/ConsoleCursor.js';
 import type {
   ConsoleAdminRole,
   IConsoleAccountAdminStore,
+  PrincipalDirectoryCursor,
+  UnlinkedIdentityCursor,
 } from '../../stores/IConsoleAccountAdminStore.js';
 import {
   serializeAccountPrincipal,
@@ -10,17 +13,60 @@ import {
   type AccountPrincipalListDto,
   type AccountRoleListDto,
 } from './AccountAdminDtos.js';
+import {
+  serializeAccountUnlinkedIdentityList,
+  type AccountUnlinkedIdentityListDto,
+} from './AccountAdminIdentityDtos.js';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export interface AccountPrincipalListQuery {
   readonly sub?: string;
+  readonly search?: string;
+  readonly role?: ConsoleAdminRole;
+  readonly enabled?: boolean;
   readonly limit?: number;
+  /** Opaque Family-B cursor from a prior page's `next_cursor`. Foreign/garbage tokens page from the start. */
+  readonly cursor?: string | null;
+}
+
+export interface AccountUnlinkedIdentityListQuery {
+  readonly limit?: number;
+  readonly cursor?: string | null;
 }
 
 export class AccountAdminReadService {
   constructor(private readonly store: IConsoleAccountAdminStore) {}
 
   async listUsers(query: AccountPrincipalListQuery = {}): Promise<AccountPrincipalListDto> {
-    return serializeAccountPrincipalList(await this.store.listPrincipals(query));
+    const limit = query.limit ?? 100;
+    const after = decodePrincipalCursor(query.cursor ?? null);
+    const page = await this.store.listPrincipals({
+      sub: query.sub,
+      search: query.search,
+      role: query.role,
+      enabled: query.enabled,
+      limit,
+      after: after ?? undefined,
+    });
+    return serializeAccountPrincipalList(page.items, {
+      limit,
+      cursor: query.cursor ?? null,
+      next_cursor: page.nextCursor ? encodePrincipalCursor(page.nextCursor) : null,
+    });
+  }
+
+  async listUnlinkedIdentities(
+    query: AccountUnlinkedIdentityListQuery = {},
+  ): Promise<AccountUnlinkedIdentityListDto> {
+    const limit = query.limit ?? 100;
+    const after = decodeIdentityCursor(query.cursor ?? null);
+    const page = await this.store.listUnlinkedIdentities({ limit, after: after ?? undefined });
+    return serializeAccountUnlinkedIdentityList(page.items, {
+      limit,
+      cursor: query.cursor ?? null,
+      next_cursor: page.nextCursor ? encodeIdentityCursor(page.nextCursor) : null,
+    });
   }
 
   async getUser(userId: string): Promise<AccountPrincipalDto | null> {
@@ -37,4 +83,33 @@ export class AccountAdminReadService {
     const roles: readonly ConsoleAdminRole[] = await this.store.listActiveRoles(userId);
     return serializeAccountRoleList(userId, roles);
   }
+}
+
+function encodePrincipalCursor(cursor: PrincipalDirectoryCursor): string {
+  return encodeConsoleCursor({ c: cursor.createdAt.toISOString(), i: cursor.userId });
+}
+
+/** Foreign/garbage/non-UUID tokens decode to null so traversal restarts from the first page (§5.3). */
+function decodePrincipalCursor(token: string | null): PrincipalDirectoryCursor | null {
+  if (!token) return null;
+  const payload = decodeConsoleCursor(token);
+  const createdAtRaw = payload?.c;
+  const userId = payload?.i;
+  if (typeof createdAtRaw !== 'string' || typeof userId !== 'string' || !UUID_PATTERN.test(userId)) return null;
+  const createdAt = new Date(createdAtRaw);
+  return Number.isNaN(createdAt.getTime()) ? null : { createdAt, userId };
+}
+
+function encodeIdentityCursor(cursor: UnlinkedIdentityCursor): string {
+  return encodeConsoleCursor({ c: cursor.createdAt.toISOString(), s: cursor.sub });
+}
+
+function decodeIdentityCursor(token: string | null): UnlinkedIdentityCursor | null {
+  if (!token) return null;
+  const payload = decodeConsoleCursor(token);
+  const createdAtRaw = payload?.c;
+  const sub = payload?.s;
+  if (typeof createdAtRaw !== 'string' || typeof sub !== 'string' || sub.length === 0 || sub.length > 320) return null;
+  const createdAt = new Date(createdAtRaw);
+  return Number.isNaN(createdAt.getTime()) ? null : { createdAt, sub };
 }

--- a/src/web-console/modules/audit/AuditDtos.ts
+++ b/src/web-console/modules/audit/AuditDtos.ts
@@ -4,16 +4,13 @@ import type {
   ConsoleAdminAuditRedactedRecord,
   ConsoleAdminAuditResult,
 } from '../../audit/index.js';
-import type { ConsoleCapability } from '../../platform/ConsolePlatformTypes.js';
+import type { ConsoleCapability, ConsolePageDto } from '../../platform/ConsolePlatformTypes.js';
 
-export interface AuditPageDto<T> {
-  readonly items: readonly T[];
-  readonly page: {
-    readonly limit: number;
-    readonly cursor: string | null;
-    readonly next_cursor: string | null;
-  };
-}
+/**
+ * Audit list envelope. Aliased to the shared {@link ConsolePageDto} so every
+ * paginated console surface returns one identical Family-B shape.
+ */
+export type AuditPageDto<T> = ConsolePageDto<T>;
 
 export interface AdminAuditEventDto {
   readonly id: string;

--- a/src/web-console/modules/console-meta/ConsoleMetaModule.ts
+++ b/src/web-console/modules/console-meta/ConsoleMetaModule.ts
@@ -1,0 +1,107 @@
+/**
+ * Console bootstrap metadata: static, non-per-user data the SPA needs to
+ * feature-detect and render RBAC affordances without hard-coding server truth.
+ *
+ * - `GET /api/v1/me/manifest` — the registered route/capability manifest, so the UI
+ *   knows which routes exist (flag-gated modules are simply absent) instead of
+ *   probing for 404s.
+ * - `GET /api/v1/me/role-catalog` — the administrative role set, the capability set,
+ *   and the role→capability grant map, so a permissions UI stops hard-coding them.
+ *
+ * Both are `self`-audience reads (any authenticated console user) carrying no per-user
+ * data; capabilities still gate the actual operations the manifest advertises.
+ */
+import type {
+  ConsoleModuleDescriptor,
+  ConsoleRouteManifest,
+  ConsoleRouteManifestEntry,
+} from '../../platform/ConsolePlatformTypes.js';
+import { CONSOLE_CAPABILITIES, type ConsoleCapability } from '../../platform/ConsolePlatformTypes.js';
+import { CONSOLE_ADMIN_ROLES, type ConsoleAdminRole } from '../../stores/IConsoleAccountAdminStore.js';
+import { ROLE_GRANT_CAPABILITIES } from '../account-admin/AccountAdminRoleAuthority.js';
+
+const SELF_CAPABILITY = 'console:self';
+
+export interface RoleCatalogDto {
+  readonly roles: readonly ConsoleAdminRole[];
+  readonly capabilities: readonly ConsoleCapability[];
+  readonly grants: Readonly<Record<ConsoleAdminRole, readonly ConsoleCapability[]>>;
+}
+
+export interface ConsoleMetaModuleOptions {
+  /** Resolved lazily at request time, after every module has registered. */
+  readonly getRouteManifest: () => ConsoleRouteManifest;
+}
+
+export function createConsoleMetaModule(options: ConsoleMetaModuleOptions): ConsoleModuleDescriptor {
+  return {
+    id: 'consoleMeta',
+    apiVersion: 'v1',
+    capabilities: [SELF_CAPABILITY],
+    routes: [
+      {
+        method: 'GET',
+        path: '/api/v1/me/manifest',
+        audience: 'self',
+        requiredCapability: SELF_CAPABILITY,
+        ownership: 'authenticated_user',
+        elevation: 'none',
+        privacyClass: 'self_private',
+        idempotency: 'not_applicable',
+        privacyProjector: projectRouteManifest,
+        handler: () => Promise.resolve({ status: 200, body: options.getRouteManifest() }),
+      },
+      {
+        method: 'GET',
+        path: '/api/v1/me/role-catalog',
+        audience: 'self',
+        requiredCapability: SELF_CAPABILITY,
+        ownership: 'authenticated_user',
+        elevation: 'none',
+        privacyClass: 'self_private',
+        idempotency: 'not_applicable',
+        privacyProjector: projectRoleCatalog,
+        handler: () => Promise.resolve({ status: 200, body: buildRoleCatalog() }),
+      },
+    ],
+  };
+}
+
+function buildRoleCatalog(): RoleCatalogDto {
+  return {
+    roles: [...CONSOLE_ADMIN_ROLES],
+    capabilities: [...CONSOLE_CAPABILITIES],
+    grants: ROLE_GRANT_CAPABILITIES,
+  };
+}
+
+export function projectRouteManifest(value: unknown): ConsoleRouteManifest {
+  const manifest = value as ConsoleRouteManifest;
+  return {
+    apiVersion: 'v1',
+    routes: (Array.isArray(manifest.routes) ? manifest.routes : []).map(projectManifestEntry),
+  };
+}
+
+function projectManifestEntry(entry: ConsoleRouteManifestEntry): ConsoleRouteManifestEntry {
+  return {
+    moduleId: entry.moduleId,
+    method: entry.method,
+    path: entry.path,
+    audience: entry.audience,
+    requiredCapability: entry.requiredCapability,
+    ownership: entry.ownership,
+    elevation: entry.elevation,
+    privacyClass: entry.privacyClass,
+    idempotency: entry.idempotency,
+    ...(entry.rateLimit ? { rateLimit: entry.rateLimit } : {}),
+    ...(entry.auditOperation ? { auditOperation: entry.auditOperation } : {}),
+    ...(entry.responseKind ? { responseKind: entry.responseKind } : {}),
+  };
+}
+
+// The catalog is entirely server-owned static data, so the projector re-derives it
+// from the constants rather than trusting the value it is handed.
+export function projectRoleCatalog(_value: unknown): RoleCatalogDto {
+  return buildRoleCatalog();
+}

--- a/src/web-console/modules/console-meta/ConsoleMetaModule.ts
+++ b/src/web-console/modules/console-meta/ConsoleMetaModule.ts
@@ -11,12 +11,13 @@
  * Both are `self`-audience reads (any authenticated console user) carrying no per-user
  * data; capabilities still gate the actual operations the manifest advertises.
  */
-import type {
-  ConsoleModuleDescriptor,
-  ConsoleRouteManifest,
-  ConsoleRouteManifestEntry,
+import {
+  CONSOLE_CAPABILITIES,
+  type ConsoleCapability,
+  type ConsoleModuleDescriptor,
+  type ConsoleRouteManifest,
+  type ConsoleRouteManifestEntry,
 } from '../../platform/ConsolePlatformTypes.js';
-import { CONSOLE_CAPABILITIES, type ConsoleCapability } from '../../platform/ConsolePlatformTypes.js';
 import { CONSOLE_ADMIN_ROLES, type ConsoleAdminRole } from '../../stores/IConsoleAccountAdminStore.js';
 import { ROLE_GRANT_CAPABILITIES } from '../account-admin/AccountAdminRoleAuthority.js';
 

--- a/src/web-console/modules/integrations/IntegrationDescriptorAuthoringService.ts
+++ b/src/web-console/modules/integrations/IntegrationDescriptorAuthoringService.ts
@@ -18,9 +18,11 @@ import {
   serializeIntegrationDescriptor,
   serializeIntegrationDescriptorList,
   serializeIntegrationOpenApiSpecMetadata,
+  serializeIntegrationSpecOperations,
 } from './IntegrationDtos.js';
 import {
   countSpecOperations,
+  deriveSpecOperationSummaries,
   IntegrationOperationCatalogError,
   prepareOpenApiSpecForDescriptor,
 } from './IntegrationOperationCatalog.js';
@@ -237,6 +239,22 @@ export class IntegrationDescriptorAuthoringService {
         spec: record.spec,
         createdAt: record.createdAt,
         updatedAt: record.updatedAt,
+      }),
+    };
+  }
+
+  async listSpecOperations(req: ConsoleRequest): Promise<ConsoleHandlerResult> {
+    const auth = requireConsoleAuthentication(req);
+    const descriptor = await this.findOwned(singleParamValue(req.params.id), auth.userId);
+    if (!descriptor) return notFound();
+    const record = await this.options.specStore.findByDescriptorId(descriptor.id);
+    if (!record) return specNotFound();
+    return {
+      status: 200,
+      body: serializeIntegrationSpecOperations({
+        descriptorId: record.descriptorId,
+        specHash: record.specHash,
+        operations: deriveSpecOperationSummaries(descriptor, record.spec),
       }),
     };
   }

--- a/src/web-console/modules/integrations/IntegrationDtos.ts
+++ b/src/web-console/modules/integrations/IntegrationDtos.ts
@@ -4,6 +4,7 @@ import type {
   UserIntegrationRecord,
   UserIntegrationStatus,
 } from '../../stores/IUserIntegrationStore.js';
+import type { IntegrationOperationSummary } from './IntegrationOperationCatalog.js';
 import type {
   IntegrationAuthStrategy,
   IntegrationDescriptorOwnership,
@@ -292,5 +293,42 @@ export function serializeIntegrationOpenApiSpecMetadata(input: {
     spec_bytes: Buffer.byteLength(JSON.stringify(input.spec), 'utf8'),
     created_at: input.createdAt.toISOString(),
     updated_at: input.updatedAt.toISOString(),
+  };
+}
+
+export interface IntegrationSpecOperationDto {
+  readonly operation_id: string;
+  readonly method: string;
+  readonly path: string;
+  readonly read_write_class: 'read' | 'write';
+  readonly summary: string | null;
+  readonly description: string | null;
+  readonly required_scopes: readonly string[];
+}
+
+/** The operations a BYO descriptor's uploaded spec exposes (scope-independent). */
+export interface IntegrationSpecOperationsDto {
+  readonly descriptor_id: string;
+  readonly spec_hash: string;
+  readonly operations: readonly IntegrationSpecOperationDto[];
+}
+
+export function serializeIntegrationSpecOperations(input: {
+  readonly descriptorId: string;
+  readonly specHash: string;
+  readonly operations: readonly IntegrationOperationSummary[];
+}): IntegrationSpecOperationsDto {
+  return {
+    descriptor_id: input.descriptorId,
+    spec_hash: input.specHash,
+    operations: input.operations.map(op => ({
+      operation_id: op.operationId,
+      method: op.method,
+      path: op.path,
+      read_write_class: op.readWriteClass,
+      summary: op.summary,
+      description: op.description,
+      required_scopes: [...op.requiredScopes],
+    })),
   };
 }

--- a/src/web-console/modules/integrations/IntegrationModule.ts
+++ b/src/web-console/modules/integrations/IntegrationModule.ts
@@ -30,6 +30,7 @@ import {
   projectIntegrationDescriptorList,
   projectIntegrationList,
   projectIntegrationOpenApiSpecMetadata,
+  projectIntegrationSpecOperations,
 } from './IntegrationPrivacyProjectors.js';
 
 const SELF_CAPABILITY = 'console:self';
@@ -361,6 +362,18 @@ function byoDescriptorRoutes(
       idempotency: 'not_applicable',
       privacyProjector: projectIntegrationOpenApiSpecMetadata,
       handler: req => authoring.getSpec(req),
+    },
+    {
+      method: 'GET',
+      path: `${basePath}/:id/spec/operations`,
+      audience: 'self',
+      requiredCapability: SELF_CAPABILITY,
+      ownership: 'authenticated_user',
+      elevation: 'none',
+      privacyClass: 'self_private',
+      idempotency: 'not_applicable',
+      privacyProjector: projectIntegrationSpecOperations,
+      handler: req => authoring.listSpecOperations(req),
     },
   ];
 }

--- a/src/web-console/modules/integrations/IntegrationOperationCatalog.ts
+++ b/src/web-console/modules/integrations/IntegrationOperationCatalog.ts
@@ -459,6 +459,18 @@ export function countSpecOperations(
   return deriveOperations(descriptor, spec, new Set()).length;
 }
 
+/**
+ * Scope-independent operation summaries for the spec-authoring surface. Works on an
+ * owned-but-not-connected descriptor (no granted scopes), so it powers the BYO
+ * "which operations does this spec expose" picker without requiring a live connection.
+ */
+export function deriveSpecOperationSummaries(
+  descriptor: IntegrationDescriptorRecord,
+  spec: Readonly<Record<string, unknown>>,
+): readonly IntegrationOperationSummary[] {
+  return deriveOperations(descriptor, spec, new Set());
+}
+
 function deriveOperations(
   descriptor: IntegrationDescriptorRecord,
   spec: Readonly<Record<string, unknown>>,

--- a/src/web-console/modules/integrations/IntegrationPrivacyProjectors.ts
+++ b/src/web-console/modules/integrations/IntegrationPrivacyProjectors.ts
@@ -7,6 +7,8 @@ import {
   type IntegrationDescriptorStaticApiKeyDto,
   type IntegrationListDto,
   type IntegrationOpenApiSpecMetadataDto,
+  type IntegrationSpecOperationDto,
+  type IntegrationSpecOperationsDto,
   type IntegrationStatusDto,
   type IntegrationStatusDtoStatus,
   type PortfolioSyncDirection,
@@ -123,6 +125,29 @@ export function projectIntegrationOpenApiSpecMetadata(value: unknown): Integrati
     spec_bytes: numberField(input, 'spec_bytes'),
     created_at: stringField(input, 'created_at'),
     updated_at: stringField(input, 'updated_at'),
+  };
+}
+
+export function projectIntegrationSpecOperations(value: unknown): IntegrationSpecOperationsDto {
+  const input = asRecord(value);
+  const operations = Array.isArray(input.operations) ? input.operations : [];
+  return {
+    descriptor_id: stringField(input, 'descriptor_id'),
+    spec_hash: stringField(input, 'spec_hash'),
+    operations: operations.map(projectSpecOperation),
+  };
+}
+
+function projectSpecOperation(value: unknown): IntegrationSpecOperationDto {
+  const op = asRecord(value);
+  return {
+    operation_id: stringField(op, 'operation_id'),
+    method: stringField(op, 'method'),
+    path: stringField(op, 'path'),
+    read_write_class: stringField(op, 'read_write_class') === 'write' ? 'write' : 'read',
+    summary: nullableStringField(op, 'summary'),
+    description: nullableStringField(op, 'description'),
+    required_scopes: stringArray(op.required_scopes),
   };
 }
 

--- a/src/web-console/modules/runtime-sessions/RuntimeSessionDtos.ts
+++ b/src/web-console/modules/runtime-sessions/RuntimeSessionDtos.ts
@@ -1,4 +1,8 @@
-import type { RuntimeTerminationReason } from '../../services/runtime/IRuntimeSessionControlStore.js';
+import type { ConsolePageDto } from '../../platform/ConsolePlatformTypes.js';
+import type {
+  RuntimeTerminationAckResult,
+  RuntimeTerminationReason,
+} from '../../services/runtime/IRuntimeSessionControlStore.js';
 
 export interface RuntimeSessionSelfDto {
   readonly session_id: string;
@@ -34,12 +38,27 @@ export interface RuntimeSessionOperationalDto extends RuntimeSessionAccountDto {
   } | null;
 }
 
+/** Family-B cursor page of the cross-user operational sessions list. */
+export type RuntimeSessionOperationalListDto = ConsolePageDto<RuntimeSessionOperationalDto>;
+
 export interface RuntimeTerminationAcceptedDto {
   readonly session_id: string;
   readonly command_id: string;
   readonly target_replica_id: string;
   readonly reason: RuntimeTerminationReason;
   readonly status: 'accepted';
+}
+
+/**
+ * Completion status of an async termination command. `pending` = no ack row yet
+ * (the owning replica has not reported back); otherwise the replica's ack result.
+ */
+export interface RuntimeTerminationCommandStatusDto {
+  readonly command_id: string;
+  readonly status: 'pending' | RuntimeTerminationAckResult;
+  readonly acknowledged_at: string | null;
+  readonly replica_id: string | null;
+  readonly error_code: string | null;
 }
 
 export interface RuntimeSessionRevokeAllDto {

--- a/src/web-console/modules/runtime-sessions/RuntimeSessionModule.ts
+++ b/src/web-console/modules/runtime-sessions/RuntimeSessionModule.ts
@@ -10,6 +10,7 @@ import type {
 import { isRuntimeSessionStatus } from '../../services/runtime/IRuntimeSessionControlStore.js';
 import type { IConsoleAccountAdminStore } from '../../stores/IConsoleAccountAdminStore.js';
 import { boundedString, firstQueryValue } from '../../platform/ConsoleListQuery.js';
+import { isUuid } from '../../stores/ConsoleStoreValidation.js';
 import { requireConsoleAuthentication } from '../../middleware/ConsoleAuthentication.js';
 import { RuntimeSessionService, type OperationalSessionListQuery } from './RuntimeSessionService.js';
 import {
@@ -297,7 +298,10 @@ function parseOperationalListQuery(
   const cursor = boundedString(firstQueryValue(req.query.cursor), 512);
   if (cursor !== null) value.cursor = cursor;
   const userId = boundedString(firstQueryValue(req.query.user_id), 64);
-  if (userId !== null) value.userId = userId;
+  if (userId !== null) {
+    if (!isUuid(userId)) return { kind: 'invalid', detail: 'user_id must be a UUID.' };
+    value.userId = userId;
+  }
   const statusRaw = firstQueryValue(req.query.status);
   if (statusRaw !== null) {
     if (!isRuntimeSessionStatus(statusRaw)) return { kind: 'invalid', detail: 'status must be "active" or "closing".' };

--- a/src/web-console/modules/runtime-sessions/RuntimeSessionModule.ts
+++ b/src/web-console/modules/runtime-sessions/RuntimeSessionModule.ts
@@ -3,11 +3,17 @@ import type {
   ConsoleModuleDescriptor,
   ConsoleRequest,
 } from '../../platform/ConsolePlatformTypes.js';
-import type { IRuntimeSessionControlStore } from '../../services/runtime/IRuntimeSessionControlStore.js';
+import type {
+  IRuntimeSessionControlStore,
+  RuntimeSessionStatus,
+} from '../../services/runtime/IRuntimeSessionControlStore.js';
+import { isRuntimeSessionStatus } from '../../services/runtime/IRuntimeSessionControlStore.js';
 import type { IConsoleAccountAdminStore } from '../../stores/IConsoleAccountAdminStore.js';
+import { boundedString, firstQueryValue } from '../../platform/ConsoleListQuery.js';
 import { requireConsoleAuthentication } from '../../middleware/ConsoleAuthentication.js';
-import { RuntimeSessionService } from './RuntimeSessionService.js';
+import { RuntimeSessionService, type OperationalSessionListQuery } from './RuntimeSessionService.js';
 import {
+  projectRuntimeCommandStatus,
   projectRuntimeRevokeAll,
   projectRuntimeSessionAccountList,
   projectRuntimeSessionOperational,
@@ -21,7 +27,9 @@ const RUNTIME_CAPABILITY_SELF = 'console:self';
 const RUNTIME_CAPABILITY_ACCOUNTS = 'console:admin:accounts';
 const RUNTIME_CAPABILITY_OPERATE = 'console:admin:operate';
 const SESSION_ID_PARAM = 'session_id';
+const COMMAND_ID_PARAM = 'command_id';
 const RUNTIME_SESSION_NOT_FOUND_DETAIL = 'Runtime session was not found.';
+const RUNTIME_COMMAND_NOT_FOUND_DETAIL = 'Runtime termination command was not found.';
 
 export interface RuntimeSessionModuleOptions {
   readonly runtimeStore: IRuntimeSessionControlStore;
@@ -89,6 +97,18 @@ export function createRuntimeSessionModule(options: RuntimeSessionModuleOptions)
     },
     {
       method: 'GET',
+      path: '/api/v1/me/sessions/commands/:command_id',
+      audience: 'self',
+      requiredCapability: RUNTIME_CAPABILITY_SELF,
+      ownership: 'authenticated_user',
+      elevation: 'none',
+      privacyClass: 'self_private',
+      idempotency: 'not_applicable',
+      privacyProjector: projectRuntimeCommandStatus,
+      handler: req => getSelfCommandStatus(req, service),
+    },
+    {
+      method: 'GET',
       path: '/api/v1/admin/accounts/users/:user_id/sessions',
       audience: 'admin',
       requiredCapability: RUNTIME_CAPABILITY_ACCOUNTS,
@@ -133,7 +153,19 @@ export function createRuntimeSessionModule(options: RuntimeSessionModuleOptions)
       idempotency: 'not_applicable',
       auditOperation: 'operate.sessions.list',
       privacyProjector: projectRuntimeSessionOperationalList,
-      handler: () => service.listOperationalSessions().then(sessions => ({ status: 200, body: { sessions } })),
+      handler: req => listOperationalSessions(req, service),
+    },
+    {
+      method: 'GET',
+      path: '/api/v1/admin/operate/sessions/commands/:command_id',
+      audience: 'admin',
+      requiredCapability: RUNTIME_CAPABILITY_OPERATE,
+      elevation: 'admin_30m',
+      privacyClass: 'operational_allowlist',
+      idempotency: 'not_applicable',
+      auditOperation: 'operate.sessions.command_status',
+      privacyProjector: projectRuntimeCommandStatus,
+      handler: req => getOperateCommandStatus(req, service),
     },
     {
       method: 'GET',
@@ -224,11 +256,54 @@ async function revokeAllAccountSessions(req: ConsoleRequest, service: RuntimeSes
   return body ? { status: 202, body } : notFound('User principal was not found.');
 }
 
+async function listOperationalSessions(req: ConsoleRequest, service: RuntimeSessionService): Promise<ConsoleHandlerResult> {
+  const parsed = parseOperationalListQuery(req);
+  if (parsed.kind === 'invalid') return problem(400, 'invalid_request', parsed.detail);
+  return { status: 200, body: await service.listOperationalSessions(parsed.value) };
+}
+
 async function getOperationalSession(req: ConsoleRequest, service: RuntimeSessionService): Promise<ConsoleHandlerResult> {
   const sessionId = requiredParam(req, SESSION_ID_PARAM);
   if (!sessionId) return invalidParam(SESSION_ID_PARAM);
   const body = await service.getOperationalSession(sessionId);
   return body ? { status: 200, body } : notFound(RUNTIME_SESSION_NOT_FOUND_DETAIL);
+}
+
+async function getOperateCommandStatus(req: ConsoleRequest, service: RuntimeSessionService): Promise<ConsoleHandlerResult> {
+  const commandId = requiredParam(req, COMMAND_ID_PARAM);
+  if (!commandId) return invalidParam(COMMAND_ID_PARAM);
+  const body = await service.getCommandStatus(commandId);
+  return body ? { status: 200, body } : notFound(RUNTIME_COMMAND_NOT_FOUND_DETAIL);
+}
+
+async function getSelfCommandStatus(req: ConsoleRequest, service: RuntimeSessionService): Promise<ConsoleHandlerResult> {
+  const actor = requireConsoleAuthentication(req);
+  const commandId = requiredParam(req, COMMAND_ID_PARAM);
+  if (!commandId) return invalidParam(COMMAND_ID_PARAM);
+  const body = await service.getSelfCommandStatus(actor.userId, commandId);
+  return body ? { status: 200, body } : notFound(RUNTIME_COMMAND_NOT_FOUND_DETAIL);
+}
+
+function parseOperationalListQuery(
+  req: ConsoleRequest,
+): { readonly kind: 'valid'; readonly value: OperationalSessionListQuery } | { readonly kind: 'invalid'; readonly detail: string } {
+  const value: { limit?: number; cursor?: string | null; userId?: string; status?: RuntimeSessionStatus } = {};
+  const limitRaw = firstQueryValue(req.query.limit);
+  if (limitRaw !== null) {
+    const limit = Number(limitRaw);
+    if (!Number.isInteger(limit)) return { kind: 'invalid', detail: 'limit must be an integer.' };
+    value.limit = limit;
+  }
+  const cursor = boundedString(firstQueryValue(req.query.cursor), 512);
+  if (cursor !== null) value.cursor = cursor;
+  const userId = boundedString(firstQueryValue(req.query.user_id), 64);
+  if (userId !== null) value.userId = userId;
+  const statusRaw = firstQueryValue(req.query.status);
+  if (statusRaw !== null) {
+    if (!isRuntimeSessionStatus(statusRaw)) return { kind: 'invalid', detail: 'status must be "active" or "closing".' };
+    value.status = statusRaw;
+  }
+  return { kind: 'valid', value };
 }
 
 async function terminateOperationalSession(req: ConsoleRequest, service: RuntimeSessionService): Promise<ConsoleHandlerResult> {

--- a/src/web-console/modules/runtime-sessions/RuntimeSessionPrivacyProjectors.ts
+++ b/src/web-console/modules/runtime-sessions/RuntimeSessionPrivacyProjectors.ts
@@ -1,11 +1,18 @@
+import type { ConsolePageInfo } from '../../platform/ConsolePlatformTypes.js';
 import type {
   RuntimeSessionAccountDto,
   RuntimeSessionOperationalDto,
+  RuntimeSessionOperationalListDto,
   RuntimeSessionRevokeAllDto,
   RuntimeSessionSelfDto,
   RuntimeTerminationAcceptedDto,
+  RuntimeTerminationCommandStatusDto,
 } from './RuntimeSessionDtos.js';
 import { isRuntimeTerminationReason } from '../../services/runtime/IRuntimeSessionControlStore.js';
+
+const COMMAND_STATUS_VALUES = new Set<RuntimeTerminationCommandStatusDto['status']>([
+  'pending', 'terminated', 'already_absent', 'failed',
+]);
 
 export function projectRuntimeSessionSelf(value: unknown): RuntimeSessionSelfDto {
   const record = objectValue(value);
@@ -56,8 +63,42 @@ export function projectRuntimeSessionOperational(value: unknown): RuntimeSession
   };
 }
 
-export function projectRuntimeSessionOperationalList(value: unknown): { sessions: RuntimeSessionOperationalDto[] } {
-  return { sessions: arrayValue(objectValue(value).sessions).map(item => projectRuntimeSessionOperational(item)) };
+// Family-B cursor page (cross-user aggregate scales with the session population).
+export function projectRuntimeSessionOperationalList(value: unknown): RuntimeSessionOperationalListDto {
+  const record = objectValue(value);
+  return {
+    items: arrayValue(record.items).map(item => projectRuntimeSessionOperational(item)),
+    page: projectConsolePageInfo(record.page),
+  };
+}
+
+export function projectRuntimeCommandStatus(value: unknown): RuntimeTerminationCommandStatusDto {
+  const record = objectValue(value);
+  const status = record.status;
+  const projectedStatus = typeof status === 'string' && COMMAND_STATUS_VALUES.has(status as RuntimeTerminationCommandStatusDto['status'])
+    ? status as RuntimeTerminationCommandStatusDto['status']
+    : 'pending';
+  return {
+    command_id: stringField(record, 'command_id'),
+    status: projectedStatus,
+    acknowledged_at: nullableStringField(record, 'acknowledged_at'),
+    replica_id: nullableStringField(record, 'replica_id'),
+    error_code: nullableStringField(record, 'error_code'),
+  };
+}
+
+function projectConsolePageInfo(value: unknown): ConsolePageInfo {
+  const page = objectValue(value);
+  return {
+    limit: numberField(page, 'limit'),
+    cursor: nullableStringField(page, 'cursor'),
+    next_cursor: nullableStringField(page, 'next_cursor'),
+  };
+}
+
+function nullableStringField(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === 'string' ? value : null;
 }
 
 export function projectRuntimeTermination(value: unknown): RuntimeTerminationAcceptedDto {

--- a/src/web-console/modules/runtime-sessions/RuntimeSessionService.ts
+++ b/src/web-console/modules/runtime-sessions/RuntimeSessionService.ts
@@ -1,15 +1,29 @@
 import type {
+  IRuntimeSessionControlStore,
+  RuntimeOperationalCursor,
   RuntimeSessionPresence,
+  RuntimeTerminationAck,
   RuntimeTerminationReason,
- IRuntimeSessionControlStore } from '../../services/runtime/IRuntimeSessionControlStore.js';
+} from '../../services/runtime/IRuntimeSessionControlStore.js';
+import { decodeConsoleCursor, encodeConsoleCursor } from '../../platform/ConsoleCursor.js';
 import type { IConsoleAccountAdminStore } from '../../stores/IConsoleAccountAdminStore.js';
 import type {
   RuntimeSessionAccountDto,
   RuntimeSessionOperationalDto,
+  RuntimeSessionOperationalListDto,
   RuntimeSessionRevokeAllDto,
   RuntimeSessionSelfDto,
   RuntimeTerminationAcceptedDto,
+  RuntimeTerminationCommandStatusDto,
 } from './RuntimeSessionDtos.js';
+import type { RuntimeSessionStatus } from '../../../database/schema/index.js';
+
+export interface OperationalSessionListQuery {
+  readonly limit?: number;
+  readonly cursor?: string | null;
+  readonly userId?: string;
+  readonly status?: RuntimeSessionStatus;
+}
 
 export class RuntimeSessionService {
   constructor(private readonly options: {
@@ -64,14 +78,48 @@ export class RuntimeSessionService {
     };
   }
 
-  async listOperationalSessions(): Promise<RuntimeSessionOperationalDto[]> {
-    const sessions = await this.options.runtimeStore.listOperationalPresence({ now: this.now() });
-    return sessions.map(toOperationalDto);
+  async listOperationalSessions(
+    query: OperationalSessionListQuery = {},
+  ): Promise<RuntimeSessionOperationalListDto> {
+    const limit = query.limit ?? 100;
+    const after = decodeOperationalCursor(query.cursor ?? null);
+    const page = await this.options.runtimeStore.listOperationalPresence({
+      now: this.now(),
+      limit,
+      after: after ?? undefined,
+      userId: query.userId,
+      status: query.status,
+    });
+    return {
+      items: page.items.map(toOperationalDto),
+      page: {
+        limit,
+        cursor: query.cursor ?? null,
+        next_cursor: page.nextCursor ? encodeOperationalCursor(page.nextCursor) : null,
+      },
+    };
   }
 
   async getOperationalSession(sessionId: string): Promise<RuntimeSessionOperationalDto | null> {
     const session = await this.options.runtimeStore.findPresence(sessionId, this.now());
     return session ? toOperationalDto(session) : null;
+  }
+
+  /** Operator-facing termination command status (any command). Null when the command id is unknown. */
+  async getCommandStatus(commandId: string): Promise<RuntimeTerminationCommandStatusDto | null> {
+    const command = await this.options.runtimeStore.getCommand(commandId);
+    if (!command) return null;
+    return toCommandStatusDto(commandId, await this.options.runtimeStore.getCommandAck(commandId));
+  }
+
+  /** Self-facing command status: only the caller's own termination commands are visible. */
+  async getSelfCommandStatus(
+    userId: string,
+    commandId: string,
+  ): Promise<RuntimeTerminationCommandStatusDto | null> {
+    const command = await this.options.runtimeStore.getCommand(commandId);
+    if (command?.requestedBy.userId !== userId) return null;
+    return toCommandStatusDto(commandId, await this.options.runtimeStore.getCommandAck(commandId));
   }
 
   async terminateOperationalSession(sessionId: string, operatorUserId: string): Promise<RuntimeTerminationAcceptedDto | null> {
@@ -144,4 +192,37 @@ function toOperationalDto(session: RuntimeSessionPresence): RuntimeSessionOperat
     lease_until: session.leaseUntil.toISOString(),
     client_info: session.clientInfo ? { ...session.clientInfo } : null,
   };
+}
+
+function toCommandStatusDto(
+  commandId: string,
+  ack: RuntimeTerminationAck | null,
+): RuntimeTerminationCommandStatusDto {
+  if (!ack) {
+    return { command_id: commandId, status: 'pending', acknowledged_at: null, replica_id: null, error_code: null };
+  }
+  return {
+    command_id: commandId,
+    status: ack.result,
+    acknowledged_at: ack.acknowledgedAt.toISOString(),
+    replica_id: ack.replicaId,
+    error_code: ack.errorCode,
+  };
+}
+
+function encodeOperationalCursor(cursor: RuntimeOperationalCursor): string {
+  return encodeConsoleCursor({ t: cursor.lastActiveAt.toISOString(), s: cursor.sessionId });
+}
+
+/** Foreign/garbage tokens decode to null so traversal restarts from the first page (§5.3). */
+function decodeOperationalCursor(token: string | null): RuntimeOperationalCursor | null {
+  if (!token) return null;
+  const payload = decodeConsoleCursor(token);
+  const lastActiveRaw = payload?.t;
+  const sessionId = payload?.s;
+  if (typeof lastActiveRaw !== 'string' || typeof sessionId !== 'string' || sessionId.length === 0 || sessionId.length > 200) {
+    return null;
+  }
+  const lastActiveAt = new Date(lastActiveRaw);
+  return Number.isNaN(lastActiveAt.getTime()) ? null : { lastActiveAt, sessionId };
 }

--- a/src/web-console/platform/ConsoleListQuery.ts
+++ b/src/web-console/platform/ConsoleListQuery.ts
@@ -27,24 +27,3 @@ export function boundedString(value: string | null, maxLength: number): string |
   const trimmed = value.trim();
   return trimmed ? trimmed.slice(0, maxLength) : null;
 }
-
-export interface ConsolePageParams {
-  readonly limit: number;
-  readonly cursor: string | null;
-}
-
-/**
- * Standard Family-B page params off a request: `?limit` (1..`ceiling`, default
- * `defaultLimit`) and `?cursor` (opaque, ≤512 chars — the {@link
- * import('./ConsoleCursor.js')} guard rejects longer tokens as first-page).
- */
-export function parseConsolePageParams(
-  req: ConsoleRequest,
-  defaultLimit = 100,
-  ceiling = 100,
-): ConsolePageParams {
-  return {
-    limit: boundedLimit(firstQueryValue(req.query.limit), defaultLimit, ceiling),
-    cursor: boundedString(firstQueryValue(req.query.cursor), 512),
-  };
-}

--- a/src/web-console/platform/ConsoleListQuery.ts
+++ b/src/web-console/platform/ConsoleListQuery.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared query-parameter helpers for console list surfaces, so every module
+ * parses `?limit` / `?cursor` / filter params the same way instead of
+ * hand-rolling its own bounded parsers.
+ */
+import type { ConsoleRequest } from './ConsolePlatformTypes.js';
+
+/** First scalar value of a query param that Express may deliver as an array. */
+export function firstQueryValue(value: ConsoleRequest['query'][string]): string | null {
+  if (Array.isArray(value)) {
+    const first = value[0];
+    return typeof first === 'string' ? first : null;
+  }
+  return typeof value === 'string' ? value : null;
+}
+
+/** A 1..`ceiling` integer limit; non-numeric or absent input yields `fallback`. */
+export function boundedLimit(value: string | null, fallback: number, ceiling = 100): number {
+  const parsed = value ? Number.parseInt(value, 10) : fallback;
+  if (!Number.isSafeInteger(parsed)) return fallback;
+  return Math.min(Math.max(parsed, 1), ceiling);
+}
+
+/** A trimmed, length-capped string, or null when absent/empty. */
+export function boundedString(value: string | null, maxLength: number): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, maxLength) : null;
+}
+
+export interface ConsolePageParams {
+  readonly limit: number;
+  readonly cursor: string | null;
+}
+
+/**
+ * Standard Family-B page params off a request: `?limit` (1..`ceiling`, default
+ * `defaultLimit`) and `?cursor` (opaque, ≤512 chars — the {@link
+ * import('./ConsoleCursor.js')} guard rejects longer tokens as first-page).
+ */
+export function parseConsolePageParams(
+  req: ConsoleRequest,
+  defaultLimit = 100,
+  ceiling = 100,
+): ConsolePageParams {
+  return {
+    limit: boundedLimit(firstQueryValue(req.query.limit), defaultLimit, ceiling),
+    cursor: boundedString(firstQueryValue(req.query.cursor), 512),
+  };
+}

--- a/src/web-console/platform/ConsolePlatformTypes.ts
+++ b/src/web-console/platform/ConsolePlatformTypes.ts
@@ -286,3 +286,19 @@ export interface ConsoleRouteManifest {
   readonly apiVersion: 'v1';
   readonly routes: readonly ConsoleRouteManifestEntry[];
 }
+
+/**
+ * Family-B (cursor list) page envelope shared by every paginated console list
+ * surface. `next_cursor: null` is the sole exhaustion signal — there is no
+ * `has_more` and no `total` (API contract §5.3).
+ */
+export interface ConsolePageInfo {
+  readonly limit: number;
+  readonly cursor: string | null;
+  readonly next_cursor: string | null;
+}
+
+export interface ConsolePageDto<T> {
+  readonly items: readonly T[];
+  readonly page: ConsolePageInfo;
+}

--- a/src/web-console/services/runtime/IRuntimeSessionControlStore.ts
+++ b/src/web-console/services/runtime/IRuntimeSessionControlStore.ts
@@ -84,6 +84,25 @@ export interface RuntimeSessionListQuery {
   readonly now?: Date;
 }
 
+/** Keyset position for the cross-user operational sessions list: `(last_active_at, session_id)` of the prior page's last row. */
+export interface RuntimeOperationalCursor {
+  readonly lastActiveAt: Date;
+  readonly sessionId: string;
+}
+
+export interface RuntimeOperationalListQuery {
+  readonly limit?: number;
+  readonly now?: Date;
+  readonly after?: RuntimeOperationalCursor;
+  readonly userId?: string;
+  readonly status?: RuntimeSessionStatus;
+}
+
+export interface RuntimeOperationalPresencePage {
+  readonly items: RuntimeSessionPresence[];
+  readonly nextCursor: RuntimeOperationalCursor | null;
+}
+
 export interface RuntimeTerminationCommand {
   readonly commandId: string;
   readonly kind: 'terminate_session';
@@ -143,7 +162,7 @@ export interface IRuntimeSessionControlStore {
   sweepStalePresence(before?: Date): Promise<number>;
   findPresence(sessionId: string, now?: Date): Promise<RuntimeSessionPresence | null>;
   listPresenceByUser(userId: string, query?: RuntimeSessionListQuery): Promise<RuntimeSessionPresence[]>;
-  listOperationalPresence(query?: RuntimeSessionListQuery): Promise<RuntimeSessionPresence[]>;
+  listOperationalPresence(query?: RuntimeOperationalListQuery): Promise<RuntimeOperationalPresencePage>;
   createTerminationCommand(input: RuntimeTerminationCommandInput): Promise<RuntimeTerminationCommand>;
   listPendingCommandsForReplica(
     replicaId: string,
@@ -151,6 +170,8 @@ export interface IRuntimeSessionControlStore {
   ): Promise<RuntimeTerminationCommand[]>;
   acknowledgeCommand(input: RuntimeTerminationAckInput): Promise<boolean>;
   getCommandAck(commandId: string): Promise<RuntimeTerminationAck | null>;
+  /** The termination command row by id (for command-status ownership checks). Null when unknown. */
+  getCommand(commandId: string): Promise<RuntimeTerminationCommand | null>;
 }
 
 const STATUSES = ['active', 'closing'] as const satisfies readonly RuntimeSessionStatus[];
@@ -222,6 +243,34 @@ export function validateRuntimeListQuery(query: RuntimeSessionListQuery = {}): R
     limit,
     now: query.now ?? new Date(),
   };
+}
+
+export interface ValidatedRuntimeOperationalListQuery {
+  readonly limit: number;
+  readonly now: Date;
+  readonly after: RuntimeOperationalCursor | undefined;
+  readonly userId: string | undefined;
+  readonly status: RuntimeSessionStatus | undefined;
+}
+
+export function validateRuntimeOperationalListQuery(
+  query: RuntimeOperationalListQuery = {},
+): ValidatedRuntimeOperationalListQuery {
+  const limit = query.limit ?? 100;
+  if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+    throw new ConsoleStoreValidationError('runtime session list limit must be between 1 and 500');
+  }
+  if (query.userId !== undefined) assertUuid(query.userId, 'userId');
+  if (query.status !== undefined && !isRuntimeSessionStatus(query.status)) {
+    throw new ConsoleStoreValidationError(`unknown runtime session status '${query.status}'`);
+  }
+  if (query.after !== undefined) {
+    validateSessionId(query.after.sessionId);
+    if (!(query.after.lastActiveAt instanceof Date) || Number.isNaN(query.after.lastActiveAt.getTime())) {
+      throw new ConsoleStoreValidationError('after.lastActiveAt must be a valid date');
+    }
+  }
+  return { limit, now: query.now ?? new Date(), after: query.after, userId: query.userId, status: query.status };
 }
 
 export function validateSessionId(sessionId: string): void {

--- a/src/web-console/services/runtime/InMemoryRuntimeSessionControlStore.ts
+++ b/src/web-console/services/runtime/InMemoryRuntimeSessionControlStore.ts
@@ -2,6 +2,9 @@ import { randomUUID } from 'node:crypto';
 
 import type {
   IRuntimeSessionControlStore,
+  RuntimeOperationalCursor,
+  RuntimeOperationalListQuery,
+  RuntimeOperationalPresencePage,
   RuntimeSessionHeartbeatInput,
   RuntimeSessionHeartbeatResult,
   RuntimeSessionListQuery,
@@ -17,6 +20,7 @@ import {
   cloneRuntimeTerminationAck,
   cloneRuntimeTerminationCommand,
   validateRuntimeListQuery,
+  validateRuntimeOperationalListQuery,
   validateRuntimeSessionHeartbeatInput,
   validateRuntimeSessionPresenceInput,
   validateRuntimeTerminationAckInput,
@@ -118,14 +122,20 @@ export class InMemoryRuntimeSessionControlStore implements IRuntimeSessionContro
       .map(item => cloneRuntimeSessionPresence(item));
   }
 
-  async listOperationalPresence(query: RuntimeSessionListQuery = {}): Promise<RuntimeSessionPresence[]> {
+  async listOperationalPresence(query: RuntimeOperationalListQuery = {}): Promise<RuntimeOperationalPresencePage> {
     await Promise.resolve();
-    const parsed = validateRuntimeListQuery(query);
-    return [...this.presence.values()]
-      .filter(item => isVisiblePresence(item, parsed.now))
-      .sort(comparePresence)
-      .slice(0, parsed.limit)
-      .map(item => cloneRuntimeSessionPresence(item));
+    const parsed = validateRuntimeOperationalListQuery(query);
+    const filtered = [...this.presence.values()]
+      .filter(item => item.status === (parsed.status ?? 'active') && item.leaseUntil > parsed.now)
+      .filter(item => !parsed.userId || item.userId === parsed.userId)
+      .filter(item => !parsed.after || isAfterOperationalKey(item, parsed.after))
+      .sort(compareOperationalKey);
+    const items = filtered.slice(0, parsed.limit).map(item => cloneRuntimeSessionPresence(item));
+    const last = items.at(-1);
+    const nextCursor: RuntimeOperationalCursor | null = filtered.length > parsed.limit && last
+      ? { lastActiveAt: last.lastActiveAt, sessionId: last.sessionId }
+      : null;
+    return { items, nextCursor };
   }
 
   async createTerminationCommand(input: RuntimeTerminationCommandInput): Promise<RuntimeTerminationCommand> {
@@ -179,6 +189,24 @@ export class InMemoryRuntimeSessionControlStore implements IRuntimeSessionContro
     const ack = this.acknowledgements.get(commandId);
     return ack ? cloneRuntimeTerminationAck(ack) : null;
   }
+
+  async getCommand(commandId: string): Promise<RuntimeTerminationCommand | null> {
+    await Promise.resolve();
+    assertUuid(commandId, 'commandId');
+    const command = this.commands.get(commandId);
+    return command ? cloneRuntimeTerminationCommand(command) : null;
+  }
+}
+
+/** In-memory mirror of the Postgres `(last_active_at DESC, session_id DESC)` operational ordering + `< cursor` predicate. */
+function compareOperationalKey(left: RuntimeSessionPresence, right: RuntimeSessionPresence): number {
+  const byTime = right.lastActiveAt.getTime() - left.lastActiveAt.getTime();
+  return byTime === 0 ? right.sessionId.localeCompare(left.sessionId) : byTime;
+}
+
+function isAfterOperationalKey(item: RuntimeSessionPresence, after: RuntimeOperationalCursor): boolean {
+  const byTime = item.lastActiveAt.getTime() - after.lastActiveAt.getTime();
+  return byTime === 0 ? item.sessionId.localeCompare(after.sessionId) < 0 : byTime < 0;
 }
 
 function isVisiblePresence(presence: RuntimeSessionPresence, now: Date): boolean {

--- a/src/web-console/services/runtime/PostgresRuntimeSessionControlStore.ts
+++ b/src/web-console/services/runtime/PostgresRuntimeSessionControlStore.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gt, isNull, lt } from 'drizzle-orm';
+import { and, desc, eq, gt, isNull, lt, sql, type SQL } from 'drizzle-orm';
 
 import { withSystemContext } from '../../../database/admin.js';
 import type { DatabaseInstance } from '../../../database/connection.js';
@@ -10,6 +10,8 @@ import {
 } from '../../../database/schema/index.js';
 import type {
   IRuntimeSessionControlStore,
+  RuntimeOperationalListQuery,
+  RuntimeOperationalPresencePage,
   RuntimeSessionHeartbeatInput,
   RuntimeSessionHeartbeatResult,
   RuntimeSessionListQuery,
@@ -25,6 +27,7 @@ import {
   cloneRuntimeTerminationAck,
   cloneRuntimeTerminationCommand,
   validateRuntimeListQuery,
+  validateRuntimeOperationalListQuery,
   validateRuntimeSessionHeartbeatInput,
   validateRuntimeSessionPresenceInput,
   validateRuntimeTerminationAckInput,
@@ -91,18 +94,33 @@ export class PostgresRuntimeSessionControlStore implements IRuntimeSessionContro
     return rows.map(row => fromPresenceRow(row));
   }
 
-  async listOperationalPresence(query: RuntimeSessionListQuery = {}): Promise<RuntimeSessionPresence[]> {
-    const parsed = validateRuntimeListQuery(query);
+  // Known limitation: the keyset sorts/cursors on last_active_at, which a heartbeat
+  // mutates. A session that heartbeats above the page cursor between page requests can
+  // be skipped from a full paged sweep — acceptable for a live operational snapshot
+  // (it re-appears near the top on the next sweep), but callers doing an exhaustive
+  // cross-page audit should be aware it is best-effort, not a consistent point-in-time cut.
+  async listOperationalPresence(query: RuntimeOperationalListQuery = {}): Promise<RuntimeOperationalPresencePage> {
+    const parsed = validateRuntimeOperationalListQuery(query);
+    const conditions: SQL[] = [
+      eq(runtimeSessionPresence.status, parsed.status ?? 'active'),
+      gt(runtimeSessionPresence.leaseUntil, parsed.now),
+    ];
+    if (parsed.userId) conditions.push(eq(runtimeSessionPresence.userId, parsed.userId));
+    if (parsed.after) {
+      conditions.push(sql`(${runtimeSessionPresence.lastActiveAt}, ${runtimeSessionPresence.sessionId}) < (${parsed.after.lastActiveAt}::timestamptz, ${parsed.after.sessionId})`);
+    }
     const rows = await withSystemContext(this.db, tx =>
       tx.select().from(runtimeSessionPresence)
-        .where(and(
-          eq(runtimeSessionPresence.status, 'active'),
-          gt(runtimeSessionPresence.leaseUntil, parsed.now),
-        ))
-        .orderBy(desc(runtimeSessionPresence.lastActiveAt), runtimeSessionPresence.sessionId)
-        .limit(parsed.limit),
+        .where(and(...conditions))
+        .orderBy(desc(runtimeSessionPresence.lastActiveAt), desc(runtimeSessionPresence.sessionId))
+        .limit(parsed.limit + 1),
     );
-    return rows.map(row => fromPresenceRow(row));
+    const items = rows.slice(0, parsed.limit).map(row => fromPresenceRow(row));
+    const last = items.at(-1);
+    const nextCursor = rows.length > parsed.limit && last
+      ? { lastActiveAt: last.lastActiveAt, sessionId: last.sessionId }
+      : null;
+    return { items, nextCursor };
   }
 
   async createTerminationCommand(input: RuntimeTerminationCommandInput): Promise<RuntimeTerminationCommand> {
@@ -141,6 +159,16 @@ export class PostgresRuntimeSessionControlStore implements IRuntimeSessionContro
         .limit(1),
     );
     return rows[0] ? fromAckRow(rows[0]) : null;
+  }
+
+  async getCommand(commandId: string): Promise<RuntimeTerminationCommand | null> {
+    assertUuid(commandId, 'commandId');
+    const rows = await withSystemContext(this.db, tx =>
+      tx.select().from(runtimeControlCommands)
+        .where(eq(runtimeControlCommands.commandId, commandId))
+        .limit(1),
+    );
+    return rows[0] ? fromCommandRow(rows[0]) : null;
   }
 }
 

--- a/src/web-console/stores/ConsoleStoreValidation.ts
+++ b/src/web-console/stores/ConsoleStoreValidation.ts
@@ -67,9 +67,14 @@ export function assertDigest(value: Buffer, name: string): void {
 }
 
 export function assertUuid(value: string, name: string): void {
-  if (!UUID_PATTERN.test(value)) {
+  if (!isUuid(value)) {
     throw new ConsoleStoreValidationError(`${name} must be a UUID`);
   }
+}
+
+/** Non-throwing UUID-format check, for request parsers that return a 400 rather than throw. */
+export function isUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
 }
 
 /**

--- a/src/web-console/stores/IConsoleAccountAdminStore.ts
+++ b/src/web-console/stores/IConsoleAccountAdminStore.ts
@@ -42,10 +42,29 @@ export interface PrincipalStateChange {
   readonly changedAt: Date;
 }
 
-export interface PrincipalDirectoryQuery {
-  readonly sub?: string;
-  readonly limit?: number;
+/** Keyset position for the users directory: the `(created_at, id)` of the last row of the prior page. */
+export interface PrincipalDirectoryCursor {
+  readonly createdAt: Date;
+  readonly userId: string;
 }
+
+export interface PrincipalDirectoryQuery {
+  /** Exact-match on a linked login `sub` (support/debug lookup). */
+  readonly sub?: string;
+  /** Case-insensitive prefix match on username / email / display name. */
+  readonly search?: string;
+  readonly role?: ConsoleAdminRole;
+  readonly enabled?: boolean;
+  readonly limit?: number;
+  readonly after?: PrincipalDirectoryCursor;
+}
+
+export interface PrincipalDirectoryPage {
+  readonly items: ConsolePrincipalSummary[];
+  readonly nextCursor: PrincipalDirectoryCursor | null;
+}
+
+export const PRINCIPAL_SEARCH_MAX_LENGTH = 128;
 
 export interface RoleGrantInput {
   readonly userId: string;
@@ -117,6 +136,22 @@ export interface IdentityMutationResult {
   readonly linkedUserId: string | null;
 }
 
+/** Keyset position for the unlinked-logins directory: `(created_at, sub)` of the prior page's last row. */
+export interface UnlinkedIdentityCursor {
+  readonly createdAt: Date;
+  readonly sub: string;
+}
+
+export interface UnlinkedIdentityQuery {
+  readonly limit?: number;
+  readonly after?: UnlinkedIdentityCursor;
+}
+
+export interface UnlinkedIdentityPage {
+  readonly items: LinkedIdentity[];
+  readonly nextCursor: UnlinkedIdentityCursor | null;
+}
+
 /**
  * Outcome of a deletion attempt.
  *
@@ -134,7 +169,7 @@ export interface PrincipalDeletionOutcome {
 }
 
 export interface IConsoleAccountAdminStore {
-  listPrincipals(query?: PrincipalDirectoryQuery): Promise<ConsolePrincipalSummary[]>;
+  listPrincipals(query?: PrincipalDirectoryQuery): Promise<PrincipalDirectoryPage>;
   findPrincipal(userId: string): Promise<ConsolePrincipalSummary | null>;
   findPrincipalByAccountCorrelationId(accountCorrelationId: string): Promise<ConsolePrincipalSummary | null>;
   listActiveRoles(userId: string): Promise<ConsoleAdminRole[]>;
@@ -153,6 +188,8 @@ export interface IConsoleAccountAdminStore {
   deletePrincipal(input: PrincipalDeletionInput): Promise<PrincipalDeletionOutcome | null>;
   /** Provider logins (auth accounts) currently linked to this user. */
   listLinkedIdentities(userId: string): Promise<LinkedIdentity[]>;
+  /** Logins not yet attached to any user (`user_id IS NULL`) — the link picker's source, keyset-paged. */
+  listUnlinkedIdentities(query?: UnlinkedIdentityQuery): Promise<UnlinkedIdentityPage>;
   /** A single login by its `sub`, with its current link state. Null if unknown. */
   findIdentityBySub(sub: string): Promise<LinkedIdentity | null>;
   /** Attach an unlinked login to this user. Returns null when the login is gone. */
@@ -179,8 +216,35 @@ export function validatePrincipalDirectoryQuery(query: PrincipalDirectoryQuery =
   if (query.sub?.trim() === '') {
     throw new ConsoleStoreValidationError('sub filter must be non-empty when provided');
   }
+  if (query.search !== undefined) {
+    if (query.search.trim() === '') {
+      throw new ConsoleStoreValidationError('search filter must be non-empty when provided');
+    }
+    if (query.search.length > PRINCIPAL_SEARCH_MAX_LENGTH) {
+      throw new ConsoleStoreValidationError(`search filter must be at most ${PRINCIPAL_SEARCH_MAX_LENGTH} characters`);
+    }
+  }
+  if (query.role !== undefined) assertAdminRole(query.role, 'role filter');
   if (query.limit !== undefined && (!Number.isInteger(query.limit) || query.limit < 1 || query.limit > 200)) {
     throw new ConsoleStoreValidationError('principal directory limit must be between 1 and 200');
+  }
+  if (query.after !== undefined) {
+    assertUuid(query.after.userId, 'after.userId');
+    if (!(query.after.createdAt instanceof Date) || Number.isNaN(query.after.createdAt.getTime())) {
+      throw new ConsoleStoreValidationError('after.createdAt must be a valid date');
+    }
+  }
+}
+
+export function validateUnlinkedIdentityQuery(query: UnlinkedIdentityQuery = {}): void {
+  if (query.limit !== undefined && (!Number.isInteger(query.limit) || query.limit < 1 || query.limit > 200)) {
+    throw new ConsoleStoreValidationError('unlinked identity limit must be between 1 and 200');
+  }
+  if (query.after !== undefined) {
+    validateIdentitySub(query.after.sub, 'after.sub');
+    if (!(query.after.createdAt instanceof Date) || Number.isNaN(query.after.createdAt.getTime())) {
+      throw new ConsoleStoreValidationError('after.createdAt must be a valid date');
+    }
   }
 }
 

--- a/src/web-console/stores/InMemoryConsoleAccountAdminStore.ts
+++ b/src/web-console/stores/InMemoryConsoleAccountAdminStore.ts
@@ -16,6 +16,8 @@ import type {
   PrincipalAuthzVersionBumpInput,
   PrincipalDeletionInput,
   PrincipalDeletionOutcome,
+  PrincipalDirectoryCursor,
+  PrincipalDirectoryPage,
   PrincipalDirectoryQuery,
   PrincipalDisableInput,
   PrincipalEnableInput,
@@ -23,6 +25,9 @@ import type {
   PrincipalStateChange,
   RoleGrantInput,
   RoleRevokeInput,
+  UnlinkedIdentityCursor,
+  UnlinkedIdentityPage,
+  UnlinkedIdentityQuery,
 } from './IConsoleAccountAdminStore.js';
 import {
   clonePrincipalSummary,
@@ -31,6 +36,7 @@ import {
   validateIdentitySub,
   validateIdentityUnlinkInput,
   validatePrincipalDirectoryQuery,
+  validateUnlinkedIdentityQuery,
   validatePrincipalDisableInput,
   validatePrincipalEnableInput,
   validatePrincipalAuthzVersionBumpInput,
@@ -75,13 +81,41 @@ export class InMemoryConsoleAccountAdminStore implements IConsoleAccountAdminSto
     }
   }
 
-  async listPrincipals(query: PrincipalDirectoryQuery = {}): Promise<ConsolePrincipalSummary[]> {
+  async listPrincipals(query: PrincipalDirectoryQuery = {}): Promise<PrincipalDirectoryPage> {
     await Promise.resolve();
     validatePrincipalDirectoryQuery(query);
+    const limit = query.limit ?? 100;
+    const search = query.search?.toLowerCase();
     const filtered = [...this.principals.values()]
-      .filter(principal => !query.sub || principal.primarySub === query.sub)
-      .sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime());
-    return filtered.slice(0, query.limit ?? 100).map(principal => this.withCurrentRoles(principal));
+      .map(principal => this.withCurrentRoles(principal))
+      .filter(p => !query.sub || p.primarySub === query.sub)
+      .filter(p => query.enabled === undefined || (p.disabledAt === null) === query.enabled)
+      .filter(p => !query.role || p.roles.includes(query.role))
+      .filter(p => !search || matchesPrincipalSearch(p, search))
+      .filter(p => !query.after || isAfterPrincipalKey(p, query.after))
+      .sort(comparePrincipalKey);
+    const items = filtered.slice(0, limit);
+    const last = items.at(-1);
+    const nextCursor: PrincipalDirectoryCursor | null = filtered.length > limit && last
+      ? { createdAt: last.createdAt, userId: last.userId }
+      : null;
+    return { items, nextCursor };
+  }
+
+  async listUnlinkedIdentities(query: UnlinkedIdentityQuery = {}): Promise<UnlinkedIdentityPage> {
+    await Promise.resolve();
+    validateUnlinkedIdentityQuery(query);
+    const limit = query.limit ?? 100;
+    const filtered = [...this.identities.values()]
+      .filter(identity => identity.linkedUserId === null)
+      .filter(identity => !query.after || isAfterIdentityKey(identity, query.after))
+      .sort(compareIdentityKey);
+    const items = filtered.slice(0, limit).map(cloneLinkedIdentity);
+    const last = items.at(-1);
+    const nextCursor: UnlinkedIdentityCursor | null = filtered.length > limit && last
+      ? { createdAt: last.createdAt, sub: last.sub }
+      : null;
+    return { items, nextCursor };
   }
 
   async findPrincipal(userId: string): Promise<ConsolePrincipalSummary | null> {
@@ -323,6 +357,32 @@ function cloneLinkedIdentity(identity: LinkedIdentity): LinkedIdentity {
     createdAt: new Date(identity.createdAt),
     lastAuthAt: identity.lastAuthAt ? new Date(identity.lastAuthAt) : null,
   };
+}
+
+/** In-memory mirror of the Postgres `(created_at, id)` keyset ordering + `> cursor` predicate. */
+function comparePrincipalKey(a: ConsolePrincipalSummary, b: ConsolePrincipalSummary): number {
+  const byTime = a.createdAt.getTime() - b.createdAt.getTime();
+  return byTime === 0 ? a.userId.localeCompare(b.userId) : byTime;
+}
+
+function isAfterPrincipalKey(p: ConsolePrincipalSummary, after: PrincipalDirectoryCursor): boolean {
+  const byTime = p.createdAt.getTime() - after.createdAt.getTime();
+  return byTime === 0 ? p.userId.localeCompare(after.userId) > 0 : byTime > 0;
+}
+
+function matchesPrincipalSearch(p: ConsolePrincipalSummary, lowerPrefix: string): boolean {
+  return [p.username, p.email ?? '', p.displayName ?? '']
+    .some(field => field.toLowerCase().startsWith(lowerPrefix));
+}
+
+function compareIdentityKey(a: LinkedIdentity, b: LinkedIdentity): number {
+  const byTime = a.createdAt.getTime() - b.createdAt.getTime();
+  return byTime === 0 ? a.sub.localeCompare(b.sub) : byTime;
+}
+
+function isAfterIdentityKey(identity: LinkedIdentity, after: UnlinkedIdentityCursor): boolean {
+  const byTime = identity.createdAt.getTime() - after.createdAt.getTime();
+  return byTime === 0 ? identity.sub.localeCompare(after.sub) > 0 : byTime > 0;
 }
 
 function stateChangeFromPrincipal(

--- a/src/web-console/stores/PostgresConsoleAccountAdminStore.ts
+++ b/src/web-console/stores/PostgresConsoleAccountAdminStore.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, sql } from 'drizzle-orm';
+import { and, eq, isNull, sql, type SQL } from 'drizzle-orm';
 
 import { withSystemContext } from '../../database/admin.js';
 import type { DatabaseInstance } from '../../database/connection.js';
@@ -21,6 +21,7 @@ import type {
   PrincipalAuthzVersionBumpInput,
   PrincipalDeletionInput,
   PrincipalDeletionOutcome,
+  PrincipalDirectoryPage,
   PrincipalDirectoryQuery,
   PrincipalDisableInput,
   PrincipalEnableInput,
@@ -28,6 +29,8 @@ import type {
   PrincipalStateChange,
   RoleGrantInput,
   RoleRevokeInput,
+  UnlinkedIdentityPage,
+  UnlinkedIdentityQuery,
 } from './IConsoleAccountAdminStore.js';
 import {
   assertAdminRole,
@@ -37,6 +40,7 @@ import {
   validateIdentitySub,
   validateIdentityUnlinkInput,
   validatePrincipalDirectoryQuery,
+  validateUnlinkedIdentityQuery,
   validatePrincipalDisableInput,
   validatePrincipalEnableInput,
   validatePrincipalAuthzVersionBumpInput,
@@ -72,7 +76,7 @@ type PrincipalRow = Record<string, unknown> & {
 export class PostgresConsoleAccountAdminStore implements IConsoleAccountAdminStore {
   constructor(private readonly db: DatabaseInstance) {}
 
-  async listPrincipals(query: PrincipalDirectoryQuery = {}): Promise<ConsolePrincipalSummary[]> {
+  async listPrincipals(query: PrincipalDirectoryQuery = {}): Promise<PrincipalDirectoryPage> {
     validatePrincipalDirectoryQuery(query);
     const limit = query.limit ?? 100;
     const rows: PrincipalRow[] = await withSystemContext(this.db, tx => tx.execute(sql`
@@ -115,14 +119,16 @@ export class PostgresConsoleAccountAdminStore implements IConsoleAccountAdminSto
         WHERE uar.user_id = u.id AND uar.revoked_at IS NULL
       ) role_summary ON true
       WHERE u.deleted_at IS NULL
-        AND (${query.sub ?? null}::TEXT IS NULL OR EXISTS (
-          SELECT 1 FROM auth_accounts aa
-          WHERE aa.user_id = u.id AND aa.sub = ${query.sub ?? null}
-        ))
+        ${buildPrincipalDirectoryFilters(query)}
       ORDER BY u.created_at ASC, u.id ASC
-      LIMIT ${limit}
+      LIMIT ${limit + 1}
     `));
-    return rows.map(row => fromPrincipalRow(row));
+    const items = rows.slice(0, limit).map(row => fromPrincipalRow(row));
+    const last = items.at(-1);
+    const nextCursor = rows.length > limit && last
+      ? { createdAt: last.createdAt, userId: last.userId }
+      : null;
+    return { items, nextCursor };
   }
 
   async findPrincipal(userId: string): Promise<ConsolePrincipalSummary | null> {
@@ -207,6 +213,26 @@ export class PostgresConsoleAccountAdminStore implements IConsoleAccountAdminSto
     return rows[0] ? toLinkedIdentity(rows[0]) : null;
   }
 
+  async listUnlinkedIdentities(query: UnlinkedIdentityQuery = {}): Promise<UnlinkedIdentityPage> {
+    validateUnlinkedIdentityQuery(query);
+    const limit = query.limit ?? 100;
+    const conditions: SQL[] = [isNull(authAccounts.userId)];
+    if (query.after) {
+      conditions.push(sql`(${authAccounts.createdAt}, ${authAccounts.sub}) > (${query.after.createdAt}::timestamptz, ${query.after.sub})`);
+    }
+    const rows = await withSystemContext(this.db, tx =>
+      tx.select(IDENTITY_COLUMNS).from(authAccounts)
+        .where(and(...conditions))
+        .orderBy(authAccounts.createdAt, authAccounts.sub)
+        .limit(limit + 1));
+    const items = rows.slice(0, limit).map(toLinkedIdentity);
+    const last = items.at(-1);
+    const nextCursor = rows.length > limit && last
+      ? { createdAt: last.createdAt, sub: last.sub }
+      : null;
+    return { items, nextCursor };
+  }
+
   async linkIdentity(input: IdentityLinkInput): Promise<IdentityMutationResult | null> {
     return withSystemContext(this.db, tx => linkConsoleIdentityWithTx(tx, input));
   }
@@ -232,6 +258,40 @@ export class PostgresConsoleAccountAdminStore implements IConsoleAccountAdminSto
     return rows[0] ? fromPrincipalRow(rows[0]) : null;
   }
 
+}
+
+/** Escape LIKE metacharacters so user input is matched literally (prefix search uses `... ESCAPE '\'`). */
+function escapeLikePrefix(term: string): string {
+  return term.replaceAll(/[\\%_]/g, match => `\\${match}`);
+}
+
+/**
+ * Compose the optional users-directory predicates (sub / search / role / enabled / keyset cursor)
+ * as trailing `AND …` fragments appended after the base `WHERE u.deleted_at IS NULL`.
+ */
+function buildPrincipalDirectoryFilters(query: PrincipalDirectoryQuery): SQL {
+  const parts: SQL[] = [];
+  if (query.sub) {
+    parts.push(sql`AND EXISTS (SELECT 1 FROM auth_accounts aa WHERE aa.user_id = u.id AND aa.sub = ${query.sub})`);
+  }
+  if (query.search) {
+    const prefix = `${escapeLikePrefix(query.search)}%`;
+    parts.push(sql`AND (
+      lower(u.username) LIKE lower(${prefix}) ESCAPE '\\'
+      OR lower(COALESCE(u.email, primary_account.email, '')) LIKE lower(${prefix}) ESCAPE '\\'
+      OR lower(COALESCE(u.display_name, primary_account.display_name, '')) LIKE lower(${prefix}) ESCAPE '\\'
+    )`);
+  }
+  if (query.role) {
+    parts.push(sql`AND EXISTS (SELECT 1 FROM user_admin_roles uar WHERE uar.user_id = u.id AND uar.revoked_at IS NULL AND uar.role = ${query.role})`);
+  }
+  if (query.enabled !== undefined) {
+    parts.push(query.enabled ? sql`AND u.disabled_at IS NULL` : sql`AND u.disabled_at IS NOT NULL`);
+  }
+  if (query.after) {
+    parts.push(sql`AND (u.created_at, u.id) > (${query.after.createdAt}::timestamptz, ${query.after.userId}::uuid)`);
+  }
+  return parts.length > 0 ? sql.join(parts, sql` `) : sql``;
 }
 
 export async function grantConsoleAdminRoleWithTx(

--- a/tests/unit/web-console/WebConsoleRegistrar.test.ts
+++ b/tests/unit/web-console/WebConsoleRegistrar.test.ts
@@ -9,6 +9,7 @@ import { InMemoryUserConfigStore } from '../../../src/storage/userConfig/InMemor
 const CONSOLE_SELF_CAPABILITY = 'console:self';
 const SHARED_HOSTED_PROFILE = 'shared-hosted';
 const TEST_PUBLIC_BASE_URL = 'https://console.example.test';
+const FIXED_NOW_ISO = '2026-05-26T12:00:00.000Z';
 
 jest.unstable_mockModule('../../../src/web-console/stores/PostgresConsoleSessionStore.js', () => ({
   PostgresConsoleSessionStore: class PostgresConsoleSessionStore {
@@ -193,7 +194,7 @@ describe('WebConsoleRegistrar', () => {
     const composition = await new WebConsoleRegistrar({
       opaqueValueHmacKey: Buffer.alloc(32, 11),
       reportCleanupError,
-      now: () => new Date('2026-05-26T12:00:00.000Z'),
+      now: () => new Date(FIXED_NOW_ISO),
     }).bootstrapAndRegister(container);
 
     expect(composition).toMatchObject({
@@ -836,7 +837,7 @@ describe('WebConsoleRegistrar', () => {
 
   it('serves representative public, self, and admin paths through the dormant mounted router', async () => {
     const container = new TestContainer();
-    container.seed('SystemDatabaseInstance', {});
+    container.seed('SystemDatabaseInstance', { execute: jest.fn().mockResolvedValue([]) });
     container.seed('AuditHmacResolver', { resolve: jest.fn() });
     container.seed('UserConfigStore', productionAdapter());
     container.seed('SigningKeyStore', productionAdapter());
@@ -877,7 +878,7 @@ describe('WebConsoleRegistrar', () => {
       approvalAuditQuery: productionAdapter(),
       authenticationAuditQuery: productionAdapter(),
       registerCleanup: false,
-      now: () => new Date('2026-05-26T12:00:00.000Z'),
+      now: () => new Date(FIXED_NOW_ISO),
     }).bootstrapAndRegister(container);
 
     const app = express();
@@ -889,7 +890,7 @@ describe('WebConsoleRegistrar', () => {
       body: {
         status: 'ok',
         ready: true,
-        checked_at: '2026-05-26T12:00:00.000Z',
+        checked_at: FIXED_NOW_ISO,
       },
     });
     await expect(request(app).get('/api/v1/me/profile')).resolves.toMatchObject({
@@ -902,9 +903,71 @@ describe('WebConsoleRegistrar', () => {
     });
   });
 
+  it('reports readiness as degraded when the database liveness probe fails', async () => {
+    const container = new TestContainer();
+    // The real `SELECT 1` liveness probe now fails closed instead of the
+    // representative-paths fixture's always-succeeding stub.
+    container.seed('SystemDatabaseInstance', { execute: jest.fn().mockRejectedValue(new Error('db down')) });
+    container.seed('AuditHmacResolver', { resolve: jest.fn() });
+    container.seed('UserConfigStore', productionAdapter());
+    container.seed('SigningKeyStore', productionAdapter());
+    container.seed('RateLimitStore', productionAdapter());
+    container.seed('WebConsoleSessionActivationStateAdapter', productionAdapter());
+    container.seed('WebConsoleSessionActivationEventSink', productionAdapter());
+    container.seed('LifecycleService', { registerPeriodicTask: jest.fn() });
+    const { WebConsoleRegistrar } = await import('../../../src/web-console/index.js');
+
+    const composition = await new WebConsoleRegistrar({
+      activationProfile: SHARED_HOSTED_PROFILE,
+      enableApiV1Mount: true,
+      productionReadiness: {
+        databaseVerificationReady: true,
+        portfolioSyncWorkerReady: true,
+      },
+      securityInvalidationReplicaId: 'replica-a',
+      opaqueValueHmacKey: Buffer.alloc(32, 37),
+      protectedCorrelationSelectorHmacKey: Buffer.alloc(32, 38),
+      secretEncryptionKey: {
+        keyId: 'prod-key',
+        key: Buffer.alloc(32, 39),
+      },
+      authStorage: productionAdapter(),
+      oauthGrantRevocationService: productionAdapter(),
+      consoleOAuthClient: productionAdapter(),
+      accountInviteIssuer: productionAdapter(),
+      githubIntegrationProvider: productionAdapter(),
+      publicBaseUrl: TEST_PUBLIC_BASE_URL,
+      portfolioStore: productionAdapter(),
+      approvalStore: productionAdapter(),
+      approvalEventSink: productionAdapter(),
+      executionReader: productionAdapter(),
+      gatekeeperReader: productionAdapter(),
+      telemetryQuery: productionAdapter(),
+      ownedActivityQuery: productionAdapter(),
+      ownedMetricQuery: productionAdapter(),
+      approvalAuditQuery: productionAdapter(),
+      authenticationAuditQuery: productionAdapter(),
+      registerCleanup: false,
+      now: () => new Date(FIXED_NOW_ISO),
+    }).bootstrapAndRegister(container);
+
+    const app = express();
+    app.use(composition.apiV1Mount?.router ?? express.Router());
+    composition.apiV1Mount?.markMounted();
+
+    await expect(request(app).get('/api/v1/health/ready')).resolves.toMatchObject({
+      status: 503,
+      body: {
+        status: 'not_ready',
+        ready: false,
+        checked_at: FIXED_NOW_ISO,
+      },
+    });
+  });
+
   it('uses the deployment-derived replica id when hosted/shared startup omits an explicit one', async () => {
     const container = new TestContainer();
-    container.seed('SystemDatabaseInstance', {});
+    container.seed('SystemDatabaseInstance', { execute: jest.fn().mockResolvedValue([]) });
     container.seed('AuditHmacResolver', { resolve: jest.fn() });
     container.seed('UserConfigStore', productionAdapter());
     container.seed('SigningKeyStore', productionAdapter());
@@ -993,7 +1056,7 @@ describe('WebConsoleRegistrar', () => {
     }).bootstrapAndRegister(container);
 
     const registeredIds = new Set(composition.registry.createRouteManifest().routes.map(route => route.moduleId));
-    expect([...registeredIds].sort((a, b) => a.localeCompare(b))).toEqual(['auth', 'health']);
+    expect([...registeredIds].sort((a, b) => a.localeCompare(b))).toEqual(['auth', 'consoleMeta', 'health']);
     expect(composition.apiV1Mount).toBeNull();
     expect(composition.routesMounted).toBe(false);
   });
@@ -1561,7 +1624,7 @@ describe('WebConsoleRegistrar', () => {
 
   it('fails clearly when PostgreSQL self-service settings lacks UserConfigStore', async () => {
     const container = new TestContainer();
-    container.seed('SystemDatabaseInstance', {});
+    container.seed('SystemDatabaseInstance', { execute: jest.fn().mockResolvedValue([]) });
     container.seed('AuditHmacResolver', { resolve: jest.fn() });
     container.seed('LifecycleService', { registerPeriodicTask: jest.fn() });
     seedCanonicalPortfolioManagers(container);
@@ -1575,7 +1638,7 @@ describe('WebConsoleRegistrar', () => {
 
   it('fails clearly when PostgreSQL storage lacks durable admin audit HMAC resolution', async () => {
     const container = new TestContainer();
-    container.seed('SystemDatabaseInstance', {});
+    container.seed('SystemDatabaseInstance', { execute: jest.fn().mockResolvedValue([]) });
     container.seed('LifecycleService', { registerPeriodicTask: jest.fn() });
     seedCanonicalPortfolioManagers(container);
     const { WebConsoleRegistrar } = await import('../../../src/web-console/index.js');
@@ -1588,7 +1651,7 @@ describe('WebConsoleRegistrar', () => {
 
   it('fails clearly when a database is configured but the element managers are unregistered', async () => {
     const container = new TestContainer();
-    container.seed('SystemDatabaseInstance', {});
+    container.seed('SystemDatabaseInstance', { execute: jest.fn().mockResolvedValue([]) });
     container.seed('AuditHmacResolver', { resolve: jest.fn() });
     container.seed('UserConfigStore', { load: jest.fn(), save: jest.fn() });
     container.seed('SigningKeyStore', new InMemorySigningKeyStore());
@@ -1606,7 +1669,7 @@ describe('WebConsoleRegistrar', () => {
 
   it('fails clearly when a database is configured and the manager-backed portfolio store is disabled', async () => {
     const container = new TestContainer();
-    container.seed('SystemDatabaseInstance', {});
+    container.seed('SystemDatabaseInstance', { execute: jest.fn().mockResolvedValue([]) });
     container.seed('AuditHmacResolver', { resolve: jest.fn() });
     container.seed('UserConfigStore', { load: jest.fn(), save: jest.fn() });
     container.seed('SigningKeyStore', new InMemorySigningKeyStore());

--- a/tests/unit/web-console/WebConsoleRouteManifestParity.test.ts
+++ b/tests/unit/web-console/WebConsoleRouteManifestParity.test.ts
@@ -155,6 +155,12 @@ const CONTRACT_ROUTES = [
   'GET /api/v1/admin/security/auth-policy',
   'PUT /api/v1/admin/security/auth-policy',
   'POST /api/v1/admin/security/users/:user_id/factors/totp/reset',
+  'GET /api/v1/me/manifest',
+  'GET /api/v1/me/role-catalog',
+  'GET /api/v1/admin/accounts/identities/unlinked',
+  'GET /api/v1/me/sessions/commands/:command_id',
+  'GET /api/v1/admin/operate/sessions/commands/:command_id',
+  'GET /api/v1/me/integrations/descriptors/:id/spec/operations',
   'GET /api/v1/health',
   'GET /api/v1/health/ready',
 ].sort((a, b) => a.localeCompare(b));

--- a/tests/unit/web-console/modules/AccountAdminModule.test.ts
+++ b/tests/unit/web-console/modules/AccountAdminModule.test.ts
@@ -35,6 +35,8 @@ const ACCOUNT_CREDENTIALS_REVOKE_ALL_PATH = '/api/v1/admin/accounts/users/:user_
 const ACCOUNT_ALLOWLIST_PATH = '/api/v1/admin/accounts/allowlist';
 const ACCOUNT_ALLOWLIST_ITEM_PATH = '/api/v1/admin/accounts/allowlist/:id';
 const ACCOUNT_BOOTSTRAP_PATH = '/api/v1/admin/accounts/bootstrap';
+const ADMIN_USERS_PATH = '/api/v1/admin/accounts/users';
+const ALICE_EMAIL = 'alice@example.test';
 const SELF_CAPABILITY = 'console:self';
 const ACCOUNT_ADMIN_CAPABILITY = 'console:admin:accounts';
 const OPERATE_CAPABILITY = 'console:admin:operate';
@@ -61,7 +63,7 @@ function store(): InMemoryConsoleAccountAdminStore {
     primarySub: PRIMARY_SUB,
     username: 'alice',
     displayName: 'Alice Example',
-    email: 'alice@example.test',
+    email: ALICE_EMAIL,
     emailVerified: true,
     authMethods: ['github'],
     roles: [ACCOUNT_ADMIN_ROLE],
@@ -294,7 +296,7 @@ describe('AccountAdminModule', () => {
       {
         moduleId: 'accountAdmin',
         method: 'GET',
-        path: '/api/v1/admin/accounts/users',
+        path: ADMIN_USERS_PATH,
         audience: 'admin',
         requiredCapability: ACCOUNT_ADMIN_CAPABILITY,
         ownership: 'none',
@@ -462,6 +464,18 @@ describe('AccountAdminModule', () => {
       {
         moduleId: 'accountAdmin',
         method: 'GET',
+        path: '/api/v1/admin/accounts/identities/unlinked',
+        audience: 'admin',
+        requiredCapability: ACCOUNT_ADMIN_CAPABILITY,
+        ownership: 'none',
+        elevation: 'admin_30m',
+        privacyClass: ACCOUNT_METADATA_PRIVACY,
+        idempotency: IDEMPOTENCY_NOT_APPLICABLE,
+        auditOperation: 'accounts.identities.unlinked.list',
+      },
+      {
+        moduleId: 'accountAdmin',
+        method: 'GET',
         path: ACCOUNT_ALLOWLIST_PATH,
         audience: 'admin',
         requiredCapability: ACCOUNT_ADMIN_CAPABILITY,
@@ -549,24 +563,24 @@ describe('AccountAdminModule', () => {
 
   it('serializes principal directory DTOs through the metadata allowlist', async () => {
     const { module } = mutationFixture();
-    const route = findRoute(module.routes, '/api/v1/admin/accounts/users');
+    const route = findRoute(module.routes, ADMIN_USERS_PATH);
 
     const result = await route.handler(consoleRequest({
       query: { limit: '20', sub: PRIMARY_SUB },
     }));
     const rawBody = result.body as Record<string, unknown>;
-    const firstUser = (rawBody.users as Record<string, unknown>[])[0];
+    const firstUser = (rawBody.items as Record<string, unknown>[])[0];
     firstUser.authz_version = 3;
     firstUser.account_correlation_id = ACCOUNT_CORRELATION_ID;
     firstUser.private_settings = { leaked: true };
 
     expect(route.privacyProjector?.(result.body)).toEqual({
-      users: [{
+      items: [{
         user_id: USER_ID,
         primary_sub: PRIMARY_SUB,
         username: 'alice',
         display_name: 'Alice Example',
-        email: 'alice@example.test',
+        email: ALICE_EMAIL,
         email_verified: true,
         auth_methods: ['github'],
         roles: [ACCOUNT_ADMIN_ROLE],
@@ -575,6 +589,7 @@ describe('AccountAdminModule', () => {
         last_login_at: LAST_LOGIN.toISOString(),
         admin_factor_enrolled: true,
       }],
+      page: { limit: 20, cursor: null, next_cursor: null },
     });
   });
 
@@ -995,7 +1010,7 @@ describe('AccountAdminModule', () => {
     });
     expect(add.privacyProjector?.({
       ...(created.body as Record<string, unknown>),
-      normalized_value: 'alice@example.test',
+      normalized_value: ALICE_EMAIL,
       revoked_at: NOW.toISOString(),
       raw_secret: 'nope',
     })).toEqual(created.body);
@@ -1021,7 +1036,7 @@ describe('AccountAdminModule', () => {
     });
     await expect(get.handler(consoleRequest({ params: { id: entryId } })))
       .resolves.toMatchObject({ status: 404, body: { code: 'not_found' } });
-    await expect(add.handler(consoleRequest({ body: { kind: 'email', value: 'alice@example.test' } })))
+    await expect(add.handler(consoleRequest({ body: { kind: 'email', value: ALICE_EMAIL } })))
       .resolves.toMatchObject({ status: 201 });
 
     expect(adminAuditWriter.getEvents().map(event => [event.operation, event.result, event.errorCode])).toEqual([
@@ -1079,7 +1094,7 @@ describe('AccountAdminModule', () => {
 
   it('rejects malformed list query parameters before hitting the store', async () => {
     const { module } = mutationFixture();
-    const route = findRoute(module.routes, '/api/v1/admin/accounts/users');
+    const route = findRoute(module.routes, ADMIN_USERS_PATH);
 
     await expect(route.handler(consoleRequest({ query: { limit: 'NaN' } })))
       .resolves.toMatchObject({ status: 400, body: { code: 'invalid_request' } });
@@ -2132,5 +2147,210 @@ describe('AccountAdminModule', () => {
     });
 
     await expect(runner.run(() => Promise.resolve('committed'))).rejects.toThrow('without admin audit');
+  });
+});
+
+describe('AccountAdminModule principal directory filters and pagination', () => {
+  const DIR_ID_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const DIR_ID_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+  const DIR_ID_C = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+  const DIR_ID_D = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+  const DIR_CORR_A = '1a1a1a1a-1a1a-4a1a-8a1a-1a1a1a1a1a1a';
+  const DIR_CORR_B = '2b2b2b2b-2b2b-4b2b-8b2b-2b2b2b2b2b2b';
+  const DIR_CORR_C = '3c3c3c3c-3c3c-4c3c-8c3c-3c3c3c3c3c3c';
+  const DIR_CORR_D = '4d4d4d4d-4d4d-4d4d-8d4d-4d4d4d4d4d4d';
+
+  type DirectoryPrincipalFixture = ConstructorParameters<typeof InMemoryConsoleAccountAdminStore>[0][number];
+
+  function directoryPrincipal(overrides: Partial<DirectoryPrincipalFixture> = {}): DirectoryPrincipalFixture {
+    return {
+      userId: USER_ID,
+      primarySub: `sub-${overrides.userId ?? USER_ID}`,
+      username: 'user',
+      displayName: null,
+      email: null,
+      emailVerified: false,
+      authMethods: ['local-password'],
+      roles: [],
+      disabledAt: null,
+      createdAt: NOW,
+      lastLoginAt: null,
+      adminFactorEnrolled: false,
+      accountCorrelationId: ACCOUNT_CORRELATION_ID,
+      authzVersion: 1,
+      ...overrides,
+    };
+  }
+
+  it('narrows the directory by search prefix, role, and enabled status', async () => {
+    const principals = new InMemoryConsoleAccountAdminStore([
+      directoryPrincipal({
+        userId: DIR_ID_A,
+        username: 'alice',
+        email: ALICE_EMAIL,
+        displayName: 'Alice Example',
+        accountCorrelationId: DIR_CORR_A,
+        roles: ['account_admin'],
+        createdAt: NOW,
+      }),
+      directoryPrincipal({
+        userId: DIR_ID_B,
+        username: 'bob',
+        email: 'bob@example.test',
+        displayName: 'Bob Example',
+        accountCorrelationId: DIR_CORR_B,
+        roles: ['operator'],
+        createdAt: new Date(NOW.getTime() + 1000),
+      }),
+      directoryPrincipal({
+        userId: DIR_ID_C,
+        username: 'carol',
+        email: 'carol@example.test',
+        displayName: 'Carol Example',
+        accountCorrelationId: DIR_CORR_C,
+        roles: [],
+        disabledAt: NOW,
+        createdAt: new Date(NOW.getTime() + 2000),
+      }),
+    ]);
+    const { module } = mutationFixture(principals);
+    const route = findRoute(module.routes, ADMIN_USERS_PATH);
+
+    const bySearch = await route.handler(consoleRequest({ query: { search: 'ali' } }));
+    expect((bySearch.body as { items: Array<{ user_id: string }> }).items.map(item => item.user_id))
+      .toEqual([DIR_ID_A]);
+
+    const byRole = await route.handler(consoleRequest({ query: { role: 'operator' } }));
+    expect((byRole.body as { items: Array<{ user_id: string }> }).items.map(item => item.user_id))
+      .toEqual([DIR_ID_B]);
+
+    const byDisabled = await route.handler(consoleRequest({ query: { enabled: 'false' } }));
+    expect((byDisabled.body as { items: Array<{ user_id: string }> }).items.map(item => item.user_id))
+      .toEqual([DIR_ID_C]);
+
+    const byEnabled = await route.handler(consoleRequest({ query: { enabled: 'true' } }));
+    expect((byEnabled.body as { items: Array<{ user_id: string }> }).items.map(item => item.user_id).sort((a, b) => a.localeCompare(b)))
+      .toEqual([DIR_ID_A, DIR_ID_B].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it('paginates the directory with a stable (created_at, user_id) cursor, tiebreaking equal timestamps, and restarts on a garbage cursor', async () => {
+    const principals = new InMemoryConsoleAccountAdminStore([
+      // A and B share createdAt: the keyset tiebreaker (ascending user_id) must
+      // place A before B, or a page boundary would skip or duplicate a row.
+      directoryPrincipal({ userId: DIR_ID_A, username: 'user-a', accountCorrelationId: DIR_CORR_A, createdAt: NOW }),
+      directoryPrincipal({ userId: DIR_ID_B, username: 'user-b', accountCorrelationId: DIR_CORR_B, createdAt: NOW }),
+      directoryPrincipal({
+        userId: DIR_ID_C,
+        username: 'user-c',
+        accountCorrelationId: DIR_CORR_C,
+        createdAt: new Date(NOW.getTime() + 1000),
+      }),
+      directoryPrincipal({
+        userId: DIR_ID_D,
+        username: 'user-d',
+        accountCorrelationId: DIR_CORR_D,
+        createdAt: new Date(NOW.getTime() + 2000),
+      }),
+    ]);
+    const { module } = mutationFixture(principals);
+    const route = findRoute(module.routes, ADMIN_USERS_PATH);
+
+    const collected: string[] = [];
+    let cursor: string | undefined;
+    for (let page = 0; page < 10; page += 1) {
+      const result = await route.handler(consoleRequest({ query: { limit: '1', ...(cursor ? { cursor } : {}) } }));
+      const body = result.body as {
+        items: Array<{ user_id: string }>;
+        page: { next_cursor: string | null };
+      };
+      expect(body.items).toHaveLength(1);
+      collected.push(...body.items.map(item => item.user_id));
+      if (!body.page.next_cursor) break;
+      cursor = body.page.next_cursor;
+    }
+
+    expect(collected).toEqual([DIR_ID_A, DIR_ID_B, DIR_ID_C, DIR_ID_D]);
+    expect(new Set(collected).size).toBe(4);
+
+    const garbage = await route.handler(consoleRequest({ query: { cursor: 'not-a-real-cursor' } }));
+    expect((garbage.body as { items: Array<{ user_id: string }> }).items.map(item => item.user_id)[0])
+      .toBe(DIR_ID_A);
+  });
+});
+
+describe('AccountAdminModule unlinked identities', () => {
+  const SUB_LINKED = 'github_linked-1';
+  const SUB_UNLINKED_A = 'github_unlinked-a';
+  const SUB_UNLINKED_B = 'github_unlinked-b';
+  const SUB_UNLINKED_C = 'github_unlinked-c';
+  const SUB_UNLINKED_D = 'github_unlinked-d';
+
+  type IdentityFixture = ConstructorParameters<typeof InMemoryConsoleAccountAdminStore>[1][number];
+
+  function identityFixture(overrides: Partial<IdentityFixture> = {}): IdentityFixture {
+    return {
+      sub: 'github_default',
+      provider: 'github',
+      externalSub: 'default',
+      email: null,
+      emailVerified: false,
+      displayName: null,
+      linkedUserId: null,
+      createdAt: NOW,
+      lastAuthAt: null,
+      ...overrides,
+    };
+  }
+
+  it('excludes linked identities from the unlinked directory', async () => {
+    const accountAdminStore = new InMemoryConsoleAccountAdminStore([], [
+      identityFixture({ sub: SUB_LINKED, linkedUserId: USER_ID, createdAt: NOW }),
+      identityFixture({ sub: SUB_UNLINKED_A, createdAt: new Date(NOW.getTime() + 1000) }),
+      identityFixture({ sub: SUB_UNLINKED_B, createdAt: new Date(NOW.getTime() + 2000) }),
+    ]);
+    const { module } = mutationFixture(accountAdminStore);
+    const route = findRoute(module.routes, '/api/v1/admin/accounts/identities/unlinked');
+
+    const result = await route.handler(consoleRequest());
+    const subs = (result.body as { items: Array<{ sub: string; linked_user_id: string | null }> }).items;
+
+    expect(subs.map(item => item.sub)).toEqual([SUB_UNLINKED_A, SUB_UNLINKED_B]);
+    expect(subs.every(item => item.linked_user_id === null)).toBe(true);
+  });
+
+  it('paginates unlinked identities with a stable (created_at, sub) cursor, tiebreaking equal timestamps, and restarts on a garbage cursor', async () => {
+    const accountAdminStore = new InMemoryConsoleAccountAdminStore([], [
+      identityFixture({ sub: SUB_LINKED, linkedUserId: USER_ID, createdAt: NOW }),
+      // A and B share createdAt: the (created_at, sub) tiebreaker (ascending sub)
+      // must place A before B.
+      identityFixture({ sub: SUB_UNLINKED_A, createdAt: NOW }),
+      identityFixture({ sub: SUB_UNLINKED_B, createdAt: NOW }),
+      identityFixture({ sub: SUB_UNLINKED_C, createdAt: new Date(NOW.getTime() + 1000) }),
+      identityFixture({ sub: SUB_UNLINKED_D, createdAt: new Date(NOW.getTime() + 2000) }),
+    ]);
+    const { module } = mutationFixture(accountAdminStore);
+    const route = findRoute(module.routes, '/api/v1/admin/accounts/identities/unlinked');
+
+    const collected: string[] = [];
+    let cursor: string | undefined;
+    for (let page = 0; page < 10; page += 1) {
+      const result = await route.handler(consoleRequest({ query: { limit: '1', ...(cursor ? { cursor } : {}) } }));
+      const body = result.body as {
+        items: Array<{ sub: string }>;
+        page: { next_cursor: string | null };
+      };
+      expect(body.items).toHaveLength(1);
+      collected.push(...body.items.map(item => item.sub));
+      if (!body.page.next_cursor) break;
+      cursor = body.page.next_cursor;
+    }
+
+    expect(collected).toEqual([SUB_UNLINKED_A, SUB_UNLINKED_B, SUB_UNLINKED_C, SUB_UNLINKED_D]);
+    expect(collected).not.toContain(SUB_LINKED);
+    expect(new Set(collected).size).toBe(4);
+
+    const garbage = await route.handler(consoleRequest({ query: { cursor: 'not-a-real-cursor' } }));
+    expect((garbage.body as { items: Array<{ sub: string }> }).items.map(item => item.sub)[0])
+      .toBe(SUB_UNLINKED_A);
   });
 });

--- a/tests/unit/web-console/modules/ConsoleMetaModule.test.ts
+++ b/tests/unit/web-console/modules/ConsoleMetaModule.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from '@jest/globals';
+
+import type { ConsoleRequest, ConsoleRouteManifest } from '../../../../src/web-console/platform/ConsolePlatformTypes.js';
+import { CONSOLE_CAPABILITIES } from '../../../../src/web-console/platform/ConsolePlatformTypes.js';
+import { ConsoleModuleRegistry } from '../../../../src/web-console/platform/ConsoleModuleRegistry.js';
+import {
+  createConsoleMetaModule,
+  projectRoleCatalog,
+  projectRouteManifest,
+} from '../../../../src/web-console/modules/console-meta/ConsoleMetaModule.js';
+import { CONSOLE_ADMIN_ROLES } from '../../../../src/web-console/stores/IConsoleAccountAdminStore.js';
+import { ROLE_GRANT_CAPABILITIES } from '../../../../src/web-console/modules/account-admin/AccountAdminRoleAuthority.js';
+
+const EMPTY_MANIFEST: ConsoleRouteManifest = { apiVersion: 'v1', routes: [] };
+const FAKE_REQUEST = {} as ConsoleRequest;
+
+function metaModule(getRouteManifest: () => ConsoleRouteManifest = () => EMPTY_MANIFEST) {
+  return createConsoleMetaModule({ getRouteManifest });
+}
+
+describe('ConsoleMetaModule', () => {
+  it('registers only self-audience manifest and role-catalog routes under /api/v1/me', () => {
+    const registry = new ConsoleModuleRegistry();
+    registry.register(metaModule());
+    const routes = registry.createRouteManifest().routes;
+    expect(routes.map(route => `${route.method} ${route.path}`)).toEqual([
+      'GET /api/v1/me/manifest',
+      'GET /api/v1/me/role-catalog',
+    ]);
+    expect(routes.every(route => route.audience === 'self' && route.requiredCapability === 'console:self')).toBe(true);
+  });
+
+  it('serves the route manifest lazily so it reflects modules registered later', async () => {
+    let calls = 0;
+    const route = metaModule(() => {
+      calls += 1;
+      return EMPTY_MANIFEST;
+    }).routes.find(candidate => candidate.path === '/api/v1/me/manifest');
+    expect(calls).toBe(0);
+    const result = await route?.handler(FAKE_REQUEST);
+    expect(result).toEqual({ status: 200, body: EMPTY_MANIFEST });
+    expect(calls).toBe(1);
+  });
+
+  it('serves the role/capability catalog with the role→capability grant map', async () => {
+    const route = metaModule().routes.find(candidate => candidate.path === '/api/v1/me/role-catalog');
+    const result = await route?.handler(FAKE_REQUEST);
+    expect(result?.body).toEqual({
+      roles: [...CONSOLE_ADMIN_ROLES],
+      capabilities: [...CONSOLE_CAPABILITIES],
+      grants: ROLE_GRANT_CAPABILITIES,
+    });
+  });
+
+  it('manifest projector strips producer-added fields from entries', () => {
+    const projected = projectRouteManifest({
+      apiVersion: 'v1',
+      routes: [{
+        moduleId: 'x',
+        method: 'GET',
+        path: '/api/v1/x',
+        audience: 'self',
+        requiredCapability: 'console:self',
+        ownership: 'authenticated_user',
+        elevation: 'none',
+        privacyClass: 'self_private',
+        idempotency: 'not_applicable',
+        leaked_secret: 'nope',
+      }],
+    });
+    expect(projected.routes[0]).not.toHaveProperty('leaked_secret');
+    expect(projected.routes[0]).toMatchObject({ moduleId: 'x', method: 'GET', path: '/api/v1/x' });
+  });
+
+  it('role-catalog projector re-derives from the server-owned constants, ignoring foreign input', () => {
+    const catalog = projectRoleCatalog({ roles: ['forged'], capabilities: ['forged'], grants: { admin: ['forged'] } });
+    expect(catalog.roles).toEqual([...CONSOLE_ADMIN_ROLES]);
+    expect(catalog.capabilities).toEqual([...CONSOLE_CAPABILITIES]);
+    expect(catalog.grants.admin).toEqual([...ROLE_GRANT_CAPABILITIES.admin]);
+  });
+});

--- a/tests/unit/web-console/modules/IntegrationDescriptorAuthoring.test.ts
+++ b/tests/unit/web-console/modules/IntegrationDescriptorAuthoring.test.ts
@@ -634,6 +634,55 @@ describe('IntegrationDescriptorAuthoringService spec management', () => {
     expect(noDescriptor.status).toBe(404);
     expect(bodyOf(noDescriptor)).toMatchObject({ code: 'integration_descriptor_not_found' });
   });
+
+  it('lists the operations exposed by an owned descriptor spec', async () => {
+    const { service } = fixture();
+    const created = bodyOf(await service.create(consoleRequest({ body: oauthBody() })));
+    const descriptorId = created.id as string;
+
+    const beforeIngest = await service.listSpecOperations(consoleRequest({ params: { id: descriptorId } }));
+    expect(beforeIngest.status).toBe(404);
+    expect(bodyOf(beforeIngest)).toMatchObject({ code: 'integration_spec_not_found' });
+
+    const putResult = await service.putSpec(consoleRequest({
+      params: { id: descriptorId },
+      body: { spec: openApiSpec() },
+    }));
+    const specHash = bodyOf(putResult).spec_hash as string;
+
+    const result = await service.listSpecOperations(consoleRequest({ params: { id: descriptorId } }));
+    expect(result.status).toBe(200);
+    expect(bodyOf(result)).toEqual({
+      descriptor_id: descriptorId,
+      spec_hash: specHash,
+      operations: [expect.objectContaining({
+        operation_id: 'listContacts',
+        method: 'GET',
+        path: '/contacts',
+        read_write_class: 'read',
+      })],
+    });
+  });
+
+  it('scopes spec operation listing to the descriptor owner and 404s an unknown descriptor', async () => {
+    const { service } = fixture();
+    const created = bodyOf(await service.create(consoleRequest({ body: oauthBody() })));
+    const descriptorId = created.id as string;
+    await service.putSpec(consoleRequest({
+      params: { id: descriptorId },
+      body: { spec: openApiSpec() },
+    }));
+
+    const foreign = await service.listSpecOperations(consoleRequest({
+      params: { id: descriptorId },
+      consoleAuthentication: authenticatedContext(OTHER_USER_ID),
+    }));
+    expect(foreign.status).toBe(404);
+    expect(bodyOf(foreign)).toMatchObject({ code: 'integration_descriptor_not_found' });
+
+    const unknown = await service.listSpecOperations(consoleRequest({ params: { id: UNKNOWN_ID } }));
+    expect(unknown.status).toBe(404);
+  });
 });
 
 describe('IntegrationModule per-request provider routes', () => {
@@ -912,6 +961,7 @@ describe('IntegrationModule descriptor routes', () => {
       `GET ${DESCRIPTORS_PATH}`,
       `GET ${DESCRIPTORS_PATH}/:id`,
       `GET ${DESCRIPTORS_PATH}/:id/spec`,
+      `GET ${DESCRIPTORS_PATH}/:id/spec/operations`,
       `PATCH ${DESCRIPTORS_PATH}/:id`,
       `POST ${DESCRIPTORS_PATH}`,
       `PUT ${DESCRIPTORS_PATH}/:id/spec`,

--- a/tests/unit/web-console/modules/RuntimeSessionModule.test.ts
+++ b/tests/unit/web-console/modules/RuntimeSessionModule.test.ts
@@ -617,4 +617,13 @@ describe('RuntimeSessionModule', () => {
     expect(body.items.map(item => item.session_id).sort((a, b) => a.localeCompare(b)))
       .toEqual([SECOND_SESSION_ID, SESSION_ID].sort((a, b) => a.localeCompare(b)));
   });
+
+  it('rejects a non-UUID user_id filter with a 400 rather than reaching the store', async () => {
+    const { module } = await fixture();
+    const listRoute = findRoute(module.routes, 'GET', OPERATE_SESSIONS_PATH);
+
+    const result = await listRoute.handler(request({ query: { user_id: 'not-a-uuid' } }));
+    expect(result.status).toBe(400);
+    expect((result.body as { code: string }).code).toBe('invalid_request');
+  });
 });

--- a/tests/unit/web-console/modules/RuntimeSessionModule.test.ts
+++ b/tests/unit/web-console/modules/RuntimeSessionModule.test.ts
@@ -21,6 +21,7 @@ const SECOND_SESSION_ID = 'mcp-session-2';
 const RUNTIME_TRANSPORT = 'streamable-http';
 const NOW = new Date('2026-05-28T14:00:00.000Z');
 const FIVE_MINUTES = new Date('2026-05-28T14:05:00.000Z');
+const OPERATE_SESSIONS_PATH = '/api/v1/admin/operate/sessions';
 
 function accountStore(): InMemoryConsoleAccountAdminStore {
   return new InMemoryConsoleAccountAdminStore([
@@ -158,6 +159,14 @@ describe('RuntimeSessionModule', () => {
       }),
       expect.objectContaining({
         method: 'GET',
+        path: '/api/v1/me/sessions/commands/:command_id',
+        audience: 'self',
+        requiredCapability: 'console:self',
+        ownership: 'authenticated_user',
+        idempotency: 'not_applicable',
+      }),
+      expect.objectContaining({
+        method: 'GET',
         path: '/api/v1/admin/accounts/users/:user_id/sessions',
         requiredCapability: 'console:admin:accounts',
         elevation: 'admin_30m',
@@ -178,10 +187,16 @@ describe('RuntimeSessionModule', () => {
       }),
       expect.objectContaining({
         method: 'GET',
-        path: '/api/v1/admin/operate/sessions',
+        path: OPERATE_SESSIONS_PATH,
         requiredCapability: 'console:admin:operate',
         privacyClass: 'operational_allowlist',
         auditOperation: 'operate.sessions.list',
+      }),
+      expect.objectContaining({
+        method: 'GET',
+        path: '/api/v1/admin/operate/sessions/commands/:command_id',
+        requiredCapability: 'console:admin:operate',
+        auditOperation: 'operate.sessions.command_status',
       }),
       expect.objectContaining({
         method: 'GET',
@@ -317,12 +332,14 @@ describe('RuntimeSessionModule', () => {
 
   it('exposes operator pseudonymous projection and operator termination', async () => {
     const { module, runtimeStore } = await fixture();
-    const listRoute = findRoute(module.routes, 'GET', '/api/v1/admin/operate/sessions');
+    const listRoute = findRoute(module.routes, 'GET', OPERATE_SESSIONS_PATH);
     const showRoute = findRoute(module.routes, 'GET', '/api/v1/admin/operate/sessions/:session_id');
     const deleteRoute = findRoute(module.routes, 'DELETE', '/api/v1/admin/operate/sessions/:session_id');
 
     const list = await listRoute.handler(request());
-    const projected = projectRuntimeSessionOperational((list.body as { sessions: unknown[] }).sessions[0]);
+    const items = (list.body as { items: Array<{ session_id: string }> }).items;
+    const target = items.find(session => session.session_id === SESSION_ID);
+    const projected = projectRuntimeSessionOperational(target);
     expect(projected).toMatchObject({
       session_id: SESSION_ID,
       account_correlation_id: ACCOUNT_CORRELATION_ID,
@@ -408,5 +425,196 @@ describe('RuntimeSessionModule', () => {
         status: 'accepted',
       })).toMatchObject({ reason });
     }
+  });
+
+  it('reports operator command status transitioning from pending to acknowledged, and 404s unknown commands', async () => {
+    const { module, runtimeStore } = await fixture();
+    const route = findRoute(module.routes, 'GET', '/api/v1/admin/operate/sessions/commands/:command_id');
+
+    const command = await runtimeStore.createTerminationCommand({
+      sessionId: SESSION_ID,
+      targetReplicaId: 'replica-a',
+      reason: 'operator_terminated',
+      requestedAt: NOW,
+      requestedBy: { kind: 'operator', userId: SECOND_USER_ID },
+    });
+
+    await expect(route.handler(request({ params: { command_id: command.commandId } })))
+      .resolves.toMatchObject({
+        status: 200,
+        body: {
+          command_id: command.commandId,
+          status: 'pending',
+          replica_id: null,
+          acknowledged_at: null,
+        },
+      });
+
+    await expect(runtimeStore.acknowledgeCommand({
+      commandId: command.commandId,
+      replicaId: 'replica-a',
+      acknowledgedAt: FIVE_MINUTES,
+      result: 'terminated',
+    })).resolves.toBe(true);
+
+    await expect(route.handler(request({ params: { command_id: command.commandId } })))
+      .resolves.toMatchObject({
+        status: 200,
+        body: {
+          command_id: command.commandId,
+          status: 'terminated',
+          replica_id: 'replica-a',
+          acknowledged_at: FIVE_MINUTES.toISOString(),
+        },
+      });
+
+    await expect(route.handler(request({ params: { command_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' } })))
+      .resolves.toMatchObject({ status: 404, body: { code: 'not_found' } });
+  });
+
+  it('scopes self command status to the requesting user and hides commands requested by others', async () => {
+    const { module, runtimeStore } = await fixture();
+    const route = findRoute(module.routes, 'GET', '/api/v1/me/sessions/commands/:command_id');
+
+    const ownCommand = await runtimeStore.createTerminationCommand({
+      sessionId: SESSION_ID,
+      targetReplicaId: 'replica-a',
+      reason: 'user_requested',
+      requestedAt: NOW,
+      requestedBy: { kind: 'self', userId: USER_ID },
+    });
+    const foreignCommand = await runtimeStore.createTerminationCommand({
+      sessionId: SECOND_SESSION_ID,
+      targetReplicaId: 'replica-b',
+      reason: 'user_requested',
+      requestedAt: NOW,
+      requestedBy: { kind: 'self', userId: SECOND_USER_ID },
+    });
+
+    // request() authenticates as USER_ID (see the fixture above).
+    await expect(route.handler(request({ params: { command_id: ownCommand.commandId } })))
+      .resolves.toMatchObject({
+        status: 200,
+        body: { command_id: ownCommand.commandId, status: 'pending' },
+      });
+    await expect(route.handler(request({ params: { command_id: foreignCommand.commandId } })))
+      .resolves.toMatchObject({ status: 404, body: { code: 'not_found' } });
+    await expect(route.handler(request({ params: { command_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' } })))
+      .resolves.toMatchObject({ status: 404, body: { code: 'not_found' } });
+  });
+
+  it('paginates operator session listing via keyset cursor with a deterministic tiebreak', async () => {
+    const runtimeStore = new InMemoryRuntimeSessionControlStore();
+    await runtimeStore.registerPresence({
+      sessionId: 'mcp-session-a',
+      userId: USER_ID,
+      accountCorrelationId: ACCOUNT_CORRELATION_ID,
+      replicaId: 'replica-a',
+      transport: RUNTIME_TRANSPORT,
+      startedAt: NOW,
+      lastActiveAt: NOW,
+      leaseUntil: FIVE_MINUTES,
+    });
+    // Same lastActiveAt as mcp-session-a: the (last_active_at DESC, session_id DESC)
+    // tiebreaker must place this one first ('b' > 'a').
+    await runtimeStore.registerPresence({
+      sessionId: 'mcp-session-b',
+      userId: USER_ID,
+      accountCorrelationId: ACCOUNT_CORRELATION_ID,
+      replicaId: 'replica-a',
+      transport: RUNTIME_TRANSPORT,
+      startedAt: NOW,
+      lastActiveAt: NOW,
+      leaseUntil: FIVE_MINUTES,
+    });
+    await runtimeStore.registerPresence({
+      sessionId: 'mcp-session-c',
+      userId: SECOND_USER_ID,
+      accountCorrelationId: SECOND_ACCOUNT_CORRELATION_ID,
+      replicaId: 'replica-b',
+      transport: RUNTIME_TRANSPORT,
+      startedAt: NOW,
+      lastActiveAt: FIVE_MINUTES,
+      leaseUntil: new Date(FIVE_MINUTES.getTime() + 300_000),
+    });
+    const module = createRuntimeSessionModule({
+      runtimeStore,
+      accountAdminStore: accountStore(),
+      now: () => NOW,
+    });
+    const listRoute = findRoute(module.routes, 'GET', OPERATE_SESSIONS_PATH);
+
+    const collected: string[] = [];
+    let cursor: string | undefined;
+    for (let page = 0; page < 10; page += 1) {
+      const result = await listRoute.handler(request({ query: { limit: '1', ...(cursor ? { cursor } : {}) } }));
+      const body = result.body as {
+        items: Array<{ session_id: string }>;
+        page: { next_cursor: string | null };
+      };
+      expect(body.items).toHaveLength(1);
+      collected.push(...body.items.map(item => item.session_id));
+      if (!body.page.next_cursor) break;
+      cursor = body.page.next_cursor;
+    }
+
+    // Descending (last_active_at, session_id): c (latest) first, then b before a (tiebreak).
+    expect(collected).toEqual(['mcp-session-c', 'mcp-session-b', 'mcp-session-a']);
+    expect(new Set(collected).size).toBe(3);
+  });
+
+  it('filters operator session listing by user_id and status', async () => {
+    const runtimeStore = new InMemoryRuntimeSessionControlStore();
+    await runtimeStore.registerPresence({
+      sessionId: 'mcp-session-x',
+      userId: USER_ID,
+      accountCorrelationId: ACCOUNT_CORRELATION_ID,
+      replicaId: 'replica-a',
+      transport: RUNTIME_TRANSPORT,
+      startedAt: NOW,
+      lastActiveAt: NOW,
+      leaseUntil: FIVE_MINUTES,
+    });
+    await runtimeStore.registerPresence({
+      sessionId: 'mcp-session-y',
+      userId: SECOND_USER_ID,
+      accountCorrelationId: SECOND_ACCOUNT_CORRELATION_ID,
+      replicaId: 'replica-b',
+      transport: RUNTIME_TRANSPORT,
+      startedAt: NOW,
+      lastActiveAt: NOW,
+      leaseUntil: FIVE_MINUTES,
+    });
+    await runtimeStore.markPresenceClosing('mcp-session-y', NOW);
+    const module = createRuntimeSessionModule({
+      runtimeStore,
+      accountAdminStore: accountStore(),
+      now: () => NOW,
+    });
+    const listRoute = findRoute(module.routes, 'GET', OPERATE_SESSIONS_PATH);
+
+    const byUser = await listRoute.handler(request({ query: { user_id: USER_ID } }));
+    expect((byUser.body as { items: Array<{ session_id: string }> }).items.map(item => item.session_id))
+      .toEqual(['mcp-session-x']);
+
+    const byStatusClosing = await listRoute.handler(request({ query: { status: 'closing' } }));
+    expect((byStatusClosing.body as { items: Array<{ session_id: string }> }).items.map(item => item.session_id))
+      .toEqual(['mcp-session-y']);
+
+    // Default (no status filter) only surfaces active sessions.
+    const defaultActive = await listRoute.handler(request());
+    expect((defaultActive.body as { items: Array<{ session_id: string }> }).items.map(item => item.session_id))
+      .toEqual(['mcp-session-x']);
+  });
+
+  it('treats a garbage session-list cursor as the first page rather than erroring', async () => {
+    const { module } = await fixture();
+    const listRoute = findRoute(module.routes, 'GET', OPERATE_SESSIONS_PATH);
+
+    const result = await listRoute.handler(request({ query: { cursor: 'not-a-real-cursor', limit: '10' } }));
+    expect(result.status).toBe(200);
+    const body = result.body as { items: Array<{ session_id: string }> };
+    expect(body.items.map(item => item.session_id).sort((a, b) => a.localeCompare(b)))
+      .toEqual([SECOND_SESSION_ID, SESSION_ID].sort((a, b) => a.localeCompare(b)));
   });
 });

--- a/tests/unit/web-console/stores/ConsoleSecurityStores.test.ts
+++ b/tests/unit/web-console/stores/ConsoleSecurityStores.test.ts
@@ -1367,7 +1367,7 @@ describe('InMemoryRuntimeSessionControlStore', () => {
       },
     });
     await expect(store.listPresenceByUser(USER_ID, { now: FIVE_MINUTES })).resolves.toHaveLength(1);
-    await expect(store.listOperationalPresence({ now: FIVE_MINUTES })).resolves.toHaveLength(1);
+    expect((await store.listOperationalPresence({ now: FIVE_MINUTES })).items).toHaveLength(1);
     await expect(store.findPresence(RUNTIME_SESSION_ID, THIRTY_MINUTES)).resolves.toBeNull();
     await expect(store.findPresence(RUNTIME_SESSION_ID, ONE_HOUR)).resolves.toBeNull();
 
@@ -1447,9 +1447,10 @@ describe('InMemoryRuntimeSessionControlStore', () => {
     ]);
     await expect(store.sweepStalePresence(FIVE_MINUTES)).resolves.toBe(0);
     await expect(store.sweepStalePresence(THIRTY_MINUTES)).resolves.toBe(1);
-    await expect(store.listOperationalPresence({ now: THIRTY_MINUTES })).resolves.toEqual([
-      expect.objectContaining({ sessionId: RUNTIME_SESSION_ID, replicaId: 'replica-b' }),
-    ]);
+    await expect(store.listOperationalPresence({ now: THIRTY_MINUTES })).resolves.toEqual({
+      items: [expect.objectContaining({ sessionId: RUNTIME_SESSION_ID, replicaId: 'replica-b' })],
+      nextCursor: null,
+    });
   });
 
   it('persists pending termination commands and idempotent acknowledgements', async () => {

--- a/tests/unit/web-console/stores/PostgresConsoleStores.test.ts
+++ b/tests/unit/web-console/stores/PostgresConsoleStores.test.ts
@@ -1524,22 +1524,25 @@ describe('PostgresConsoleAccountAdminStore', () => {
     transaction.execute = jest.fn(() => Promise.resolve([row]));
     const store = new PostgresConsoleAccountAdminStore({} as DatabaseInstance);
 
-    await expect(store.listPrincipals({ sub: PRIMARY_SUB, limit: 20 })).resolves.toEqual([{
-      userId: USER_ID,
-      primarySub: PRIMARY_SUB,
-      username: 'alice',
-      displayName: 'Alice',
-      email: ALICE_EMAIL,
-      emailVerified: true,
-      authMethods: ['github'],
-      roles: ['account_admin'],
-      disabledAt: null,
-      createdAt: NOW,
-      lastLoginAt: FIVE_MINUTES,
-      adminFactorEnrolled: true,
-      accountCorrelationId: ACCOUNT_CORRELATION_ID,
-      authzVersion: 3,
-    }]);
+    await expect(store.listPrincipals({ sub: PRIMARY_SUB, limit: 20 })).resolves.toEqual({
+      items: [{
+        userId: USER_ID,
+        primarySub: PRIMARY_SUB,
+        username: 'alice',
+        displayName: 'Alice',
+        email: ALICE_EMAIL,
+        emailVerified: true,
+        authMethods: ['github'],
+        roles: ['account_admin'],
+        disabledAt: null,
+        createdAt: NOW,
+        lastLoginAt: FIVE_MINUTES,
+        adminFactorEnrolled: true,
+        accountCorrelationId: ACCOUNT_CORRELATION_ID,
+        authzVersion: 3,
+      }],
+      nextCursor: null,
+    });
 
     transaction.execute = jest.fn(() => Promise.resolve([principalProjectionRow({ roles: ['unknown'] })]));
     await expect(store.findPrincipal(USER_ID)).rejects.toThrow('unknown administrative role');
@@ -1741,7 +1744,7 @@ describe('PostgresRuntimeSessionControlStore', () => {
 
     await expect(store.findPresence(RUNTIME_SESSION_ID, NOW)).resolves.toMatchObject({ sessionId: RUNTIME_SESSION_ID });
     await expect(store.listPresenceByUser(USER_ID, { now: NOW })).resolves.toHaveLength(1);
-    await expect(store.listOperationalPresence({ now: NOW })).resolves.toHaveLength(1);
+    expect((await store.listOperationalPresence({ now: NOW })).items).toHaveLength(1);
   });
 
   it('sweeps stale runtime presence rows', async () => {


### PR DESCRIPTION
## Summary

The cross-tenant users directory and cross-user active-sessions list now use cursor pagination with server-side search/filter instead of a capped one-shot response, so they stay usable past the old row cap. The console also serves the metadata a UI needs to build against without hardcoding server truth.

**Lists → cursor pagination + filter**
- Users directory: search by name/email, filter by role and enabled/disabled.
- Operational sessions: filter by user and status.

These two lists grow with the tenant/session population rather than one person's activity, so a bounded snapshot no longer fits. Per-user lists (a user's own sessions, their portfolio) are unchanged.

**New discovery / utility endpoints**
- `GET /api/v1/me/manifest` — the registered routes and their required capabilities, so the SPA can feature-detect instead of probing for 404s.
- `GET /api/v1/me/role-catalog` — the admin roles and the capabilities each grants, so a permissions UI stops hardcoding the mapping.
- `GET .../sessions/commands/:command_id` (self + operate) — poll an async session-termination to completion.
- `GET .../descriptors/:id/spec/operations` — enumerate the operations a BYO integration spec exposes.
- `GET /api/v1/admin/accounts/identities/unlinked` — logins not yet attached to a user (the identity-link picker source).

**Health honesty**
- The operations database health check now runs a real query, so a configured-but-unreachable database reports degraded instead of green.

Migration `0044` adds the indexes backing the paginated queries.

## Testing
Full unit, integration, and security suites pass; lint and typecheck are clean. New behavioral tests cover the endpoints, keyset pagination (tie boundaries and multi-page traversal), the filters, the cross-user ownership guard on command status, and the database-degraded health path.
