### PR TITLE
fix(auth): harden hosted-http multi-user save context and OAuth helper

### DIFF
--- a/oauth-helper.mjs
+++ b/oauth-helper.mjs
@@ -7,7 +7,8 @@
  * It's spawned as a detached process when authentication is initiated, polls GitHub
  * for the OAuth token, stores it securely, and then exits.
  * 
- * Usage: node oauth-helper.mjs <device_code> <interval> <expires_in> <client_id>
+ * Usage: DOLLHOUSE_OAUTH_HELPER_DEVICE_CODE=<device_code> node oauth-helper.mjs <interval> <expires_in> <client_id>
+ *   (device_code is passed via env, not argv, to keep the bearer secret out of ps/proc)
  * 
  * This solves the MCP server lifecycle issue where the server may shut down
  * between tool calls, breaking background OAuth polling.
@@ -49,14 +50,21 @@ const RESULT_MESSAGES = {
 
 const ALLOWED_RESULT_ERROR_CODES = new Set(Object.keys(RESULT_MESSAGES));
 
-// Parse command line arguments
+// Parse command line arguments. The device_code is a short-lived bearer secret
+// for the pending authorization, so it is passed via environment variable rather
+// than argv (argv is visible to other local processes via `ps` / /proc/<pid>/cmdline).
 const args = process.argv.slice(2);
-if (args.length < 4) {
-  console.error('Usage: oauth-helper.mjs <device_code> <interval> <expires_in> <client_id>');
+if (args.length < 3) {
+  console.error('Usage: oauth-helper.mjs <interval> <expires_in> <client_id>  (device code via DOLLHOUSE_OAUTH_HELPER_DEVICE_CODE)');
   process.exit(1);
 }
 
-const [deviceCode, intervalStr, expiresInStr, clientId] = args;
+const [intervalStr, expiresInStr, clientId] = args;
+const deviceCode = process.env.DOLLHOUSE_OAUTH_HELPER_DEVICE_CODE || '';
+if (!deviceCode) {
+  console.error('OAUTH_HELPER: missing DOLLHOUSE_OAUTH_HELPER_DEVICE_CODE environment variable');
+  process.exit(1);
+}
 const pollIntervalSeconds = Number.parseInt(intervalStr, 10) || DEFAULT_POLL_INTERVAL;
 const expiresIn = Number.parseInt(expiresInStr, 10) || DEFAULT_EXPIRES_IN;
 

--- a/src/handlers/GitHubAuthHandler.ts
+++ b/src/handlers/GitHubAuthHandler.ts
@@ -6,7 +6,7 @@
  * @security-audit-suppress DMCP-SEC-006
  */
 
-import { GitHubAuthManager, DeviceCodeResponse } from '../auth/GitHubAuthManager.js';
+import type { GitHubAuthManager, DeviceCodeResponse } from '../auth/GitHubAuthManager.js';
 import { ConfigManager } from '../config/ConfigManager.js';
 import { logger } from '../utils/logger.js';
 import { PackageResourceLocator } from '../paths/PackageResourceLocator.js';
@@ -14,10 +14,10 @@ import * as path from 'path';
 import { homedir } from 'os';
 import * as child_process from 'child_process';
 import { randomUUID } from 'node:crypto';
-import { InitializationService } from '../services/InitializationService.js';
-import { PersonaIndicatorService } from '../services/PersonaIndicatorService.js';
+import type { InitializationService } from '../services/InitializationService.js';
+import type { PersonaIndicatorService } from '../services/PersonaIndicatorService.js';
 import { SecurityMonitor } from '../security/securityMonitor.js';
-import { FileOperationsService } from '../services/FileOperationsService.js';
+import type { FileOperationsService } from '../services/FileOperationsService.js';
 import type { PathService } from '../paths/PathService.js';
 import { readHandoffToken, deleteHandoffToken, sweepHandoffArtifacts } from '../security/oauthHelperTokenHandoff.js';
 
@@ -244,7 +244,7 @@ export class GitHubAuthHandler {
     private logSpawningOAuthHelper(helperPath: string, clientId: string, deviceResponse: DeviceCodeResponse): void {
         logger.debug('OAUTH_STEP_6: Spawning helper process', {
           helperPath,
-          clientId: clientId?.substring(0, 8) + '...',
+          clientId: clientId.substring(0, 8) + '...',
           deviceCode: deviceResponse.device_code.substring(0, 8) + '...'
         });
     }
@@ -283,9 +283,9 @@ export class GitHubAuthHandler {
         logger.error('OAUTH_INDEX_2774: Failed to spawn OAuth helper process', {
           error: spawnError,
           helperPath,
-          clientId: clientId?.substring(0, 8) + '...',
-          errorCode: (spawnError as any)?.code,
-          syscall: (spawnError as any)?.syscall
+          clientId: clientId.substring(0, 8) + '...',
+          errorCode: (spawnError as NodeJS.ErrnoException | undefined)?.code,
+          syscall: (spawnError as NodeJS.ErrnoException | undefined)?.syscall
         });
 
         const errorDetail = this.formatOAuthHelperSpawnError(spawnError, helperPath);
@@ -1118,7 +1118,6 @@ export class GitHubAuthHandler {
     private spawnHelperProcess(helperPath: string, deviceResponse: DeviceCodeResponse, clientId: string, flowId: string) {
         return child_process.spawn('node', [
             helperPath,
-            deviceResponse.device_code,
             (deviceResponse.interval || 5).toString(),
             deviceResponse.expires_in.toString(),
             clientId
@@ -1130,7 +1129,10 @@ export class GitHubAuthHandler {
                 ...process.env,
                 DOLLHOUSE_OAUTH_HELPER_AUTH_DIR: this.getOAuthHelperAuthDir(),
                 DOLLHOUSE_OAUTH_HELPER_LOG_FILE: this.getOAuthHelperLogFile(),
-                DOLLHOUSE_OAUTH_HELPER_FLOW_ID: flowId
+                DOLLHOUSE_OAUTH_HELPER_FLOW_ID: flowId,
+                // device_code is a bearer secret — pass via env, not argv (which is
+                // visible to other local processes via `ps` / /proc/<pid>/cmdline).
+                DOLLHOUSE_OAUTH_HELPER_DEVICE_CODE: deviceResponse.device_code
             }
         });
     }

--- a/src/handlers/mcp-aql/MCPAQLHandler.ts
+++ b/src/handlers/mcp-aql/MCPAQLHandler.ts
@@ -33,7 +33,7 @@ import { ElementCRUDDispatcher } from './ElementCRUDDispatcher.js';
 import { ConfigDispatcher } from './ConfigDispatcher.js';
 import { AgentExecutionHandler } from './AgentExecutionHandler.js';
 import { GatekeeperHandler } from './GatekeeperHandler.js';
-import { MemorySaveHandler } from './MemorySaveHandler.js';
+import { MemorySaveHandler, type SaveContextScope } from './MemorySaveHandler.js';
 import { buildOperationSummary } from './OperationSummary.js';
 import { applyFieldSelection } from './FieldSelection.js';
 import { initializeNormalizers } from './normalizers/index.js';
@@ -402,7 +402,7 @@ export interface HandlerRegistry {
  * Keeps coupling loose — only requires what MCPAQLHandler actually needs.
  * Issue #301: Request correlation support.
  */
-export interface CorrelationIdProvider {
+export interface CorrelationIdProvider extends SaveContextScope {
   getCorrelationId(): string | undefined;
   getSessionContext?(): { sessionId: string } | undefined;
 }
@@ -495,7 +495,9 @@ export class MCPAQLHandler {
     this.searchHandler = new SearchHandler(handlers);
     this.elementCRUDDispatcher = new ElementCRUDDispatcher(handlers);
     this.configDispatcher = new ConfigDispatcher(handlers);
-    this.memorySaveHandler = new MemorySaveHandler(handlers, (name) => this.sessionKey(name));
+    // Pass the context tracker so pending memory saves can re-establish their
+    // per-user context during a shutdown flush (#2329 multi-user correctness).
+    this.memorySaveHandler = new MemorySaveHandler(handlers, (name) => this.sessionKey(name), contextTracker);
     this.agentExecutionHandler = new AgentExecutionHandler(
       handlers,
       this.executingAgents,

--- a/src/handlers/mcp-aql/MemorySaveHandler.ts
+++ b/src/handlers/mcp-aql/MemorySaveHandler.ts
@@ -3,13 +3,28 @@ import { SecurityMonitor } from '../../security/securityMonitor.js';
 import { logger } from '../../utils/logger.js';
 import type { MemoryManager } from '../../elements/memories/MemoryManager.js';
 import type { Memory } from '../../elements/memories/Memory.js';
+import type { ExecutionContext } from '../../security/encryption/ContextTracker.js';
 import type { HandlerRegistry } from './MCPAQLHandler.js';
 import { validateRequiredString } from './shared.js';
+
+/**
+ * Capability used to re-establish a save's originating per-user execution context
+ * when persisting outside the original request. The shutdown flush runs with no
+ * ambient AsyncLocalStorage context, so without re-establishing it a file-mode
+ * per-user save resolves to the shared baseDir. Both methods are optional so
+ * callers without a context tracker (stdio, tests) degrade to context-less saves.
+ */
+export interface SaveContextScope {
+  getContext?(): ExecutionContext | undefined;
+  runAsync?<T>(context: ExecutionContext, fn: () => Promise<T>): Promise<T>;
+}
 
 interface PendingSave {
   timer: ReturnType<typeof setTimeout>;
   memory: Memory;
   manager: MemoryManager;
+  /** Per-user execution context captured when the save was scheduled (#2329). */
+  context?: ExecutionContext;
 }
 
 interface SaveFrequencyCounter {
@@ -28,6 +43,8 @@ interface FailedSave {
   error: Error;
   memory: Memory;
   manager: MemoryManager;
+  /** Per-user execution context captured at the time the save failed (#2329). */
+  context?: ExecutionContext;
 }
 
 export class MemorySaveHandler {
@@ -48,6 +65,7 @@ export class MemorySaveHandler {
   constructor(
     private readonly handlers: HandlerRegistry,
     private readonly sessionKey: (name: string) => string,
+    private readonly contextScope?: SaveContextScope,
   ) {}
 
   async dispatch(method: string, params: Record<string, unknown>): Promise<unknown> {
@@ -117,14 +135,13 @@ export class MemorySaveHandler {
    * Unrecoverable losses are reported loudly. Unlike session cleanup, shutdown
    * is a last-ditch best-effort flush across all sessions.
    *
-   * Multi-user caveat: this runs at process shutdown, so unlike the per-session
-   * debounce timers (which persist in their propagated AsyncLocalStorage context)
-   * it may execute with no active session context. In file mode with a per-user
-   * layout a save issued here can resolve to the shared baseDir rather than the
-   * owning user's dir — an accepted best-effort tradeoff at process death, where
-   * losing the entry entirely would be worse. The durable fix (session/user
-   * context propagation into shutdown) is tracked with the broader per-session-DI
-   * hardening, not here.
+   * Multi-user handling: this runs at process shutdown, outside the per-session
+   * debounce timers' propagated AsyncLocalStorage context. Each pending and failed
+   * save captures its owning session's context when it is scheduled, and the flush
+   * re-establishes that context (runInSaveContext) before writing, so in file mode
+   * with a per-user layout each save resolves to the owning user's dir rather than
+   * the shared baseDir. When no context was captured (stdio/single-user) the write
+   * proceeds context-less as before.
    */
   async flushPendingSaves(): Promise<void> {
     const pending = [...this.pendingSaves.entries()];
@@ -133,29 +150,41 @@ export class MemorySaveHandler {
       logger.info(`[MCPAQLHandler] Flushing ${pending.length} pending memory save(s) on shutdown (total coalesced: ${this.debounceMetrics.coalesced}, total written: ${this.debounceMetrics.written})`);
     }
     const flushedKeys = new Set<string>();
-    for (const [key, { timer, memory, manager }] of pending) {
+    for (const [key, { timer, memory, manager, context }] of pending) {
       clearTimeout(timer);
       flushedKeys.add(key);
-      await this.flushOne(key, memory, manager, 'shutdown');
+      await this.flushOne(key, memory, manager, 'shutdown', context);
     }
     // Retry any failure-ledger entry not already attempted above. Direct Map
     // iteration is safe: saveMemoryTracked only deletes the current key on
     // success, which the iteration protocol tolerates.
-    for (const [key, { memory, manager }] of this.failedMemorySaves) {
+    for (const [key, { memory, manager, context }] of this.failedMemorySaves) {
       if (flushedKeys.has(key)) continue;
-      await this.flushOne(key, memory, manager, 'shutdown-retry');
+      await this.flushOne(key, memory, manager, 'shutdown-retry', context);
     }
   }
 
   /** Write one tracked save during shutdown flush, reporting unrecoverable loss. */
-  private async flushOne(key: string, memory: Memory, manager: MemoryManager, reason: string): Promise<void> {
+  private async flushOne(key: string, memory: Memory, manager: MemoryManager, reason: string, context?: ExecutionContext): Promise<void> {
     try {
-      await this.saveMemoryTracked(key, memory, manager);
+      // Re-establish the save's originating per-user context. Shutdown runs with
+      // no ambient AsyncLocalStorage context, so without this a file-mode
+      // per-user save would resolve to the shared baseDir instead of the owner's.
+      await this.runInSaveContext(context, () => this.saveMemoryTracked(key, memory, manager));
       this.debounceMetrics.written++;
     } catch (err) {
       const entryCount = typeof memory.getEntries === 'function' ? memory.getEntries().size : 'unknown';
       logger.error(`[MCPAQLHandler] Flush save failed for memory '${key}' on ${reason} (entries: ${entryCount}) — unpersisted entries will be lost if the process exits: ${err}`);
     }
+  }
+
+  /** Run a save within a previously-captured per-user context when one is
+   *  available (and the tracker supports it); otherwise run directly. */
+  private runInSaveContext<T>(context: ExecutionContext | undefined, fn: () => Promise<T>): Promise<T> {
+    if (context && this.contextScope?.runAsync) {
+      return this.contextScope.runAsync(context, fn);
+    }
+    return fn();
   }
 
   getSaveFrequencyCountersForTesting(): Map<string, SaveFrequencyCounter> {
@@ -289,6 +318,9 @@ export class MemorySaveHandler {
     manager: MemoryManager,
   ): void {
     const key = this.memorySaveKey(memoryName);
+    // Capture the originating per-user context now, while a request context is
+    // active, so a shutdown flush (which runs with none) can re-establish it.
+    const context = this.contextScope?.getContext?.();
     const existing = this.pendingSaves.get(key);
     if (existing) {
       clearTimeout(existing.timer);
@@ -306,7 +338,7 @@ export class MemorySaveHandler {
     if (typeof timer === 'object' && 'unref' in timer) {
       timer.unref();
     }
-    this.pendingSaves.set(key, { timer, memory, manager });
+    this.pendingSaves.set(key, { timer, memory, manager, context });
   }
 
   /**
@@ -338,6 +370,10 @@ export class MemorySaveHandler {
           error: err instanceof Error ? err : new Error(String(err)),
           memory,
           manager,
+          // getContext() here returns the ambient context on the normal debounced
+          // path, and the re-established context when retried from the shutdown
+          // flush (flushOne runs saveMemoryTracked inside runInSaveContext).
+          context: this.contextScope?.getContext?.(),
         });
       }
       throw err;

--- a/src/server/StreamableHttpServer.ts
+++ b/src/server/StreamableHttpServer.ts
@@ -468,6 +468,36 @@ function runHostedDeploymentSafetyChecks(config: HostedDeploymentSafetyConfig): 
       `https:// redirect URI validation.`,
     );
   }
+
+  // Checked last: once the network-exposure guards above pass, the deployment is
+  // reachable correctly, so the only remaining concern is at-rest secret
+  // protection. Encrypted GitHub tokens (github_token.enc in file mode) and the
+  // OAuth device-flow handoff fall back to a machine-derived passphrase when
+  // DOLLHOUSE_TOKEN_SECRET is unset. That passphrase has no per-install entropy
+  // (derived from homedir + USER, with the PBKDF2 salt stored beside the
+  // ciphertext), so anyone who reads the on-disk ciphertext could derive the key
+  // and decrypt every user's tokens offline. Fail closed; an operator who has
+  // accepted this at-rest risk can opt back in with
+  // DOLLHOUSE_ALLOW_INSECURE_TOKEN_STORE=true.
+  if (!process.env.DOLLHOUSE_TOKEN_SECRET?.trim()) {
+    const insecureTokenStoreDetail =
+      'DOLLHOUSE_TOKEN_SECRET is not set for this exposed multi-user deployment. ' +
+      'Encrypted GitHub tokens and OAuth handoff files would use a machine-derived ' +
+      'passphrase with no per-install entropy, so anyone who reads the on-disk ' +
+      'ciphertext could decrypt every user\'s at-rest secrets offline. Set ' +
+      'DOLLHOUSE_TOKEN_SECRET to a strong random value.';
+    if (process.env.DOLLHOUSE_ALLOW_INSECURE_TOKEN_STORE?.trim().toLowerCase() === 'true') {
+      logger.warn(
+        `[StreamableHttpServer] ${insecureTokenStoreDetail} Continuing anyway because ` +
+        'DOLLHOUSE_ALLOW_INSECURE_TOKEN_STORE=true.',
+      );
+    } else {
+      throw new Error(
+        `[StreamableHttpServer] Refusing to start: ${insecureTokenStoreDetail} To start ` +
+        'anyway (not recommended), set DOLLHOUSE_ALLOW_INSECURE_TOKEN_STORE=true.',
+      );
+    }
+  }
 }
 
 export async function createStreamableHttpRuntime(

--- a/tests/unit/auth/oauth-helper.test.ts
+++ b/tests/unit/auth/oauth-helper.test.ts
@@ -15,6 +15,8 @@ import {
 const TEST_CLIENT_ID = 'Ov23liABCDEFGHIJKLMNOP';
 // A fixed UUID flow id used where the server would normally generate one.
 const TEST_FLOW_ID = '11111111-1111-4111-8111-111111111111';
+const HELPER_FILENAME = 'oauth-helper.mjs';
+const HELPER_STATE_FILE = 'oauth-helper-state.json';
 
 async function readRequestBody(req: IncomingMessage): Promise<string> {
   const chunks: Buffer[] = [];
@@ -48,7 +50,6 @@ function spawnHelper(helperPath: string, tokenUrl: string, homeDir: string, extr
   const stderr: string[] = [];
   const child = spawn(process.execPath, [
     helperPath,
-    'device-code-for-test',
     '1',
     '20',
     TEST_CLIENT_ID
@@ -59,6 +60,8 @@ function spawnHelper(helperPath: string, tokenUrl: string, homeDir: string, extr
       DOLLHOUSE_OAUTH_TOKEN_URL: tokenUrl,
       DOLLHOUSE_OAUTH_DEBUG: 'true',
       DOLLHOUSE_TOKEN_SECRET: 'oauth-helper-test-secret',
+      // device_code now travels via env (out of argv); the stub endpoint asserts it below.
+      DOLLHOUSE_OAUTH_HELPER_DEVICE_CODE: 'device-code-for-test',
       GITHUB_TOKEN: '',
       TEST_GITHUB_TOKEN: '',
       GITHUB_TEST_TOKEN: '',
@@ -67,8 +70,8 @@ function spawnHelper(helperPath: string, tokenUrl: string, homeDir: string, extr
     stdio: ['ignore', 'pipe', 'pipe']
   });
 
-  child.stdout?.on('data', chunk => stdout.push(String(chunk)));
-  child.stderr?.on('data', chunk => stderr.push(String(chunk)));
+  child.stdout.on('data', chunk => stdout.push(String(chunk)));
+  child.stderr.on('data', chunk => stderr.push(String(chunk)));
 
   return Object.assign(child, {
     readOutput: () => ({
@@ -106,9 +109,9 @@ async function waitForFile(filePath: string, timeoutMs = 5_000): Promise<void> {
   throw new Error(`Timed out waiting for ${filePath}`);
 }
 
-describe('oauth-helper.mjs', () => {
+describe(HELPER_FILENAME, () => {
   it('writes the token to an encrypted handoff and keeps no plaintext or canonical store', async () => {
-    const helperSource = await fs.readFile(path.join(process.cwd(), 'oauth-helper.mjs'), 'utf-8');
+    const helperSource = await fs.readFile(path.join(process.cwd(), HELPER_FILENAME), 'utf-8');
 
     // The detached helper must hand the token off encrypted, not write the
     // canonical token store or a plaintext fallback (#2334).
@@ -119,7 +122,7 @@ describe('oauth-helper.mjs', () => {
   });
 
   it('hands a device-flow token to the server via the encrypted handoff and writes a terminal result', async () => {
-    const helperPath = path.join(process.cwd(), 'oauth-helper.mjs');
+    const helperPath = path.join(process.cwd(), HELPER_FILENAME);
     const distHandoffPath = path.join(process.cwd(), 'dist', 'security', 'oauthHelperTokenHandoff.js');
     const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'oauth-helper-e2e-'));
     const originalTokenSecret = process.env.DOLLHOUSE_TOKEN_SECRET;
@@ -159,7 +162,7 @@ describe('oauth-helper.mjs', () => {
     await fs.mkdir(authDir, { recursive: true });
     // The server writes the state (with the flow id) before spawning; simulate that.
     await fs.writeFile(
-      path.join(authDir, 'oauth-helper-state.json'),
+      path.join(authDir, HELPER_STATE_FILE),
       JSON.stringify({ flowId: TEST_FLOW_ID, userCode: 'ABCD-1234' }),
       'utf-8'
     );
@@ -198,7 +201,7 @@ describe('oauth-helper.mjs', () => {
       await expect(fs.access(path.join(authDir, 'github_token.enc'))).rejects.toMatchObject({ code: 'ENOENT' });
       await expect(fs.access(path.join(authDir, LEGACY_PLAINTEXT_TOKEN_FILE))).rejects.toMatchObject({ code: 'ENOENT' });
       // State/pid cleaned up on success (state flow id matched this flow).
-      await expect(fs.access(path.join(authDir, 'oauth-helper-state.json'))).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.access(path.join(authDir, HELPER_STATE_FILE))).rejects.toMatchObject({ code: 'ENOENT' });
       await expect(fs.access(path.join(authDir, 'oauth-helper.pid'))).rejects.toMatchObject({ code: 'ENOENT' });
     } finally {
       await closeServer(server);
@@ -209,12 +212,12 @@ describe('oauth-helper.mjs', () => {
   }, 15_000);
 
   it('persists GitHub slow_down backoff across polling attempts', async () => {
-    const helperPath = path.join(process.cwd(), 'oauth-helper.mjs');
+    const helperPath = path.join(process.cwd(), HELPER_FILENAME);
     const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'oauth-helper-slow-down-'));
     const expectedToken = 'gho_test_slow_down_token_1234567890';
     let polls = 0;
 
-    const server = createServer(async (_req, res) => {
+    const server = createServer((_req, res) => {
       polls += 1;
       if (polls === 1) {
         json(res, 200, { error: 'slow_down' });
@@ -264,7 +267,7 @@ describe('oauth-helper.mjs', () => {
       return;
     }
 
-    const helperPath = path.join(process.cwd(), 'oauth-helper.mjs');
+    const helperPath = path.join(process.cwd(), HELPER_FILENAME);
     const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'oauth-helper-interrupt-'));
 
     const server = createServer((_req, res) => {
@@ -279,7 +282,7 @@ describe('oauth-helper.mjs', () => {
 
     const authDir = path.join(tempHome, '.dollhouse', '.auth');
     await fs.mkdir(authDir, { recursive: true });
-    await fs.writeFile(path.join(authDir, 'oauth-helper-state.json'), JSON.stringify({ stale: true }), 'utf-8');
+    await fs.writeFile(path.join(authDir, HELPER_STATE_FILE), JSON.stringify({ stale: true }), 'utf-8');
 
     try {
       const child = spawnHelper(helperPath, `http://127.0.0.1:${address.port}/token`, tempHome);
@@ -298,7 +301,7 @@ describe('oauth-helper.mjs', () => {
       expect(terminalResult.errorCode).toBe('interrupted');
       expect(terminalResult.message).toBe('OAuth helper was interrupted before authentication completed.');
 
-      await expect(fs.access(path.join(authDir, 'oauth-helper-state.json'))).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(fs.access(path.join(authDir, HELPER_STATE_FILE))).rejects.toMatchObject({ code: 'ENOENT' });
       await expect(fs.access(path.join(authDir, 'oauth-helper.pid'))).rejects.toMatchObject({ code: 'ENOENT' });
     } finally {
       await closeServer(server);
@@ -307,7 +310,7 @@ describe('oauth-helper.mjs', () => {
   }, 15_000);
 
   it('does not remove state or pid files owned by a newer helper flow', async () => {
-    const helperPath = path.join(process.cwd(), 'oauth-helper.mjs');
+    const helperPath = path.join(process.cwd(), HELPER_FILENAME);
     const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'oauth-helper-flow-race-'));
     let releaseOldFlow = false;
 
@@ -323,7 +326,7 @@ describe('oauth-helper.mjs', () => {
 
     const authDir = path.join(tempHome, '.dollhouse', '.auth');
     const pidFile = path.join(authDir, 'oauth-helper.pid');
-    const stateFile = path.join(authDir, 'oauth-helper-state.json');
+    const stateFile = path.join(authDir, HELPER_STATE_FILE);
     const resultFile = path.join(authDir, 'oauth-helper-result.json');
 
     try {
@@ -395,6 +398,16 @@ describe('oauthHelperTokenHandoff', () => {
     expect(onDisk).not.toContain('gho_round_trip_token');
 
     await expect(readHandoffToken(authDir, FLOW_A)).resolves.toBe('gho_round_trip_token');
+  });
+
+  it('round-trips using the machine-passphrase fallback when DOLLHOUSE_TOKEN_SECRET is unset', async () => {
+    // Exercise the getMachinePassphrase() fallback path (the other tests always
+    // set DOLLHOUSE_TOKEN_SECRET). Write and read run in the same process, so the
+    // machine-derived passphrase matches and the token round-trips.
+    delete process.env.DOLLHOUSE_TOKEN_SECRET;
+    const authDir = path.join(tempRoot, 'user', '.auth');
+    await writeHandoffToken(authDir, FLOW_A, 'gho_machine_fallback_token');
+    await expect(readHandoffToken(authDir, FLOW_A)).resolves.toBe('gho_machine_fallback_token');
   });
 
   it('returns null for a different (stale/foreign) flow id', async () => {

--- a/tests/unit/handlers/mcp-aql/MemorySaveHandler.test.ts
+++ b/tests/unit/handlers/mcp-aql/MemorySaveHandler.test.ts
@@ -47,7 +47,7 @@ function makeMemory(name: string): MockMemory {
   };
 }
 
-function makeHandler(memory: MockMemory, sessionId = 'sessA') {
+function makeHandler(memory: MockMemory, sessionId = 'sessA', contextScope?: HandlerCtorArgs[2]) {
   const manager = {
     find: jest.fn(() => Promise.resolve(memory)),
     save: jest.fn(() => Promise.resolve()),
@@ -56,7 +56,7 @@ function makeHandler(memory: MockMemory, sessionId = 'sessA') {
   const handlers = { memoryManager: manager } as unknown as HandlerCtorArgs[0];
   // Session-scoped key, matching MCPAQLHandler.sessionKey('name') => `${sessionId}:${name}`
   let currentSession = sessionId;
-  const handler = new MemorySaveHandler(handlers, (name: string) => `${currentSession}:${name}`);
+  const handler = new MemorySaveHandler(handlers, (name: string) => `${currentSession}:${name}`, contextScope);
   const internals = handler as unknown as HandlerInternals;
   return {
     handler,
@@ -152,6 +152,88 @@ describe('MemorySaveHandler', () => {
       expect(ctx.internals.pendingSaves.has('sessA:shared-name')).toBe(true);
       expect(ctx.internals.pendingSaves.has('sessB:shared-name')).toBe(true);
       expect(ctx.internals.pendingSaves.size).toBe(2);
+    });
+  });
+
+  describe('shutdown flush re-establishes per-user context (#2329 multi-user)', () => {
+    // A time-sensitive context tracker: like AsyncLocalStorage, it exposes a
+    // context ONLY while a request is notionally active. At process shutdown the
+    // ambient context is gone. This distinguishes a correct implementation (which
+    // captures the context when the save is SCHEDULED) from the regression the fix
+    // guards against (re-fetching the context at FLUSH time, when it is empty).
+    function timeSensitiveScope() {
+      let ambient: unknown;
+      const runContexts: unknown[] = [];
+      const scope = {
+        getContext: jest.fn(() => ambient),
+        runAsync: jest.fn((ctx: unknown, fn: () => Promise<unknown>) => {
+          runContexts.push(ctx);
+          return fn();
+        }),
+      };
+      return {
+        scope,
+        runContexts,
+        setAmbient: (ctx: unknown) => { ambient = ctx; },
+      };
+    }
+
+    it('replays the context captured at schedule time, not one re-fetched at shutdown', async () => {
+      const memory = makeMemory('notes');
+      const scheduledContext = { session: { userId: 'alice', sessionId: 'sessA' } };
+      const { scope, runContexts, setAmbient } = timeSensitiveScope();
+      const { handler, manager } = makeHandler(memory, 'sessA', scope as unknown as HandlerCtorArgs[2]);
+
+      // Request active: the save captures alice's context as it is scheduled.
+      setAmbient(scheduledContext);
+      await handler.dispatch('addEntry', { element_name: 'notes', content: 'hi' });
+
+      // Shutdown: ambient context is gone. A regression that re-fetched
+      // getContext() here would get undefined, skip runAsync, and write to the
+      // shared baseDir. A correct flush replays the captured context instead.
+      setAmbient(undefined);
+      await handler.flushPendingSaves();
+
+      expect(scope.runAsync).toHaveBeenCalledTimes(1);
+      expect(runContexts).toEqual([scheduledContext]);
+      expect(manager.save).toHaveBeenCalledWith(memory);
+    });
+
+    it('flushes each session\'s save under its OWN captured context (no cross-user bleed)', async () => {
+      const memory = makeMemory('notes');
+      const ctxAlice = { session: { userId: 'alice', sessionId: 'sessA' } };
+      const ctxBob = { session: { userId: 'bob', sessionId: 'sessB' } };
+      const { scope, runContexts, setAmbient } = timeSensitiveScope();
+      const ctx = makeHandler(memory, 'sessA', scope as unknown as HandlerCtorArgs[2]);
+
+      // Alice schedules a save for 'notes' inside her request context.
+      setAmbient(ctxAlice);
+      await ctx.handler.dispatch('addEntry', { element_name: 'notes', content: 'from alice' });
+      // Bob schedules a save for the SAME-named memory inside his own context.
+      ctx.setSession('sessB');
+      setAmbient(ctxBob);
+      await ctx.handler.dispatch('addEntry', { element_name: 'notes', content: 'from bob' });
+
+      // Two independent pending saves keyed by session.
+      expect(ctx.internals.pendingSaves.size).toBe(2);
+
+      // Shutdown flush with no ambient context: each save must run under its own
+      // originating context — not undefined, not a single shared one, and not the
+      // other user's (which would land alice's entry in bob's dir or vice versa).
+      setAmbient(undefined);
+      await ctx.handler.flushPendingSaves();
+
+      expect(scope.runAsync).toHaveBeenCalledTimes(2);
+      expect(runContexts).toContain(ctxAlice);
+      expect(runContexts).toContain(ctxBob);
+    });
+
+    it('flushes directly when no context tracker is available (stdio / tests)', async () => {
+      const memory = makeMemory('notes');
+      const { handler, manager } = makeHandler(memory, 'sessA'); // no contextScope
+      await handler.dispatch('addEntry', { element_name: 'notes', content: 'hi' });
+      await handler.flushPendingSaves();
+      expect(manager.save).toHaveBeenCalledWith(memory);
     });
   });
 });

--- a/tests/unit/server/hostedDeploymentSafety.test.ts
+++ b/tests/unit/server/hostedDeploymentSafety.test.ts
@@ -12,10 +12,25 @@
  *     in AuthProviderFactory handles that case.
  */
 
-import { describe, it, expect } from '@jest/globals';
+/* eslint-disable sonarjs/no-hardcoded-ip -- private-CIDR literals are intentional
+   trusted-proxy fixtures exercising the deployment-safety guards. */
+
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
 import { assertHostedDeploymentSafety } from '../../../src/server/StreamableHttpServer.js';
+import { logger } from '../../../src/utils/logger.js';
 
 describe('assertHostedDeploymentSafety', () => {
+  // The token-secret guard hard-fails an exposed multi-user deployment when
+  // DOLLHOUSE_TOKEN_SECRET is unset. That gate is orthogonal to the host/auth/
+  // proxy guards the other cases exercise, so provide a secret by default; the
+  // dedicated 'DOLLHOUSE_TOKEN_SECRET enforcement' block manages its own absence.
+  const suiteTokenSecret = process.env.DOLLHOUSE_TOKEN_SECRET;
+  beforeEach(() => { process.env.DOLLHOUSE_TOKEN_SECRET = 'suite-default-token-secret'; });
+  afterEach(() => {
+    if (suiteTokenSecret === undefined) delete process.env.DOLLHOUSE_TOKEN_SECRET;
+    else process.env.DOLLHOUSE_TOKEN_SECRET = suiteTokenSecret;
+  });
+
   it('passes for loopback bind regardless of other settings', async () => {
     await expect(assertHostedDeploymentSafety({
       host: '127.0.0.1',
@@ -251,5 +266,60 @@ describe('assertHostedDeploymentSafety', () => {
       authEnabled: true,
       trustedProxies: [],
     })).rejects.toThrow(/DOLLHOUSE_TRUSTED_PROXIES is unset/);
+  });
+
+  describe('DOLLHOUSE_TOKEN_SECRET enforcement', () => {
+    const originalSecret = process.env.DOLLHOUSE_TOKEN_SECRET;
+    const originalAllowInsecure = process.env.DOLLHOUSE_ALLOW_INSECURE_TOKEN_STORE;
+    afterEach(() => {
+      if (originalSecret === undefined) delete process.env.DOLLHOUSE_TOKEN_SECRET;
+      else process.env.DOLLHOUSE_TOKEN_SECRET = originalSecret;
+      if (originalAllowInsecure === undefined) delete process.env.DOLLHOUSE_ALLOW_INSECURE_TOKEN_STORE;
+      else process.env.DOLLHOUSE_ALLOW_INSECURE_TOKEN_STORE = originalAllowInsecure;
+      jest.restoreAllMocks();
+    });
+
+    // A properly-secured exposed multi-user config (auth on, native TLS with
+    // loopback-only trusted proxies) so the earlier checks pass and we reach the
+    // token-secret guard rather than an earlier throw.
+    const securedConfig = { host: '0.0.0.0', methods: ['github'], authEnabled: true, trustedProxies: ['loopback'], nativeTls: true } as const;
+
+    it('refuses to start when DOLLHOUSE_TOKEN_SECRET is unset on an exposed multi-user deployment', async () => {
+      delete process.env.DOLLHOUSE_TOKEN_SECRET;
+      delete process.env.DOLLHOUSE_ALLOW_INSECURE_TOKEN_STORE;
+
+      await expect(assertHostedDeploymentSafety({ ...securedConfig }))
+        .rejects.toThrow(/Refusing to start: DOLLHOUSE_TOKEN_SECRET is not set/);
+    });
+
+    it('warns but starts when the insecure token store is explicitly allowed', async () => {
+      delete process.env.DOLLHOUSE_TOKEN_SECRET;
+      process.env.DOLLHOUSE_ALLOW_INSECURE_TOKEN_STORE = 'true';
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      await expect(assertHostedDeploymentSafety({ ...securedConfig })).resolves.toBeUndefined();
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('DOLLHOUSE_TOKEN_SECRET is not set'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('DOLLHOUSE_ALLOW_INSECURE_TOKEN_STORE=true'));
+    });
+
+    it('accepts the opt-out value case-insensitively (TRUE)', async () => {
+      delete process.env.DOLLHOUSE_TOKEN_SECRET;
+      process.env.DOLLHOUSE_ALLOW_INSECURE_TOKEN_STORE = 'TRUE';
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      await expect(assertHostedDeploymentSafety({ ...securedConfig })).resolves.toBeUndefined();
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('DOLLHOUSE_TOKEN_SECRET is not set'));
+    });
+
+    it('does not warn or throw when DOLLHOUSE_TOKEN_SECRET is set', async () => {
+      process.env.DOLLHOUSE_TOKEN_SECRET = 'a-strong-random-secret';
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      await expect(assertHostedDeploymentSafety({ ...securedConfig })).resolves.toBeUndefined();
+
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('DOLLHOUSE_TOKEN_SECRET is not set'));
+    });
   });
 });


### PR DESCRIPTION
Follow-up hardening for the hosted, multi-user HTTP deployment. Three fixes surfaced during review of the develop→codex sync, plus a lint/comment cleanup pass on the touched files.

### Multi-user save context on shutdown flush (#2329)
The shutdown flush of debounced memory saves ran outside the per-user `AsyncLocalStorage` context, so in file mode a save issued at process death could resolve to the shared base directory instead of the owning user's. Each pending and failed save now captures its originating context when scheduled, and the flush re-establishes it before writing, so every save lands in the owner's directory. Callers without a context tracker (stdio / single-user) degrade cleanly to context-less writes.

### OAuth device code off the process argv (#2334)
The device-flow bearer code was passed to the spawned OAuth helper as a CLI argument, exposing it via `ps` / `/proc/<pid>/cmdline`. It now travels through `DOLLHOUSE_OAUTH_HELPER_DEVICE_CODE` in the child's environment, which is owner-readable only. It remains unpersisted and redacted from logs.

### Fail closed when the token secret is unset
On an exposed multi-user bind, an unset `DOLLHOUSE_TOKEN_SECRET` means encrypted GitHub tokens and OAuth handoff files fall back to a machine-derived passphrase with no per-install entropy — anyone able to read the on-disk ciphertext could decrypt every user's tokens offline. The server now **refuses to start** in that configuration, matching its sibling auth/proxy guards, rather than only warning.

**Operator note:** deployments that knowingly accept this at-rest risk can opt back in with `DOLLHOUSE_ALLOW_INSECURE_TOKEN_STORE=true`, which restores warn-and-continue.

### Testing
Full unit and integration suites pass. New coverage: a time-sensitive and a two-session cross-user test proving each save flushes under its own captured context; refuse / opt-out / secret-set cases for the startup guard; and a machine-passphrase fallback round-trip.
