### PR TITLE
feat(web-console): add session inspection and controls

### DIFF
--- a/src/web-console/ui/console.css
+++ b/src/web-console/ui/console.css
@@ -161,7 +161,7 @@
   font-size: var(--step--1);
 }
 .fm-key { color: var(--ink-500); }
-.fm-val { color: var(--ink-900); word-break: break-word; }
+.fm-val { color: var(--ink-900); overflow-wrap: anywhere; }
 
 /* List view: show element names in full — the legacy clamped the title to a
    fixed 13rem column with an ellipsis, which truncated real (longer) names. */
@@ -463,6 +463,155 @@
 .session-danger { color: #dc2626; border-color: color-mix(in srgb, #dc2626 35%, var(--line)); }
 .session-danger:hover { background: color-mix(in srgb, #dc2626 10%, transparent); }
 .session-empty { color: var(--ink-500); font-size: var(--step--1); padding: 0.6rem 0.25rem; }
+.session-command-summary {
+  max-width: var(--max-width);
+  min-height: 1.2rem;
+  margin: 0.5rem auto 0;
+  padding: 0 0.25rem;
+  color: var(--ink-700);
+  font-size: var(--step--1);
+}
+.session-command-inline {
+  max-width: 160px;
+  color: var(--ink-500);
+  font-family: var(--font-mono);
+  font-size: calc(var(--step--1) - 2px);
+  text-align: right;
+}
+.session-command-inline--acknowledged { color: #15803d; }
+.session-command-inline--timeout,
+.session-command-inline--unavailable { color: #b45309; }
+
+/* Owned MCP session detail. Snapshots poll only while this tab is visible. */
+.session-detail-shell { max-width: var(--max-width); margin: var(--gutter) auto 0; padding: 0 0.25rem 2rem; }
+.session-detail-back {
+  appearance: none;
+  border: 0;
+  background: none;
+  color: var(--signal);
+  cursor: pointer;
+  font: inherit;
+  padding: 0.25rem 0;
+  margin-bottom: 0.8rem;
+}
+.session-detail-back:hover { text-decoration: underline; }
+.session-detail-header,
+.session-detail-panel {
+  background: var(--paper-strong);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md, 0.6rem);
+  box-shadow: var(--shadow-soft);
+}
+.session-detail-header { padding: 1rem 1.1rem; }
+.session-detail-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; }
+.session-detail-heading h2,
+.session-detail-state h2 {
+  margin: 0;
+  color: var(--ink-900);
+  font-family: var(--font-heading);
+  font-size: var(--step-1);
+}
+.session-detail-heading p,
+.session-detail-state p { margin: 0.3rem 0; color: var(--ink-500); font-size: var(--step--1); }
+.session-detail-eyebrow {
+  margin: 0 0 0.15rem !important;
+  color: var(--ink-500);
+  font-family: var(--font-mono);
+  font-size: calc(var(--step--1) - 1px) !important;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.session-detail-id { display: block; margin-top: 0.45rem; color: var(--ink-700); font-size: calc(var(--step--1) - 1px); overflow-wrap: anywhere; }
+.session-detail-actions,
+.session-detail-row-actions { display: flex; flex-wrap: wrap; gap: 0.4rem; justify-content: flex-end; }
+.session-detail-refresh { min-height: 1.2rem; margin-top: 0.75rem; color: var(--ink-500); font-size: calc(var(--step--1) - 1px); }
+.session-detail-refresh--stale { color: #b45309; }
+.session-command-status {
+  margin-top: 0.8rem;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-1);
+  color: var(--ink-700);
+  font-size: var(--step--1);
+}
+.session-command-status--acknowledged { border-color: color-mix(in srgb, #22c55e 40%, var(--line)); }
+.session-command-status--timeout,
+.session-command-status--unavailable { border-color: color-mix(in srgb, #f59e0b 45%, var(--line)); }
+.session-detail-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.8rem; margin-top: 0.8rem; }
+.session-detail-panel { padding: 0.9rem 1rem; min-width: 0; }
+.session-detail-panel--approvals,
+.session-detail-panel--logs { grid-column: 1 / -1; }
+.session-detail-panel-heading { padding-bottom: 0.65rem; margin-bottom: 0.35rem; border-bottom: 1px solid var(--line); }
+.session-detail-panel-heading h3 { margin: 0; color: var(--ink-900); font-family: var(--font-heading); font-size: var(--step-0); }
+.session-detail-panel-heading p { margin: 0.18rem 0 0; color: var(--ink-500); font-size: calc(var(--step--1) - 1px); }
+.session-detail-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 0.75rem; padding: 0.65rem 0; border-bottom: 1px solid var(--line); }
+.session-detail-row:last-child { border-bottom: 0; }
+.session-detail-row > div:first-child { min-width: 0; }
+.session-detail-row strong { display: block; color: var(--ink-900); font-size: var(--step--1); overflow-wrap: anywhere; }
+.session-detail-row span { display: block; margin-top: 0.12rem; color: var(--ink-500); font-size: calc(var(--step--1) - 1px); }
+.session-activation-form { display: grid; grid-template-columns: minmax(120px, 0.7fr) minmax(180px, 1.3fr) auto; gap: 0.55rem; align-items: end; padding-top: 0.8rem; }
+.session-activation-form label { display: flex; flex-direction: column; gap: 0.25rem; color: var(--ink-700); font-size: calc(var(--step--1) - 1px); }
+.session-activation-form select,
+.session-activation-form input {
+  min-width: 0;
+  padding: 0.45rem 0.55rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  color: var(--ink-900);
+  font: inherit;
+}
+.session-approval { padding: 0.2rem 0; border-bottom: 1px solid var(--line); }
+.session-approval:last-child { border-bottom: 0; }
+.session-approval > p { margin: 0.25rem 0 0.45rem; color: var(--ink-700); font-size: var(--step--1); }
+.session-approval summary { cursor: pointer; color: var(--signal); font-size: var(--step--1); }
+.session-approval pre {
+  max-height: 220px;
+  overflow: auto;
+  padding: 0.65rem;
+  border-radius: var(--radius-sm);
+  background: var(--surface-1);
+  color: var(--ink-700);
+  font-size: calc(var(--step--1) - 2px);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.session-execution-output { margin-top: 0.65rem; padding: 0.65rem; border-radius: var(--radius-sm); background: var(--surface-1); }
+.session-execution-output h4 { margin: 0 0 0.45rem; color: var(--ink-900); }
+.session-execution-output div { margin-top: 0.35rem; }
+.session-execution-output span { display: block; color: var(--ink-500); font-size: calc(var(--step--1) - 1px); }
+.session-stat-grid,
+.session-metric-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.5rem; }
+.session-stat-grid > div,
+.session-metric-grid > div { padding: 0.55rem 0.65rem; border-radius: var(--radius-sm); background: var(--surface-1); }
+.session-stat-grid span,
+.session-metric-grid span { display: block; color: var(--ink-500); font-size: calc(var(--step--1) - 2px); overflow-wrap: anywhere; }
+.session-stat-grid strong,
+.session-metric-grid strong { display: block; margin-top: 0.15rem; color: var(--ink-900); font-family: var(--font-mono); font-size: var(--step--1); }
+.session-log-list { max-height: 360px; overflow: auto; }
+.session-log-row { display: grid; grid-template-columns: 90px minmax(140px, 0.7fr) minmax(0, 1.3fr); gap: 0.65rem; padding: 0.45rem 0; border-bottom: 1px solid var(--line); font-size: calc(var(--step--1) - 1px); }
+.session-log-row:last-child { border-bottom: 0; }
+.session-log-row time { color: var(--ink-500); font-family: var(--font-mono); }
+.session-log-row strong { color: var(--ink-900); overflow-wrap: anywhere; }
+.session-log-row span { color: var(--ink-700); overflow-wrap: anywhere; }
+.session-log-row--error strong { color: #dc2626; }
+
+@media (max-width: 760px) {
+  .session-card { align-items: flex-start; flex-wrap: wrap; }
+  .session-main { flex-basis: calc(100% - 3rem); }
+  .session-badges,
+  .session-actions { margin-left: 2.15rem; }
+  .session-command-inline { margin-left: 2.15rem; max-width: none; text-align: left; }
+  .session-detail-grid { grid-template-columns: 1fr; }
+  .session-detail-panel--approvals,
+  .session-detail-panel--logs { grid-column: auto; }
+  .session-detail-heading { flex-direction: column; }
+  .session-detail-actions { justify-content: flex-start; }
+  .session-activation-form { grid-template-columns: 1fr; }
+  .session-log-row { grid-template-columns: 76px minmax(0, 1fr); }
+  .session-log-row span { grid-column: 1 / -1; }
+}
 
 /* ── Confirm dialog ─────────────────────────────────────────────────────── */
 .confirm-modal { position: fixed; inset: 0; z-index: 130; display: flex; align-items: center; justify-content: center; }
@@ -541,7 +690,7 @@
 .ua-panel-note { color: var(--ink-500); font-size: var(--step--1); margin: 0 0 0.7rem; line-height: 1.45; }
 .ua-kv { display: flex; gap: 0.8rem; padding: 0.28rem 0; font-size: var(--step--1); }
 .ua-kv-k { color: var(--ink-500); min-width: 130px; flex-shrink: 0; }
-.ua-kv-v { color: var(--ink-900); word-break: break-word; display: flex; flex-wrap: wrap; gap: 0.3rem; }
+.ua-kv-v { color: var(--ink-900); overflow-wrap: anywhere; display: flex; flex-wrap: wrap; gap: 0.3rem; }
 
 .ua-roles-grid { display: flex; flex-direction: column; gap: 0.5rem; }
 .ua-role-opt { display: grid; grid-template-columns: auto 1fr; align-items: center; gap: 0.5rem 0.6rem; cursor: pointer; }

--- a/src/web-console/ui/polling.js
+++ b/src/web-console/ui/polling.js
@@ -52,6 +52,21 @@ export function createVisiblePoller(task, { intervalMs = 5_000, onError = () => 
   });
 }
 
+/**
+ * @typedef {{ status: string, error_code?: string | null }} PollStatus
+ * @typedef {{
+ *   signal?: AbortSignal,
+ *   intervalMs?: number,
+ *   timeoutMs?: number,
+ *   onUpdate?: (status: PollStatus) => void,
+ * }} PollUntilTerminalOptions
+ */
+
+/**
+ * @param {(signal?: AbortSignal) => Promise<PollStatus>} readStatus
+ * @param {PollUntilTerminalOptions} [options]
+ * @returns {Promise<{ timedOut: boolean, status: PollStatus | null }>}
+ */
 export async function pollUntilTerminal(
   readStatus,
   { signal, intervalMs = 500, timeoutMs = 10_000, onUpdate = () => {} } = {},

--- a/src/web-console/ui/polling.js
+++ b/src/web-console/ui/polling.js
@@ -63,7 +63,7 @@ export function createVisiblePoller(task, { intervalMs = 5_000, onError = () => 
  */
 
 /**
- * @param {(signal?: AbortSignal) => Promise<PollStatus>} readStatus
+ * @param {(signal?: AbortSignal) => Promise<unknown>} readStatus
  * @param {PollUntilTerminalOptions} [options]
  * @returns {Promise<{ timedOut: boolean, status: PollStatus | null }>}
  */
@@ -72,17 +72,33 @@ export async function pollUntilTerminal(
   { signal, intervalMs = 500, timeoutMs = 10_000, onUpdate = () => {} } = {},
 ) {
   const deadline = Date.now() + timeoutMs;
+  /** @type {PollStatus | null} */
   let latest = null;
   while (Date.now() < deadline) {
     if (signal?.aborted) throw abortError();
-    latest = await readStatus(signal);
+    const status = await readStatus(signal);
+    if (!isPollStatus(status)) {
+      throw new TypeError('Polling status response must include a non-empty status.');
+    }
+    latest = status;
     onUpdate(latest);
-    if (latest?.status && latest.status !== 'pending') {
+    if (latest.status !== 'pending') {
       return { timedOut: false, status: latest };
     }
     await abortableDelay(intervalMs, signal);
   }
   return { timedOut: true, status: latest };
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is PollStatus}
+ */
+function isPollStatus(value) {
+  return value !== null &&
+    typeof value === 'object' &&
+    typeof value.status === 'string' &&
+    value.status.length > 0;
 }
 
 function abortableDelay(ms, signal) {

--- a/src/web-console/ui/polling.js
+++ b/src/web-console/ui/polling.js
@@ -1,0 +1,93 @@
+/** Small polling primitives shared by session surfaces. */
+
+export function isAbortError(error) {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+export function createVisiblePoller(task, { intervalMs = 5_000, onError = () => {} } = {}) {
+  let active = false;
+  let timer;
+  let controller;
+  let running = false;
+
+  const schedule = () => {
+    if (!active) return;
+    timer = globalThis.setTimeout(run, intervalMs);
+  };
+
+  const run = async () => {
+    if (!active || running) return;
+    running = true;
+    controller = new AbortController();
+    try {
+      await task(controller.signal);
+    } catch (error) {
+      if (!isAbortError(error)) onError(error);
+    } finally {
+      controller = undefined;
+      running = false;
+      schedule();
+    }
+  };
+
+  return Object.freeze({
+    start({ immediate = true } = {}) {
+      if (active) return;
+      active = true;
+      if (immediate) run().catch(onError);
+      else schedule();
+    },
+    stop() {
+      active = false;
+      if (timer !== undefined) globalThis.clearTimeout(timer);
+      timer = undefined;
+      controller?.abort();
+    },
+    refresh() {
+      if (!active) return;
+      if (timer !== undefined) globalThis.clearTimeout(timer);
+      timer = undefined;
+      run().catch(onError);
+    },
+  });
+}
+
+export async function pollUntilTerminal(
+  readStatus,
+  { signal, intervalMs = 500, timeoutMs = 10_000, onUpdate = () => {} } = {},
+) {
+  const deadline = Date.now() + timeoutMs;
+  let latest = null;
+  while (Date.now() < deadline) {
+    if (signal?.aborted) throw abortError();
+    latest = await readStatus(signal);
+    onUpdate(latest);
+    if (latest?.status && latest.status !== 'pending') {
+      return { timedOut: false, status: latest };
+    }
+    await abortableDelay(intervalMs, signal);
+  }
+  return { timedOut: true, status: latest };
+}
+
+function abortableDelay(ms, signal) {
+  if (signal?.aborted) return Promise.reject(abortError());
+  return new Promise((resolve, reject) => {
+    const timer = globalThis.setTimeout(done, ms);
+    function done() {
+      signal?.removeEventListener('abort', aborted);
+      resolve();
+    }
+    function aborted() {
+      globalThis.clearTimeout(timer);
+      reject(abortError());
+    }
+    signal?.addEventListener('abort', aborted, { once: true });
+  });
+}
+
+function abortError() {
+  const error = new Error('Polling aborted.');
+  error.name = 'AbortError';
+  return error;
+}

--- a/src/web-console/ui/session-detail.js
+++ b/src/web-console/ui/session-detail.js
@@ -1,0 +1,643 @@
+/** Owned MCP session detail, HITL decisions, activations, and telemetry snapshots. */
+
+import { get, post, del } from './api.js';
+import { createVisiblePoller, isAbortError } from './polling.js';
+
+const POLL_INTERVAL_MS = 4_000;
+const ACTIVATABLE_TYPES = ['personas', 'skills', 'agents', 'memories', 'ensembles'];
+
+export async function createSessionDetail(host, sessionId, ctx) {
+  const encodedSessionId = encodeURIComponent(sessionId);
+  const basePath = `/me/sessions/${encodedSessionId}`;
+  const routes = routeAvailability(ctx.hasRoute);
+  const state = createState(routes);
+  const actionControllers = new Set();
+  let destroyed = false;
+  let visible = true;
+
+  host.innerHTML = detailShell(routes);
+  host.addEventListener('click', onClick);
+  host.addEventListener('submit', onSubmit);
+
+  const poller = createVisiblePoller(refreshLiveSnapshots, {
+    intervalMs: POLL_INTERVAL_MS,
+    onError: markStale,
+  });
+
+  await loadInitial();
+  if (!destroyed && visible && !state.expired) poller.start({ immediate: false });
+
+  return Object.freeze({
+    destroy,
+    setVisible(nextVisible) {
+      visible = nextVisible;
+      if (!visible || state.expired) poller.stop();
+      else poller.start();
+    },
+    setCommandStatus(command) {
+      state.command = command;
+      renderHeader();
+      if (command?.phase === 'acknowledged' && command.status !== 'failed') markExpired();
+    },
+  });
+
+  async function loadInitial() {
+    renderHeader();
+    const activeController = trackController();
+    try {
+      const sessionResponse = await get(basePath, { signal: activeController.signal });
+      if (!acceptSessionResponse(sessionResponse)) return;
+      await Promise.all([
+        loadActivations(activeController.signal),
+        loadApprovals(activeController.signal),
+        loadExecutions(activeController.signal),
+        loadGatekeeper(activeController.signal),
+        loadLogs(activeController.signal),
+        loadMetrics(activeController.signal),
+      ]);
+      markFresh();
+    } catch (error) {
+      if (!isAbortError(error)) showDetailError();
+    } finally {
+      releaseController(activeController);
+    }
+  }
+
+  async function refreshLiveSnapshots(signal) {
+    const sessionResponse = await get(basePath, { signal });
+    if (!acceptSessionResponse(sessionResponse)) return;
+    await Promise.all([
+      loadApprovals(signal),
+      loadExecutions(signal),
+      loadGatekeeper(signal),
+      loadLogs(signal),
+      loadMetrics(signal),
+    ]);
+    markFresh();
+  }
+
+  function acceptSessionResponse(response) {
+    if (response.status === 404) {
+      markExpired();
+      return false;
+    }
+    if (response.status !== 200 || !response.body) {
+      showDetailError();
+      return false;
+    }
+    state.session = response.body;
+    state.loading = false;
+    state.error = false;
+    renderHeader();
+    return true;
+  }
+
+  async function loadActivations(signal) {
+    await loadCollection('activations', `${basePath}/activations`, 'activations', signal);
+  }
+
+  async function loadApprovals(signal) {
+    await loadCollection('approvals', `${basePath}/approvals`, 'approvals', signal);
+  }
+
+  async function loadExecutions(signal) {
+    await loadCollection('executions', `${basePath}/executions`, 'executions', signal);
+  }
+
+  async function loadGatekeeper(signal) {
+    await loadObject('gatekeeper', `${basePath}/gatekeeper`, signal);
+  }
+
+  async function loadLogs(signal) {
+    await loadCollection('logs', `${basePath}/logs?limit=20`, 'items', signal);
+  }
+
+  async function loadMetrics(signal) {
+    await loadCollection('metrics', `${basePath}/metrics`, 'metrics', signal);
+  }
+
+  async function loadCollection(key, path, bodyKey, signal) {
+    const resource = state.resources[key];
+    if (!resource.available) return;
+    await loadResource(resource, path, signal, body => Array.isArray(body?.[bodyKey]) ? body[bodyKey] : []);
+    renderResource(key);
+  }
+
+  async function loadObject(key, path, signal) {
+    const resource = state.resources[key];
+    if (!resource.available) return;
+    await loadResource(resource, path, signal, body => body || null);
+    renderResource(key);
+  }
+
+  async function loadResource(resource, path, signal, project) {
+    try {
+      const response = await get(path, { signal });
+      if (response.status === 404) {
+        markExpired();
+        return;
+      }
+      if (response.status !== 200) {
+        resource.status = 'error';
+        return;
+      }
+      resource.data = project(response.body);
+      resource.status = 'ready';
+    } catch (error) {
+      if (isAbortError(error)) throw error;
+      resource.status = 'error';
+    }
+  }
+
+  async function onClick(event) {
+    const button = event.target.closest('button');
+    if (!button || !host.contains(button)) return;
+    if (button.matches('[data-session-back]')) {
+      ctx.onBack();
+      return;
+    }
+    if (button.matches('[data-detail-refresh]')) {
+      poller.refresh();
+      return;
+    }
+    if (button.matches('[data-session-disconnect]')) {
+      await ctx.onDisconnect(sessionId);
+      return;
+    }
+    if (button.dataset.approvalId && button.dataset.approvalAction) {
+      await decideApproval(button.dataset.approvalId, button.dataset.approvalAction, button.dataset.approvalScope);
+      return;
+    }
+    if (button.dataset.deactivateType && button.dataset.deactivateName) {
+      await deactivate(button.dataset.deactivateType, button.dataset.deactivateName);
+      return;
+    }
+    if (button.dataset.executionId) await loadExecutionDetail(button.dataset.executionId);
+  }
+
+  async function onSubmit(event) {
+    if (!event.target.matches('#session-activation-form')) return;
+    event.preventDefault();
+    const data = new FormData(event.target);
+    const type = data.get('type');
+    const name = data.get('name');
+    await activate(
+      typeof type === 'string' ? type : '',
+      typeof name === 'string' ? name : '',
+    );
+  }
+
+  async function activate(type, name) {
+    const trimmedName = name.trim();
+    if (!ACTIVATABLE_TYPES.includes(type) || !trimmedName) {
+      ctx.toast('Choose an element type and enter its portfolio name.', 'warn');
+      return;
+    }
+    const response = await actionRequest(signal => post(`${basePath}/activations`, {
+      body: { type, name: trimmedName },
+      signal,
+    }));
+    if (!response) return;
+    if (response.status !== 200) {
+      ctx.toast(response.status === 404 ? 'That portfolio element or session is no longer available.' : 'Could not activate that element.', 'error');
+      return;
+    }
+    ctx.toast('Element activated for this session.', 'success');
+    host.querySelector('#session-activation-form')?.reset();
+    await refreshAfterAction(loadActivations);
+  }
+
+  async function deactivate(type, name) {
+    const confirmed = await ctx.confirm(`Deactivate ${name} for this session?`, 'Deactivate');
+    if (!confirmed) return;
+    const response = await actionRequest(signal => del(
+      `${basePath}/activations/${encodeURIComponent(type)}/${encodeURIComponent(name)}`,
+      { signal },
+    ));
+    if (!response) return;
+    if (response.status !== 200 && response.status !== 204) {
+      ctx.toast('Could not deactivate that element.', 'error');
+      return;
+    }
+    ctx.toast('Element deactivated.', 'success');
+    await refreshAfterAction(loadActivations);
+  }
+
+  async function decideApproval(approvalId, action, scope = 'once') {
+    if (action === 'deny') {
+      const confirmed = await ctx.confirm('Deny this request? The waiting operation will not run.', 'Deny request');
+      if (!confirmed) return;
+    }
+    if (action === 'approve' && scope === 'session') {
+      const confirmed = await ctx.confirm('Approve this tool for the rest of this session?', 'Approve for session');
+      if (!confirmed) return;
+    }
+    const verb = action === 'approve' ? 'approve' : 'deny';
+    const response = await actionRequest(signal => post(
+      `${basePath}/approvals/${encodeURIComponent(approvalId)}/${verb}`,
+      { body: action === 'approve' ? { scope } : {}, signal },
+    ));
+    if (!response) return;
+    if (response.status !== 200) {
+      ctx.toast('That approval could not be updated.', 'error');
+      return;
+    }
+    ctx.toast(action === 'approve' ? 'Approval recorded.' : 'Denial recorded.', 'success');
+    await refreshAfterAction(loadApprovals, loadGatekeeper);
+  }
+
+  async function loadExecutionDetail(goalId) {
+    if (!routes.executionDetail) return;
+    const output = host.querySelector('#session-execution-detail');
+    if (output) output.innerHTML = placeholder('Loading execution detail…');
+    const response = await actionRequest(signal => get(
+      `${basePath}/executions/${encodeURIComponent(goalId)}`,
+      { signal },
+    ));
+    if (!output || !response) return;
+    if (response.status !== 200) {
+      output.innerHTML = placeholder('Execution detail is no longer available.');
+      return;
+    }
+    output.innerHTML = executionDetailMarkup(response.body);
+  }
+
+  async function actionRequest(request) {
+    const controller = trackController();
+    try {
+      return await request(controller.signal);
+    } catch (error) {
+      if (!isAbortError(error)) ctx.toast('The request could not reach the server.', 'error');
+      return null;
+    } finally {
+      releaseController(controller);
+    }
+  }
+
+  async function refreshAfterAction(...loaders) {
+    const controller = trackController();
+    try {
+      await Promise.all(loaders.map(loader => loader(controller.signal)));
+    } catch (error) {
+      if (!isAbortError(error)) ctx.toast('The latest session snapshot could not be loaded.', 'warn');
+    } finally {
+      releaseController(controller);
+    }
+  }
+
+  function trackController() {
+    const controller = new AbortController();
+    actionControllers.add(controller);
+    return controller;
+  }
+
+  function releaseController(controller) {
+    actionControllers.delete(controller);
+  }
+
+  function markFresh() {
+    state.stale = false;
+    state.updatedAt = new Date();
+    renderStatus();
+  }
+
+  function markStale() {
+    if (destroyed || state.expired) return;
+    state.stale = true;
+    renderStatus();
+  }
+
+  function showDetailError() {
+    state.loading = false;
+    state.error = true;
+    renderHeader();
+  }
+
+  function markExpired() {
+    if (state.expired) return;
+    state.expired = true;
+    state.loading = false;
+    poller.stop();
+    renderHeader();
+    host.querySelector('#session-detail-panels')?.setAttribute('hidden', '');
+  }
+
+  function renderHeader() {
+    const header = host.querySelector('#session-detail-header');
+    if (!header) return;
+    if (state.loading) {
+      header.innerHTML = placeholder('Loading session detail…');
+      return;
+    }
+    if (state.expired) {
+      header.innerHTML = `<div class="session-detail-state" role="status">
+        <h2>Session unavailable</h2>
+        <p>This session ended, expired, or is not available to this account.</p>
+        ${commandMarkup(state.command)}
+        <button class="btn btn-ghost" data-session-back type="button">Back to sessions</button>
+      </div>`;
+      return;
+    }
+    if (state.error || !state.session) {
+      header.innerHTML = `<div class="session-detail-state" role="alert">
+        <h2>Could not load this session</h2>
+        <p>The server could not provide a current session snapshot.</p>
+        <button class="btn btn-ghost" data-detail-refresh type="button">Retry</button>
+      </div>`;
+      return;
+    }
+    const session = state.session;
+    const client = clientName(session);
+    header.innerHTML = `
+      <div class="session-detail-heading">
+        <div>
+          <p class="session-detail-eyebrow">Connected app</p>
+          <h2>${escapeHtml(client)}</h2>
+          <p>${escapeHtml(relAgo(session.created_at))} · ${Number(session.request_count || 0).toLocaleString()} requests · ${Number(session.error_count || 0).toLocaleString()} errors</p>
+          ${sidLine(session.session_id)}
+        </div>
+        <div class="session-detail-actions">
+          ${routes.disconnect ? '<button class="btn btn-ghost session-danger" data-session-disconnect type="button">Disconnect</button>' : ''}
+          <button class="btn btn-ghost" data-detail-refresh type="button">Refresh</button>
+        </div>
+      </div>
+      ${commandMarkup(state.command)}
+      <div id="session-detail-status" class="session-detail-refresh" aria-live="polite"></div>`;
+    renderStatus();
+  }
+
+  function renderStatus() {
+    const status = host.querySelector('#session-detail-status');
+    if (!status) return;
+    if (state.stale) {
+      status.textContent = 'Live refresh is temporarily unavailable. Showing the last successful snapshot.';
+      status.classList.add('session-detail-refresh--stale');
+      return;
+    }
+    status.classList.remove('session-detail-refresh--stale');
+    status.textContent = state.updatedAt ? `Snapshot refreshed ${relAgo(state.updatedAt.toISOString())}.` : 'Loading snapshots…';
+  }
+
+  function renderResource(key) {
+    const body = host.querySelector(`[data-session-resource="${key}"]`);
+    if (!body) return;
+    const resource = state.resources[key];
+    if (resource.status === 'loading') {
+      body.innerHTML = placeholder('Loading…');
+      return;
+    }
+    if (resource.status === 'error') {
+      body.innerHTML = placeholder('This snapshot could not be refreshed.');
+      return;
+    }
+    body.innerHTML = resourceMarkup(key, resource.data, routes);
+  }
+
+  function destroy() {
+    destroyed = true;
+    poller.stop();
+    actionControllers.forEach(controller => controller.abort());
+    actionControllers.clear();
+    host.removeEventListener('click', onClick);
+    host.removeEventListener('submit', onSubmit);
+  }
+}
+
+function routeAvailability(hasRoute = () => false) {
+  return Object.freeze({
+    disconnect: hasRoute('DELETE', '/me/sessions/:session_id'),
+    activations: hasRoute('GET', '/me/sessions/:session_id/activations'),
+    activate: hasRoute('POST', '/me/sessions/:session_id/activations'),
+    deactivate: hasRoute('DELETE', '/me/sessions/:session_id/activations/:type/:name'),
+    approvals: hasRoute('GET', '/me/sessions/:session_id/approvals'),
+    approve: hasRoute('POST', '/me/sessions/:session_id/approvals/:approval_id/approve'),
+    deny: hasRoute('POST', '/me/sessions/:session_id/approvals/:approval_id/deny'),
+    executions: hasRoute('GET', '/me/sessions/:session_id/executions'),
+    executionDetail: hasRoute('GET', '/me/sessions/:session_id/executions/:goal_id'),
+    gatekeeper: hasRoute('GET', '/me/sessions/:session_id/gatekeeper'),
+    logs: hasRoute('GET', '/me/sessions/:session_id/logs'),
+    metrics: hasRoute('GET', '/me/sessions/:session_id/metrics'),
+  });
+}
+
+function createState(routes) {
+  const resource = available => ({ available, status: available ? 'loading' : 'unavailable', data: null });
+  return {
+    loading: true,
+    error: false,
+    expired: false,
+    stale: false,
+    updatedAt: null,
+    session: null,
+    command: null,
+    resources: {
+      activations: resource(routes.activations),
+      approvals: resource(routes.approvals),
+      executions: resource(routes.executions),
+      gatekeeper: resource(routes.gatekeeper),
+      logs: resource(routes.logs),
+      metrics: resource(routes.metrics),
+    },
+  };
+}
+
+function detailShell(routes) {
+  const panels = [
+    ['approvals', 'Pending decisions', 'Review human-in-the-loop requests.'],
+    ['activations', 'Active elements', 'Elements attached to this MCP session.'],
+    ['executions', 'Executions', 'Current execution snapshots.'],
+    ['gatekeeper', 'Gatekeeper', 'Permission and confirmation snapshot.'],
+    ['logs', 'Session activity', 'Limited event snapshot; this is not a live stream.'],
+    ['metrics', 'Session metrics', 'Small counters and gauges from the latest snapshot.'],
+  ].filter(([key]) => routes[key]);
+  const panelMarkup = panels.map(([key, title, note]) => `
+    <section class="session-detail-panel session-detail-panel--${key}">
+      <div class="session-detail-panel-heading"><h3>${title}</h3><p>${note}</p></div>
+      <div data-session-resource="${key}">${placeholder('Loading…')}</div>
+    </section>`).join('');
+  return `
+    <div class="session-detail-shell">
+      <button class="session-detail-back" data-session-back type="button">&#8592; All sessions</button>
+      <section id="session-detail-header" class="session-detail-header">${placeholder('Loading session detail…')}</section>
+      <div id="session-detail-panels" class="session-detail-grid">
+        ${panelMarkup || placeholder('No session detail resources are available in this deployment.')}
+      </div>
+    </div>`;
+}
+
+function resourceMarkup(key, data, routes) {
+  if (key === 'activations') return activationsMarkup(data, routes);
+  if (key === 'approvals') return approvalsMarkup(data, routes);
+  if (key === 'executions') return executionsMarkup(data, routes);
+  if (key === 'gatekeeper') return gatekeeperMarkup(data);
+  if (key === 'logs') return logsMarkup(data);
+  return metricsMarkup(data);
+}
+
+function activationsMarkup(activations, routes) {
+  const items = Array.isArray(activations) ? activations : [];
+  const list = items.map(item => `
+    <div class="session-detail-row">
+      <div><strong>${escapeHtml(item.display_name || item.name)}</strong><span>${escapeHtml(item.type)} · activated ${escapeHtml(relAgo(item.activated_at))}</span></div>
+      ${routes.deactivate ? `<button class="btn btn-ghost session-danger" data-deactivate-type="${escapeHtml(item.type)}" data-deactivate-name="${escapeHtml(item.name)}" type="button">Deactivate</button>` : ''}
+    </div>`).join('') || empty('No elements are active for this session.');
+  const form = routes.activate ? `
+    <form id="session-activation-form" class="session-activation-form">
+      <label>Type<select name="type">${ACTIVATABLE_TYPES.map(type => `<option value="${type}">${type}</option>`).join('')}</select></label>
+      <label>Portfolio name<input name="name" required autocomplete="off" placeholder="element-name"></label>
+      <button class="btn btn-primary" type="submit">Activate</button>
+    </form>` : '';
+  return list + form;
+}
+
+function approvalsMarkup(approvals, routes) {
+  const items = Array.isArray(approvals) ? approvals : [];
+  if (items.length === 0) return empty('No approval requests for this session.');
+  return items.map(approval => {
+    const actions = approval.status === 'pending' ? approvalActions(approval, routes) : '';
+    return `<article class="session-approval session-approval--${escapeHtml(approval.status)}">
+      <div class="session-detail-row">
+        <div><strong>${escapeHtml(approval.tool_name)}</strong><span>${escapeHtml(approval.risk_level)} risk · score ${Number(approval.risk_score || 0)} · ${escapeHtml(approval.status)}</span></div>
+        ${actions}
+      </div>
+      <p>${escapeHtml(approval.reason || 'No reason supplied.')}</p>
+      <details><summary>Request details</summary><pre>${escapeHtml(prettyJson(approval.tool_input_detail || approval.tool_input_digest))}</pre></details>
+    </article>`;
+  }).join('');
+}
+
+function approvalActions(approval, routes) {
+  const id = escapeHtml(approval.approval_id);
+  const approve = routes.approve ? `
+    <button class="btn btn-primary" data-approval-id="${id}" data-approval-action="approve" data-approval-scope="once" type="button">Approve once</button>
+    <button class="btn btn-ghost" data-approval-id="${id}" data-approval-action="approve" data-approval-scope="session" type="button">Approve for session</button>` : '';
+  const deny = routes.deny ? `<button class="btn btn-ghost session-danger" data-approval-id="${id}" data-approval-action="deny" type="button">Deny</button>` : '';
+  return `<div class="session-detail-row-actions">${approve}${deny}</div>`;
+}
+
+function executionsMarkup(executions, routes) {
+  const items = Array.isArray(executions) ? executions : [];
+  const list = items.map(item => `
+    <div class="session-detail-row">
+      <div><strong>${escapeHtml(item.agent_name)}</strong><span>${escapeHtml(item.status)}${item.current_step ? ` · ${escapeHtml(item.current_step)}` : ''}</span></div>
+      ${routes.executionDetail ? `<button class="btn btn-ghost" data-execution-id="${escapeHtml(item.goal_id)}" type="button">Details</button>` : ''}
+    </div>`).join('') || empty('No executions have been recorded for this session.');
+  return `${list}<div id="session-execution-detail"></div>`;
+}
+
+function executionDetailMarkup(execution) {
+  const output = Array.isArray(execution?.output) ? execution.output : [];
+  return `<div class="session-execution-output">
+    <h4>${escapeHtml(execution?.agent_name || 'Execution detail')}</h4>
+    ${output.map(item => `<div><strong>${escapeHtml(item.kind)}</strong><span>${escapeHtml(item.message)} · ${escapeHtml(relAgo(item.occurred_at))}</span></div>`).join('') || empty('No execution output is available.')}
+  </div>`;
+}
+
+function gatekeeperMarkup(gatekeeper) {
+  if (!gatekeeper) return empty('No gatekeeper snapshot is available.');
+  const confirmations = Array.isArray(gatekeeper.confirmations) ? gatekeeper.confirmations : [];
+  const confirmationRows = confirmations.map(confirmationMarkup).join('');
+  return `<div class="session-stat-grid">
+      ${stat('Prompt active', gatekeeper.permission_prompt_active ? 'Yes' : 'No')}
+      ${stat('Pending', gatekeeper.pending_approval_count)}
+      ${stat('Confirmations', gatekeeper.confirmation_count)}
+      ${stat('Retained approvals', gatekeeper.retained_approval_count)}
+    </div>${confirmationRows}`;
+}
+
+function logsMarkup(logs) {
+  const items = Array.isArray(logs) ? logs : [];
+  if (items.length === 0) return empty('No session activity has been recorded.');
+  return `<div class="session-log-list">${items.map(logMarkup).join('')}</div>`;
+}
+
+function metricsMarkup(metrics) {
+  const items = Array.isArray(metrics) ? metrics : [];
+  if (items.length === 0) return empty('No session metrics have been recorded.');
+  return `<div class="session-metric-grid">${items.map(metricMarkup).join('')}</div>`;
+}
+
+function commandMarkup(command) {
+  if (!command) return '';
+  const acknowledged = acknowledgedCommandLabel(command);
+  const labels = {
+    accepted: 'Disconnect accepted by the server.',
+    pending: 'Waiting for the owning replica to acknowledge the disconnect.',
+    acknowledged,
+    timeout: 'Disconnect is still pending; acknowledgement polling timed out.',
+    unavailable: 'Disconnect accepted; command-status tracking is unavailable.',
+  };
+  return `<div class="session-command-status session-command-status--${escapeHtml(command.phase)}" role="status">${labels[command.phase] || 'Disconnect status updated.'}</div>`;
+}
+
+function confirmationMarkup(item) {
+  return `<div class="session-detail-row"><div><strong>${escapeHtml(item.operation)}</strong><span>${escapeHtml(item.scope)} · used ${Number(item.use_count || 0)} time(s)</span></div></div>`;
+}
+
+function logMarkup(item) {
+  return `<div class="session-log-row session-log-row--${escapeHtml(item.level)}">
+    <time>${escapeHtml(formatTime(item.ts))}</time>
+    <strong>${escapeHtml(item.event)}</strong>
+    <span>${escapeHtml(item.message || item.subsystem || '')}</span>
+  </div>`;
+}
+
+function metricMarkup(item) {
+  return `<div><span>${escapeHtml(item.name)}</span><strong>${Number(item.value || 0).toLocaleString()} ${escapeHtml(item.unit || '')}</strong></div>`;
+}
+
+function acknowledgedCommandLabel(command) {
+  if (command.status !== 'failed') return `Disconnect acknowledged: ${escapeHtml(command.status || 'completed')}.`;
+  const error = command.errorCode ? ` (${escapeHtml(command.errorCode)})` : '';
+  return `Disconnect failed${error}.`;
+}
+
+function stat(label, value) {
+  return `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(String(value ?? 0))}</strong></div>`;
+}
+
+function clientName(session) {
+  const name = session.client_info?.name || 'MCP client';
+  return session.client_info?.version ? `${name} ${session.client_info.version}` : name;
+}
+
+function sidLine(id) {
+  return `<code class="session-detail-id">${escapeHtml(id || '')}</code>`;
+}
+
+function placeholder(text) {
+  return `<div class="panel-placeholder">${escapeHtml(text)}</div>`;
+}
+
+function empty(text) {
+  return `<p class="session-empty">${escapeHtml(text)}</p>`;
+}
+
+function prettyJson(value) {
+  try { return JSON.stringify(value, null, 2); } catch { return '{}'; }
+}
+
+function formatTime(value) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 'unknown' : date.toLocaleTimeString();
+}
+
+function relAgo(value) {
+  if (!value) return 'unknown';
+  const age = Date.now() - new Date(value).getTime();
+  if (!Number.isFinite(age) || age < 60_000) return 'just now';
+  const minutes = Math.floor(age / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}

--- a/src/web-console/ui/session-detail.js
+++ b/src/web-console/ui/session-detail.js
@@ -68,6 +68,7 @@ export async function createSessionDetail(host, sessionId, ctx) {
     const sessionResponse = await get(basePath, { signal });
     if (!acceptSessionResponse(sessionResponse)) return;
     await Promise.all([
+      loadActivations(signal),
       loadApprovals(signal),
       loadExecutions(signal),
       loadGatekeeper(signal),
@@ -355,7 +356,7 @@ export async function createSessionDetail(host, sessionId, ctx) {
           <p class="session-detail-eyebrow">Connected app</p>
           <h2>${escapeHtml(client)}</h2>
           <p>${escapeHtml(relAgo(session.created_at))} · ${Number(session.request_count || 0).toLocaleString()} requests · ${Number(session.error_count || 0).toLocaleString()} errors</p>
-          ${sidLine(session.session_id)}
+          ${sessionIdCode(session.session_id)}
         </div>
         <div class="session-detail-actions">
           ${routes.disconnect ? '<button class="btn btn-ghost session-danger" data-session-disconnect type="button">Disconnect</button>' : ''}
@@ -602,7 +603,7 @@ function clientName(session) {
   return session.client_info?.version ? `${name} ${session.client_info.version}` : name;
 }
 
-function sidLine(id) {
+function sessionIdCode(id) {
   return `<code class="session-detail-id">${escapeHtml(id || '')}</code>`;
 }
 

--- a/src/web-console/ui/session-detail.js
+++ b/src/web-console/ui/session-detail.js
@@ -2,6 +2,7 @@
 
 import { get, post, del } from './api.js';
 import { createVisiblePoller, isAbortError } from './polling.js';
+import { escapeHtml, relAgo } from './ui-utils.js';
 
 const POLL_INTERVAL_MS = 4_000;
 const ACTIVATABLE_TYPES = ['personas', 'skills', 'agents', 'memories', 'ensembles'];
@@ -620,24 +621,4 @@ function prettyJson(value) {
 function formatTime(value) {
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? 'unknown' : date.toLocaleTimeString();
-}
-
-function relAgo(value) {
-  if (!value) return 'unknown';
-  const age = Date.now() - new Date(value).getTime();
-  if (!Number.isFinite(age) || age < 60_000) return 'just now';
-  const minutes = Math.floor(age / 60_000);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  return `${Math.floor(hours / 24)}d ago`;
-}
-
-function escapeHtml(value) {
-  return String(value ?? '')
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
 }

--- a/src/web-console/ui/sessions.js
+++ b/src/web-console/ui/sessions.js
@@ -11,52 +11,121 @@
  */
 
 import { get, post, del } from './api.js';
+import { noConsoleRoute } from './console-meta.js';
+import { createSessionDetail } from './session-detail.js';
+import { isAbortError, pollUntilTerminal } from './polling.js';
 
 let host;
 let notify = () => {};
 let viewLogs = null; // ctx.viewSessionLogs(logSessionId) — set by the shell
 let canViewLogs = false;
+let routeAvailable = noConsoleRoute;
+let tabVisible = true;
+let listController;
+let detailController;
+let detailSessionId = null;
+const commandControllers = new Map();
 const availableActions = {
   revokeConsole: false,
   revokeOtherConsoleSessions: false,
   disconnectMcp: false,
   disconnectAllMcp: false,
+  inspectMcp: false,
+  commandStatus: false,
 };
 
-const state = { console: [], mcp: [], loading: true, error: false };
+const state = {
+  console: [],
+  mcp: [],
+  loading: true,
+  error: false,
+  commands: new Map(),
+  bulkCommandSessions: new Set(),
+  bulkStatus: '',
+};
 
 export async function init(panelEl, ctx = {}) {
   host = panelEl;
   notify = ctx.toast || notify;
   viewLogs = ctx.viewSessionLogs || null;
+  routeAvailable = ctx.hasRoute || routeAvailable;
   canViewLogs = ctx.hasRoute?.('GET', '/me/logs') === true;
   availableActions.revokeConsole = ctx.hasRoute?.('DELETE', '/me/security/sessions/:session_id') === true;
   availableActions.revokeOtherConsoleSessions = ctx.hasRoute?.('POST', '/me/security/sessions/revoke-all-others') === true;
   availableActions.disconnectMcp = ctx.hasRoute?.('DELETE', '/me/sessions/:session_id') === true;
   availableActions.disconnectAllMcp = ctx.hasRoute?.('POST', '/me/sessions/revoke-all') === true;
+  availableActions.inspectMcp = ctx.hasRoute?.('GET', '/me/sessions/:session_id') === true;
+  availableActions.commandStatus = ctx.hasRoute?.('GET', '/me/sessions/commands/:command_id') === true;
+  showList();
+  await load();
+  globalThis.addEventListener('dh:tab-activated', onTabActivated);
+}
+
+function showList({ refresh = false } = {}) {
+  detailController?.destroy();
+  detailController = undefined;
+  detailSessionId = null;
   host.innerHTML = shell();
   host.querySelector('#sess-refresh').addEventListener('click', load);
   host.querySelector('#sess-revoke-others')?.addEventListener('click', signOutEverywhereElse);
-  await load();
-  // Re-fetch when the user returns to the tab (sessions drift over time).
-  globalThis.addEventListener('dh:tab-activated', (e) => { if (e.detail?.name === 'sessions') load(); });
+  renderBody();
+  if (refresh) load();
+}
+
+async function showDetail(sessionId) {
+  listController?.abort();
+  detailController?.destroy();
+  detailSessionId = sessionId;
+  detailController = await createSessionDetail(host, sessionId, {
+    toast: notify,
+    hasRoute: routeAvailable,
+    confirm: confirmDialog,
+    onBack: () => showList({ refresh: true }),
+    onDisconnect: disconnectMcp,
+  });
+  detailController.setVisible(tabVisible);
+}
+
+function onTabActivated(event) {
+  tabVisible = event.detail?.name === 'sessions';
+  detailController?.setVisible(tabVisible);
+  if (!tabVisible) {
+    listController?.abort();
+    abortCommandPolling();
+    return;
+  }
+  resumeCommandPolling();
+  if (!detailController) load();
 }
 
 /* ── Data ───────────────────────────────────────────────────────────────── */
 
 async function load() {
+  if (!tabVisible || detailController) return;
+  listController?.abort();
+  const controller = new AbortController();
+  listController = controller;
   state.loading = true;
   state.error = false;
   renderBody();
-  const [sec, mcp] = await Promise.all([
-    get('/me/security/sessions').catch(() => null),
-    get('/me/sessions').catch(() => null),
-  ]);
-  state.console = sec?.status === 200 && Array.isArray(sec.body?.sessions) ? sec.body?.sessions : [];
-  state.mcp = mcp?.status === 200 && Array.isArray(mcp.body?.sessions) ? mcp.body.sessions : [];
-  state.error = sec?.status !== 200;
-  state.loading = false;
-  renderBody();
+  try {
+    const [sec, mcp] = await Promise.all([
+      get('/me/security/sessions', { signal: controller.signal }),
+      get('/me/sessions', { signal: controller.signal }),
+    ]);
+    state.console = sec.status === 200 && Array.isArray(sec.body?.sessions) ? sec.body.sessions : [];
+    state.mcp = mcp.status === 200 && Array.isArray(mcp.body?.sessions) ? mcp.body.sessions : [];
+    state.error = sec.status !== 200 || mcp.status !== 200;
+    state.loading = false;
+    renderBody();
+  } catch (error) {
+    if (isAbortError(error)) return;
+    state.loading = false;
+    state.error = true;
+    renderBody();
+  } finally {
+    if (listController === controller) listController = undefined;
+  }
 }
 
 /* ── Markup ─────────────────────────────────────────────────────────────── */
@@ -71,6 +140,7 @@ function shell() {
       ${bulkAction ? `<button class="btn btn-ghost session-danger" id="sess-revoke-others" type="button">${bulkAction.label}</button>` : ''}
     </div>
   </div>
+  <div class="session-command-summary" id="sessions-command-summary" role="status" aria-live="polite">${escapeHtml(state.bulkStatus)}</div>
   <div id="sessions-body"></div>`;
 }
 
@@ -102,6 +172,8 @@ function bulkActionConfig() {
 }
 
 function renderBody() {
+  const summary = host.querySelector('#sessions-command-summary');
+  if (summary) summary.textContent = state.bulkStatus;
   const body = host.querySelector('#sessions-body');
   if (!body) return;
   if (state.loading) { body.innerHTML = '<div class="panel-placeholder">Loading sessions…</div>'; return; }
@@ -123,6 +195,8 @@ function renderBody() {
     b.addEventListener('click', () => revokeConsole(b.dataset.revokeConsole, b.dataset.current === '1')));
   body.querySelectorAll('[data-disconnect-mcp]').forEach(b =>
     b.addEventListener('click', () => disconnectMcp(b.dataset.disconnectMcp)));
+  body.querySelectorAll('[data-inspect-mcp]').forEach(b =>
+    b.addEventListener('click', () => showDetail(b.dataset.inspectMcp)));
   body.querySelectorAll('[data-logs-console]').forEach(b =>
     b.addEventListener('click', () => jumpToLogs('web-console:' + b.dataset.logsConsole)));
   body.querySelectorAll('[data-logs-mcp]').forEach(b =>
@@ -183,9 +257,11 @@ function mcpCard(s) {
       </div>
       <div class="session-badges">${recencyBadge(s.last_active_at)}</div>
       <div class="session-actions">
+        ${availableActions.inspectMcp ? `<button class="btn btn-primary" data-inspect-mcp="${escapeHtml(s.session_id)}" type="button">Inspect</button>` : ''}
         ${canViewLogs ? `<button class="btn btn-ghost session-link" data-logs-mcp="${escapeHtml(s.session_id)}" type="button">View logs</button>` : ''}
         ${availableActions.disconnectMcp ? `<button class="btn btn-ghost session-danger" data-disconnect-mcp="${escapeHtml(s.session_id)}" type="button">Disconnect</button>` : ''}
       </div>
+      ${sessionCommandMarkup(state.commands.get(s.session_id))}
     </div>`;
 }
 
@@ -232,8 +308,15 @@ async function disconnectMcp(sessionId) {
   if (!ok) return;
   const res = await del('/me/sessions/' + encodeURIComponent(sessionId)).catch(() => null);
   if (!res || (res.status !== 202 && res.status !== 200)) { notify('Could not disconnect that app.', 'error'); return; }
-  notify('Disconnect requested.', 'info');
-  setTimeout(load, 900); // termination is async (202 accepted)
+  const commandId = res.body?.command_id;
+  if (state.bulkCommandSessions.delete(sessionId)) updateBulkCommandStatus();
+  updateCommand(sessionId, { phase: 'accepted', status: 'accepted', commandId });
+  notify('Disconnect accepted.', 'info');
+  if (!commandId || !availableActions.commandStatus) {
+    updateCommand(sessionId, { phase: 'unavailable', status: 'accepted' });
+    return;
+  }
+  await trackTerminationCommand(sessionId, commandId);
 }
 
 async function signOutEverywhereElse() {
@@ -241,6 +324,8 @@ async function signOutEverywhereElse() {
   if (!bulkAction) return;
   const ok = await confirmDialog(bulkAction.prompt, bulkAction.confirmLabel);
   if (!ok) return;
+  state.bulkStatus = '';
+  state.bulkCommandSessions.clear();
   let consoleRevoked = 0;
   let appsDisconnected = 0;
   const [c, m] = await Promise.all([
@@ -254,7 +339,26 @@ async function signOutEverywhereElse() {
   if (c?.status === 200) consoleRevoked = Number(c.body?.revoked ?? 0);
   if (m && (m.status === 202 || m.status === 200)) appsDisconnected = Number(m.body?.requested ?? 0);
   notify(bulkActionResult(consoleRevoked, appsDisconnected), 'success');
-  setTimeout(load, 900);
+  const commands = Array.isArray(m?.body?.commands) ? m.body.commands : [];
+  if (commands.length > 0) {
+    commands.forEach(command => state.bulkCommandSessions.add(command.session_id));
+    commands.forEach(command => updateCommand(command.session_id, {
+      phase: 'accepted',
+      status: 'accepted',
+      commandId: command.command_id,
+    }));
+    if (availableActions.commandStatus) {
+      await Promise.all(commands.map(command => trackTerminationCommand(command.session_id, command.command_id)));
+    } else {
+      commands.forEach(command => updateCommand(command.session_id, {
+        phase: 'unavailable',
+        status: 'accepted',
+        commandId: command.command_id,
+      }));
+    }
+    updateBulkCommandStatus();
+  }
+  renderBody();
 }
 
 function bulkActionResult(consoleRevoked, appsDisconnected) {
@@ -263,6 +367,102 @@ function bulkActionResult(consoleRevoked, appsDisconnected) {
   }
   if (availableActions.revokeOtherConsoleSessions) return `Signed out ${consoleRevoked} other session(s).`;
   return `Disconnected ${appsDisconnected} app(s).`;
+}
+
+async function trackTerminationCommand(sessionId, commandId) {
+  if (!commandId) return;
+  commandControllers.get(sessionId)?.abort();
+  const controller = new AbortController();
+  commandControllers.set(sessionId, controller);
+  try {
+    const result = await pollUntilTerminal(
+      async signal => {
+        const response = await get(`/me/sessions/commands/${encodeURIComponent(commandId)}`, { signal });
+        if (response.status === 200) return response.body;
+        return { status: 'failed', error_code: response.problemCode || 'command_status_unavailable' };
+      },
+      {
+        signal: controller.signal,
+        onUpdate: status => updateCommand(sessionId, {
+          phase: 'pending',
+          status: status?.status || 'pending',
+          commandId,
+        }),
+      },
+    );
+    if (result.timedOut) {
+      updateCommand(sessionId, { phase: 'timeout', status: 'pending', commandId });
+      return;
+    }
+    updateCommand(sessionId, {
+      phase: 'acknowledged',
+      status: result.status?.status,
+      errorCode: result.status?.error_code,
+      commandId,
+    });
+    if (result.status?.status === 'failed') notify('The connected app could not be disconnected.', 'error');
+    else notify('Connected app disconnected.', 'success');
+  } catch (error) {
+    if (!isAbortError(error)) updateCommand(sessionId, {
+      phase: 'timeout',
+      status: 'pending',
+      commandId,
+    });
+  } finally {
+    if (commandControllers.get(sessionId) === controller) commandControllers.delete(sessionId);
+  }
+}
+
+function updateCommand(sessionId, command) {
+  state.commands.set(sessionId, command);
+  if (state.bulkCommandSessions.has(sessionId)) updateBulkCommandStatus();
+  if (detailSessionId === sessionId) detailController?.setCommandStatus(command);
+  else renderBody();
+}
+
+function updateBulkCommandStatus() {
+  const counts = { acknowledged: 0, failed: 0, pending: 0, unavailable: 0 };
+  state.bulkCommandSessions.forEach(sessionId => {
+    const command = state.commands.get(sessionId);
+    if (command?.phase === 'acknowledged') {
+      counts[command.status === 'failed' ? 'failed' : 'acknowledged'] += 1;
+    } else if (command?.phase === 'unavailable') {
+      counts.unavailable += 1;
+    } else {
+      counts.pending += 1;
+    }
+  });
+  const parts = [];
+  if (counts.acknowledged > 0) parts.push(`${counts.acknowledged} disconnect(s) acknowledged`);
+  if (counts.failed > 0) parts.push(`${counts.failed} failed`);
+  if (counts.pending > 0) parts.push(`${counts.pending} still pending`);
+  if (counts.unavailable > 0) parts.push(`${counts.unavailable} accepted without status tracking`);
+  state.bulkStatus = parts.length > 0 ? `${parts.join('; ')}.` : '';
+}
+
+function abortCommandPolling() {
+  commandControllers.forEach(controller => controller.abort());
+  commandControllers.clear();
+}
+
+function resumeCommandPolling() {
+  state.commands.forEach((command, sessionId) => {
+    const pending = command.phase === 'accepted' || command.phase === 'pending';
+    if (!pending || !command.commandId || commandControllers.has(sessionId)) return;
+    trackTerminationCommand(sessionId, command.commandId).catch(() => null);
+  });
+}
+
+function sessionCommandMarkup(command) {
+  if (!command) return '';
+  const labels = {
+    accepted: 'accepted',
+    pending: 'pending acknowledgement',
+    acknowledged: command.status === 'failed' ? 'disconnect failed' : command.status,
+    timeout: 'still pending',
+    unavailable: 'accepted; status unavailable',
+  };
+  return `<span class="session-command-inline session-command-inline--${escapeHtml(command.phase)}">${escapeHtml(labels[command.phase] || 'updated')}</span>`;
 }
 
 function jumpToLogs(logSessionId) {
@@ -275,6 +475,7 @@ function jumpToLogs(logSessionId) {
 function confirmDialog(message, confirmLabel) {
   return new Promise((resolve) => {
     document.getElementById('confirm-modal')?.remove();
+    const previousFocus = document.activeElement;
     const modal = document.createElement('div');
     modal.className = 'confirm-modal';
     modal.id = 'confirm-modal';
@@ -288,13 +489,33 @@ function confirmDialog(message, confirmLabel) {
         </div>
       </div>`;
     document.body.appendChild(modal);
-    const done = (val) => { modal.remove(); document.removeEventListener('keydown', onKey); resolve(val); };
-    const onKey = (e) => { if (e.key === 'Escape') done(false); };
+    const buttons = [...modal.querySelectorAll('button')];
+    const done = (val) => {
+      modal.remove();
+      document.removeEventListener('keydown', onKey);
+      if (previousFocus instanceof HTMLElement) previousFocus.focus();
+      resolve(val);
+    };
+    const onKey = (e) => {
+      if (e.key === 'Escape') done(false);
+      if (e.key !== 'Tab' || buttons.length === 0) return;
+      const current = buttons.indexOf(document.activeElement);
+      const next = focusTargetIndex(current, buttons.length, e.shiftKey);
+      e.preventDefault();
+      buttons[next].focus();
+    };
     modal.querySelector('.confirm-backdrop').addEventListener('click', () => done(false));
     modal.querySelector('[data-confirm="0"]').addEventListener('click', () => done(false));
     modal.querySelector('[data-confirm="1"]').addEventListener('click', () => done(true));
     document.addEventListener('keydown', onKey);
+    modal.querySelector('[data-confirm="1"]').focus();
   });
+}
+
+function focusTargetIndex(current, length, reverse) {
+  if (!reverse) return (current + 1) % length;
+  if (current <= 0) return length - 1;
+  return current - 1;
 }
 
 /* ── Helpers ────────────────────────────────────────────────────────────── */

--- a/src/web-console/ui/sessions.js
+++ b/src/web-console/ui/sessions.js
@@ -344,9 +344,12 @@ async function signOutEverywhereElse() {
       ? post('/me/sessions/revoke-all').catch(() => null)
       : null,
   ]);
-  if (c?.status === 200) consoleRevoked = Number(c.body?.revoked ?? 0);
-  if (m && (m.status === 202 || m.status === 200)) appsDisconnected = Number(m.body?.requested ?? 0);
-  notify(bulkActionResult(consoleRevoked, appsDisconnected), 'success');
+  const consoleFailed = availableActions.revokeOtherConsoleSessions && c?.status !== 200;
+  const appsFailed = availableActions.disconnectAllMcp && m?.status !== 202 && m?.status !== 200;
+  if (!consoleFailed) consoleRevoked = Number(c?.body?.revoked ?? 0);
+  if (!appsFailed) appsDisconnected = Number(m?.body?.requested ?? 0);
+  const outcome = bulkActionResult(consoleRevoked, appsDisconnected, consoleFailed, appsFailed);
+  notify(outcome.message, outcome.kind);
   const commands = Array.isArray(m?.body?.commands) ? m.body.commands : [];
   if (commands.length > 0) {
     commands.forEach(command => state.bulkCommandSessions.add(command.session_id));
@@ -369,12 +372,35 @@ async function signOutEverywhereElse() {
   renderBody();
 }
 
-function bulkActionResult(consoleRevoked, appsDisconnected) {
-  if (availableActions.revokeOtherConsoleSessions && availableActions.disconnectAllMcp) {
-    return `Signed out ${consoleRevoked} other session(s); disconnected ${appsDisconnected} app(s).`;
+function bulkActionResult(consoleRevoked, appsDisconnected, consoleFailed, appsFailed) {
+  if (consoleFailed && appsFailed) {
+    return {
+      message: 'Could not sign out other console sessions or disconnect connected apps.',
+      kind: 'error',
+    };
   }
-  if (availableActions.revokeOtherConsoleSessions) return `Signed out ${consoleRevoked} other session(s).`;
-  return `Disconnected ${appsDisconnected} app(s).`;
+  if (consoleFailed) {
+    const message = availableActions.disconnectAllMcp
+      ? `Could not sign out other console sessions; disconnected ${appsDisconnected} app(s).`
+      : 'Could not sign out other console sessions.';
+    return { message, kind: availableActions.disconnectAllMcp ? 'warn' : 'error' };
+  }
+  if (appsFailed) {
+    const message = availableActions.revokeOtherConsoleSessions
+      ? `Signed out ${consoleRevoked} other session(s); could not disconnect connected apps.`
+      : 'Could not disconnect connected apps.';
+    return { message, kind: availableActions.revokeOtherConsoleSessions ? 'warn' : 'error' };
+  }
+  if (availableActions.revokeOtherConsoleSessions && availableActions.disconnectAllMcp) {
+    return {
+      message: `Signed out ${consoleRevoked} other session(s); disconnected ${appsDisconnected} app(s).`,
+      kind: 'success',
+    };
+  }
+  if (availableActions.revokeOtherConsoleSessions) {
+    return { message: `Signed out ${consoleRevoked} other session(s).`, kind: 'success' };
+  }
+  return { message: `Disconnected ${appsDisconnected} app(s).`, kind: 'success' };
 }
 
 async function trackTerminationCommand(sessionId, commandId) {

--- a/src/web-console/ui/sessions.js
+++ b/src/web-console/ui/sessions.js
@@ -16,6 +16,9 @@ import { createSessionDetail } from './session-detail.js';
 import { isAbortError, pollUntilTerminal } from './polling.js';
 import { confirmDialog, escapeHtml, relAgo } from './ui-utils.js';
 
+// app.js memoizes each tab's load/init promise, so this module is mounted once
+// per page. Module-level state and the global listener intentionally share that
+// same page lifetime.
 let host;
 let notify = () => {};
 let viewLogs = null; // ctx.viewSessionLogs(logSessionId) — set by the shell
@@ -368,8 +371,9 @@ async function signOutEverywhereElse() {
       }));
     }
     updateBulkCommandStatus();
+  } else {
+    renderBody();
   }
-  renderBody();
 }
 
 function bulkActionResult(consoleRevoked, appsDisconnected, consoleFailed, appsFailed) {

--- a/src/web-console/ui/styles.css
+++ b/src/web-console/ui/styles.css
@@ -1924,7 +1924,7 @@ fieldset.topic-filters {
   font-size: 0.8rem;
   line-height: 1.55;
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: anywhere;
   background: color-mix(in srgb, var(--ink-900) 6%, var(--paper));
   border-radius: var(--radius-sm);
   padding: 0.55rem 0.75rem;

--- a/src/web-console/ui/ui-utils.js
+++ b/src/web-console/ui/ui-utils.js
@@ -39,8 +39,8 @@ export function confirmDialog(message, confirmLabel) {
     modal.id = 'confirm-modal';
     modal.innerHTML = `
       <div class="confirm-backdrop"></div>
-      <div class="confirm-card" role="dialog" aria-modal="true">
-        <p class="confirm-msg">${escapeHtml(message)}</p>
+      <div class="confirm-card" role="dialog" aria-modal="true" aria-labelledby="confirm-modal-message">
+        <p class="confirm-msg" id="confirm-modal-message">${escapeHtml(message)}</p>
         <div class="confirm-actions">
           <button class="btn btn-ghost" data-confirm="0" type="button">Cancel</button>
           <button class="btn btn-primary" data-confirm="1" type="button">${escapeHtml(confirmLabel)}</button>

--- a/tests/integration/web-console-e2e/harness/sessionUiMock.ts
+++ b/tests/integration/web-console-e2e/harness/sessionUiMock.ts
@@ -1,0 +1,248 @@
+import type { Page, Route } from '@playwright/test';
+
+export const SESSION_UI_ID = '11111111-1111-4111-8111-111111111111';
+const GOAL_ID = 'goal-session-ui';
+const APPROVE_APPROVAL_ID = 'cli-22222222-2222-4222-8222-222222222222';
+const DENY_APPROVAL_ID = 'cli-44444444-4444-4444-8444-444444444444';
+
+type CommandOutcome = 'terminated' | 'failed';
+
+export interface SessionUiMockState {
+  approvalReads: number;
+  commandReads: number;
+  detailUnavailable: boolean;
+}
+
+export async function installSessionUiMock(
+  page: Page,
+  options: { detailUnavailable?: boolean; commandOutcome?: CommandOutcome } = {},
+): Promise<SessionUiMockState> {
+  const state: SessionUiMockState = {
+    approvalReads: 0,
+    commandReads: 0,
+    detailUnavailable: options.detailUnavailable ?? false,
+  };
+  const approvalStatuses = new Map([
+    [APPROVE_APPROVAL_ID, 'pending'],
+    [DENY_APPROVAL_ID, 'pending'],
+  ]);
+  let activations = [activation('alpha-persona')];
+
+  await page.route('**/api/v1/me/sessions**', async route => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    const method = request.method();
+    const reply = responseFor(method, path, state, {
+      approvalStatuses,
+      activations,
+      commandOutcome: options.commandOutcome ?? 'terminated',
+      setApprovalStatus: (approvalId, value) => { approvalStatuses.set(approvalId, value); },
+      setActivations: value => { activations = value; },
+    });
+    await fulfill(route, reply.status, reply.body);
+  });
+  return state;
+}
+
+interface MutableMockData {
+  approvalStatuses: ReadonlyMap<string, string>;
+  activations: Array<Record<string, unknown>>;
+  commandOutcome: CommandOutcome;
+  setApprovalStatus(approvalId: string, value: string): void;
+  setActivations(value: Array<Record<string, unknown>>): void;
+}
+
+function responseFor(method: string, path: string, state: SessionUiMockState, data: MutableMockData) {
+  const base = `/api/v1/me/sessions/${SESSION_UI_ID}`;
+  if (state.detailUnavailable && path.startsWith(base)) return missing();
+  if (method === 'GET') return getResponse(path, base, state, data);
+  if (method === 'POST') return postResponse(path, base, data);
+  if (method === 'DELETE') return deleteResponse(path, base, data);
+  return missing();
+}
+
+function getResponse(path: string, base: string, state: SessionUiMockState, data: MutableMockData) {
+  if (path === '/api/v1/me/sessions') return ok({ sessions: [session()] });
+  if (path === base) return ok(session());
+  if (path === `${base}/activations`) return ok({ activations: data.activations });
+  if (path === `${base}/approvals`) {
+    state.approvalReads += 1;
+    return ok({ approvals: [
+      approval(APPROVE_APPROVAL_ID, data.approvalStatuses.get(APPROVE_APPROVAL_ID) ?? 'pending', 'install_collection_content'),
+      approval(DENY_APPROVAL_ID, data.approvalStatuses.get(DENY_APPROVAL_ID) ?? 'pending', 'delete_element'),
+    ] });
+  }
+  if (path === `${base}/executions`) return ok({ executions: [execution()] });
+  if (path === `${base}/executions/${GOAL_ID}`) return ok(executionDetail());
+  if (path === `${base}/gatekeeper`) return ok(gatekeeper());
+  if (path === `${base}/logs`) return ok({ items: [activity()] });
+  if (path === `${base}/metrics`) return ok({ checked_at: new Date().toISOString(), metrics: [metric()] });
+  if (path.includes('/commands/')) {
+    state.commandReads += 1;
+    return ok(commandStatus(state.commandReads > 1 ? data.commandOutcome : 'pending'));
+  }
+  return missing();
+}
+
+function postResponse(path: string, base: string, data: MutableMockData) {
+  if (path === '/api/v1/me/sessions/revoke-all') {
+    return {
+      status: 202,
+      body: {
+        requested: 1,
+        commands: [{
+          session_id: SESSION_UI_ID,
+          command_id: '33333333-3333-4333-8333-333333333333',
+          status: 'accepted',
+        }],
+      },
+    };
+  }
+  if (path === `${base}/activations`) {
+    const updated = [activation('beta-skill', 'skills')];
+    data.setActivations(updated);
+    return ok(updated[0]);
+  }
+  const approvalPath = `${base}/approvals/`;
+  if (path.startsWith(approvalPath)) {
+    const [approvalId, decision] = path.slice(approvalPath.length).split('/');
+    if (approvalId && decision === 'approve') {
+      data.setApprovalStatus(approvalId, 'approved');
+      return ok(approval(approvalId, 'approved', approvalToolName(approvalId)));
+    }
+    if (approvalId && decision === 'deny') {
+      data.setApprovalStatus(approvalId, 'denied');
+      return ok(approval(approvalId, 'denied', approvalToolName(approvalId)));
+    }
+  }
+  return missing();
+}
+
+function deleteResponse(path: string, base: string, data: MutableMockData) {
+  if (path === base) {
+    return { status: 202, body: { command_id: '33333333-3333-4333-8333-333333333333', status: 'accepted' } };
+  }
+  if (path.startsWith(`${base}/activations/`)) {
+    data.setActivations([]);
+    return ok({ deactivated: true });
+  }
+  return missing();
+}
+
+async function fulfill(route: Route, status: number, body: unknown): Promise<void> {
+  await route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
+}
+
+function ok(body: unknown) {
+  return { status: 200, body };
+}
+
+function missing() {
+  return { status: 404, body: { code: 'not_found', detail: 'Runtime session was not found.' } };
+}
+
+function session() {
+  const now = new Date().toISOString();
+  return {
+    session_id: SESSION_UI_ID,
+    transport: 'streamable-http',
+    client_info: { name: 'Claude Code', version: '1.2.3' },
+    created_at: now,
+    last_active_at: now,
+    request_count: 12,
+    error_count: 1,
+    status: 'active',
+  };
+}
+
+function activation(name: string, type = 'personas') {
+  return { type, name, display_name: name, activated_at: new Date().toISOString() };
+}
+
+function approval(approvalId: string, status: string, toolName: string) {
+  const now = new Date();
+  return {
+    approval_id: approvalId,
+    session_id: SESSION_UI_ID,
+    status,
+    tool_name: toolName,
+    tool_input_digest: { collection_path: 'library/skills/example' },
+    tool_input_detail: null,
+    risk_level: 'medium',
+    risk_score: 45,
+    irreversible: false,
+    reason: 'Installing portfolio content requires confirmation.',
+    policy_source: 'session_policy',
+    scope: 'once',
+    requested_at: now.toISOString(),
+    expires_at: new Date(now.getTime() + 300_000).toISOString(),
+    decided_at: status === 'pending' ? null : now.toISOString(),
+  };
+}
+
+function approvalToolName(approvalId: string) {
+  return approvalId === DENY_APPROVAL_ID ? 'delete_element' : 'install_collection_content';
+}
+
+function execution() {
+  const now = new Date().toISOString();
+  return {
+    goal_id: GOAL_ID,
+    session_id: SESSION_UI_ID,
+    agent_name: 'release-helper',
+    status: 'running',
+    progress: 50,
+    started_at: now,
+    updated_at: now,
+    completed_at: null,
+    current_step: 'Validate package',
+    stable_error_code: null,
+  };
+}
+
+function executionDetail() {
+  return {
+    ...execution(),
+    output: [{ kind: 'progress', message: 'Package validation started.', occurred_at: new Date().toISOString() }],
+  };
+}
+
+function gatekeeper() {
+  return {
+    session_id: SESSION_UI_ID,
+    permission_prompt_active: true,
+    confirmation_count: 1,
+    pending_approval_count: 1,
+    retained_approval_count: 0,
+    client: { name: 'Claude Code', version: '1.2.3' },
+    confirmations: [{ operation: 'read', element_type: 'skills', scope: 'session', confirmed_at: new Date().toISOString(), use_count: 2 }],
+    pending_approvals: [],
+  };
+}
+
+function activity() {
+  return {
+    ts: new Date().toISOString(),
+    session_id: SESSION_UI_ID,
+    level: 'info',
+    subsystem: 'runtime',
+    event: 'request.completed',
+    message: 'Request completed.',
+    correlation_id: null,
+    stable_error_code: null,
+  };
+}
+
+function metric() {
+  return { name: 'requests.total', kind: 'counter', value: 12, unit: 'requests', dimensions: {} };
+}
+
+function commandStatus(status: 'pending' | CommandOutcome) {
+  return {
+    command_id: '33333333-3333-4333-8333-333333333333',
+    status,
+    acknowledged_at: status === 'pending' ? null : new Date().toISOString(),
+    replica_id: status === 'terminated' ? 'replica-e2e' : null,
+    error_code: status === 'failed' ? 'session_disconnect_failed' : null,
+  };
+}

--- a/tests/integration/web-console-e2e/harness/sessionUiMock.ts
+++ b/tests/integration/web-console-e2e/harness/sessionUiMock.ts
@@ -15,7 +15,11 @@ export interface SessionUiMockState {
 
 export async function installSessionUiMock(
   page: Page,
-  options: { detailUnavailable?: boolean; commandOutcome?: CommandOutcome } = {},
+  options: {
+    detailUnavailable?: boolean;
+    commandOutcome?: CommandOutcome;
+    bulkRequestFails?: boolean;
+  } = {},
 ): Promise<SessionUiMockState> {
   const state: SessionUiMockState = {
     approvalReads: 0,
@@ -36,6 +40,7 @@ export async function installSessionUiMock(
       approvalStatuses,
       activations,
       commandOutcome: options.commandOutcome ?? 'terminated',
+      bulkRequestFails: options.bulkRequestFails ?? false,
       setApprovalStatus: (approvalId, value) => { approvalStatuses.set(approvalId, value); },
       setActivations: value => { activations = value; },
     });
@@ -48,6 +53,7 @@ interface MutableMockData {
   approvalStatuses: ReadonlyMap<string, string>;
   activations: Array<Record<string, unknown>>;
   commandOutcome: CommandOutcome;
+  bulkRequestFails: boolean;
   setApprovalStatus(approvalId: string, value: string): void;
   setActivations(value: Array<Record<string, unknown>>): void;
 }
@@ -86,6 +92,9 @@ function getResponse(path: string, base: string, state: SessionUiMockState, data
 
 function postResponse(path: string, base: string, data: MutableMockData) {
   if (path === '/api/v1/me/sessions/revoke-all') {
+    if (data.bulkRequestFails) {
+      return { status: 503, body: { code: 'service_unavailable' } };
+    }
     return {
       status: 202,
       body: {

--- a/tests/integration/web-console-e2e/harness/sessionUiMock.ts
+++ b/tests/integration/web-console-e2e/harness/sessionUiMock.ts
@@ -11,6 +11,7 @@ export interface SessionUiMockState {
   approvalReads: number;
   commandReads: number;
   detailUnavailable: boolean;
+  setActivations(names: readonly string[]): void;
 }
 
 export async function installSessionUiMock(
@@ -21,17 +22,17 @@ export async function installSessionUiMock(
     bulkRequestFails?: boolean;
   } = {},
 ): Promise<SessionUiMockState> {
+  let activations = [activation('alpha-persona')];
   const state: SessionUiMockState = {
     approvalReads: 0,
     commandReads: 0,
     detailUnavailable: options.detailUnavailable ?? false,
+    setActivations: names => { activations = names.map(name => activation(name)); },
   };
   const approvalStatuses = new Map([
     [APPROVE_APPROVAL_ID, 'pending'],
     [DENY_APPROVAL_ID, 'pending'],
   ]);
-  let activations = [activation('alpha-persona')];
-
   await page.route('**/api/v1/me/sessions**', async route => {
     const request = route.request();
     const path = new URL(request.url()).pathname;

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -160,6 +160,10 @@ test('owned session workspace handles HITL, snapshots, polling cleanup, and term
   await page.locator(CONFIRM_ACTION).click();
   await expect(page.locator('.session-detail-panel--activations')).toContainText('No elements are active for this session.');
 
+  mock.setActivations(['remote-persona']);
+  await page.locator('[data-detail-refresh]').click();
+  await expect(page.locator('.session-detail-panel--activations')).toContainText('remote-persona');
+
   await page.locator('[data-execution-id]').click();
   await expect(page.locator('#session-execution-detail')).toContainText('Package validation started.');
 

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -15,6 +15,7 @@ const MANIFEST_URL = '**/api/v1/me/manifest';
 const SESSIONS_TAB = '.console-tab[data-tab="sessions"]';
 const SESSION_DETAIL_HEADER = '#session-detail-header';
 const CONFIRM_ACTION = '[data-confirm="1"]';
+const BULK_SESSION_ACTION = '#sess-revoke-others';
 const AUTH_ME_URL = '**/api/v1/auth/me';
 const ADMIN_USER_SESSIONS_URL = '**/api/v1/admin/accounts/users/*/sessions';
 
@@ -121,7 +122,7 @@ test('console UI serves its asset graph and boots from server metadata', async (
   await page.locator(SESSIONS_TAB).click();
   await expect(page.locator('#sessions-body .session-card').first()).toBeVisible();
   await expect(page.locator('[data-revoke-console], [data-disconnect-mcp]')).toHaveCount(0);
-  await expect(page.locator('#sess-revoke-others')).toHaveText('Sign out other console sessions');
+  await expect(page.locator(BULK_SESSION_ACTION)).toHaveText('Sign out other console sessions');
 
   await page.locator('#site-account').click();
   await page.locator('#account-security').click();
@@ -203,11 +204,43 @@ test('bulk session termination reports command acknowledgement accurately', asyn
   await loginFromConsole(page);
   await page.locator(SESSIONS_TAB).click();
 
-  await page.locator('#sess-revoke-others').click();
+  await page.locator(BULK_SESSION_ACTION).click();
   await page.locator(CONFIRM_ACTION).click();
 
   await expect(page.locator('#sessions-command-summary')).toContainText('1 disconnect(s) acknowledged.');
   expect(mock.commandReads).toBeGreaterThanOrEqual(2);
+});
+
+test('bulk session termination reports partial failure without claiming full success', async ({ page }) => {
+  await installSessionUiMock(page, { bulkRequestFails: true });
+  await loginFromConsole(page);
+  await page.locator(SESSIONS_TAB).click();
+
+  await page.locator(BULK_SESSION_ACTION).click();
+  await page.locator(CONFIRM_ACTION).click();
+
+  await expect(page.locator('#toast-stack .toast--warn')).toContainText(
+    'could not disconnect connected apps',
+  );
+  await expect(page.locator('#sessions-command-summary')).toBeEmpty();
+});
+
+test('bulk session termination reports total failure as an error', async ({ page }) => {
+  await filterManifestRoutes(page, new Set([
+    'POST /api/v1/me/security/sessions/revoke-all-others',
+  ]));
+  await installSessionUiMock(page, { bulkRequestFails: true });
+  await loginFromConsole(page);
+  await page.locator(SESSIONS_TAB).click();
+
+  await expect(page.locator(BULK_SESSION_ACTION)).toHaveText('Disconnect all connected apps');
+  await page.locator(BULK_SESSION_ACTION).click();
+  await page.locator(CONFIRM_ACTION).click();
+
+  await expect(page.locator('#toast-stack .toast--error')).toContainText(
+    'Could not disconnect connected apps',
+  );
+  await expect(page.locator('#sessions-command-summary')).toBeEmpty();
 });
 
 test('session detail uses the same neutral state for missing or non-owned sessions', async ({ page }) => {

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -6,11 +6,14 @@ import { test, expect, type Page } from '@playwright/test';
 import { TOTP, Secret } from 'otpauth';
 
 import { SEED_PASSWORD } from '../harness/seed.js';
+import { installSessionUiMock } from '../harness/sessionUiMock.js';
 import { BASE_URL } from '../setup/provision.js';
 
 const USER = 'e2e_admin';
 const OPERATE = '/api/v1/admin/operate/health';
 const MANIFEST_URL = '**/api/v1/me/manifest';
+const SESSIONS_TAB = '.console-tab[data-tab="sessions"]';
+const SESSION_DETAIL_HEADER = '#session-detail-header';
 
 async function filterManifestRoutes(page: Page, unavailableRoutes: ReadonlySet<string>): Promise<void> {
   await page.route(MANIFEST_URL, async route => {
@@ -85,7 +88,7 @@ test('console UI serves its asset graph and boots from server metadata', async (
   await page.locator('#pf-grid').waitFor({ state: 'visible' });
 
   await expect(page.locator('.console-tab[data-tab="portfolio"]')).toBeVisible();
-  await expect(page.locator('.console-tab[data-tab="sessions"]')).toBeVisible();
+  await expect(page.locator(SESSIONS_TAB)).toBeVisible();
   await expect(page.locator('.console-tab[data-tab="permissions"]')).toHaveCount(0);
   await expect(page.locator('.console-tab[data-tab="setup"]')).toHaveCount(0);
   await expect(page.locator('#pf-source')).toBeHidden();
@@ -95,7 +98,7 @@ test('console UI serves its asset graph and boots from server metadata', async (
   expect([...loadedPaths]).toContain('/ui/portfolio.js');
   expect(assetFailures).toEqual([]);
 
-  await page.locator('.console-tab[data-tab="sessions"]').click();
+  await page.locator(SESSIONS_TAB).click();
   await expect(page.locator('#sessions-body .session-card').first()).toBeVisible();
   await expect(page.locator('[data-revoke-console], [data-disconnect-mcp]')).toHaveCount(0);
   await expect(page.locator('#sess-revoke-others')).toHaveText('Sign out other console sessions');
@@ -104,6 +107,98 @@ test('console UI serves its asset graph and boots from server metadata', async (
   await page.locator('#account-security').click();
   await expect(page.locator('#security-modal')).toBeVisible();
   await expect(page.locator('#sec-enroll')).toHaveCount(0);
+});
+
+test('owned session workspace handles HITL, snapshots, polling cleanup, and termination acknowledgement', async ({ page }) => {
+  const mock = await installSessionUiMock(page);
+  await loginFromConsole(page);
+  await page.locator(SESSIONS_TAB).click();
+
+  await page.locator('[data-inspect-mcp]').click();
+  await expect(page.locator(SESSION_DETAIL_HEADER)).toContainText('Claude Code 1.2.3');
+  await expect(page.locator('.session-detail-panel--approvals')).toContainText('install_collection_content');
+  await expect(page.locator('.session-detail-panel--logs')).toContainText('request.completed');
+  await expect(page.locator('.session-detail-panel--metrics')).toContainText('requests.total');
+
+  const approvals = page.locator('.session-approval');
+  const installApproval = approvals.filter({ hasText: 'install_collection_content' });
+  await installApproval.locator('[data-approval-action="approve"][data-approval-scope="once"]').click();
+  await expect(installApproval).toContainText('approved');
+
+  const deleteApproval = approvals.filter({ hasText: 'delete_element' });
+  await deleteApproval.locator('[data-approval-action="deny"]').click();
+  await page.locator('[data-confirm="1"]').click();
+  await expect(deleteApproval).toContainText('denied');
+
+  await page.locator('#session-activation-form select[name="type"]').selectOption('skills');
+  await page.locator('#session-activation-form input[name="name"]').fill('beta-skill');
+  await page.locator('#session-activation-form button[type="submit"]').click();
+  await expect(page.locator('.session-detail-panel--activations')).toContainText('beta-skill');
+
+  await page.locator('[data-deactivate-name="beta-skill"]').click();
+  await page.locator('[data-confirm="1"]').click();
+  await expect(page.locator('.session-detail-panel--activations')).toContainText('No elements are active for this session.');
+
+  await page.locator('[data-execution-id]').click();
+  await expect(page.locator('#session-execution-detail')).toContainText('Package validation started.');
+
+  await page.locator('.console-tab[data-tab="portfolio"]').click();
+  await page.waitForTimeout(100);
+  const readsWhileHidden = mock.approvalReads;
+  await page.waitForTimeout(4_500);
+  expect(mock.approvalReads, 'session polling stops while another tab is active').toBe(readsWhileHidden);
+
+  await page.locator(SESSIONS_TAB).click();
+  await expect(page.locator(SESSION_DETAIL_HEADER)).toContainText('Claude Code 1.2.3');
+  await page.locator('[data-session-disconnect]').click();
+  await page.locator('[data-confirm="1"]').click();
+  await expect(page.locator(SESSION_DETAIL_HEADER)).toContainText('Session unavailable');
+  expect(mock.commandReads).toBeGreaterThanOrEqual(2);
+});
+
+test('session termination keeps a failed acknowledgement visible', async ({ page }) => {
+  const mock = await installSessionUiMock(page, { commandOutcome: 'failed' });
+  await loginFromConsole(page);
+  await page.locator(SESSIONS_TAB).click();
+  await page.locator('[data-inspect-mcp]').click();
+
+  await page.locator('[data-session-disconnect]').click();
+  await page.locator('[data-confirm="1"]').click();
+
+  await expect(page.locator('.session-command-status')).toContainText('Waiting for the owning replica');
+  expect(mock.commandReads).toBe(1);
+  await page.locator('.console-tab[data-tab="portfolio"]').click();
+  const readsWhileHidden = mock.commandReads;
+  await page.waitForTimeout(1_000);
+  expect(mock.commandReads, 'termination polling stops while another tab is active').toBe(readsWhileHidden);
+
+  await page.locator(SESSIONS_TAB).click();
+  await expect(page.locator('.session-command-status')).toContainText('Disconnect failed (session_disconnect_failed).');
+  await expect(page.locator(SESSION_DETAIL_HEADER)).toContainText('Claude Code 1.2.3');
+  expect(mock.commandReads).toBeGreaterThanOrEqual(2);
+});
+
+test('bulk session termination reports command acknowledgement accurately', async ({ page }) => {
+  const mock = await installSessionUiMock(page);
+  await loginFromConsole(page);
+  await page.locator(SESSIONS_TAB).click();
+
+  await page.locator('#sess-revoke-others').click();
+  await page.locator('[data-confirm="1"]').click();
+
+  await expect(page.locator('#sessions-command-summary')).toContainText('1 disconnect(s) acknowledged.');
+  expect(mock.commandReads).toBeGreaterThanOrEqual(2);
+});
+
+test('session detail uses the same neutral state for missing or non-owned sessions', async ({ page }) => {
+  await installSessionUiMock(page, { detailUnavailable: true });
+  await loginFromConsole(page);
+  await page.locator(SESSIONS_TAB).click();
+  await page.locator('[data-inspect-mcp]').click();
+
+  await expect(page.locator(SESSION_DETAIL_HEADER)).toContainText('Session unavailable');
+  await expect(page.locator(SESSION_DETAIL_HEADER)).toContainText('ended, expired, or is not available to this account');
+  await expect(page.locator('#session-detail-panels')).toBeHidden();
 });
 
 test('console auth lifecycle: login -> enroll TOTP -> step-up -> step-down -> logout', async ({ page }) => {

--- a/tests/integration/web-console-e2e/specs/me-runtime-sessions.e2e-spec.ts
+++ b/tests/integration/web-console-e2e/specs/me-runtime-sessions.e2e-spec.ts
@@ -1,3 +1,4 @@
+import { seedRuntimeSession } from '../harness/seed.js';
 import { setupWorld, type World } from '../harness/world.js';
 
 let world: World;
@@ -21,6 +22,20 @@ describe('/me/sessions (MCP runtime sessions)', () => {
   it('terminating an unknown session is 404 (not 500)', async () => {
     const res = await world.clients.userA.delete(`/api/v1/me/sessions/${UNKNOWN}`);
     expect([404, 400]).toContain(res.status);
+  });
+
+  it('tracks an owned termination command without exposing it cross-user', async () => {
+    const sessionId = await seedRuntimeSession(world.userA);
+    const terminate = await world.clients.userA.delete(`/api/v1/me/sessions/${sessionId}`);
+    expect(terminate.status).toBe(202);
+    const commandId = (terminate.body as { command_id: string }).command_id;
+
+    const ownStatus = await world.clients.userA.get(`/api/v1/me/sessions/commands/${commandId}`);
+    expect(ownStatus.status).toBe(200);
+    expect(ownStatus.body).toMatchObject({ command_id: commandId, status: 'pending' });
+
+    const foreignStatus = await world.clients.userB.get(`/api/v1/me/sessions/commands/${commandId}`);
+    expect(foreignStatus.status).toBe(404);
   });
 });
 

--- a/tests/unit/web-console/ui/ConsolePolling.test.ts
+++ b/tests/unit/web-console/ui/ConsolePolling.test.ts
@@ -61,4 +61,13 @@ describe('web-console polling utilities', () => {
     })).rejects.toMatchObject({ name: 'AbortError' });
     expect(readStatus).toHaveBeenCalledTimes(1);
   });
+
+  it('rejects a malformed status response instead of silently timing out', async () => {
+    const readStatus = jest.fn(() => Promise.resolve({}));
+
+    await expect(pollUntilTerminal(readStatus)).rejects.toThrow(
+      'Polling status response must include a non-empty status.',
+    );
+    expect(readStatus).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/unit/web-console/ui/ConsolePolling.test.ts
+++ b/tests/unit/web-console/ui/ConsolePolling.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { pollUntilTerminal } from '../../../../src/web-console/ui/polling';
+
+describe('web-console polling utilities', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns immediately when the first status is terminal', async () => {
+    const readStatus = jest.fn(() => Promise.resolve({ status: 'terminated' }));
+
+    await expect(pollUntilTerminal(readStatus)).resolves.toEqual({
+      timedOut: false,
+      status: { status: 'terminated' },
+    });
+    expect(readStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues from pending to a terminal status', async () => {
+    jest.useFakeTimers();
+    const readStatus = jest.fn<() => Promise<{ status: string }>>()
+      .mockResolvedValueOnce({ status: 'pending' })
+      .mockResolvedValueOnce({ status: 'terminated' });
+
+    const result = pollUntilTerminal(readStatus, { intervalMs: 100, timeoutMs: 1_000 });
+    await jest.advanceTimersByTimeAsync(100);
+
+    await expect(result).resolves.toEqual({
+      timedOut: false,
+      status: { status: 'terminated' },
+    });
+    expect(readStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns the latest status when the timeout expires', async () => {
+    jest.useFakeTimers();
+    const readStatus = jest.fn(() => Promise.resolve({ status: 'pending' }));
+
+    const result = pollUntilTerminal(readStatus, { intervalMs: 100, timeoutMs: 250 });
+    await jest.advanceTimersByTimeAsync(300);
+
+    await expect(result).resolves.toEqual({
+      timedOut: true,
+      status: { status: 'pending' },
+    });
+    expect(readStatus).toHaveBeenCalledTimes(3);
+  });
+
+  it('rejects with AbortError when cancellation interrupts polling', async () => {
+    const controller = new AbortController();
+    const readStatus = jest.fn(() => {
+      controller.abort();
+      return Promise.resolve({ status: 'pending' });
+    });
+
+    await expect(pollUntilTerminal(readStatus, {
+      signal: controller.signal,
+      intervalMs: 100,
+      timeoutMs: 1_000,
+    })).rejects.toMatchObject({ name: 'AbortError' });
+    expect(readStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/web-console/ui/ConsoleUiUtils.test.ts
+++ b/tests/unit/web-console/ui/ConsoleUiUtils.test.ts
@@ -41,6 +41,10 @@ describe('web-console UI utilities', () => {
     opener.focus();
 
     const result = confirmDialog('<Disconnect & revoke?>', '"Disconnect"');
+    const dialog = document.querySelector('[role="dialog"]');
+    const labelId = dialog?.getAttribute('aria-labelledby');
+    expect(labelId).toBe('confirm-modal-message');
+    expect(document.getElementById(labelId ?? '')?.textContent).toBe('<Disconnect & revoke?>');
     expect(document.querySelector('.confirm-msg')?.textContent).toBe('<Disconnect & revoke?>');
     expect(document.querySelector('[data-confirm="1"]')?.textContent).toBe('"Disconnect"');
     expect(document.activeElement).toBe(document.querySelector('[data-confirm="1"]'));


### PR DESCRIPTION
## Summary

Adds a session workspace to the web console for inspecting and controlling authenticated MCP runtime sessions.

## What changed

- Adds session detail views for activations, Gatekeeper approvals, agent executions, logs, and metrics.
- Adds approval and denial actions, activation management, individual termination, and bulk termination controls.
- Tracks asynchronous disconnect commands through completion and reports failed or already-absent outcomes.
- Adds finite, visibility-aware, abortable polling for session data.
- Preserves neutral not-found behavior for missing or non-owned sessions.
- Improves confirmation-dialog keyboard focus and reuses that behavior across session controls.

## Test coverage

- Covers the owned-session workspace, approval decisions, activation changes, polling, and termination flows in browser tests.
- Covers failed and bulk termination outcomes.
- Covers neutral handling for missing and cross-user sessions.
- Extends authentication lifecycle coverage for step-down and elevation expiry.
- Extends shared UI utility unit coverage for confirmation-dialog focus behavior.

## Verification

- ESLint passed for the complete touched-file set.
- Local Sonar lint passed.
- TypeScript type-check passed.
- Focused UI/unit tests passed: 24/24.
- Source browser suite passed: 6/6.
- Manual headed-browser preview completed successfully.

## Scope

This change is limited to web-console UI assets and test coverage. It does not change production backend services, database schemas, migrations, dependencies, or lockfiles.