### PR TITLE
feat(web-console): add guided portfolio authoring and account settings

### DIFF
--- a/data/HASHES.json
+++ b/data/HASHES.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-30T14:14:20.349Z",
+  "generated": "2026-07-21T12:16:32.803Z",
   "files": {
     "README.md": "545d52950dd98a66149c9ed0e370adc42392e34d9f896980a70248f16f3605aa",
     "agents/code-reviewer.md": "211cf981038183fc792ab1fb7dddf341c1733d96390699d3ccd066a8c201cb6c",

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -842,7 +842,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     // deleting the associated UUID-keyed state rows.
     const lookupPath = isDb ? this.stripExtension(sanitizedPath) : sanitizedPath;
     const existing = isDb
-      ? await this.findByName(lookupPath).catch(() => {})
+      ? await this.findByName(lookupPath).catch(() => null)
       : await this.load(lookupPath).catch(() => null);
     const name = isDb
       ? existing?.metadata.name ?? sanitizedPath

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -3,7 +3,7 @@
  * Manages agent CRUD operations, metadata sanitization, and state persistence.
  */
 
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { Agent } from './Agent.js';
 import {
@@ -18,7 +18,7 @@ import {
   normalizeResilienceKeys,
   normalizeGoalKeys,
 } from './constants.js';
-import {
+import type {
   AgentMetadata,
   AgentState,
   ExecuteAgentResult,
@@ -26,9 +26,12 @@ import {
   AgentGoalParameter,
   AgentMetadataV2,
   AgentGoal,
-  DEFAULT_SAFETY_CONFIG,
   ExecutionContext,
   AutonomyDirective,
+  DangerZoneBlocker,
+} from './types.js';
+import {
+  DEFAULT_SAFETY_CONFIG
 } from './types.js';
 import { getGatheredData, type GatheredData } from './gatheredData.js';
 import { evaluateAutonomy } from './autonomyEvaluator.js';
@@ -43,7 +46,8 @@ import {
   createDangerZoneOperation,
   createExecutionContext,
 } from './safetyTierService.js';
-import { BaseElementManager, ElementManagerDeps } from '../base/BaseElementManager.js';
+import type { ElementManagerDeps } from '../base/BaseElementManager.js';
+import { BaseElementManager } from '../base/BaseElementManager.js';
 import { isWritableStorageLayer } from '../../storage/IStorageLayer.js';
 import { AGENT_STATE_MAX_YAML_SIZE, FileAgentStateStore } from '../../storage/FileAgentStateStore.js';
 import type { IAgentStateStore } from '../../storage/IAgentStateStore.js';
@@ -70,7 +74,7 @@ export interface AgentManagerDeps extends ElementManagerDeps {
   /** Issue #1948: Resolves any element manager by name (for element-agnostic activation). */
   elementManagerResolver?: (managerName: string) => ResolvedElementManager | null;
   /** Issue #1948: DangerZoneEnforcer for autonomy evaluation. */
-  dangerZoneEnforcer?: import('./types.js').DangerZoneBlocker;
+  dangerZoneEnforcer?: DangerZoneBlocker;
   /** Issue #1948: VerificationStore/ChallengeStore for danger zone verification codes. */
   verificationStore?: { set: (id: string, challenge: { code: string; expiresAt: number; reason: string }) => void };
 }
@@ -83,10 +87,10 @@ import { ContentValidator } from '../../security/contentValidator.js';
 import { InputNormalizer } from '../../security/InputNormalizer.js';
 import { SafeRegex } from '../../security/dosProtection.js';
 import { logger } from '../../utils/logger.js';
-import { TriggerValidationService } from '../../services/validation/TriggerValidationService.js';
-import { ValidationService } from '../../services/validation/ValidationService.js';
-import { SerializationService } from '../../services/SerializationService.js';
-import { MetadataService } from '../../services/MetadataService.js';
+import type { TriggerValidationService } from '../../services/validation/TriggerValidationService.js';
+import type { ValidationService } from '../../services/validation/ValidationService.js';
+import type { SerializationService } from '../../services/SerializationService.js';
+import type { MetadataService } from '../../services/MetadataService.js';
 import { ElementMessages } from '../../utils/elementMessages.js';
 import { ElementNotFoundError } from '../../utils/ErrorHandler.js';
 import { sanitizeGatekeeperPolicy } from '../../handlers/mcp-aql/policies/ElementPolicies.js';
@@ -126,20 +130,22 @@ interface ActivationResult {
   activationWarnings: Array<{ elementType: string; elementName: string; error: string }>;
 }
 
+type AgentStepOutcome = 'success' | 'failure' | 'partial';
+
 export class AgentManager extends BaseElementManager<Agent> {
   private readonly stateCache: Map<string, AgentState> = new Map();
   private readonly stateStore: IAgentStateStore;
   private readonly hydratedAgents = new WeakSet<Agent>();
-  private triggerValidationService: TriggerValidationService;
-  private validationService: ValidationService;
-  private serializationService: SerializationService;
-  private metadataService: MetadataService;
+  private readonly triggerValidationService: TriggerValidationService;
+  private readonly validationService: ValidationService;
+  private readonly serializationService: SerializationService;
+  private readonly metadataService: MetadataService;
   // Fallback for tests/callers that don't inject the registry
   private readonly _localActiveAgentNames: Set<string> = new Set();
 
   // Issue #1948: Instance-injected dependencies (replaces static resolvers)
   private _elementManagerResolver?: (managerName: string) => ResolvedElementManager | null;
-  private _dangerZoneEnforcer?: import('./types.js').DangerZoneBlocker;
+  private _dangerZoneEnforcer?: DangerZoneBlocker;
   private _verificationStore?: { set: (id: string, challenge: { code: string; expiresAt: number; reason: string }) => void };
   private static warnedDbModeOrphanedStateFiles = false;
 
@@ -213,7 +219,7 @@ export class AgentManager extends BaseElementManager<Agent> {
   }
 
   /** Issue #1948: Set DangerZoneEnforcer on this instance. */
-  setDangerZoneEnforcerInstance(enforcer: import('./types.js').DangerZoneBlocker): void {
+  setDangerZoneEnforcerInstance(enforcer: DangerZoneBlocker): void {
     this._dangerZoneEnforcer = enforcer;
   }
 
@@ -286,10 +292,10 @@ export class AgentManager extends BaseElementManager<Agent> {
 
       // Issue #613: Check metadata name uniqueness (not just filename)
       const existingAgents = await this.list();
-      const duplicate = existingAgents.find(a =>
+      const duplicateExists = existingAgents.some(a =>
         a.metadata.name.toLowerCase() === sanitizedInput.name.toLowerCase()
       );
-      if (duplicate) {
+      if (duplicateExists) {
         return {
           success: false,
           message: `Agent '${sanitizedInput.name}' already exists`
@@ -359,7 +365,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     if (!validationResult.isValid) {
       return AgentManager.createFailure(`Validation failed: ${validationResult.errors.join(', ')}`);
     }
-    if (validationResult.warnings && validationResult.warnings.length > 0) {
+    if (validationResult.warnings.length > 0) {
       logger.warn(`Agent creation warnings: ${validationResult.warnings.join(', ')}`);
     }
     return null;
@@ -395,9 +401,11 @@ export class AgentManager extends BaseElementManager<Agent> {
     agent.extensions = {
       ...agent.extensions,
       specializations: normalizedMetadata.specializations ?? agent.extensions?.specializations ?? [],
-      decisionFramework: normalizedMetadata.decisionFramework ?? agent.extensions?.decisionFramework,
+      decisionFramework: (normalizedMetadata as Record<string, unknown>).decisionFramework ??
+        (agent.extensions as Record<string, unknown>).decisionFramework,
       riskTolerance: normalizedMetadata.riskTolerance ?? agent.extensions?.riskTolerance,
-      learningEnabled: normalizedMetadata.learningEnabled ?? agent.extensions?.learningEnabled,
+      learningEnabled: (normalizedMetadata as Record<string, unknown>).learningEnabled ??
+        (agent.extensions as Record<string, unknown>).learningEnabled,
     };
     agent.instructions = sanitizedInput.instructions;
     agent.extensions.instructions = sanitizedInput.instructions;
@@ -496,12 +504,10 @@ export class AgentManager extends BaseElementManager<Agent> {
       );
 
       // Pass 2: slug match (handles dashes, underscores, casing differences)
-      if (!match) {
-        match = agents.find((a) => {
-          const slug = this.normalizeFilename(a.metadata.name);
-          return slug === searchSlug || slug === searchLower;
-        });
-      }
+      match ??= agents.find((a) => {
+        const slug = this.normalizeFilename(a.metadata.name);
+        return slug === searchSlug || slug === searchLower;
+      });
 
       if (match) {
         logger.warn(
@@ -544,7 +550,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     }
 
     // Log warnings if any
-    if (validationResult.warnings && validationResult.warnings.length > 0) {
+    if (validationResult.warnings.length > 0) {
       logger.warn(`Agent update warnings: ${validationResult.warnings.join(', ')}`);
     }
 
@@ -629,7 +635,7 @@ export class AgentManager extends BaseElementManager<Agent> {
   /**
    * Import an agent from serialized content.
    */
-  async importElement(data: string, format: 'json' | 'yaml' | 'markdown' = 'markdown'): Promise<Agent> {
+  importElement(data: string, format: 'json' | 'yaml' | 'markdown' = 'markdown'): Promise<Agent> {
     if (format === 'json') {
       const parsed = this.serializationService.parseJson(data, {
         source: 'AgentManager.importElement'
@@ -642,7 +648,7 @@ export class AgentManager extends BaseElementManager<Agent> {
         ...agent.extensions,
         instructions: parsed.instructions || ''
       };
-      return agent;
+      return Promise.resolve(agent);
     }
 
     // Use SerializationService for frontmatter parsing
@@ -653,11 +659,16 @@ export class AgentManager extends BaseElementManager<Agent> {
     });
 
     const agent = new Agent(result.data as AgentMetadata, this.metadataService);
+    const metadataInstructions = typeof result.data.instructions === 'string'
+      ? result.data.instructions
+      : undefined;
+    agent.instructions = metadataInstructions ?? result.content.trim();
+    agent.content = metadataInstructions ? result.content.trim() : '';
     agent.extensions = {
       ...agent.extensions,
-      instructions: result.content.trim()
+      instructions: agent.instructions
     };
-    return agent;
+    return Promise.resolve(agent);
   }
 
   /**
@@ -826,11 +837,23 @@ export class AgentManager extends BaseElementManager<Agent> {
       : this.normalizeAgentFilePath(filePath);
     // State-file name derives from the agent's logical name in DB mode, or
     // from the stripped filename in file mode.
-    const existing = await this.load(sanitizedPath).catch(() => null);
+    // DB callers may still supply the canonical filename used by the portfolio
+    // adapter. Resolve it by logical name so we can recover elements.id before
+    // deleting the associated UUID-keyed state rows.
+    const lookupPath = isDb ? this.stripExtension(sanitizedPath) : sanitizedPath;
+    const existing = isDb
+      ? await this.findByName(lookupPath).catch(() => {})
+      : await this.load(lookupPath).catch(() => null);
     const name = isDb
       ? existing?.metadata.name ?? sanitizedPath
       : this.stripExtension(sanitizedPath);
-    const agentElementId = isDb ? sanitizedPath : existing?.id ?? sanitizedPath;
+    // Agent.id is a logical runtime identifier, not necessarily elements.id.
+    // The DB storage index maps the resolved metadata name to the actual UUID
+    // path used by the elements and agent_states foreign-key columns.
+    const indexedElementId = isDb && existing
+      ? this.storageLayer.getPathByName(existing.metadata.name)
+      : undefined;
+    const agentElementId = indexedElementId ?? existing?.id ?? sanitizedPath;
     await super.delete(sanitizedPath);
 
     await this.stateStore.delete({ name, agentElementId });
@@ -1057,8 +1080,8 @@ export class AgentManager extends BaseElementManager<Agent> {
           author: agent.metadata.author,
           safetyTier: result.safetyTier,
           riskScore: safetyTierResult?.riskScore,
-          parameterKeys: Object.keys(parameters || {}),
-          goalCount: metadata.goal?.parameters?.length || 0,
+          parameterKeys: Object.keys(parameters),
+          goalCount: (metadata.goal as Partial<AgentGoalConfig>).parameters?.length ?? 0,
         }
       });
 
@@ -1076,7 +1099,8 @@ export class AgentManager extends BaseElementManager<Agent> {
     }
 
     const metadata = agent.metadata as AgentMetadataV2;
-    if (metadata.goal?.template) {
+    const goal = (metadata as Partial<AgentMetadataV2>).goal;
+    if (goal?.template) {
       return agent;
     }
     await this.convertLegacyAgentForExecution(agent, name, metadata);
@@ -1145,7 +1169,11 @@ export class AgentManager extends BaseElementManager<Agent> {
     if (!cyclePath) {
       return;
     }
-    const cycleStart = cyclePath.indexOf(cyclePath[cyclePath.length - 1]);
+    const cycleEnd = cyclePath.at(-1);
+    if (cycleEnd === undefined) {
+      return;
+    }
+    const cycleStart = cyclePath.indexOf(cycleEnd);
     const cycle = cyclePath.slice(cycleStart);
     throw new Error(AgentManager.formatCircularActivationError(cycle));
   }
@@ -1326,9 +1354,9 @@ export class AgentManager extends BaseElementManager<Agent> {
    */
   private validateParameterSecurity(parameters: Record<string, unknown>): void {
     // 1. Prototype pollution check — reject dangerous keys
-    const FORBIDDEN_KEYS = ['__proto__', 'constructor', 'prototype'];
+    const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
     for (const key of Object.keys(parameters)) {
-      if (FORBIDDEN_KEYS.includes(key)) {
+      if (FORBIDDEN_KEYS.has(key)) {
         SecurityMonitor.logSecurityEvent({
           type: 'TOKEN_VALIDATION_FAILURE',
           severity: 'HIGH',
@@ -1378,7 +1406,7 @@ export class AgentManager extends BaseElementManager<Agent> {
       operationName?: 'execute_agent' | 'continue_execution';
     } = {}
   ): void {
-    const paramDefs = goalConfig.parameters || [];
+    const paramDefs = (goalConfig as Partial<AgentGoalConfig>).parameters ?? [];
     this.assertRequiredParametersPresent(paramDefs, parameters, context);
     for (const [key, value] of Object.entries(parameters)) {
       this.validateProvidedParameter(key, value, paramDefs);
@@ -1422,10 +1450,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     }
 
     const actualType = typeof value;
-    if (
-      (paramDef.type === 'string' || paramDef.type === 'number' || paramDef.type === 'boolean') &&
-      paramDef.type !== actualType
-    ) {
+    if (paramDef.type !== actualType) {
       throw new Error(`Parameter '${key}' must be a ${paramDef.type}, got ${actualType}`);
     }
     this.warnForOversizedStringParameter(key, value, actualType);
@@ -1498,7 +1523,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     for (const [key, value] of Object.entries(parameters)) {
       // Escape key to prevent regex metacharacters from causing ReDoS (Issue #103)
       const escapedKey = SafeRegex.escape(key);
-      rendered = rendered.replace(new RegExp(`\\{${escapedKey}\\}`, 'g'), String(value));
+      rendered = rendered.replaceAll(new RegExp(String.raw`\{${escapedKey}\}`, 'g'), String(value));
     }
 
     // Cap rendered goal length to prevent oversized payloads
@@ -1520,7 +1545,7 @@ export class AgentManager extends BaseElementManager<Agent> {
    * @private
    */
   private detectUnmatchedPlaceholders(rendered: string): string[] {
-    const placeholderPattern = /\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g;
+    const placeholderPattern = /\{([a-zA-Z_]\w*)\}/g;
     const unmatched: string[] = [];
     let match: RegExpExecArray | null;
     while ((match = placeholderPattern.exec(rendered)) !== null) {
@@ -1534,7 +1559,7 @@ export class AgentManager extends BaseElementManager<Agent> {
    * Used by both the static pre-flight check and the runtime chain check.
    */
   private static formatCircularActivationError(cyclePath: string[]): string {
-    const agentName = cyclePath[cyclePath.length - 1];
+    const agentName = cyclePath.at(-1);
     return (
       `Circular agent activation detected (cycle of ${cyclePath.length - 1}): ` +
       `${cyclePath.join(' → ')}. ` +
@@ -1927,7 +1952,10 @@ export class AgentManager extends BaseElementManager<Agent> {
   ): Promise<number> {
     const agent = typeof agentOrName === 'string' ? null : agentOrName;
     const name = typeof agentOrName === 'string' ? agentOrName : nameOrState as string;
-    const state = typeof agentOrName === 'string' ? nameOrState as AgentState : maybeState!;
+    const state = typeof agentOrName === 'string' ? nameOrState as AgentState : maybeState;
+    if (!state) {
+      throw new Error('Agent state is required when saving state for an agent instance');
+    }
     return this.stateStore.save(
       { name, agentElementId: agent ? this.getAgentElementId(agent, name) : name },
       state,
@@ -1996,7 +2024,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     await defaultFileStore.warnIfOrphanedStateFiles();
   }
 
-  protected override async parseMetadata(data: any): Promise<AgentMetadata> {
+  protected override parseMetadata(data: any): Promise<AgentMetadata> {
     const metadata = { ...data };
     this.normalizeAndValidateMetadataHeader(metadata);
     this.validateMetadataTextFields(metadata);
@@ -2012,7 +2040,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     this.validateResilienceMetadata(metadata, agentName);
     this.validateTagsMetadata(metadata, agentName);
 
-    return metadata as AgentMetadata;
+    return Promise.resolve(metadata as AgentMetadata);
   }
 
   private normalizeAndValidateMetadataHeader(metadata: Record<string, any>): void {
@@ -2060,10 +2088,10 @@ export class AgentManager extends BaseElementManager<Agent> {
         maxLength: SECURITY_LIMITS.MAX_TAG_LENGTH,
         allowSpaces: true
       });
-      if (!result.isValid) {
+      if (!result.isValid || result.sanitizedValue === undefined) {
         throw new Error(`Invalid specialization "${value}": ${result.errors?.join(', ')}`);
       }
-      validatedSpecializations.push(result.sanitizedValue!);
+      validatedSpecializations.push(result.sanitizedValue);
     }
     metadata.specializations = validatedSpecializations;
   }
@@ -2306,7 +2334,7 @@ export class AgentManager extends BaseElementManager<Agent> {
     return agent;
   }
 
-  protected override async serializeElement(agent: Agent): Promise<string> {
+  protected override serializeElement(agent: Agent): Promise<string> {
     const metadata = this.buildBaseSerializedMetadata(agent);
     const metadataV2 = agent.metadata as AgentMetadataV2;
     this.addSerializedV2Metadata(metadata, metadataV2);
@@ -2322,13 +2350,13 @@ export class AgentManager extends BaseElementManager<Agent> {
     }
     const body = agent.content || this.buildDefaultBody(agent);
 
-    return this.serializationService.createFrontmatter(metadata, body, {
+    return Promise.resolve(this.serializationService.createFrontmatter(metadata, body, {
       method: 'manual',
       schema: 'json',  // Use JSON schema to preserve booleans/numbers in v2 metadata
       cleanMetadata: true,
       cleaningStrategy: 'remove-both',  // Remove both null and undefined
       sortKeys: true
-    });
+    }));
   }
 
   private buildBaseSerializedMetadata(agent: Agent): Record<string, unknown> {
@@ -2349,7 +2377,8 @@ export class AgentManager extends BaseElementManager<Agent> {
     metadata: Record<string, unknown>,
     metadataV2: AgentMetadataV2
   ): void {
-    if (metadataV2.goal) metadata.goal = metadataV2.goal;
+    const goal = (metadataV2 as unknown as Record<string, unknown>).goal;
+    if (goal) metadata.goal = goal;
     if (metadataV2.activates) metadata.activates = metadataV2.activates;
     if (metadataV2.tools) metadata.tools = metadataV2.tools;
     if (metadataV2.systemPrompt) metadata.systemPrompt = metadataV2.systemPrompt;
@@ -2362,13 +2391,14 @@ export class AgentManager extends BaseElementManager<Agent> {
     metadata: Record<string, unknown>,
     metadataV2: AgentMetadataV2
   ): void {
-    if (metadataV2.goal) {
+    const legacyMetadata = metadataV2 as unknown as Record<string, unknown>;
+    if (legacyMetadata.goal) {
       return;
     }
-    if (metadataV2.decisionFramework) metadata.decisionFramework = metadataV2.decisionFramework;
-    if (metadataV2.riskTolerance) metadata.riskTolerance = metadataV2.riskTolerance;
-    if (metadataV2.learningEnabled !== undefined) metadata.learningEnabled = metadataV2.learningEnabled;
-    if (metadataV2.maxConcurrentGoals !== undefined) metadata.maxConcurrentGoals = metadataV2.maxConcurrentGoals;
+    if (legacyMetadata.decisionFramework) metadata.decisionFramework = legacyMetadata.decisionFramework;
+    if (legacyMetadata.riskTolerance) metadata.riskTolerance = legacyMetadata.riskTolerance;
+    if (legacyMetadata.learningEnabled !== undefined) metadata.learningEnabled = legacyMetadata.learningEnabled;
+    if (legacyMetadata.maxConcurrentGoals !== undefined) metadata.maxConcurrentGoals = legacyMetadata.maxConcurrentGoals;
   }
 
   private addSerializedCommonMetadata(
@@ -2380,22 +2410,22 @@ export class AgentManager extends BaseElementManager<Agent> {
       metadata.tags = metadataV2.tags;
     }
     if (metadataV2.triggers) metadata.triggers = metadataV2.triggers;
-    if (metadataV2.ruleEngineConfig !== undefined) metadata.ruleEngineConfig = metadataV2.ruleEngineConfig;
+    const legacyRuleEngineConfig = (metadataV2 as unknown as Record<string, unknown>).ruleEngineConfig;
+    if (legacyRuleEngineConfig !== undefined) metadata.ruleEngineConfig = legacyRuleEngineConfig;
   }
 
   private buildDefaultInstructions(agent: Agent): string {
     const nameHeader = agent.metadata.name ? `# ${agent.metadata.name}\n\n` : '';
-    const description = agent.metadata.description ?? '';
+    const description = agent.metadata.description;
     return `${nameHeader}${description}`.trim();
   }
 
   private buildDefaultBody(agent: Agent): string {
-    const name = (agent.metadata.name ?? '').trim();
-    const description = (agent.metadata.description ?? '').trim();
-    const lines: string[] = [];
-    if (name) {
-      lines.push(`# ${name}`);
-      lines.push('');
+    const name = agent.metadata.name.trim();
+    const description = agent.metadata.description.trim();
+      const lines: string[] = [];
+      if (name) {
+        lines.push(`# ${name}`, '');
     }
     if (description) {
       lines.push(description);
@@ -2438,17 +2468,19 @@ export class AgentManager extends BaseElementManager<Agent> {
   }
 
   private validateCreateTools(metadata: Partial<AgentMetadataV2>, errors: string[]): void {
-    if (metadata.tools === undefined) {
+    const tools = (metadata as Record<string, unknown>).tools;
+    if (tools === undefined) {
       return;
     }
-    if (typeof metadata.tools !== 'object' || Array.isArray(metadata.tools) || metadata.tools === null) {
+    if (typeof tools !== 'object' || Array.isArray(tools) || tools === null) {
       errors.push('tools must be an object with allowed/denied arrays');
       return;
     }
-    if (!Array.isArray(metadata.tools.allowed)) {
+    const toolConfig = tools as Record<string, unknown>;
+    if (!Array.isArray(toolConfig.allowed)) {
       errors.push('tools.allowed is required and must be an array of strings');
     }
-    if (metadata.tools.denied !== undefined && !Array.isArray(metadata.tools.denied)) {
+    if (toolConfig.denied !== undefined && !Array.isArray(toolConfig.denied)) {
       errors.push('tools.denied must be an array of strings');
     }
   }
@@ -2470,15 +2502,16 @@ export class AgentManager extends BaseElementManager<Agent> {
   }
 
   private validateCreateAutonomy(metadata: Partial<AgentMetadataV2>, errors: string[]): void {
-    if (metadata.autonomy === undefined) {
+    const autonomy = (metadata as Record<string, unknown>).autonomy;
+    if (autonomy === undefined) {
       return;
     }
-    if (typeof metadata.autonomy !== 'object' || Array.isArray(metadata.autonomy) || metadata.autonomy === null) {
+    if (typeof autonomy !== 'object' || Array.isArray(autonomy) || autonomy === null) {
       errors.push('autonomy must be an object');
       return;
     }
 
-    const a = metadata.autonomy as Record<string, unknown>;
+    const a = autonomy as Record<string, unknown>;
     normalizeAutonomyKeys(a);
     this.addEnumValidationError(a, 'riskTolerance', RISK_TOLERANCE_LEVELS, 'autonomy.riskTolerance', errors);
     this.addTypeValidationError(a, 'maxAutonomousSteps', 'number', 'autonomy.maxAutonomousSteps', errors);
@@ -2487,15 +2520,16 @@ export class AgentManager extends BaseElementManager<Agent> {
   }
 
   private validateCreateResilience(metadata: Partial<AgentMetadataV2>, errors: string[]): void {
-    if (metadata.resilience === undefined) {
+    const resilience = (metadata as Record<string, unknown>).resilience;
+    if (resilience === undefined) {
       return;
     }
-    if (typeof metadata.resilience !== 'object' || Array.isArray(metadata.resilience) || metadata.resilience === null) {
+    if (typeof resilience !== 'object' || Array.isArray(resilience) || resilience === null) {
       errors.push('resilience must be an object');
       return;
     }
 
-    const r = metadata.resilience as Record<string, unknown>;
+    const r = resilience as Record<string, unknown>;
     normalizeResilienceKeys(r);
     this.addEnumValidationError(r, 'onStepLimitReached', STEP_LIMIT_ACTIONS, 'resilience.onStepLimitReached', errors);
     this.addEnumValidationError(r, 'onExecutionFailure', EXECUTION_FAILURE_ACTIONS, 'resilience.onExecutionFailure', errors);
@@ -2506,9 +2540,10 @@ export class AgentManager extends BaseElementManager<Agent> {
   }
 
   private validateCreateActivates(metadata: Partial<AgentMetadataV2>, errors: string[]): void {
+    const activates = (metadata as Record<string, unknown>).activates;
     if (
-      metadata.activates !== undefined &&
-      (typeof metadata.activates !== 'object' || Array.isArray(metadata.activates) || metadata.activates === null)
+      activates !== undefined &&
+      (typeof activates !== 'object' || Array.isArray(activates) || activates === null)
     ) {
       errors.push('activates must be an object with skills/personas/memories/templates/ensembles arrays');
     }
@@ -2650,7 +2685,7 @@ export class AgentManager extends BaseElementManager<Agent> {
   async recordAgentStep(params: {
     agentName: string;
     stepDescription: string;
-    outcome: "success" | "failure" | "partial";
+    outcome: AgentStepOutcome;
     /** Optional findings or results from this step */
     findings?: string;
     confidence?: number;
@@ -2671,7 +2706,7 @@ export class AgentManager extends BaseElementManager<Agent> {
       reasoning: string;
       framework: string;
       confidence: number;
-      outcome: "success" | "failure" | "partial";
+      outcome: AgentStepOutcome;
     };
     state: {
       goalCount: number;
@@ -2731,9 +2766,9 @@ export class AgentManager extends BaseElementManager<Agent> {
     // 8. Evaluate autonomy - should we continue or pause?
     // Issue #402: Pass DI-injected DangerZoneEnforcer via context
     // Issue #447: Apply runtime maxAutonomousSteps override if provided
-    const autonomyConfig = params.maxStepsOverride !== undefined
-      ? { ...agentMetadata.autonomy, maxAutonomousSteps: params.maxStepsOverride }
-      : agentMetadata.autonomy;
+    const autonomyConfig = params.maxStepsOverride === undefined
+      ? agentMetadata.autonomy
+      : { ...agentMetadata.autonomy, maxAutonomousSteps: params.maxStepsOverride };
 
     const autonomyDirective = evaluateAutonomy({
       agentName: params.agentName,
@@ -2783,7 +2818,7 @@ export class AgentManager extends BaseElementManager<Agent> {
   async completeAgentGoal(params: {
     agentName: string;
     goalId?: string;
-    outcome: "success" | "failure" | "partial";
+    outcome: AgentStepOutcome;
     summary: string;
   }): Promise<{
     success: boolean;
@@ -2860,7 +2895,13 @@ export class AgentManager extends BaseElementManager<Agent> {
 
     // 7. Return goal, metrics, and state
     const updatedState = agent.getState();
-    const completedGoal = updatedState.goals.find(g => g.id === goal.id)!;
+    const completedGoal = updatedState.goals.find(g => g.id === goal.id);
+    if (!completedGoal) {
+      throw new Error(`Completed goal '${goal.id}' is missing from agent state`);
+    }
+    if (!completedGoal.completedAt) {
+      throw new Error(`Completed goal '${goal.id}' is missing its completion timestamp`);
+    }
 
     return {
       success: true,
@@ -2870,7 +2911,7 @@ export class AgentManager extends BaseElementManager<Agent> {
         description: completedGoal.description,
         status: completedGoal.status as "completed" | "failed",
         createdAt: completedGoal.createdAt.toISOString(),
-        completedAt: completedGoal.completedAt!.toISOString(),
+        completedAt: completedGoal.completedAt.toISOString(),
         estimatedEffort: completedGoal.estimatedEffort,
         actualEffort: completedGoal.actualEffort
       },

--- a/src/elements/ensembles/EnsembleManager.ts
+++ b/src/elements/ensembles/EnsembleManager.ts
@@ -17,11 +17,13 @@
  * - SecureYamlParser for safe YAML parsing
  */
 
-import { Ensemble, EnsembleMetadata, EnsembleElement } from './Ensemble.js';
-import { ElementValidationResult } from '../../types/elements/IElement.js';
+import type { EnsembleMetadata, EnsembleElement } from './Ensemble.js';
+import { Ensemble } from './Ensemble.js';
+import type { ElementValidationResult } from '../../types/elements/IElement.js';
 import { ElementType } from '../../portfolio/types.js';
 import { toSingularLabel } from '../../utils/elementTypeNormalization.js';
-import { BaseElementManager, ElementManagerDeps } from '../base/BaseElementManager.js';
+import type { ElementManagerDeps } from '../base/BaseElementManager.js';
+import { BaseElementManager } from '../base/BaseElementManager.js';
 import { SecurityMonitor } from '../../security/securityMonitor.js';
 import { logger } from '../../utils/logger.js';
 import {
@@ -35,9 +37,9 @@ import {
   ACTIVATION_MODES
 } from './constants.js';
 import type { ActivationStrategy, ConflictResolutionStrategy, ElementRole, ActivationMode } from './types.js';
-import { ValidationService } from '../../services/validation/ValidationService.js';
-import { SerializationService } from '../../services/SerializationService.js';
-import { MetadataService } from '../../services/MetadataService.js';
+import type { ValidationService } from '../../services/validation/ValidationService.js';
+import type { SerializationService } from '../../services/SerializationService.js';
+import type { MetadataService } from '../../services/MetadataService.js';
 import { ElementMessages } from '../../utils/elementMessages.js';
 import { VALIDATION_PATTERNS, SECURITY_LIMITS } from '../../security/constants.js';
 import { sanitizeGatekeeperPolicy } from '../../handlers/mcp-aql/policies/ElementPolicies.js';
@@ -47,11 +49,10 @@ import { SecureYamlParser } from '../../security/secureYamlParser.js';
 import { getActiveElementLimitConfig, getMaxActiveLimit } from '../../config/active-element-limits.js';
 
 // Issue #466: Shared element type resolver — re-exported for backward compatibility
-import { resolveElementTypes } from '../../utils/elementTypeResolver.js';
 export { resolveElementTypes, type ElementManagersForResolution } from '../../utils/elementTypeResolver.js';
 
 /** @deprecated Use resolveElementTypes from '../../utils/elementTypeResolver.js' */
-export const resolveEnsembleElementTypes = resolveElementTypes;
+export { resolveElementTypes as resolveEnsembleElementTypes } from '../../utils/elementTypeResolver.js';
 
 const LEGACY_ELEMENT_FIELD_REPLACEMENTS = {
   name: 'element_name',
@@ -71,8 +72,8 @@ type LegacyElementField = keyof typeof LEGACY_ELEMENT_FIELD_REPLACEMENTS;
  */
 export class EnsembleManager extends BaseElementManager<Ensemble> {
   private readonly ensemblesDir: string;
-  private validationService: ValidationService;
-  private serializationService: SerializationService;
+  private readonly validationService: ValidationService;
+  private readonly serializationService: SerializationService;
   private readonly metadataService: MetadataService;
   private readonly _localActiveEnsembleNames: Set<string> = new Set();
   private readonly legacyElementFieldWarnings: Set<string> = new Set();
@@ -199,7 +200,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
         });
         const parsed = SecureYamlParser.safeMatter(raw);
 
-        if (!this.hasLegacyElementFields(parsed.data?.elements)) {
+        if (!this.hasLegacyElementFields(parsed.data.elements)) {
           continue;
         }
 
@@ -231,292 +232,255 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
    * @param data - Raw YAML data from frontmatter
    * @returns Validated EnsembleMetadata
    */
-  protected override async parseMetadata(data: any): Promise<EnsembleMetadata> {
-    // REFACTORED: Use validateMetadataField for field-aware error messages (#365)
-    const nameResult = this.validationService.validateMetadataField('name', data.name, {
-      required: true,
-      maxLength: SECURITY_LIMITS.MAX_NAME_LENGTH
-    });
-    if (!nameResult.isValid) {
-      throw new Error(`Validation failed: ${nameResult.errors?.join(', ')}`);
-    }
-    const name = nameResult.sanitizedValue;
-
-    if (!name) {
-      throw new Error('Ensemble metadata must include a name');
-    }
-
-    // REFACTORED: Use validateMetadataField for field-aware error messages (#365)
-    let description: string | undefined;
-    if (data.description) {
-      const descResult = this.validationService.validateMetadataField('description', data.description, {
-        required: false,
-        maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
-        pattern: VALIDATION_PATTERNS.SAFE_DESCRIPTION
-      });
-      if (!descResult.isValid) {
-        throw new Error(`Validation failed: ${descResult.errors?.join(', ')}`);
-      }
-      description = descResult.sanitizedValue;
-    }
-
-    // REFACTORED: Use ValidationService for activation strategy (support both snake_case and camelCase)
-    const activationStrategyRaw = data.activation_strategy || data.activationStrategy || ENSEMBLE_DEFAULTS.ACTIVATION_STRATEGY;
-    const activationStrategyResult = this.validationService.validateAndSanitizeInput(String(activationStrategyRaw), {
-      maxLength: SECURITY_LIMITS.MAX_ENUM_FIELD_LENGTH,
-      allowSpaces: false
-    });
-    if (!activationStrategyResult.isValid) {
-      throw new Error(`Invalid activation strategy: ${activationStrategyResult.errors?.join(', ')}`);
-    }
-    const activationStrategy = activationStrategyResult.sanitizedValue!;
-
-    // KEEP: Enum validation logic (add AFTER ValidationService sanitization)
-    if (!ACTIVATION_STRATEGIES.includes(activationStrategy as any)) {
-      throw new Error(`${ENSEMBLE_ERRORS.INVALID_STRATEGY}: ${activationStrategy}`);
-    }
-
-    // REFACTORED: Use ValidationService for conflict resolution strategy
-    const conflictResolutionRaw = data.conflict_resolution || data.conflictResolution || ENSEMBLE_DEFAULTS.CONFLICT_RESOLUTION;
-    const conflictResolutionResult = this.validationService.validateAndSanitizeInput(String(conflictResolutionRaw), {
-      maxLength: SECURITY_LIMITS.MAX_ENUM_FIELD_LENGTH,
-      allowSpaces: false
-    });
-    if (!conflictResolutionResult.isValid) {
-      throw new Error(`Invalid conflict resolution strategy: ${conflictResolutionResult.errors?.join(', ')}`);
-    }
-    const conflictResolution = conflictResolutionResult.sanitizedValue!;
-
-    // KEEP: Enum validation logic (add AFTER ValidationService sanitization)
-    if (!CONFLICT_STRATEGIES.includes(conflictResolution as any)) {
-      throw new Error(`${ENSEMBLE_ERRORS.INVALID_CONFLICT_RESOLUTION}: ${conflictResolution}`);
-    }
-
-    // REFACTORED: Use ValidationService for context sharing mode
-    const contextSharingRaw = data.context_sharing || data.contextSharing || ENSEMBLE_DEFAULTS.CONTEXT_SHARING;
-
-    // FIX: Handle boolean values (true -> 'full', false -> 'none')
-    let contextSharingValue: string;
-    if (typeof contextSharingRaw === 'boolean') {
-      contextSharingValue = contextSharingRaw ? 'full' : 'none';
-    } else {
-      contextSharingValue = String(contextSharingRaw);
-    }
-
-    const contextSharingResult = this.validationService.validateAndSanitizeInput(contextSharingValue, {
-      maxLength: SECURITY_LIMITS.MAX_ENUM_FIELD_LENGTH,
-      allowSpaces: false
-    });
-    if (!contextSharingResult.isValid) {
-      throw new Error(`Invalid context sharing mode: ${contextSharingResult.errors?.join(', ')}`);
-    }
-    const contextSharing = contextSharingResult.sanitizedValue!;
-
-    // KEEP: Enum validation logic (add AFTER ValidationService sanitization)
-    if (!['none', 'selective', 'full'].includes(contextSharing)) {
-      throw new Error(`Invalid context sharing mode: ${contextSharing}`);
-    }
-
-    // Parse resource limits (support snake_case)
-    const resourceLimitsRaw = data.resource_limits || data.resourceLimits;
-    let resourceLimits;
-
-    if (resourceLimitsRaw) {
-      resourceLimits = {
-        maxActiveElements: resourceLimitsRaw.max_active_elements || resourceLimitsRaw.maxActiveElements || ENSEMBLE_LIMITS.MAX_ELEMENTS,
-        maxMemoryMb: resourceLimitsRaw.max_memory_mb || resourceLimitsRaw.maxMemoryMb,
-        maxExecutionTimeMs: resourceLimitsRaw.max_execution_time_ms || resourceLimitsRaw.maxExecutionTimeMs || ENSEMBLE_LIMITS.MAX_ACTIVATION_TIME
-      };
-    }
-
-    // Parse elements array
-    const elementsRaw = data.elements || [];
-    if (!Array.isArray(elementsRaw)) {
-      throw new Error('Ensemble elements must be an array');
-    }
-
-    const elements: EnsembleElement[] = elementsRaw.map((elem: any, index: number) => {
-      // REFACTORED: Use ValidationService for element name
-      // Support both element_name (new standard) and name (legacy) for backwards compatibility
-      const rawElementName = elem.element_name || elem.name;
-      if (!rawElementName) {
-        throw new Error(`Element at index ${index} must have element_name (or name for backwards compatibility)`);
-      }
-      // Log deprecation warning if using legacy 'name' field
-      if (elem.name && !elem.element_name) {
-        this.warnOnceForLegacyElementField(name, index, 'name');
-      }
-      const elementNameResult = this.validationService.validateAndSanitizeInput(
-        String(rawElementName),
-        { maxLength: SECURITY_LIMITS.MAX_NAME_LENGTH, allowSpaces: true }
-      );
-      if (!elementNameResult.isValid) {
-        throw new Error(`Invalid element name at index ${index}: ${elementNameResult.errors?.join(', ')}`);
-      }
-      const elementName = elementNameResult.sanitizedValue!;
-
-      // REFACTORED: Use ValidationService for element type
-      // Support both element_type (new standard) and type (legacy) for backwards compatibility
-      const rawElementType = elem.element_type || elem.type || 'skill';
-      // Log deprecation warning if using legacy 'type' field
-      if (elem.type && !elem.element_type) {
-        this.warnOnceForLegacyElementField(name, index, 'type');
-      }
-      const elementTypeResult = this.validationService.validateAndSanitizeInput(
-        String(rawElementType),
-        { maxLength: SECURITY_LIMITS.MAX_TAG_LENGTH, allowSpaces: false }
-      );
-      if (!elementTypeResult.isValid) {
-        throw new Error(`Invalid element type at index ${index}: ${elementTypeResult.errors?.join(', ')}`);
-      }
-      const elementType = elementTypeResult.sanitizedValue!;
-
-      // REFACTORED: Use ValidationService for element role
-      const elementRoleResult = this.validationService.validateAndSanitizeInput(
-        String(elem.role || ENSEMBLE_DEFAULTS.ELEMENT_ROLE),
-        { maxLength: SECURITY_LIMITS.MAX_ENUM_FIELD_LENGTH, allowSpaces: false }
-      );
-      if (!elementRoleResult.isValid) {
-        throw new Error(`Invalid element role at index ${index}: ${elementRoleResult.errors?.join(', ')}`);
-      }
-      const elementRole = elementRoleResult.sanitizedValue!;
-
-      // KEEP: Enum validation logic (add AFTER ValidationService sanitization)
-      if (!ELEMENT_ROLES.includes(elementRole as any)) {
-        throw new Error(`${ENSEMBLE_ERRORS.INVALID_ELEMENT_ROLE}: ${elementRole}`);
-      }
-
-      // REFACTORED: Use ValidationService for element activation
-      const elementActivationResult = this.validationService.validateAndSanitizeInput(
-        String(elem.activation || 'always'),
-        { maxLength: SECURITY_LIMITS.MAX_ENUM_FIELD_LENGTH, allowSpaces: false }
-      );
-      if (!elementActivationResult.isValid) {
-        throw new Error(`Invalid element activation at index ${index}: ${elementActivationResult.errors?.join(', ')}`);
-      }
-      const elementActivation = elementActivationResult.sanitizedValue!;
-
-      // KEEP: Enum validation logic (add AFTER ValidationService sanitization)
-      if (!ACTIVATION_MODES.includes(elementActivation as any)) {
-        throw new Error(`${ENSEMBLE_ERRORS.INVALID_ACTIVATION_MODE}: ${elementActivation}`);
-      }
-
-      // Parse priority (0-100, default 50)
-      let priority = elem.priority ?? ENSEMBLE_DEFAULTS.PRIORITY;
-      if (typeof priority === 'string') {
-        priority = parseInt(priority, 10);
-      }
-      priority = Math.max(0, Math.min(100, priority));
-
-      // REFACTORED: Use ValidationService for condition (if conditional activation)
-      // Conditions need special handling - they can contain operators like ==, !=, &&, ||
-      // So we use a custom pattern that allows these characters
-      let condition: string | undefined;
-      if (elementActivation === 'conditional' && elem.condition) {
-        const conditionResult = this.validationService.validateAndSanitizeInput(
-          String(elem.condition),
-          {
-            maxLength: ENSEMBLE_LIMITS.MAX_CONDITION_LENGTH,
-            allowSpaces: true,
-            customPattern: /^[a-zA-Z0-9\s\-_.=!&|<>()]+$/  // Allow comparison/logical operators
-          }
-        );
-        if (!conditionResult.isValid) {
-          throw new Error(`Invalid condition at index ${index}: ${conditionResult.errors?.join(', ')}`);
-        }
-        condition = conditionResult.sanitizedValue;
-      }
-
-      // REFACTORED: Use ValidationService for dependencies
-      let dependencies: string[] | undefined;
-      if (elem.dependencies && Array.isArray(elem.dependencies)) {
-        const validatedDependencies: string[] = [];
-        for (const dep of elem.dependencies.slice(0, ENSEMBLE_LIMITS.MAX_DEPENDENCIES)) {
-          const depResult = this.validationService.validateAndSanitizeInput(String(dep), {
-            maxLength: SECURITY_LIMITS.MAX_NAME_LENGTH,
-            allowSpaces: true
-          });
-          if (!depResult.isValid) {
-            throw new Error(`Invalid dependency "${dep}" at index ${index}: ${depResult.errors?.join(', ')}`);
-          }
-          validatedDependencies.push(depResult.sanitizedValue!);
-        }
-        dependencies = validatedDependencies;
-      }
-
-      // REFACTORED: Use ValidationService for purpose
-      let purpose: string | undefined;
-      if (elem.purpose) {
-        const purposeResult = this.validationService.validateAndSanitizeInput(String(elem.purpose), {
-          maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
-          allowSpaces: true,
-          fieldType: 'description'  // Allow full description punctuation (commas, em-dashes, etc.)
-        });
-        if (!purposeResult.isValid) {
-          throw new Error(`Invalid purpose at index ${index}: ${purposeResult.errors?.join(', ')}`);
-        }
-        purpose = purposeResult.sanitizedValue;
-      }
-
-      return {
-        element_name: elementName,
-        element_type: elementType,
-        role: elementRole as ElementRole,
-        priority,
-        activation: elementActivation as ActivationMode,
-        condition,
-        dependencies,
-        purpose
-      };
-    });
-
-    // Validate element count
+  protected override parseMetadata(data: any): Promise<EnsembleMetadata> {
+    const name = this.parseName(data);
+    const activationStrategy = this.parseActivationStrategy(data);
+    const conflictResolution = this.parseConflictResolution(data);
+    const contextSharing = this.parseContextSharing(data);
+    const elements = this.parseElements(data, name);
     if (elements.length > ENSEMBLE_LIMITS.MAX_ELEMENTS) {
       throw new Error(ENSEMBLE_ERRORS.TOO_MANY_ELEMENTS);
     }
 
-    // Parse nesting configuration
-    const allowNested = data.allow_nested !== undefined ?
-      Boolean(data.allow_nested) :
-      (data.allowNested !== undefined ? Boolean(data.allowNested) : ENSEMBLE_DEFAULTS.ALLOW_NESTED);
-
-    const maxNestingDepth = data.max_nesting_depth || data.maxNestingDepth || ENSEMBLE_DEFAULTS.MAX_NESTING_DEPTH;
-
-    // REFACTORED: Use ValidationService for tags array
-    let tags: string[] = [];
-    if (Array.isArray(data.tags)) {
-      for (const tag of data.tags) {
-        const tagResult = this.validationService.validateAndSanitizeInput(String(tag), {
-          maxLength: SECURITY_LIMITS.MAX_TAG_LENGTH,
-          allowSpaces: true
-        });
-        if (!tagResult.isValid) {
-          throw new Error(`Invalid tag "${tag}": ${tagResult.errors?.join(', ')}`);
-        }
-        tags.push(tagResult.sanitizedValue!);
-      }
-    }
-
-    // Build metadata object (camelCase)
-    const metadata: EnsembleMetadata = {
+    return Promise.resolve({
       name,
-      description: description || '',
+      description: this.parseDescription(data),
       version: data.version || '1.0.0',
       author: data.author,
       created: data.created,
       modified: data.modified || new Date().toISOString(),
-      tags,
-      activationStrategy: activationStrategy as ActivationStrategy,
-      conflictResolution: conflictResolution as ConflictResolutionStrategy,
-      contextSharing: contextSharing as 'none' | 'selective' | 'full',
-      resourceLimits,
-      allowNested,
-      maxNestingDepth,
+      tags: this.parseTags(data),
+      instructions: typeof data.instructions === 'string' ? data.instructions : undefined,
+      activationStrategy,
+      conflictResolution,
+      contextSharing,
+      resourceLimits: this.parseResourceLimits(data),
+      allowNested: this.parseAllowNested(data),
+      maxNestingDepth: data.max_nesting_depth || data.maxNestingDepth || ENSEMBLE_DEFAULTS.MAX_NESTING_DEPTH,
       elements,
-      gatekeeper: sanitizeGatekeeperPolicy(data.gatekeeper, name, 'ensemble', data as Record<string, unknown>),  // Issue #524
-    };
+      gatekeeper: sanitizeGatekeeperPolicy(data.gatekeeper, name, 'ensemble', data as Record<string, unknown>),
+    });
+  }
 
-    return metadata;
+  private parseName(data: any): string {
+    const nameResult = this.validationService.validateMetadataField('name', data.name, {
+      required: true,
+      maxLength: SECURITY_LIMITS.MAX_NAME_LENGTH
+    });
+    const name = this.requireSanitizedValue(nameResult, 'Validation failed');
+    if (!name) {
+      throw new Error('Ensemble metadata must include a name');
+    }
+    return name;
+  }
+
+  private parseDescription(data: any): string {
+    if (!data.description) {
+      return '';
+    }
+    const result = this.validationService.validateMetadataField('description', data.description, {
+      required: false,
+      maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+      pattern: VALIDATION_PATTERNS.SAFE_DESCRIPTION
+    });
+    return this.requireSanitizedValue(result, 'Validation failed');
+  }
+
+  private parseActivationStrategy(data: any): ActivationStrategy {
+    const raw = data.activation_strategy || data.activationStrategy || ENSEMBLE_DEFAULTS.ACTIVATION_STRATEGY;
+    const activationStrategy = this.sanitizeEnumValue(raw, 'activation strategy');
+    if (!ACTIVATION_STRATEGIES.includes(activationStrategy as any)) {
+      throw new Error(`${ENSEMBLE_ERRORS.INVALID_STRATEGY}: ${activationStrategy}`);
+    }
+    return activationStrategy as ActivationStrategy;
+  }
+
+  private parseConflictResolution(data: any): ConflictResolutionStrategy {
+    const raw = data.conflict_resolution || data.conflictResolution || ENSEMBLE_DEFAULTS.CONFLICT_RESOLUTION;
+    const conflictResolution = this.sanitizeEnumValue(raw, 'conflict resolution strategy');
+    if (!CONFLICT_STRATEGIES.includes(conflictResolution as any)) {
+      throw new Error(`${ENSEMBLE_ERRORS.INVALID_CONFLICT_RESOLUTION}: ${conflictResolution}`);
+    }
+    return conflictResolution as ConflictResolutionStrategy;
+  }
+
+  private parseContextSharing(data: any): 'none' | 'selective' | 'full' {
+    const raw = data.context_sharing || data.contextSharing || ENSEMBLE_DEFAULTS.CONTEXT_SHARING;
+    let contextSharingValue = String(raw);
+    if (typeof raw === 'boolean') {
+      contextSharingValue = raw ? 'full' : 'none';
+    }
+    const contextSharing = this.sanitizeEnumValue(contextSharingValue, 'context sharing mode');
+    if (!['none', 'selective', 'full'].includes(contextSharing)) {
+      throw new Error(`Invalid context sharing mode: ${contextSharing}`);
+    }
+    return contextSharing as 'none' | 'selective' | 'full';
+  }
+
+  private sanitizeEnumValue(raw: unknown, label: string): string {
+    const result = this.validationService.validateAndSanitizeInput(String(raw), {
+      maxLength: SECURITY_LIMITS.MAX_ENUM_FIELD_LENGTH,
+      allowSpaces: false
+    });
+    return this.requireSanitizedValue(result, `Invalid ${label}`);
+  }
+
+  private parseResourceLimits(data: any): EnsembleMetadata['resourceLimits'] {
+    const resourceLimitsRaw = data.resource_limits || data.resourceLimits;
+    if (!resourceLimitsRaw) {
+      return undefined;
+    }
+    return {
+      maxActiveElements: resourceLimitsRaw.max_active_elements || resourceLimitsRaw.maxActiveElements || ENSEMBLE_LIMITS.MAX_ELEMENTS,
+      maxMemoryMb: resourceLimitsRaw.max_memory_mb || resourceLimitsRaw.maxMemoryMb,
+      maxExecutionTimeMs: resourceLimitsRaw.max_execution_time_ms || resourceLimitsRaw.maxExecutionTimeMs || ENSEMBLE_LIMITS.MAX_ACTIVATION_TIME
+    };
+  }
+
+  private parseElements(data: any, ensembleName: string): EnsembleElement[] {
+    const elementsRaw = data.elements || [];
+    if (!Array.isArray(elementsRaw)) {
+      throw new TypeError('Ensemble elements must be an array');
+    }
+    return elementsRaw.map((element: any, index: number) =>
+      this.parseElement(element, index, ensembleName));
+  }
+
+  private parseElement(element: any, index: number, ensembleName: string): EnsembleElement {
+    const role = this.parseElementRole(element, index);
+    const activation = this.parseElementActivation(element, index);
+    return {
+      element_name: this.parseElementName(element, index, ensembleName),
+      element_type: this.parseElementType(element, index, ensembleName),
+      role,
+      priority: this.parseElementPriority(element),
+      activation,
+      condition: this.parseElementCondition(element, index, activation),
+      dependencies: this.parseElementDependencies(element, index),
+      purpose: this.parseElementPurpose(element, index)
+    };
+  }
+
+  private parseElementName(element: any, index: number, ensembleName: string): string {
+    const rawName = element.element_name || element.name;
+    if (!rawName) {
+      throw new Error(`Element at index ${index} must have element_name (or name for backwards compatibility)`);
+    }
+    if (element.name && !element.element_name) {
+      this.warnOnceForLegacyElementField(ensembleName, index, 'name');
+    }
+    return this.sanitizeText(rawName, SECURITY_LIMITS.MAX_NAME_LENGTH, true, `Invalid element name at index ${index}`);
+  }
+
+  private parseElementType(element: any, index: number, ensembleName: string): string {
+    const rawType = element.element_type || element.type || 'skill';
+    if (element.type && !element.element_type) {
+      this.warnOnceForLegacyElementField(ensembleName, index, 'type');
+    }
+    return this.sanitizeText(rawType, SECURITY_LIMITS.MAX_TAG_LENGTH, false, `Invalid element type at index ${index}`);
+  }
+
+  private parseElementRole(element: any, index: number): ElementRole {
+    const role = this.sanitizeText(
+      element.role || ENSEMBLE_DEFAULTS.ELEMENT_ROLE,
+      SECURITY_LIMITS.MAX_ENUM_FIELD_LENGTH,
+      false,
+      `Invalid element role at index ${index}`,
+    );
+    if (!ELEMENT_ROLES.includes(role as any)) {
+      throw new Error(`${ENSEMBLE_ERRORS.INVALID_ELEMENT_ROLE}: ${role}`);
+    }
+    return role as ElementRole;
+  }
+
+  private parseElementActivation(element: any, index: number): ActivationMode {
+    const activation = this.sanitizeText(
+      element.activation || 'always',
+      SECURITY_LIMITS.MAX_ENUM_FIELD_LENGTH,
+      false,
+      `Invalid element activation at index ${index}`,
+    );
+    if (!ACTIVATION_MODES.includes(activation as any)) {
+      throw new Error(`${ENSEMBLE_ERRORS.INVALID_ACTIVATION_MODE}: ${activation}`);
+    }
+    return activation as ActivationMode;
+  }
+
+  private parseElementPriority(element: any): number {
+    const rawPriority = element.priority ?? ENSEMBLE_DEFAULTS.PRIORITY;
+    const priority = typeof rawPriority === 'string' ? Number.parseInt(rawPriority, 10) : rawPriority;
+    return Math.max(0, Math.min(100, priority));
+  }
+
+  private parseElementCondition(element: any, index: number, activation: ActivationMode): string | undefined {
+    if (activation !== 'conditional' || !element.condition) {
+      return undefined;
+    }
+    const result = this.validationService.validateAndSanitizeInput(String(element.condition), {
+      maxLength: ENSEMBLE_LIMITS.MAX_CONDITION_LENGTH,
+      allowSpaces: true,
+      customPattern: /^[a-zA-Z0-9\s\-_.=!&|<>()]+$/
+    });
+    return this.requireSanitizedValue(result, `Invalid condition at index ${index}`);
+  }
+
+  private parseElementDependencies(element: any, index: number): string[] | undefined {
+    if (!Array.isArray(element.dependencies)) {
+      return undefined;
+    }
+    return element.dependencies
+      .slice(0, ENSEMBLE_LIMITS.MAX_DEPENDENCIES)
+      .map((dependency: unknown) => this.sanitizeText(
+        dependency,
+        SECURITY_LIMITS.MAX_NAME_LENGTH,
+        true,
+        `Invalid dependency "${String(dependency)}" at index ${index}`,
+      ));
+  }
+
+  private parseElementPurpose(element: any, index: number): string | undefined {
+    if (!element.purpose) {
+      return undefined;
+    }
+    const result = this.validationService.validateAndSanitizeInput(String(element.purpose), {
+      maxLength: SECURITY_LIMITS.MAX_DESCRIPTION_LENGTH,
+      allowSpaces: true,
+      fieldType: 'description'
+    });
+    return this.requireSanitizedValue(result, `Invalid purpose at index ${index}`);
+  }
+
+  private sanitizeText(raw: unknown, maxLength: number, allowSpaces: boolean, errorMessage: string): string {
+    const result = this.validationService.validateAndSanitizeInput(String(raw), { maxLength, allowSpaces });
+    return this.requireSanitizedValue(result, errorMessage);
+  }
+
+  private requireSanitizedValue(
+    result: { isValid: boolean; sanitizedValue?: string; errors?: string[] },
+    errorMessage: string,
+  ): string {
+    if (!result.isValid || typeof result.sanitizedValue !== 'string') {
+      throw new Error(`${errorMessage}: ${result.errors?.join(', ')}`);
+    }
+    return result.sanitizedValue;
+  }
+
+  private parseAllowNested(data: any): boolean {
+    if (data.allow_nested !== undefined) {
+      return Boolean(data.allow_nested);
+    }
+    if (data.allowNested !== undefined) {
+      return Boolean(data.allowNested);
+    }
+    return ENSEMBLE_DEFAULTS.ALLOW_NESTED;
+  }
+
+  private parseTags(data: any): string[] {
+    if (!Array.isArray(data.tags)) {
+      return [];
+    }
+    return data.tags.map((tag: unknown) =>
+      this.sanitizeText(tag, SECURITY_LIMITS.MAX_TAG_LENGTH, true, `Invalid tag "${String(tag)}"`));
   }
 
   /**
@@ -526,14 +490,16 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
    * @param content - Markdown content (ensemble instructions/documentation)
    * @returns New Ensemble instance
    */
-  protected override createElement(metadata: EnsembleMetadata, _content: string): Ensemble {
+  protected override createElement(metadata: EnsembleMetadata, content: string): Ensemble {
     delete (metadata as any).format_version;  // Fix #912: Strip marker from runtime metadata
+    const instructions = metadata.instructions;
+    delete metadata.instructions;
     const ensemble = new Ensemble(metadata, metadata.elements, this.metadataService);
     // Extract instructions from metadata if present (v2 dual-field)
-    if (metadata.instructions) {
-      ensemble.instructions = metadata.instructions;
-      delete metadata.instructions;
+    if (instructions) {
+      ensemble.instructions = instructions;
     }
+    ensemble.content = content;
     return ensemble;
   }
 
@@ -547,7 +513,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
    * @param element - Ensemble to serialize
    * @returns File content (markdown with frontmatter)
    */
-  protected override async serializeElement(element: Ensemble): Promise<string> {
+  protected override serializeElement(element: Ensemble): Promise<string> {
     const metadata = element.metadata;
 
     // Build frontmatter data (using camelCase)
@@ -612,7 +578,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
     // Use SerializationService for frontmatter creation
     // Use CORE_SCHEMA to support numbers (priority) and booleans (allowNested)
     const body = element.content || this.buildDefaultBody(element);
-    return this.serializationService.createFrontmatter(frontmatter, body, {
+    return Promise.resolve(this.serializationService.createFrontmatter(frontmatter, body, {
       method: 'manual',
       schema: 'json',  // Fix #914: standardize on JSON schema across all managers
       cleanMetadata: true,  // Fix #913: standardize across all managers
@@ -620,16 +586,15 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       sortKeys: true,
       lineWidth: 100,
       skipInvalid: false  // Don't skip invalid - we want to catch errors
-    });
+    }));
   }
 
   private buildDefaultBody(element: Ensemble): string {
-    const name = (element.metadata.name ?? '').trim();
-    const description = (element.metadata.description ?? '').trim();
+    const name = element.metadata.name.trim();
+    const description = element.metadata.description.trim();
     const lines: string[] = [];
     if (name) {
-      lines.push(`# ${name}`);
-      lines.push('');
+      lines.push(`# ${name}`, '');
     }
     if (description) {
       lines.push(description);
@@ -662,11 +627,13 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
   ): Promise<Ensemble> {
     try {
       let parsed: any;
+      let content = '';
 
       if (format === 'json') {
         parsed = this.serializationService.parseJson(data, {
           source: 'EnsembleManager.importElement'
         });
+        content = typeof parsed.content === 'string' ? parsed.content : '';
       } else {
         // Parse YAML/Markdown using SerializationService
         const result = this.serializationService.parseFrontmatter(data, {
@@ -676,14 +643,14 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
         });
 
         parsed = result.data;
-        // Content is parsed but not used in ensemble creation
+        content = result.content;
       }
 
       // Parse metadata
       const metadata = await this.parseMetadata(parsed);
 
       // Create ensemble
-      const ensemble = new Ensemble(metadata, metadata.elements, this.metadataService);
+      const ensemble = this.createElement(metadata, content);
 
       // Log successful import
       SecurityMonitor.logSecurityEvent({
@@ -748,7 +715,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
     }
 
     // Log warnings if any
-    if (validationResult.warnings && validationResult.warnings.length > 0) {
+    if (validationResult.warnings.length > 0) {
       logger.warn(`Ensemble creation warnings: ${validationResult.warnings.join(', ')}`);
     }
 
@@ -817,7 +784,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
       maxNestingDepth: metadata.maxNestingDepth || ENSEMBLE_DEFAULTS.MAX_NESTING_DEPTH,
       elements: migratedElements,
       // Issue #524 — Gatekeeper policy (symmetric with buildMetadata deserialization)
-      gatekeeper: sanitizeGatekeeperPolicy((metadata as any).gatekeeper, metadata.name!, 'ensemble', metadata as unknown as Record<string, unknown>),
+      gatekeeper: sanitizeGatekeeperPolicy((metadata as any).gatekeeper, metadata.name, 'ensemble', metadata as unknown as Record<string, unknown>),
     };
 
     // Use inherited getElementFilename() for consistent filename normalization
@@ -825,7 +792,7 @@ export class EnsembleManager extends BaseElementManager<Ensemble> {
 
     // Issue #613: Check metadata name uniqueness (not just filename)
     const existingEnsembles = await this.list();
-    const duplicate = existingEnsembles.find(e =>
+    const duplicate = existingEnsembles.some(e =>
       e.metadata.name.toLowerCase() === fullMetadata.name.toLowerCase()
     );
     if (duplicate) {

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.32';
-export const BUILD_TIMESTAMP = '2026-04-29T22:28:09.032Z';
+export const PACKAGE_VERSION = '2.0.38';
+export const BUILD_TIMESTAMP = '2026-07-21T12:16:32.773Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';

--- a/src/web-console/modules/collection/CollectionInstallService.ts
+++ b/src/web-console/modules/collection/CollectionInstallService.ts
@@ -88,7 +88,7 @@ export class CollectionInstallService {
     // being persisted by the manager-backed store and only failing afterwards
     // in record validation — which would strand an element the console can
     // neither read nor delete.
-    const issues = validateElementPayload({
+    const issues = validateElementPayload(type, {
       name: validated.name,
       displayName,
       metadata: validated.metadata,

--- a/src/web-console/modules/portfolio/PortfolioService.ts
+++ b/src/web-console/modules/portfolio/PortfolioService.ts
@@ -126,9 +126,9 @@ export class PortfolioService {
     if (!isConsolePortfolioElementType(type)) {
       return invalidRequest('type path parameter must be a supported portfolio element type.');
     }
-    const parsed = parseElementBody(req.body, { requireName: true, requireContent: true });
+    const parsed = parseElementBody(req.body, { requireName: true, requireContent: false });
     if (parsed.kind === 'problem') return parsed.result;
-    const issues = validateElementPayload(parsed.value);
+    const issues = validateElementPayload(type, parsed.value);
     if (issues.length > 0) return validationFailed(issues);
     try {
       const record = await this.store.create({
@@ -180,7 +180,7 @@ export class PortfolioService {
       content: parsed.value.content ?? existing.content,
       tags: parsed.value.tags ?? existing.tags,
     };
-    const issues = validateElementPayload(candidate);
+    const issues = validateElementPayload(path.type, candidate);
     if (issues.length > 0) return validationFailed(issues);
     try {
       const updated = await this.store.update({
@@ -283,7 +283,7 @@ export class PortfolioService {
       content: parsed.value.content ?? existing?.content ?? '',
       tags: parsed.value.tags ?? existing?.tags ?? [],
     };
-    const issues = validateElementPayload(candidate);
+    const issues = validateElementPayload(path.type, candidate);
     return {
       status: 200,
       body: {
@@ -308,7 +308,7 @@ export class PortfolioService {
     const content = parsed.value.content ?? existing.content;
     let displayName = existing.displayName;
     if (parsed.value.displayName !== undefined) displayName = parsed.value.displayName;
-    const issues = validateElementPayload({
+    const issues = validateElementPayload(existing.type, {
       name: existing.name,
       displayName,
       metadata: parsed.value.metadata ?? existing.metadata,
@@ -503,7 +503,7 @@ function parseSyncBody(body: unknown):
  * anything persists. Exported so the collection install path applies the same
  * caps as the direct create/update routes.
  */
-export function validateElementPayload(input: {
+export function validateElementPayload(type: ConsolePortfolioElementType, input: {
   readonly name?: string;
   readonly displayName?: string | null;
   readonly metadata?: Readonly<Record<string, unknown>>;
@@ -521,13 +521,44 @@ export function validateElementPayload(input: {
   } else if (input.displayName != null && !isValidDisplayString(input.displayName, 200)) {
     issues.push(issue('display_name', 'invalid', 'display_name must be a printable string of at most 200 characters.'));
   }
-  issues.push(...validateMetadataPayload(input.metadata));
-  if (input.content === undefined || input.content.trim() === '') issues.push(issue('content', 'required', 'content is required.'));
+  issues.push(
+    ...validateMetadataPayload(input.metadata),
+    ...validateContentPayload(type, input.content, input.metadata),
+  );
   if (input.content !== undefined && Buffer.byteLength(input.content, 'utf8') > PORTFOLIO_ELEMENT_CONTENT_MAX_BYTES) {
     issues.push(issue('content', 'too_large', 'content must be at most 1 MiB.'));
   }
   issues.push(...validateTagsPayload(input.tags ?? []));
   return issues;
+}
+
+function validateContentPayload(
+  type: ConsolePortfolioElementType,
+  content: string | undefined,
+  metadata: Readonly<Record<string, unknown>> | undefined,
+): readonly PortfolioElementValidationIssueDto[] {
+  const hasContent = typeof content === 'string' && content.trim() !== '';
+  if ((type === 'templates' || type === 'memories') && !hasContent) {
+    return [issue('content', 'required', 'content is required.')];
+  }
+  if ((type === 'personas' || type === 'skills') && !hasContent && !hasInstructions(metadata)) {
+    return [issue('content', 'required', 'content or metadata.instructions is required.')];
+  }
+  if (type === 'agents' && !hasContent && !hasInstructions(metadata) && metadata?.goal === undefined) {
+    return [issue('content', 'required', 'content, metadata.instructions, or metadata.goal is required.')];
+  }
+  if (type === 'ensembles' && !hasContent && !hasInstructions(metadata) && !hasEnsembleElements(metadata)) {
+    return [issue('content', 'required', 'content, metadata.instructions, or metadata.elements is required.')];
+  }
+  return [];
+}
+
+function hasInstructions(metadata: Readonly<Record<string, unknown>> | undefined): boolean {
+  return typeof metadata?.instructions === 'string' && metadata.instructions.trim() !== '';
+}
+
+function hasEnsembleElements(metadata: Readonly<Record<string, unknown>> | undefined): boolean {
+  return Array.isArray(metadata?.elements) && metadata.elements.length > 0;
 }
 
 function validateMetadataPayload(metadata: Readonly<Record<string, unknown>> | undefined): readonly PortfolioElementValidationIssueDto[] {

--- a/src/web-console/ui/account-settings.js
+++ b/src/web-console/ui/account-settings.js
@@ -67,7 +67,7 @@ function accountPanel() {
         <button class="security-close" data-account-close type="button" aria-label="Close">&#x2715;</button>
       </header>
       <div class="account-settings-body">
-        <form class="account-settings-section" id="account-profile-form">
+        <form class="account-settings-section" id="account-profile-form" data-settings-form="profile">
           <h3>Profile</h3>
           <p class="account-settings-note">Your username and email are managed by your sign-in provider.</p>
           <label class="portfolio-field"><span>Display name</span><input name="display_name" maxlength="200" disabled></label>
@@ -75,7 +75,7 @@ function accountPanel() {
           <div class="account-settings-feedback" data-profile-feedback aria-live="polite"></div>
           <div class="account-settings-actions"><button class="btn btn-primary" type="submit" disabled>Save profile</button></div>
         </form>
-        <form class="account-settings-section" id="account-theme-form">
+        <form class="account-settings-section" id="account-theme-form" data-settings-form="theme">
           <h3>Appearance</h3>
           <p class="account-settings-note">Theme is the only advanced setting with a stable console contract today.</p>
           <label class="portfolio-field"><span>Theme</span><select name="theme" disabled><option value="light">Light</option><option value="dark">Dark</option></select></label>
@@ -188,6 +188,7 @@ async function settingsConflict(form, toast) {
 }
 
 function applySavedTheme(theme) {
+  // The app shell owns theme application and persists this event contract.
   globalThis.dispatchEvent(new CustomEvent('dh:theme-setting-changed', { detail: { theme } }));
 }
 
@@ -225,7 +226,7 @@ function settingValueLabel(value) {
 
 function setFormBusy(form, busy) {
   form.setAttribute('aria-busy', String(busy));
-  if (form.id === 'account-profile-form') {
+  if (form.dataset.settingsForm === 'profile') {
     form.elements.display_name.disabled = busy || form.dataset.canPatch !== 'true';
     form.querySelector('button[type="submit"]').disabled = busy || form.dataset.canPatch !== 'true';
     return;

--- a/src/web-console/ui/account-settings.js
+++ b/src/web-console/ui/account-settings.js
@@ -1,0 +1,250 @@
+/** Profile and allowlisted account settings self-service panel. */
+
+import { del, get, patch, put } from './api.js';
+
+const THEME_SETTING_KEY = 'display_config.theme';
+const PROFILE_PATH = '/me/profile';
+const SETTINGS_PATH = '/me/settings';
+const THEME_RESET_SELECTOR = '[data-theme-reset]';
+const UNSUPPORTED_THEME_VALUE = '__unsupported_saved_theme__';
+const SUPPORTED_THEMES = new Set(['light', 'dark']);
+
+export async function openAccountSettings({ hasRoute, toast }) {
+  const previousFocus = document.activeElement;
+  const panel = accountPanel();
+  document.body.appendChild(panel);
+  panel.querySelector('[data-account-close]').focus();
+  const close = () => {
+    panel.remove();
+    document.removeEventListener('keydown', onKey);
+    if (previousFocus instanceof HTMLElement && previousFocus.isConnected) previousFocus.focus();
+  };
+  const onKey = event => {
+    if (event.key === 'Escape') close();
+    if (event.key !== 'Tab') return;
+    const controls = [...panel.querySelectorAll('button:not(:disabled), input:not(:disabled), select:not(:disabled)')];
+    const current = controls.indexOf(document.activeElement);
+    const offset = event.shiftKey ? -1 : 1;
+    event.preventDefault();
+    controls[(current + offset + controls.length) % controls.length]?.focus();
+  };
+  panel.querySelector('.account-settings-backdrop').addEventListener('click', close);
+  panel.querySelectorAll('[data-account-close]').forEach(button => button.addEventListener('click', close));
+  document.addEventListener('keydown', onKey);
+
+  const profileForm = panel.querySelector('#account-profile-form');
+  const themeForm = panel.querySelector('#account-theme-form');
+  profileForm.hidden = !hasRoute('GET', PROFILE_PATH);
+  themeForm.hidden = !hasRoute('GET', SETTINGS_PATH);
+  profileForm.dataset.canPatch = String(hasRoute('PATCH', PROFILE_PATH));
+  themeForm.dataset.canPut = String(hasRoute('PUT', '/me/settings/:key'));
+  themeForm.dataset.canDelete = String(hasRoute('DELETE', '/me/settings/:key'));
+
+  const profilePromise = profileForm.hidden ? Promise.resolve() : loadProfile(profileForm, hasRoute);
+  const settingsPromise = themeForm.hidden ? Promise.resolve() : loadTheme(themeForm);
+  await Promise.all([profilePromise, settingsPromise]);
+
+  profileForm.addEventListener('submit', event => {
+    event.preventDefault();
+    saveProfile(profileForm, toast);
+  });
+  themeForm.addEventListener('submit', event => {
+    event.preventDefault();
+    saveTheme(themeForm, toast);
+  });
+  themeForm.querySelector(THEME_RESET_SELECTOR).addEventListener('click', () => resetTheme(themeForm, toast));
+}
+
+function accountPanel() {
+  const panel = document.createElement('div');
+  panel.className = 'account-settings-modal';
+  panel.id = 'account-settings-modal';
+  panel.innerHTML = `
+    <div class="account-settings-backdrop"></div>
+    <section class="account-settings-card" role="dialog" aria-modal="true" aria-labelledby="account-settings-title">
+      <header class="security-card-header">
+        <div><h2 class="account-settings-title" id="account-settings-title">Profile & settings</h2><p>Manage the small set of account preferences supported by this console.</p></div>
+        <button class="security-close" data-account-close type="button" aria-label="Close">&#x2715;</button>
+      </header>
+      <div class="account-settings-body">
+        <form class="account-settings-section" id="account-profile-form">
+          <h3>Profile</h3>
+          <p class="account-settings-note">Your username and email are managed by your sign-in provider.</p>
+          <label class="portfolio-field"><span>Display name</span><input name="display_name" maxlength="200" disabled></label>
+          <dl class="account-settings-meta"><div><dt>Username</dt><dd data-profile-username>Loading…</dd></div><div><dt>Email</dt><dd data-profile-email>Loading…</dd></div></dl>
+          <div class="account-settings-feedback" data-profile-feedback aria-live="polite"></div>
+          <div class="account-settings-actions"><button class="btn btn-primary" type="submit" disabled>Save profile</button></div>
+        </form>
+        <form class="account-settings-section" id="account-theme-form">
+          <h3>Appearance</h3>
+          <p class="account-settings-note">Theme is the only advanced setting with a stable console contract today.</p>
+          <label class="portfolio-field"><span>Theme</span><select name="theme" disabled><option value="light">Light</option><option value="dark">Dark</option></select></label>
+          <div class="account-settings-feedback" data-theme-feedback aria-live="polite"></div>
+          <div class="account-settings-actions"><button class="btn btn-ghost" data-theme-reset type="button" disabled>Reset saved theme</button><button class="btn btn-primary" type="submit" disabled>Save appearance</button></div>
+        </form>
+      </div>
+      <footer class="account-settings-foot"><button class="btn btn-ghost" data-account-close type="button">Close</button></footer>
+    </section>`;
+  return panel;
+}
+
+async function loadProfile(form, hasRoute) {
+  const response = await get(PROFILE_PATH);
+  if (response.status !== 200 || !response.body) {
+    showFeedback(form, 'profile', detail(response, 'Profile could not be loaded.'), 'error');
+    return;
+  }
+  form.elements.display_name.value = response.body.display_name ?? '';
+  form.elements.display_name.disabled = !hasRoute('PATCH', PROFILE_PATH);
+  form.querySelector('button[type="submit"]').disabled = !hasRoute('PATCH', PROFILE_PATH);
+  form.querySelector('[data-profile-username]').textContent = response.body.username || '—';
+  form.querySelector('[data-profile-email]').textContent = response.body.email || 'Not provided';
+}
+
+async function saveProfile(form, toast) {
+  setFormBusy(form, true);
+  try {
+    const displayName = form.elements.display_name.value.trim();
+    const response = await patch(PROFILE_PATH, { body: { display_name: displayName || null } });
+    if (response.status !== 200 || !response.body) {
+      showFeedback(form, 'profile', detail(response, 'Profile could not be saved.'), 'error');
+      return;
+    }
+    showFeedback(form, 'profile', 'Profile saved.', 'success');
+    globalThis.dispatchEvent(new CustomEvent('dh:profile-updated', { detail: { profile: response.body } }));
+    toast('Profile saved.', 'success');
+  } catch {
+    showFeedback(form, 'profile', 'Profile could not reach the server.', 'error');
+  } finally {
+    setFormBusy(form, false);
+  }
+}
+
+async function loadTheme(form) {
+  const response = await get(SETTINGS_PATH);
+  if (response.status !== 200 || !response.body) {
+    showFeedback(form, 'theme', detail(response, 'Settings could not be loaded.'), 'error');
+    return;
+  }
+  const savedTheme = response.body.display_config?.theme;
+  form.dataset.etag = response.etag || response.body.etag || '';
+  form.dataset.hasSavedTheme = String(savedTheme !== undefined && savedTheme !== null);
+  setThemeSelection(form, savedTheme);
+  setFormBusy(form, false);
+}
+
+async function saveTheme(form, toast) {
+  setFormBusy(form, true);
+  try {
+    const theme = form.elements.theme.value;
+    const response = await put(`/me/settings/${THEME_SETTING_KEY}`, {
+      body: { value: theme },
+      ifMatch: form.dataset.etag,
+    });
+    if (response.status === 412) return settingsConflict(form, toast);
+    if (response.status !== 200) {
+      showFeedback(form, 'theme', detail(response, 'Appearance could not be saved.'), 'error');
+      return;
+    }
+    form.dataset.etag = response.etag || response.body?.etag || '';
+    form.dataset.hasSavedTheme = 'true';
+    setThemeSelection(form, theme);
+    applySavedTheme(theme);
+    showFeedback(form, 'theme', 'Appearance saved.', 'success');
+    toast('Appearance saved.', 'success');
+  } catch {
+    showFeedback(form, 'theme', 'Settings could not reach the server.', 'error');
+  } finally {
+    setFormBusy(form, false);
+  }
+}
+
+async function resetTheme(form, toast) {
+  setFormBusy(form, true);
+  try {
+    const response = await del(`/me/settings/${THEME_SETTING_KEY}`, { ifMatch: form.dataset.etag });
+    if (response.status === 412) return settingsConflict(form, toast);
+    if (response.status !== 200) {
+      showFeedback(form, 'theme', detail(response, 'Saved appearance could not be reset.'), 'error');
+      return;
+    }
+    form.dataset.etag = response.etag || response.body?.etag || '';
+    form.dataset.hasSavedTheme = 'false';
+    setThemeSelection(form, null);
+    applySavedTheme('light');
+    showFeedback(form, 'theme', 'Saved theme reset to the default.', 'success');
+    toast('Saved theme reset.', 'success');
+  } catch {
+    showFeedback(form, 'theme', 'Settings could not reach the server.', 'error');
+  } finally {
+    setFormBusy(form, false);
+  }
+}
+
+async function settingsConflict(form, toast) {
+  showFeedback(form, 'theme', 'Settings changed elsewhere. Your choice was not saved; the latest settings are being loaded.', 'error');
+  toast('Appearance was not overwritten because settings changed elsewhere.', 'warn');
+  await loadTheme(form);
+}
+
+function applySavedTheme(theme) {
+  globalThis.dispatchEvent(new CustomEvent('dh:theme-setting-changed', { detail: { theme } }));
+}
+
+function setThemeSelection(form, savedTheme) {
+  form.elements.theme.querySelector('[data-unsupported-theme]')?.remove();
+  if (savedTheme === undefined || savedTheme === null) {
+    form.dataset.themeSupported = 'true';
+    form.elements.theme.value = 'light';
+    return;
+  }
+  if (typeof savedTheme === 'string' && SUPPORTED_THEMES.has(savedTheme)) {
+    form.dataset.themeSupported = 'true';
+    form.elements.theme.value = savedTheme;
+    return;
+  }
+
+  const option = document.createElement('option');
+  option.dataset.unsupportedTheme = 'true';
+  option.value = UNSUPPORTED_THEME_VALUE;
+  option.textContent = `Unsupported saved value: ${settingValueLabel(savedTheme)}`;
+  form.elements.theme.appendChild(option);
+  form.elements.theme.value = UNSUPPORTED_THEME_VALUE;
+  form.dataset.themeSupported = 'false';
+  showFeedback(form, 'theme', 'The saved theme is not supported by this console. Reset it before choosing a new theme.', 'warn');
+}
+
+function settingValueLabel(value) {
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function setFormBusy(form, busy) {
+  form.setAttribute('aria-busy', String(busy));
+  if (form.id === 'account-profile-form') {
+    form.elements.display_name.disabled = busy || form.dataset.canPatch !== 'true';
+    form.querySelector('button[type="submit"]').disabled = busy || form.dataset.canPatch !== 'true';
+    return;
+  }
+  const canEditTheme = form.dataset.canPut === 'true' && form.dataset.themeSupported !== 'false';
+  form.elements.theme.disabled = busy || !canEditTheme;
+  form.querySelector('button[type="submit"]').disabled = busy || !canEditTheme;
+  const hasSavedTheme = form.dataset.hasSavedTheme === 'true';
+  form.querySelector(THEME_RESET_SELECTOR).disabled = busy || !hasSavedTheme || form.dataset.canDelete !== 'true';
+}
+
+function showFeedback(form, area, message, kind) {
+  form.querySelector(`[data-${area}-feedback]`).innerHTML = `<p class="portfolio-message portfolio-message--${kind}">${escapeHtml(message)}</p>`;
+}
+
+function detail(response, fallback) {
+  return typeof response.body?.detail === 'string' ? response.body.detail : fallback;
+}
+
+function escapeHtml(value) {
+  return String(value ?? '').replaceAll(/[&<>"']/g, character => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[character]));
+}

--- a/src/web-console/ui/app.js
+++ b/src/web-console/ui/app.js
@@ -10,6 +10,7 @@ import { whoami, login, logout, get } from './api.js';
 import { loadConsoleMetadata } from './console-meta.js';
 import { initElevation } from './elevation.js';
 import { openSecurityPanel } from './security.js';
+import { openAccountSettings } from './account-settings.js';
 
 const THEME_KEY = 'dh-console-theme';
 
@@ -125,6 +126,10 @@ function configureAvailableTabs(metadata) {
   });
   const accountSecurity = document.getElementById('account-security');
   if (accountSecurity) accountSecurity.hidden = !metadata.hasRoute('GET', '/me/security/factors');
+  const accountSettings = document.getElementById('account-settings');
+  if (accountSettings) {
+    accountSettings.hidden = !metadata.hasRoute('GET', '/me/profile') && !metadata.hasRoute('GET', '/me/settings');
+  }
 }
 
 function showNoAvailableFeatures() {
@@ -211,6 +216,10 @@ function initAccountMenu() {
   document.getElementById('account-security')?.addEventListener('click', () => {
     setOpen(false);
     openSecurityPanel({ toast, hasRoute: consoleMetadata?.hasRoute });
+  });
+  document.getElementById('account-settings')?.addEventListener('click', () => {
+    setOpen(false);
+    openAccountSettings({ toast, hasRoute: consoleMetadata?.hasRoute || (() => false) });
   });
 }
 
@@ -312,6 +321,17 @@ function init() {
   initStepUp();
   // Reveal/hide admin-only tabs as elevation comes and goes.
   globalThis.addEventListener('dh:elevation-changed', (e) => applyAdminTabVisibility(e.detail));
+  globalThis.addEventListener('dh:profile-updated', event => {
+    const profile = event.detail?.profile;
+    const account = document.getElementById('site-account');
+    if (account && profile) account.textContent = profile.display_name || profile.username || account.textContent;
+  });
+  globalThis.addEventListener('dh:theme-setting-changed', event => {
+    const theme = event.detail?.theme;
+    if (theme !== 'light' && theme !== 'dark') return;
+    localStorage.setItem(THEME_KEY, theme);
+    applyTheme(theme);
+  });
   document.getElementById('auth-gate-signin')?.addEventListener('click', () => login('/ui'));
   document.getElementById('logout-btn')?.addEventListener('click', () => logout());
   runAuthGate();

--- a/src/web-console/ui/index.html
+++ b/src/web-console/ui/index.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="logs.css">
   <link rel="stylesheet" href="admin-metrics.css">
   <link rel="stylesheet" href="integrations.css">
+  <link rel="stylesheet" href="portfolio-actions.css">
 </head>
 <body>
 
@@ -47,6 +48,7 @@
         <div class="account-menu-wrap">
           <button class="site-account" id="site-account" type="button" aria-haspopup="menu" aria-expanded="false" aria-live="polite"></button>
           <div class="account-menu" id="account-menu" role="menu" hidden>
+            <button class="account-menu-item" id="account-settings" role="menuitem" type="button">Profile &amp; settings</button>
             <button class="account-menu-item" id="account-security" role="menuitem" type="button">Security</button>
           </div>
         </div>

--- a/src/web-console/ui/portfolio-actions.css
+++ b/src/web-console/ui/portfolio-actions.css
@@ -1,0 +1,135 @@
+/* Portfolio authoring, sync, and account self-service surfaces. */
+
+.portfolio-command-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.8rem;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--paper-strong) 88%, var(--surface-1));
+}
+.portfolio-summary { color: var(--ink-700); font-family: var(--font-mono); font-size: var(--step--1); }
+.portfolio-command-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+.portfolio-card-edit { display: flex; gap: 0.35rem; }
+.portfolio-card-edit .card-download-btn { width: auto; min-width: 2rem; padding: 0 0.5rem; }
+
+dialog.portfolio-editor,
+dialog.portfolio-sync {
+  position: fixed;
+  inset: 0;
+  z-index: 140;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  padding: clamp(0.5rem, 3vw, 2rem);
+  border: 0;
+  background: rgba(0, 0, 0, 0.42);
+  color: inherit;
+}
+dialog.portfolio-editor::backdrop,
+dialog.portfolio-sync::backdrop { background: transparent; }
+.portfolio-editor-card,
+.portfolio-sync-card {
+  display: flex;
+  flex-direction: column;
+  width: min(820px, 100%);
+  max-height: calc(100dvh - clamp(1rem, 6vw, 4rem));
+  margin: 0 auto;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--paper-strong);
+  box-shadow: var(--shadow-card);
+}
+.portfolio-sync-card { width: min(560px, 100%); }
+.portfolio-editor-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.15rem;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface-1);
+}
+.portfolio-editor-head h2,
+.account-settings-title { margin: 0; color: var(--ink-950); font-family: var(--font-heading); font-size: var(--step-2); }
+.portfolio-editor-head p,
+.security-card-header p { margin: 0.25rem 0 0; color: var(--ink-500); font-size: var(--step--1); }
+.portfolio-editor-body { flex: 1; overflow-y: auto; padding: 1rem 1.15rem; }
+.portfolio-form-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.8rem; }
+.portfolio-field { display: flex; flex-direction: column; gap: 0.3rem; color: var(--ink-700); font-size: var(--step--1); }
+.portfolio-field > span { font-weight: 650; }
+.portfolio-field small { color: var(--ink-500); font-weight: 400; }
+.portfolio-field--wide { grid-column: 1 / -1; }
+.portfolio-field input,
+.portfolio-field select,
+.portfolio-field textarea {
+  width: 100%;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  color: var(--ink-900);
+  font: inherit;
+}
+.portfolio-field textarea { resize: vertical; font-family: var(--font-mono); line-height: 1.45; }
+.portfolio-field input:focus,
+.portfolio-field select:focus,
+.portfolio-field textarea:focus { outline: 2px solid var(--signal); outline-offset: 1px; border-color: var(--signal); }
+.portfolio-field input:read-only,
+.portfolio-field select:disabled { color: var(--ink-500); background: var(--surface-1); }
+.portfolio-editor-actions,
+.account-settings-foot {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.8rem 1.15rem;
+  border-top: 1px solid var(--line);
+  background: var(--surface-1);
+}
+.portfolio-editor-spacer { flex: 1; }
+.portfolio-editor-feedback { margin-top: 0.85rem; }
+.portfolio-message { margin: 0; padding: 0.65rem 0.75rem; border: 1px solid var(--line); border-radius: var(--radius-sm); font-size: var(--step--1); }
+.portfolio-message--success { color: #166534; border-color: color-mix(in srgb, #22c55e 35%, var(--line)); background: color-mix(in srgb, #22c55e 8%, var(--paper)); }
+.portfolio-message--error { color: #b91c1c; border-color: color-mix(in srgb, #dc2626 35%, var(--line)); background: color-mix(in srgb, #dc2626 7%, var(--paper)); }
+[data-theme="dark"] .portfolio-message--success { color: #86efac; }
+[data-theme="dark"] .portfolio-message--error { color: #fca5a5; }
+.portfolio-message p { margin: 0; }
+.portfolio-message ul { margin: 0.4rem 0 0; padding-left: 1.25rem; }
+.portfolio-preview { margin-top: 0.85rem; padding: 0.8rem; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface-1); }
+.portfolio-preview h3 { margin: 0 0 0.5rem; font-size: var(--step-0); }
+.portfolio-preview pre,
+.portfolio-sync-status pre { overflow: auto; white-space: pre-wrap; overflow-wrap: anywhere; font-family: var(--font-mono); font-size: var(--step--1); }
+.portfolio-danger { color: #b91c1c; border-color: color-mix(in srgb, #dc2626 45%, var(--line)); }
+.portfolio-sync-fields { display: grid; gap: 0.9rem; }
+.portfolio-sync-status { min-height: 3rem; padding: 0.75rem; border: 1px solid var(--line); border-radius: var(--radius-sm); background: var(--surface-1); color: var(--ink-700); font-size: var(--step--1); }
+.portfolio-sync-status p { margin: 0.2rem 0; }
+
+.account-settings-modal { position: fixed; inset: 0; z-index: 135; display: flex; align-items: center; justify-content: center; padding: 1rem; }
+.account-settings-backdrop { position: absolute; inset: 0; background: rgba(0, 0, 0, 0.42); backdrop-filter: blur(2px); }
+.account-settings-card { position: relative; display: flex; flex-direction: column; width: min(660px, 96vw); max-height: min(780px, 92vh); overflow: hidden; border: 1px solid var(--line); border-radius: var(--radius-lg); background: var(--paper-strong); box-shadow: var(--shadow-card); }
+.account-settings-card .security-card-header { align-items: flex-start; }
+.account-settings-body { overflow-y: auto; padding: 0 1.15rem; }
+.account-settings-section { padding: 1.1rem 0; border-bottom: 1px solid var(--line); }
+.account-settings-section:last-child { border-bottom: 0; }
+.account-settings-section h3 { margin: 0 0 0.2rem; color: var(--ink-900); font-family: var(--font-heading); font-size: var(--step-1); }
+.account-settings-note { margin: 0 0 0.8rem; color: var(--ink-500); font-size: var(--step--1); }
+.account-settings-meta { display: grid; gap: 0.3rem; margin: 0.8rem 0; font-size: var(--step--1); }
+.account-settings-meta div { display: grid; grid-template-columns: 100px 1fr; gap: 0.6rem; }
+.account-settings-meta dt { color: var(--ink-500); }
+.account-settings-meta dd { margin: 0; color: var(--ink-900); overflow-wrap: anywhere; }
+.account-settings-feedback { margin-top: 0.7rem; }
+.account-settings-actions { display: flex; justify-content: flex-end; gap: 0.5rem; margin-top: 0.8rem; }
+.account-settings-foot { justify-content: flex-end; }
+
+@media (max-width: 640px) {
+  .portfolio-command-bar { align-items: flex-start; flex-direction: column; }
+  .portfolio-form-grid { grid-template-columns: 1fr; }
+  .portfolio-field--wide { grid-column: auto; }
+  .portfolio-editor-actions { flex-wrap: wrap; }
+  .portfolio-editor-spacer { flex-basis: 100%; }
+}

--- a/src/web-console/ui/portfolio-actions.css
+++ b/src/web-console/ui/portfolio-actions.css
@@ -12,11 +12,28 @@
   background: color-mix(in srgb, var(--paper-strong) 88%, var(--surface-1));
 }
 .portfolio-summary { color: var(--ink-700); font-family: var(--font-mono); font-size: var(--step--1); }
-.portfolio-command-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+.portfolio-command-actions { display: flex; align-items: center; justify-content: flex-end; gap: 0.45rem; flex-wrap: wrap; }
+.portfolio-command-actions #pf-sync { order: -1; }
+.portfolio-start-action {
+  display: flex;
+  flex-direction: column;
+  gap: 0.05rem;
+  min-width: 0;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid color-mix(in srgb, var(--signal) 45%, var(--line));
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--signal) 7%, var(--paper));
+  color: var(--ink-900);
+  text-align: left;
+  cursor: pointer;
+}
+.portfolio-start-action:hover { border-color: var(--signal); background: color-mix(in srgb, var(--signal) 12%, var(--paper)); }
+.portfolio-start-action:focus-visible { outline: 2px solid var(--signal); outline-offset: 2px; }
+.portfolio-start-action strong { font-family: var(--font-heading); font-size: var(--step--1); }
+.portfolio-start-action span { max-width: 180px; color: var(--ink-500); font-size: 0.68rem; }
 .portfolio-card-edit { display: flex; gap: 0.35rem; }
 .portfolio-card-edit .card-download-btn { width: auto; min-width: 2rem; padding: 0 0.5rem; }
 
-dialog.portfolio-editor,
 dialog.portfolio-sync {
   position: fixed;
   inset: 0;
@@ -30,14 +47,16 @@ dialog.portfolio-sync {
   background: rgba(0, 0, 0, 0.42);
   color: inherit;
 }
-dialog.portfolio-editor::backdrop,
 dialog.portfolio-sync::backdrop { background: transparent; }
-.portfolio-editor-card,
+.portfolio-workspace {
+  width: min(1040px, 100%);
+  margin: 0 auto;
+}
+.portfolio-editor,
 .portfolio-sync-card {
   display: flex;
   flex-direction: column;
-  width: min(820px, 100%);
-  max-height: calc(100dvh - clamp(1rem, 6vw, 4rem));
+  width: 100%;
   margin: 0 auto;
   overflow: hidden;
   border: 1px solid var(--line);
@@ -45,6 +64,7 @@ dialog.portfolio-sync::backdrop { background: transparent; }
   background: var(--paper-strong);
   box-shadow: var(--shadow-card);
 }
+.portfolio-editor { min-height: min(780px, calc(100dvh - 10rem)); }
 .portfolio-sync-card { width: min(560px, 100%); }
 .portfolio-editor-head {
   display: flex;
@@ -55,11 +75,30 @@ dialog.portfolio-sync::backdrop { background: transparent; }
   border-bottom: 1px solid var(--line);
   background: var(--surface-1);
 }
+.portfolio-back-link {
+  margin: 0 0 0.55rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--signal);
+  font: inherit;
+  font-size: var(--step--1);
+  cursor: pointer;
+}
+.portfolio-back-link:hover { text-decoration: underline; }
+.portfolio-back-link:focus-visible { outline: 2px solid var(--signal); outline-offset: 3px; }
 .portfolio-editor-head h2,
 .account-settings-title { margin: 0; color: var(--ink-950); font-family: var(--font-heading); font-size: var(--step-2); }
 .portfolio-editor-head p,
 .security-card-header p { margin: 0.25rem 0 0; color: var(--ink-500); font-size: var(--step--1); }
-.portfolio-editor-body { flex: 1; overflow-y: auto; padding: 1rem 1.15rem; }
+.portfolio-editor-body { flex: 1; padding: 1rem 1.15rem 1.5rem; }
+.portfolio-editor-feedback {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: 0.7rem 1.15rem 0;
+  background: var(--paper-strong);
+}
 .portfolio-form-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.8rem; }
 .portfolio-field { display: flex; flex-direction: column; gap: 0.3rem; color: var(--ink-700); font-size: var(--step--1); }
 .portfolio-field > span { font-weight: 650; }
@@ -82,8 +121,213 @@ dialog.portfolio-sync::backdrop { background: transparent; }
 .portfolio-field textarea:focus { outline: 2px solid var(--signal); outline-offset: 1px; border-color: var(--signal); }
 .portfolio-field input:read-only,
 .portfolio-field select:disabled { color: var(--ink-500); background: var(--surface-1); }
+.portfolio-type-chooser {
+  margin: 0 0 1rem;
+  padding: 0;
+  border: 0;
+}
+.portfolio-type-chooser legend {
+  margin-bottom: 0.55rem;
+  color: var(--ink-900);
+  font-family: var(--font-heading);
+  font-size: var(--step-0);
+  font-weight: 700;
+}
+.portfolio-type-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.55rem; }
+.portfolio-type-choice { position: relative; cursor: pointer; }
+.portfolio-type-choice input { position: absolute; width: 1px; height: 1px; opacity: 0; }
+.portfolio-type-choice > span {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  height: 100%;
+  padding: 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--paper);
+}
+.portfolio-type-choice strong { color: var(--ink-900); font-family: var(--font-heading); }
+.portfolio-type-choice small { color: var(--ink-500); font-size: var(--step--2); line-height: 1.35; }
+.portfolio-type-choice input:checked + span {
+  border-color: var(--signal);
+  background: color-mix(in srgb, var(--signal) 9%, var(--paper));
+  box-shadow: inset 0 0 0 1px var(--signal);
+}
+.portfolio-type-choice input:focus-visible + span { outline: 2px solid var(--signal); outline-offset: 2px; }
+.portfolio-builder-overview {
+  display: flex;
+  align-items: baseline;
+  gap: 0.65rem;
+  margin-bottom: 0.85rem;
+  padding: 0.7rem 0.8rem;
+  border-left: 3px solid var(--signal);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  background: color-mix(in srgb, var(--signal) 7%, var(--paper));
+}
+.portfolio-builder-overview strong { flex: none; color: var(--ink-900); font-family: var(--font-heading); }
+.portfolio-builder-overview span { color: var(--ink-600); font-size: var(--step--1); }
+.portfolio-builder-step {
+  margin-bottom: 0.85rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--paper);
+}
+.portfolio-builder-step > header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  margin-bottom: 0.8rem;
+}
+.portfolio-builder-step > header > span {
+  display: grid;
+  flex: 0 0 1.6rem;
+  width: 1.6rem;
+  height: 1.6rem;
+  place-items: center;
+  border-radius: 999px;
+  background: var(--signal);
+  color: white;
+  font-family: var(--font-mono);
+  font-size: var(--step--2);
+  font-weight: 700;
+}
+.portfolio-builder-step h3,
+.portfolio-repeat-head h4 { margin: 0; color: var(--ink-900); font-family: var(--font-heading); font-size: var(--step-0); }
+.portfolio-builder-step header p,
+.portfolio-repeat-head p { margin: 0.1rem 0 0; color: var(--ink-500); font-size: var(--step--1); }
+.portfolio-type-settings[hidden] { display: none; }
+.portfolio-check-field {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-1);
+  cursor: pointer;
+}
+.portfolio-check-field input { margin-top: 0.15rem; }
+.portfolio-check-field span { display: flex; flex-direction: column; gap: 0.1rem; }
+.portfolio-check-field strong { color: var(--ink-900); font-size: var(--step--1); }
+.portfolio-check-field small { color: var(--ink-500); font-size: var(--step--2); }
+.portfolio-repeat-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0.9rem 0 0.55rem;
+}
+.portfolio-repeat-head h4 small { color: var(--ink-500); font-family: var(--font-body); font-size: var(--step--2); font-weight: 500; }
+.portfolio-repeat-list { display: grid; gap: 0.5rem; }
+.portfolio-repeat-row {
+  display: grid;
+  grid-template-columns: minmax(100px, 0.8fr) minmax(90px, 0.6fr) minmax(150px, 1.4fr) auto auto;
+  align-items: end;
+  gap: 0.45rem;
+  padding: 0.6rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-1);
+}
+.portfolio-repeat-row--ensemble { grid-template-columns: repeat(5, minmax(80px, 0.6fr)) minmax(150px, 1.2fr) auto; }
+.portfolio-repeat-row label { display: flex; flex-direction: column; gap: 0.2rem; color: var(--ink-600); font-size: var(--step--2); }
+.portfolio-repeat-row input,
+.portfolio-repeat-row select {
+  width: 100%;
+  min-width: 0;
+  padding: 0.45rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  color: var(--ink-900);
+  font: inherit;
+}
+.portfolio-repeat-check { align-self: center; flex-direction: row !important; align-items: center; }
+.portfolio-repeat-grow { min-width: 0; }
+.portfolio-readonly-type {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+  color: var(--ink-500);
+  font-size: var(--step--1);
+}
+.portfolio-readonly-type strong {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--ink-900);
+  background: var(--surface-1);
+}
+.portfolio-advanced {
+  padding: 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-1);
+}
+.portfolio-advanced summary { color: var(--ink-900); font-weight: 700; cursor: pointer; }
+.portfolio-advanced > p { margin: 0.45rem 0 0.75rem; color: var(--ink-500); font-size: var(--step--1); }
+.portfolio-custom-metadata-notice {
+  margin: 0;
+  padding: 0.65rem 0.8rem;
+  border: 1px solid color-mix(in srgb, var(--signal) 35%, var(--line));
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--signal) 7%, var(--paper));
+  color: var(--ink-700);
+  font-size: var(--step--1);
+}
+.portfolio-metadata-enable {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--signal);
+  font: inherit;
+  font-size: var(--step--1);
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+  cursor: pointer;
+}
+.portfolio-metadata-status { display: block; color: var(--ink-500); }
+.portfolio-metadata-status.is-valid { color: #166534; }
+.portfolio-metadata-status.is-error { color: #b91c1c; }
+[data-theme="dark"] .portfolio-metadata-status.is-valid { color: #86efac; }
+[data-theme="dark"] .portfolio-metadata-status.is-error { color: #fca5a5; }
+.portfolio-import-picker { margin-bottom: 1rem; }
+.portfolio-drop-zone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.45rem;
+  padding: clamp(1.25rem, 4vw, 2.5rem);
+  border: 2px dashed color-mix(in srgb, var(--signal) 55%, var(--line));
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--signal) 5%, var(--paper));
+  text-align: center;
+}
+.portfolio-drop-zone.is-dragging { border-color: var(--signal); background: color-mix(in srgb, var(--signal) 12%, var(--paper)); }
+.portfolio-drop-zone > strong { color: var(--ink-900); font-family: var(--font-heading); font-size: var(--step-1); }
+.portfolio-drop-zone p { margin: 0; color: var(--ink-500); }
+.portfolio-drop-zone > small { color: var(--ink-500); font-size: var(--step--2); }
+.portfolio-import-source {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.65rem;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-1);
+  color: var(--ink-700);
+  font-size: var(--step--1);
+}
+.portfolio-import-source span { color: var(--ink-500); }
 .portfolio-editor-actions,
 .account-settings-foot {
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -92,8 +336,8 @@ dialog.portfolio-sync::backdrop { background: transparent; }
   background: var(--surface-1);
 }
 .portfolio-editor-spacer { flex: 1; }
-.portfolio-editor-feedback { margin-top: 0.85rem; }
 .portfolio-message { margin: 0; padding: 0.65rem 0.75rem; border: 1px solid var(--line); border-radius: var(--radius-sm); font-size: var(--step--1); }
+.portfolio-message--info { color: var(--ink-700); background: var(--surface-1); }
 .portfolio-message--success { color: #166534; border-color: color-mix(in srgb, #22c55e 35%, var(--line)); background: color-mix(in srgb, #22c55e 8%, var(--paper)); }
 .portfolio-message--error { color: #b91c1c; border-color: color-mix(in srgb, #dc2626 35%, var(--line)); background: color-mix(in srgb, #dc2626 7%, var(--paper)); }
 [data-theme="dark"] .portfolio-message--success { color: #86efac; }
@@ -128,8 +372,15 @@ dialog.portfolio-sync::backdrop { background: transparent; }
 
 @media (max-width: 640px) {
   .portfolio-command-bar { align-items: flex-start; flex-direction: column; }
+  .portfolio-command-actions { width: 100%; justify-content: flex-start; }
+  .portfolio-start-action { flex: 1; }
+  .portfolio-type-grid { grid-template-columns: 1fr; }
+  .portfolio-builder-overview { align-items: flex-start; flex-direction: column; }
   .portfolio-form-grid { grid-template-columns: 1fr; }
   .portfolio-field--wide { grid-column: auto; }
+  .portfolio-repeat-row,
+  .portfolio-repeat-row--ensemble { grid-template-columns: 1fr; align-items: stretch; }
   .portfolio-editor-actions { flex-wrap: wrap; }
   .portfolio-editor-spacer { flex-basis: 100%; }
+  .portfolio-import-source { align-items: flex-start; flex-direction: column; }
 }

--- a/src/web-console/ui/portfolio-authoring.js
+++ b/src/web-console/ui/portfolio-authoring.js
@@ -83,7 +83,7 @@ Owner: {{owner}}
 });
 const IMPORT_FILE_LIMIT_BYTES = 1_100_000;
 const IMPORT_ENVELOPE_KEYS = new Set([
-  'metadata', 'content', 'instructions', 'entries', 'stats', 'id', 'type', 'name', 'tags',
+  'metadata', 'content', 'instructions', 'entries', 'stats', 'extensions', 'id', 'type', 'name', 'tags',
   'display_name', 'canonical_name', 'validation_status', 'updated_at',
 ]);
 const GUIDED_METADATA_KEYS = new Set([
@@ -1197,7 +1197,11 @@ function normalizeImportedDraft(parsed, originalSource, filename) {
     portable,
     packageRecord,
   });
-  const explicitInstructions = firstString(nested.instructions, metadata.instructions);
+  const explicitInstructions = firstString(
+    nested.instructions,
+    metadata.instructions,
+    asRecord(nested.extensions).instructions,
+  );
   const legacyInstructionBody = parsed.format === 'markdown' &&
     ['personas', 'skills', 'agents'].includes(type) &&
     !explicitInstructions;
@@ -1244,7 +1248,7 @@ function importedMetadata(record) {
     return metadata;
   }
   const metadata = { ...record };
-  for (const key of ['content', 'instructions', 'entries', 'stats', 'extensions', 'id', 'type']) delete metadata[key];
+  for (const key of IMPORT_ENVELOPE_KEYS) delete metadata[key];
   return metadata;
 }
 

--- a/src/web-console/ui/portfolio-authoring.js
+++ b/src/web-console/ui/portfolio-authoring.js
@@ -3,11 +3,105 @@
 import { del, get, patch, post } from './api.js';
 
 const TYPES = ['personas', 'skills', 'templates', 'agents', 'memories', 'ensembles'];
+const TYPE_GUIDANCE = Object.freeze({
+  personas: {
+    label: 'Persona',
+    summary: 'Voice, behavior, and role instructions.',
+    instructionsLabel: 'Behavioral instructions',
+    instructionsHelp: 'Tell the assistant who it is and how it must behave. Use direct language such as “You are…” and “Always…”.',
+    instructionsPlaceholder: 'You are a thoughtful technical editor. Always explain tradeoffs clearly…',
+    instructionsRequired: true,
+    contentLabel: 'Reference material',
+    contentHelp: 'Optional reference material, examples, or domain knowledge the persona can draw from.',
+    placeholder: 'Add background knowledge, examples, or reference material…',
+    contentRequired: false,
+  },
+  skills: {
+    label: 'Skill',
+    summary: 'A reusable capability or procedure.',
+    instructionsLabel: 'Procedure',
+    instructionsHelp: 'Give the ordered steps and decision rules for performing this skill.',
+    instructionsPlaceholder: `When asked to review code:
+1. Identify the intended behavior…`,
+    instructionsRequired: true,
+    contentLabel: 'Supporting material',
+    contentHelp: 'Optional examples, reference material, or supporting documentation.',
+    placeholder: 'Add examples, checklists, or reference material…',
+    contentRequired: false,
+  },
+  templates: {
+    label: 'Template',
+    summary: 'Reusable content with optional variables.',
+    instructionsLabel: 'Usage instructions',
+    instructionsHelp: 'Optionally explain when and how this template should be used.',
+    instructionsPlaceholder: 'Use this template when drafting a project status update…',
+    instructionsRequired: false,
+    contentLabel: 'Template content',
+    contentHelp: 'Write the reusable content. Include any placeholders your template expects.',
+    placeholder: `# {{project_name}} status
+
+Owner: {{owner}}
+…`,
+    contentRequired: true,
+  },
+  agents: {
+    label: 'Agent',
+    summary: 'A goal-oriented autonomous configuration.',
+    instructionsLabel: 'Operating instructions',
+    instructionsHelp: 'Explain how the agent should work, make decisions, and report progress.',
+    instructionsPlaceholder: 'Work incrementally, verify each result, and pause when approval is required…',
+    instructionsRequired: false,
+    contentLabel: 'Reference material',
+    contentHelp: 'Optional reference material the agent can use while pursuing its goal.',
+    placeholder: 'Add project context, policies, or reference material…',
+    contentRequired: false,
+  },
+  memories: {
+    label: 'Memory',
+    summary: 'Durable context or structured memory entries.',
+    instructionsLabel: 'Recall instructions',
+    instructionsHelp: 'Optionally explain when this memory should be loaded or how it should be used.',
+    instructionsPlaceholder: 'Use this memory when helping with this project…',
+    instructionsRequired: false,
+    contentLabel: 'Memory content',
+    contentHelp: 'Plain text becomes one memory entry. Existing entries YAML is also accepted.',
+    placeholder: 'Enter something worth remembering, or paste an entries: YAML document…',
+    contentRequired: true,
+  },
+  ensembles: {
+    label: 'Ensemble',
+    summary: 'A coordinated set of Dollhouse elements.',
+    instructionsLabel: 'Coordination instructions',
+    instructionsHelp: 'Explain how the selected elements should work together as one system.',
+    instructionsPlaceholder: 'Let the primary persona set the voice while supporting skills provide…',
+    instructionsRequired: false,
+    contentLabel: 'Ensemble notes',
+    contentHelp: 'Optional reference notes shared by the ensemble.',
+    placeholder: 'Add shared context or reference notes…',
+    contentRequired: false,
+  },
+});
+const IMPORT_FILE_LIMIT_BYTES = 1_100_000;
+const IMPORT_ENVELOPE_KEYS = new Set([
+  'metadata', 'content', 'instructions', 'entries', 'stats', 'id', 'type', 'name', 'tags',
+  'display_name', 'canonical_name', 'validation_status', 'updated_at',
+]);
+const GUIDED_METADATA_KEYS = new Set([
+  'name', 'description', 'tags', 'instructions', 'author', 'version', 'triggers',
+  'tone', 'voice', 'domain', 'expertise', 'communication_style', 'communicationStyle',
+  'complexity', 'domains', 'prerequisites', 'category', 'parameters',
+  'output_format', 'outputFormat', 'variables',
+  'goal', 'activates', 'tools', 'autonomy',
+  'privacyLevel', 'memoryType', 'retentionDays', 'maxEntries', 'searchable', 'autoLoad',
+  'activationStrategy', 'activation_strategy', 'conflictResolution', 'conflict_resolution',
+  'contextSharing', 'context_sharing', 'allowNested', 'allow_nested', 'elements',
+]);
 const TERMINAL_SYNC_STATES = new Set(['succeeded', 'failed']);
 const SYNC_POLL_INTERVAL_MS = 1_000;
 const SYNC_POLL_LIMIT = 60;
+let activeWorkspaceCleanup = null;
 
-export function createPortfolioAuthoring({ hasRoute, notify, refresh }) {
+export function createPortfolioAuthoring({ host, hasRoute, notify, refresh }) {
   const capabilities = Object.freeze({
     create: hasRoute('POST', '/me/portfolio/elements/:type'),
     edit: hasRoute('PATCH', '/me/portfolio/elements/:type/:name'),
@@ -19,110 +113,651 @@ export function createPortfolioAuthoring({ hasRoute, notify, refresh }) {
 
   return Object.freeze({
     capabilities,
-    openCreate: () => openEditor({ mode: 'create', capabilities, notify, refresh }),
-    openEdit: element => openEditor({ mode: 'edit', element, capabilities, notify, refresh }),
+    openCreate: () => openEditor({ host, mode: 'create', capabilities, notify, refresh }),
+    openImport: () => openEditor({ host, mode: 'import', capabilities, notify, refresh }),
+    openEdit: element => openEditor({ host, mode: 'edit', element, capabilities, notify, refresh }),
     deleteElement: element => deleteElement(element, { notify, refresh }),
     openSync: () => openSync({ notify, refresh }),
   });
 }
 
-async function openEditor(context) {
+function openEditor(context) {
+  activeWorkspaceCleanup?.();
   const previousFocus = document.activeElement;
-  const dialog = editorDialog(context);
-  document.body.appendChild(dialog);
-  document.body.classList.add('modal-open');
-  dialog.showModal();
-  focusElement(dialog.querySelector('[name="type"]'));
+  const browser = context.host.querySelector('[data-portfolio-browser]');
+  const workspace = context.host.querySelector('[data-portfolio-authoring]');
+  workspace.innerHTML = editorWorkspace(context);
+  workspace.hidden = false;
+  browser.hidden = true;
+  const form = workspace.querySelector('form');
+  populateGuidedMetadata(form, context.element?.metadata ?? {}, context.element?.type ?? 'personas');
+  let initialDraft = formDraft(form);
+  let unsavedImport = false;
 
   const close = () => {
-    if (dialog.open) dialog.close();
-    dialog.remove();
-    document.body.classList.remove('modal-open');
+    document.removeEventListener('keydown', onKeydown);
+    workspace.replaceChildren();
+    workspace.hidden = true;
+    browser.hidden = false;
+    activeWorkspaceCleanup = null;
     restoreFocus(previousFocus);
   };
-  dialog.querySelector('[data-editor-close]').addEventListener('click', close);
-  dialog.addEventListener('cancel', event => { event.preventDefault(); close(); });
-  dialog.addEventListener('click', event => { if (event.target === dialog) close(); });
+  const requestClose = async () => {
+    if (unsavedImport || formDraft(form) !== initialDraft) {
+      const discard = await confirmDialog('Discard this unsaved draft?', 'Discard draft');
+      if (!discard) return;
+    }
+    close();
+  };
+  const onKeydown = event => {
+    if (event.key === 'Escape' && !workspace.hidden) {
+      event.preventDefault();
+      requestClose();
+    }
+  };
+  activeWorkspaceCleanup = close;
+  workspace.querySelectorAll('[data-editor-close]').forEach(button => {
+    button.addEventListener('click', () => requestClose());
+  });
+  document.addEventListener('keydown', onKeydown);
 
-  const form = dialog.querySelector('form');
   form.addEventListener('submit', event => {
     event.preventDefault();
-    saveEditor(form, dialog, context, close);
+    saveEditor(form, workspace, context, () => {
+      initialDraft = formDraft(form);
+      unsavedImport = false;
+      close();
+    });
   });
-  dialog.querySelector('[data-editor-validate]')?.addEventListener('click', () => validateEditor(form, dialog));
-  dialog.querySelector('[data-editor-render]')?.addEventListener('click', () => renderEditor(form, dialog));
-  dialog.querySelector('[data-editor-reload]')?.addEventListener('click', () => reloadEditor(form, dialog, context));
+  workspace.querySelector('[data-editor-validate]')?.addEventListener('click', () => validateEditor(form, workspace));
+  workspace.querySelector('[data-editor-render]')?.addEventListener('click', () => renderEditor(form, workspace));
+  workspace.querySelector('[data-editor-reload]')?.addEventListener('click', async () => {
+    const reloaded = await reloadEditor(form, workspace, context);
+    if (reloaded) initialDraft = formDraft(form);
+  });
+  form.addEventListener('change', event => {
+    if (event.target?.name === 'type') updateTypeGuidance(form, workspace);
+  });
+  wireImport(workspace, form, draft => {
+    applyImportedDraft(form, workspace, draft);
+    unsavedImport = true;
+  });
+  wireBuilderControls(workspace);
+  wireCustomMetadata(workspace, form);
+  updateTypeGuidance(form, workspace);
+  focusElement(context.mode === 'import'
+    ? workspace.querySelector('[data-import-file]')
+    : form.querySelector('[name="type"]:checked, [name="name"]'));
 }
 
-function editorDialog({ mode, element, capabilities }) {
+function editorWorkspace({ mode, element, capabilities }) {
   const isEdit = mode === 'edit';
-  const dialog = document.createElement('dialog');
-  dialog.className = 'portfolio-editor';
-  dialog.setAttribute('aria-labelledby', 'portfolio-editor-title');
-  dialog.innerHTML = `
-    <form method="dialog" class="portfolio-editor-card" novalidate>
+  const isImport = mode === 'import';
+  const copy = workspaceCopy(mode);
+  const selectedType = TYPES.includes(element?.type) ? element.type : 'personas';
+  const picker = isImport ? importPicker() : '';
+  const fields = elementFields({ element, mode, selectedType });
+  const validateAction = capabilities.validate ? validationAction(isImport) : '';
+  const previewAction = isEdit && capabilities.render
+    ? '<button class="btn btn-ghost" data-editor-render type="button">Preview</button>'
+    : '';
+  const submitAction = submitButton(mode);
+  return `
+    <form class="portfolio-editor" data-editor-mode="${mode}" novalidate>
       <header class="portfolio-editor-head">
         <div>
-          <h2 id="portfolio-editor-title">${isEdit ? 'Edit element' : 'Create element'}</h2>
-          <p>${isEdit ? 'Changes use the element ETag, so a newer version cannot be overwritten.' : 'Create a validated element in your portfolio.'}</p>
+          <button class="portfolio-back-link" data-editor-close type="button">&#8592; Back to portfolio</button>
+          <h2 id="portfolio-editor-title">${copy.title}</h2>
+          <p>${copy.description}</p>
         </div>
-        <button class="security-close" data-editor-close type="button" aria-label="Close">&#x2715;</button>
       </header>
+      <div class="portfolio-editor-feedback" data-editor-feedback aria-live="polite" tabindex="-1">
+        <p class="portfolio-message portfolio-message--info">${copy.intro}</p>
+      </div>
       <div class="portfolio-editor-body">
-        <div class="portfolio-form-grid">
-          <label class="portfolio-field"><span>Type</span>
-            <select name="type" ${isEdit ? 'disabled' : ''}>${typeOptions(element?.type)}</select>
-          </label>
-          <label class="portfolio-field"><span>Name</span>
-            <input name="name" required maxlength="200" value="${escapeAttr(element?.name ?? '')}" ${isEdit ? 'readonly' : ''}>
-          </label>
-          <label class="portfolio-field portfolio-field--wide"><span>Tags <small>(comma separated)</small></span>
-            <input name="tags" value="${escapeAttr((element?.tags ?? []).join(', '))}">
-          </label>
-          <label class="portfolio-field portfolio-field--wide"><span>Metadata <small>(JSON object)</small></span>
-            <textarea name="metadata" rows="7" spellcheck="false">${escapeHtml(JSON.stringify(element?.metadata ?? {}, null, 2))}</textarea>
-          </label>
-          <label class="portfolio-field portfolio-field--wide"><span>Content</span>
-            <textarea name="content" rows="14" required spellcheck="false">${escapeHtml(element?.content ?? '')}</textarea>
-          </label>
+        ${picker}
+        <div data-editor-fields${isImport ? ' hidden' : ''}>
+          ${fields}
+          <section class="portfolio-preview" data-editor-preview hidden aria-label="Rendered preview"></section>
         </div>
-        <div class="portfolio-editor-feedback" data-editor-feedback aria-live="polite"></div>
-        <section class="portfolio-preview" data-editor-preview hidden aria-label="Rendered preview"></section>
       </div>
       <footer class="portfolio-editor-actions">
-        ${capabilities.validate ? '<button class="btn btn-ghost" data-editor-validate type="button">Validate</button>' : ''}
-        ${isEdit && capabilities.render ? '<button class="btn btn-ghost" data-editor-render type="button">Preview</button>' : ''}
+        ${validateAction}
+        ${previewAction}
         <button class="btn btn-ghost" data-editor-reload type="button" hidden>Reload latest</button>
         <span class="portfolio-editor-spacer"></span>
         <button class="btn btn-ghost" data-editor-close type="button">Cancel</button>
-        <button class="btn btn-primary" type="submit">${isEdit ? 'Save changes' : 'Create element'}</button>
+        ${submitAction}
       </footer>
     </form>`;
-  return dialog;
 }
 
-function typeOptions(selected) {
-  return TYPES.map(type => `<option value="${type}"${type === selected ? ' selected' : ''}>${capitalize(type)}</option>`).join('');
+function workspaceCopy(mode) {
+  if (mode === 'edit') {
+    return {
+      title: 'Edit element',
+      description: 'Review and safely update this element. A newer server version cannot be overwritten.',
+      intro: 'Required fields are marked. Validate at any time to check the draft without saving it.',
+    };
+  }
+  if (mode === 'import') {
+    return {
+      title: 'Import element',
+      description: 'Choose a local Dollhouse element file, review what was detected, then validate and import it.',
+      intro: 'No file selected. Your portfolio will not change until you review and submit an imported draft.',
+    };
+  }
+  return {
+    title: 'Create element',
+    description: 'Choose what you are building, then use the guidance below to create a validated element.',
+    intro: 'Required fields are marked. Validate at any time to check the draft without saving it.',
+  };
+}
+
+function elementFields({ element, mode, selectedType }) {
+  const isEdit = mode === 'edit';
+  const typeField = isEdit
+    ? `<input name="type" type="hidden" value="${escapeAttr(selectedType)}">
+       <div class="portfolio-readonly-type"><span>Element type</span><strong>${escapeHtml(TYPE_GUIDANCE[selectedType].label)}</strong></div>`
+    : typeChooser(selectedType);
+  const readonlyName = isEdit ? 'readonly' : '';
+  return `
+    ${typeField}
+    <aside class="portfolio-builder-overview" data-builder-overview></aside>
+    <section class="portfolio-builder-step">
+      <header><span>1</span><div><h3>Purpose</h3><p>Give the element an identity and make it discoverable.</p></div></header>
+      <div class="portfolio-form-grid">
+        <label class="portfolio-field"><span>Name <small>Required</small></span>
+          <input name="name" required maxlength="200" value="${escapeAttr(element?.name ?? '')}" ${readonlyName}>
+          <small>Use a short, recognizable name. The server normalizes it for storage.</small>
+        </label>
+        <label class="portfolio-field"><span>Version</span>
+          <input name="version" maxlength="20" placeholder="1.0.0">
+          <small>Use semantic versions such as 1.0.0.</small>
+        </label>
+        <label class="portfolio-field portfolio-field--wide"><span>Description <small>Required</small></span>
+          <input name="description" required maxlength="500" value="${escapeAttr(descriptionFrom(element))}">
+          <small>One sentence explaining what this element does and when someone should use it.</small>
+        </label>
+        <label class="portfolio-field"><span>Author</span>
+          <input name="author" maxlength="100" placeholder="Your name or team">
+        </label>
+        <label class="portfolio-field"><span>Tags <small>(comma separated)</small></span>
+          <input name="tags" value="${escapeAttr((element?.tags ?? []).join(', '))}" placeholder="writing, planning">
+        </label>
+        <label class="portfolio-field portfolio-field--wide"><span>Triggers <small>(comma separated)</small></span>
+          <input name="triggers" placeholder="review, analyze, draft">
+          <small>Words that help Dollhouse discover this element. Up to 20; letters, numbers, -, _, @, and . only.</small>
+        </label>
+      </div>
+    </section>
+    <section class="portfolio-builder-step">
+      <header><span>2</span><div><h3>Behavior</h3><p>Instructions tell the assistant what to do. They are different from reference content.</p></div></header>
+      <label class="portfolio-field portfolio-field--wide"><span data-instructions-label>Instructions</span>
+        <textarea name="instructions" rows="10" spellcheck="false"></textarea>
+        <small data-instructions-help></small>
+      </label>
+    </section>
+    <section class="portfolio-builder-step">
+      <header><span>3</span><div><h3>Content</h3><p>Content is the material the element uses or produces—not a command to the assistant.</p></div></header>
+      <label class="portfolio-field portfolio-field--wide"><span data-content-label>Content</span>
+        <textarea name="content" rows="12" spellcheck="false">${escapeHtml(element?.content ?? '')}</textarea>
+        <small data-content-help></small>
+      </label>
+    </section>
+    <section class="portfolio-builder-step">
+      <header><span>4</span><div><h3>Type settings</h3><p data-type-settings-intro>Configure the fields that are valid for this element type.</p></div></header>
+      ${typeSettings()}
+    </section>
+    ${customMetadataSection(element?.metadata, mode)}`;
+}
+
+function typeSettings() {
+  return [
+    personaSettings(),
+    skillSettings(),
+    templateSettings(),
+    agentSettings(),
+    memorySettings(),
+    ensembleSettings(),
+  ].join('');
+}
+
+function personaSettings() {
+  return `
+    <div class="portfolio-type-settings" data-guided-type="personas">
+      <div class="portfolio-form-grid">
+        ${textField('persona_tone', 'Tone', 'Examples: warm, direct, analytical')}
+        ${textField('persona_voice', 'Voice', 'Examples: concise, conversational, formal')}
+        ${textField('persona_domain', 'Domain', 'The subject area this persona specializes in')}
+        ${textField('persona_expertise', 'Expertise', 'Comma-separated specialties')}
+        ${textField('persona_communication_style', 'Communication style', 'How it should structure and present answers', true)}
+      </div>
+    </div>`;
+}
+
+function skillSettings() {
+  return `
+    <div class="portfolio-type-settings" data-guided-type="skills" hidden>
+      <div class="portfolio-form-grid">
+        ${selectField('skill_complexity', 'Complexity', ['beginner', 'intermediate', 'advanced', 'expert'])}
+        ${textField('skill_domains', 'Domains', 'Comma-separated areas such as web-dev, writing')}
+        ${textField('skill_prerequisites', 'Prerequisites', 'Comma-separated knowledge or skills')}
+        ${textField('skill_category', 'Category', 'A short grouping label')}
+      </div>
+      <div class="portfolio-repeat-head"><div><h4>Parameters</h4><p>Optional inputs this skill accepts.</p></div><button class="btn btn-ghost" data-add-row="skill-parameters" type="button">Add parameter</button></div>
+      <div class="portfolio-repeat-list" data-repeat-list="skill-parameters"></div>
+    </div>`;
+}
+
+function templateSettings() {
+  return `
+    <div class="portfolio-type-settings" data-guided-type="templates" hidden>
+      <div class="portfolio-form-grid">
+        ${textField('template_category', 'Category', 'Examples: email, report, code')}
+        ${textField('template_output_format', 'Output format', 'Examples: markdown, html, json')}
+      </div>
+      <div class="portfolio-repeat-head"><div><h4>Variables</h4><p>Define every placeholder used by the template content.</p></div><button class="btn btn-ghost" data-add-row="template-variables" type="button">Add variable</button></div>
+      <div class="portfolio-repeat-list" data-repeat-list="template-variables"></div>
+    </div>`;
+}
+
+function agentSettings() {
+  return `
+    <div class="portfolio-type-settings" data-guided-type="agents" hidden>
+      <div class="portfolio-form-grid">
+        <label class="portfolio-field portfolio-field--wide"><span>Goal template <small>Required</small></span>
+          <textarea name="agent_goal_template" rows="4" placeholder="Research {topic} and produce a decision-ready recommendation."></textarea>
+          <small>Use {parameter} placeholders for values supplied when the agent runs.</small>
+        </label>
+        <label class="portfolio-field portfolio-field--wide"><span>Success criteria <small>(one per line)</small></span>
+          <textarea name="agent_success_criteria" rows="4" placeholder="Sources are cited&#10;Tradeoffs are explicit&#10;Recommendation answers the goal"></textarea>
+        </label>
+        ${textField('agent_activates_personas', 'Activate personas', 'Comma-separated element names')}
+        ${textField('agent_activates_skills', 'Activate skills', 'Comma-separated element names')}
+        ${textField('agent_tools_allowed', 'Allowed tools', 'Comma-separated MCP-AQL tool names')}
+        ${textField('agent_tools_denied', 'Denied tools', 'Comma-separated MCP-AQL tool names')}
+        ${selectField('agent_risk_tolerance', 'Risk tolerance', ['moderate', 'conservative', 'aggressive'])}
+        ${numberField('agent_max_steps', 'Maximum autonomous steps', '0 means unlimited', 0)}
+      </div>
+    </div>`;
+}
+
+function memorySettings() {
+  return `
+    <div class="portfolio-type-settings" data-guided-type="memories" hidden>
+      <div class="portfolio-form-grid">
+        ${selectField('memory_privacy_level', 'Privacy level', ['private', 'public', 'sensitive'])}
+        ${selectField('memory_type', 'Memory type', ['user', 'system', 'adapter'])}
+        ${numberField('memory_retention_days', 'Retention days', 'Leave blank to use the server default', 1)}
+        ${numberField('memory_max_entries', 'Maximum entries', 'Leave blank to use the server default', 1)}
+        ${checkboxField('memory_searchable', 'Searchable', 'Allow this memory to appear in memory search', true)}
+        ${checkboxField('memory_auto_load', 'Auto-load', 'Load this memory automatically when relevant', false)}
+      </div>
+    </div>`;
+}
+
+function ensembleSettings() {
+  return `
+    <div class="portfolio-type-settings" data-guided-type="ensembles" hidden>
+      <div class="portfolio-form-grid">
+        ${selectField('ensemble_activation_strategy', 'Activation strategy', ['all', 'sequential', 'lazy', 'conditional', 'priority'])}
+        ${selectField('ensemble_conflict_resolution', 'Conflict resolution', ['priority', 'last-write', 'first-write', 'merge', 'error'])}
+        ${selectField('ensemble_context_sharing', 'Context sharing', ['selective', 'none', 'full'])}
+        ${checkboxField('ensemble_allow_nested', 'Allow nested ensembles', 'Permit ensemble members to reference other ensembles', false)}
+      </div>
+      <div class="portfolio-repeat-head"><div><h4>Elements <small>Required</small></h4><p>Add the portfolio elements that work together in this ensemble.</p></div><button class="btn btn-ghost" data-add-row="ensemble-elements" type="button">Add element</button></div>
+      <div class="portfolio-repeat-list" data-repeat-list="ensemble-elements"></div>
+    </div>`;
+}
+
+function textField(name, label, help, wide = false) {
+  return `<label class="portfolio-field${wide ? ' portfolio-field--wide' : ''}"><span>${label}</span><input name="${name}"><small>${help}</small></label>`;
+}
+
+function numberField(name, label, help, min) {
+  return `<label class="portfolio-field"><span>${label}</span><input name="${name}" type="number" min="${min}" step="1"><small>${help}</small></label>`;
+}
+
+function selectField(name, label, values) {
+  const options = values.map(value => `<option value="${value}">${capitalize(value.replaceAll('-', ' '))}</option>`).join('');
+  return `<label class="portfolio-field"><span>${label}</span><select name="${name}">${options}</select></label>`;
+}
+
+function checkboxField(name, label, help, checked) {
+  return `<label class="portfolio-check-field"><input name="${name}" type="checkbox"${checked ? ' checked' : ''}><span><strong>${label}</strong><small>${help}</small></span></label>`;
+}
+
+function validationAction(disabled) {
+  const disabledAttribute = disabled ? ' disabled' : '';
+  return `<button class="btn btn-ghost" data-editor-validate type="button"${disabledAttribute}>Validate draft</button>`;
+}
+
+function submitButton(mode) {
+  if (mode === 'edit') return '<button class="btn btn-primary" type="submit">Save changes</button>';
+  if (mode === 'import') return '<button class="btn btn-primary" type="submit" disabled>Import element</button>';
+  return '<button class="btn btn-primary" type="submit">Create element</button>';
+}
+
+function typeChooser(selected) {
+  const choices = TYPES.map(type => {
+    const guidance = TYPE_GUIDANCE[type];
+    return `
+      <label class="portfolio-type-choice">
+        <input type="radio" name="type" value="${type}"${type === selected ? ' checked' : ''}>
+        <span><strong>${guidance.label}</strong><small>${guidance.summary}</small></span>
+      </label>`;
+  }).join('');
+  return `<fieldset class="portfolio-type-chooser"><legend>What kind of element is this?</legend><div class="portfolio-type-grid">${choices}</div></fieldset>`;
+}
+
+function importPicker() {
+  return `
+    <section class="portfolio-import-picker" data-import-picker>
+      <div class="portfolio-drop-zone" data-import-drop>
+        <strong>Choose a Dollhouse element file</strong>
+        <p>Drop a file here or browse for Markdown, YAML, or a portable JSON export.</p>
+        <label class="btn btn-primary">Choose file
+          <input data-import-file type="file" accept=".md,.markdown,.yaml,.yml,.json,text/markdown,application/yaml,application/json" hidden>
+        </label>
+        <small>Maximum file size: 1 MB. Nothing is uploaded until you press Import element.</small>
+      </div>
+      <div class="portfolio-import-source" data-import-source hidden></div>
+    </section>`;
+}
+
+function descriptionFrom(element) {
+  return typeof element?.metadata?.description === 'string' ? element.metadata.description : '';
+}
+
+function advancedMetadata(metadata) {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return {};
+  return Object.fromEntries(Object.entries(metadata).filter(([key]) => !GUIDED_METADATA_KEYS.has(key)));
+}
+
+function customMetadataSection(metadata, mode) {
+  const additional = advancedMetadata(metadata);
+  const count = Object.keys(additional).length;
+  const notice = count ? customMetadataNotice(count, mode) : '';
+  return `
+    <p class="portfolio-custom-metadata-notice" data-custom-metadata-notice${count ? '' : ' hidden'}>${escapeHtml(notice)}</p>
+    <details class="portfolio-advanced" data-custom-metadata data-metadata-origin="${escapeAttr(mode)}">
+      <summary data-custom-metadata-summary>${escapeHtml(customMetadataSummary(count))}</summary>
+      <p>Most people will not need this. Use custom metadata only when a Dollhouse schema or integration requires fields that are not available above.</p>
+      <button class="portfolio-metadata-enable" data-custom-metadata-enable type="button"${count ? ' hidden' : ''}>Add custom metadata</button>
+      <label class="portfolio-field" data-custom-metadata-editor${count ? '' : ' hidden'}>
+        <span>Raw metadata <small>(JSON object)</small></span>
+        <textarea name="metadata" rows="8" spellcheck="false" aria-describedby="portfolio-custom-metadata-help">${escapeHtml(JSON.stringify(additional, null, 2))}</textarea>
+        <small id="portfolio-custom-metadata-help">Guided fields above take precedence if the same field appears here.</small>
+        <small class="portfolio-metadata-status${count ? ' is-valid' : ''}" data-custom-metadata-status aria-live="polite">${count ? escapeHtml(validCustomMetadataMessage(count)) : ''}</small>
+      </label>
+    </details>`;
+}
+
+function wireCustomMetadata(workspace, form) {
+  const enable = workspace.querySelector('[data-custom-metadata-enable]');
+  const editor = workspace.querySelector('[data-custom-metadata-editor]');
+  const textarea = form.elements.metadata;
+  enable.addEventListener('click', () => {
+    editor.hidden = false;
+    enable.hidden = true;
+    renderCustomMetadataValidation(form, workspace);
+    textarea.focus();
+  });
+  textarea.addEventListener('input', () => renderCustomMetadataValidation(form, workspace));
+}
+
+function setCustomMetadata(form, workspace, metadata, origin) {
+  const additional = advancedMetadata(metadata);
+  const count = Object.keys(additional).length;
+  const details = workspace.querySelector('[data-custom-metadata]');
+  const editor = workspace.querySelector('[data-custom-metadata-editor]');
+  const enable = workspace.querySelector('[data-custom-metadata-enable]');
+  const notice = workspace.querySelector('[data-custom-metadata-notice]');
+  form.elements.metadata.value = JSON.stringify(additional, null, 2);
+  details.dataset.metadataOrigin = origin;
+  workspace.querySelector('[data-custom-metadata-summary]').textContent = customMetadataSummary(count);
+  editor.hidden = count === 0;
+  enable.hidden = count > 0;
+  notice.hidden = count === 0;
+  notice.textContent = count ? customMetadataNotice(count, origin) : '';
+  renderCustomMetadataValidation(form, workspace);
+}
+
+function renderCustomMetadataValidation(form, workspace) {
+  const textarea = form.elements.metadata;
+  const status = workspace.querySelector('[data-custom-metadata-status]');
+  const parsed = parseCustomMetadata(textarea.value.trim());
+  status.classList.toggle('is-error', Boolean(parsed.problem));
+  status.classList.toggle('is-valid', !parsed.problem && Boolean(textarea.value.trim()));
+  if (parsed.problem) {
+    status.textContent = parsed.problem;
+    textarea.setAttribute('aria-invalid', 'true');
+    return;
+  }
+  textarea.removeAttribute('aria-invalid');
+  const count = Object.keys(parsed.metadata).length;
+  status.textContent = textarea.value.trim()
+    ? validCustomMetadataMessage(count)
+    : 'Enter a JSON object containing only fields not covered by the guided form.';
+  workspace.querySelector('[data-custom-metadata-summary]').textContent = customMetadataSummary(count);
+}
+
+function parseCustomMetadata(text) {
+  if (!text) return { metadata: {} };
+  let metadata;
+  try {
+    metadata = JSON.parse(text);
+  } catch {
+    return { metadata: {}, problem: 'Custom metadata must be valid JSON.' };
+  }
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return { metadata: {}, problem: 'Custom metadata must be a JSON object.' };
+  }
+  return { metadata };
+}
+
+function customMetadataNotice(count, origin) {
+  const fields = `${count} additional metadata field${count === 1 ? '' : 's'}`;
+  if (origin === 'import') return `${fields} from this file will be preserved when imported.`;
+  const subject = count === 1 ? 'It' : 'They';
+  return `This element contains ${fields}. ${subject} will be preserved when saved.`;
+}
+
+function customMetadataSummary(count) {
+  if (!count) return 'Developer options';
+  const label = count === 1 ? 'field' : 'fields';
+  return `Custom metadata (${count} ${label})`;
+}
+
+function validCustomMetadataMessage(count) {
+  return `Valid JSON object · ${count} custom field${count === 1 ? '' : 's'}.`;
 }
 
 function editorPayload(form, includeName) {
   const metadataText = form.elements.metadata.value.trim();
-  let metadata;
-  try {
-    metadata = metadataText ? JSON.parse(metadataText) : {};
-  } catch {
-    return { problem: 'Metadata must be valid JSON.' };
+  const parsedMetadata = parseCustomMetadata(metadataText);
+  if (parsedMetadata.problem) return { problem: parsedMetadata.problem, field: form.elements.metadata };
+  const additionalMetadata = parsedMetadata.metadata;
+  const type = form.elements.type.value;
+  const description = form.elements.description.value.trim();
+  if (!description) return { problem: 'Description is required.', field: form.elements.description };
+  const instructions = form.elements.instructions.value.trim();
+  const guidance = TYPE_GUIDANCE[type] ?? TYPE_GUIDANCE.personas;
+  if (form.dataset.editorMode !== 'edit' && guidance.instructionsRequired && !instructions) {
+    return { problem: `${guidance.instructionsLabel} are required.`, field: form.elements.instructions };
   }
-  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
-    return { problem: 'Metadata must be a JSON object.' };
+  const content = form.elements.content.value;
+  if (guidance.contentRequired && !content.trim()) {
+    return { problem: `${guidance.contentLabel} is required.`, field: form.elements.content };
   }
+  if (type === 'agents' && !fieldText(form, 'agent_goal_template')) {
+    return { problem: 'Goal template is required for an agent.', field: form.elements.agent_goal_template };
+  }
+  const ensembleHasElement = [...form.querySelectorAll('[data-repeat-row="ensemble-elements"] [data-row-field="name"]')]
+    .some(field => field.value.trim());
+  if (type === 'ensembles' && !ensembleHasElement) {
+    return { problem: 'Add at least one element to the ensemble.', field: form.querySelector('[data-add-row="ensemble-elements"]') };
+  }
+  const typeMetadata = guidedMetadata(form, type);
   const payload = {
     tags: form.elements.tags.value.split(',').map(tag => tag.trim()).filter(Boolean),
-    metadata,
-    content: form.elements.content.value,
+    metadata: {
+      ...additionalMetadata,
+      ...commonGuidedMetadata(form),
+      ...typeMetadata,
+      description,
+      ...(instructions ? { instructions } : {}),
+    },
+    content,
   };
   if (includeName) payload.name = form.elements.name.value.trim();
   return { payload };
+}
+
+function commonGuidedMetadata(form) {
+  return compactRecord({
+    author: fieldText(form, 'author'),
+    version: fieldText(form, 'version'),
+    triggers: commaList(fieldText(form, 'triggers')),
+  });
+}
+
+function guidedMetadata(form, type) {
+  const builders = {
+    personas: personaMetadata,
+    skills: skillMetadata,
+    templates: templateMetadata,
+    agents: agentMetadata,
+    memories: memoryMetadata,
+    ensembles: ensembleMetadata,
+  };
+  return builders[type]?.(form) ?? {};
+}
+
+function personaMetadata(form) {
+  return compactRecord({
+    tone: fieldText(form, 'persona_tone'),
+    voice: fieldText(form, 'persona_voice'),
+    domain: fieldText(form, 'persona_domain'),
+    expertise: commaList(fieldText(form, 'persona_expertise')),
+    communication_style: fieldText(form, 'persona_communication_style'),
+  });
+}
+
+function skillMetadata(form) {
+  return compactRecord({
+    complexity: fieldText(form, 'skill_complexity'),
+    domains: commaList(fieldText(form, 'skill_domains')),
+    prerequisites: commaList(fieldText(form, 'skill_prerequisites')),
+    category: fieldText(form, 'skill_category'),
+    parameters: repeatedRows(form, 'skill-parameters', definitionFromRow),
+  });
+}
+
+function templateMetadata(form) {
+  return compactRecord({
+    category: fieldText(form, 'template_category'),
+    output_format: fieldText(form, 'template_output_format'),
+    variables: repeatedRows(form, 'template-variables', definitionFromRow),
+  });
+}
+
+function agentMetadata(form) {
+  const template = fieldText(form, 'agent_goal_template');
+  const successCriteria = lineList(fieldText(form, 'agent_success_criteria'));
+  const activates = compactRecord({
+    personas: commaList(fieldText(form, 'agent_activates_personas')),
+    skills: commaList(fieldText(form, 'agent_activates_skills')),
+  });
+  const allowed = commaList(fieldText(form, 'agent_tools_allowed'));
+  const denied = commaList(fieldText(form, 'agent_tools_denied'));
+  const tools = allowed.length || denied.length
+    ? { allowed, ...(denied.length ? { denied } : {}) }
+    : undefined;
+  const maxAutonomousSteps = optionalNumber(fieldText(form, 'agent_max_steps'));
+  const autonomy = compactRecord({
+    riskTolerance: fieldText(form, 'agent_risk_tolerance'),
+    maxAutonomousSteps,
+  });
+  return compactRecord({
+    goal: template ? { template, parameters: [], ...(successCriteria.length ? { successCriteria } : {}) } : undefined,
+    activates,
+    tools,
+    autonomy,
+  });
+}
+
+function memoryMetadata(form) {
+  return compactRecord({
+    privacyLevel: fieldText(form, 'memory_privacy_level'),
+    memoryType: fieldText(form, 'memory_type'),
+    retentionDays: optionalNumber(fieldText(form, 'memory_retention_days')),
+    maxEntries: optionalNumber(fieldText(form, 'memory_max_entries')),
+    searchable: form.elements.memory_searchable.checked,
+    autoLoad: form.elements.memory_auto_load.checked,
+  });
+}
+
+function ensembleMetadata(form) {
+  return compactRecord({
+    activationStrategy: fieldText(form, 'ensemble_activation_strategy'),
+    conflictResolution: fieldText(form, 'ensemble_conflict_resolution'),
+    contextSharing: fieldText(form, 'ensemble_context_sharing'),
+    allowNested: form.elements.ensemble_allow_nested.checked,
+    elements: repeatedRows(form, 'ensemble-elements', ensembleElementFromRow),
+  });
+}
+
+function repeatedRows(form, kind, mapper) {
+  return [...form.querySelectorAll(`[data-repeat-row="${kind}"]`)].map(row => mapper(row)).filter(Boolean);
+}
+
+function definitionFromRow(row) {
+  const name = row.querySelector('[data-row-field="name"]').value.trim();
+  if (!name) return null;
+  return compactRecord({
+    name,
+    type: row.querySelector('[data-row-field="type"]').value,
+    description: row.querySelector('[data-row-field="description"]').value.trim(),
+    required: row.querySelector('[data-row-field="required"]').checked,
+  });
+}
+
+function ensembleElementFromRow(row) {
+  const elementName = row.querySelector('[data-row-field="name"]').value.trim();
+  if (!elementName) return null;
+  return compactRecord({
+    element_name: elementName,
+    element_type: row.querySelector('[data-row-field="type"]').value,
+    role: row.querySelector('[data-row-field="role"]').value,
+    priority: Number(row.querySelector('[data-row-field="priority"]').value),
+    activation: row.querySelector('[data-row-field="activation"]').value,
+    purpose: row.querySelector('[data-row-field="purpose"]').value.trim(),
+  });
+}
+
+function compactRecord(record) {
+  return Object.fromEntries(Object.entries(record).filter(([, value]) => {
+    if (value === undefined || value === '') return false;
+    return !Array.isArray(value) || value.length > 0;
+  }));
+}
+
+function fieldText(form, name) {
+  return typeof form.elements[name]?.value === 'string' ? form.elements[name].value.trim() : '';
+}
+
+function commaList(value) {
+  return value.split(',').map(item => item.trim()).filter(Boolean);
+}
+
+function lineList(value) {
+  return value.split(/\r?\n/u).map(item => item.trim()).filter(Boolean);
+}
+
+function optionalNumber(value) {
+  return value === '' ? undefined : Number(value);
 }
 
 function editorPath(form, suffix = '') {
@@ -131,126 +766,550 @@ function editorPath(form, suffix = '') {
   return `/me/portfolio/elements/${type}/${name}${suffix}`;
 }
 
-async function validateEditor(form, dialog) {
+async function validateEditor(form, workspace) {
   if (!form.elements.name.value.trim()) {
-    showEditorMessage(dialog, 'Name is required.', 'error');
+    showEditorMessage(workspace, 'Name is required.', 'error', form.elements.name);
     return false;
   }
   const parsed = editorPayload(form, false);
-  if (parsed.problem) return showEditorMessage(dialog, parsed.problem, 'error');
-  setEditorBusy(dialog, true);
+  if (parsed.problem) return showEditorMessage(workspace, parsed.problem, 'error', parsed.field ?? form.elements.metadata);
+  setEditorBusy(workspace, true);
   try {
     const response = await post(editorPath(form, '/validate'), { body: parsed.payload });
-    showValidation(dialog, response);
+    showValidation(workspace, response, form);
     return response.status === 200 && response.body?.valid === true;
   } catch {
-    showEditorMessage(dialog, 'Validation could not reach the server.', 'error');
+    showEditorMessage(workspace, 'Validation could not reach the server.', 'error');
     return false;
   } finally {
-    setEditorBusy(dialog, false);
+    setEditorBusy(workspace, false);
   }
 }
 
-function showValidation(dialog, response) {
+function showValidation(workspace, response, form) {
   if (response.status !== 200) {
-    showEditorMessage(dialog, responseDetail(response, 'Validation failed.'), 'error');
+    showEditorMessage(workspace, responseDetail(response, 'Validation failed.'), 'error');
     return;
   }
   const issues = Array.isArray(response.body?.issues) ? response.body.issues : [];
   if (response.body?.valid) {
-    showEditorMessage(dialog, 'Validation passed.', 'success');
+    showEditorMessage(workspace, 'Validation passed. This draft is ready to save.', 'success');
     return;
   }
   const list = issues.map(issue => `<li><strong>${escapeHtml(issue.path || 'element')}</strong>: ${escapeHtml(issue.message || issue.code || 'Invalid value')}</li>`).join('');
-  dialog.querySelector('[data-editor-feedback]').innerHTML = `<div class="portfolio-message portfolio-message--error"><p>Fix these validation issues:</p><ul>${list}</ul></div>`;
+  showEditorHtml(
+    workspace,
+    `<div class="portfolio-message portfolio-message--error"><p>Fix these validation issues:</p><ul>${list}</ul></div>`,
+    fieldForIssue(form, issues[0]?.path),
+  );
 }
 
-async function renderEditor(form, dialog) {
+async function renderEditor(form, workspace) {
   const parsed = editorPayload(form, false);
-  if (parsed.problem) return showEditorMessage(dialog, parsed.problem, 'error');
-  setEditorBusy(dialog, true);
+  if (parsed.problem) return showEditorMessage(workspace, parsed.problem, 'error', parsed.field ?? form.elements.metadata);
+  setEditorBusy(workspace, true);
   try {
     const response = await post(editorPath(form, '/render'), { body: parsed.payload });
     if (response.status !== 200 || typeof response.body?.preview !== 'string') {
-      showEditorMessage(dialog, responseDetail(response, 'Preview failed.'), 'error');
+      showEditorMessage(workspace, responseDetail(response, 'Preview failed.'), 'error');
       return;
     }
-    const preview = dialog.querySelector('[data-editor-preview]');
+    const preview = workspace.querySelector('[data-editor-preview]');
     preview.hidden = false;
     preview.innerHTML = `<h3>Server preview</h3><pre>${escapeHtml(response.body.preview)}</pre>`;
-    showEditorMessage(dialog, 'Preview refreshed from the server.', 'success');
+    showEditorMessage(workspace, 'Preview refreshed from the server.', 'success');
   } catch {
-    showEditorMessage(dialog, 'Preview could not reach the server.', 'error');
+    showEditorMessage(workspace, 'Preview could not reach the server.', 'error');
   } finally {
-    setEditorBusy(dialog, false);
+    setEditorBusy(workspace, false);
   }
 }
 
-async function saveEditor(form, dialog, context, close) {
-  const includeName = context.mode === 'create';
+async function saveEditor(form, workspace, context, close) {
+  const includeName = context.mode !== 'edit';
   const parsed = editorPayload(form, includeName);
-  if (parsed.problem) return showEditorMessage(dialog, parsed.problem, 'error');
-  if (!form.elements.name.value.trim()) return showEditorMessage(dialog, 'Name is required.', 'error');
-  setEditorBusy(dialog, true);
+  if (parsed.problem) return showEditorMessage(workspace, parsed.problem, 'error', parsed.field ?? form.elements.metadata);
+  if (!form.elements.name.value.trim()) return showEditorMessage(workspace, 'Name is required.', 'error', form.elements.name);
+  setEditorBusy(workspace, true);
   try {
     if (context.capabilities.validate) {
-      const valid = await validateDraft(form, dialog, parsed.payload);
+      const valid = await validateDraft(form, workspace, parsed.payload);
       if (!valid) return;
     }
     const response = includeName
       ? await post(`/me/portfolio/elements/${encodeURIComponent(form.elements.type.value)}`, { body: parsed.payload })
       : await patch(editorPath(form), { body: parsed.payload, ifMatch: context.element?._etag });
     if (response.status === 412) {
-      showConflict(dialog);
+      showConflict(workspace);
+      return;
+    }
+    if (includeName && response.status === 409) {
+      showEditorMessage(workspace, 'An element with this type and name already exists. Nothing was overwritten. Choose another name or cancel this draft.', 'error', form.elements.name);
       return;
     }
     const expectedStatus = includeName ? 201 : 200;
     if (response.status !== expectedStatus) {
-      showEditorMessage(dialog, responseDetail(response, 'The element could not be saved.'), 'error');
+      showEditorMessage(workspace, responseDetail(response, 'The element could not be saved.'), 'error');
       return;
     }
-    context.notify(`${includeName ? 'Created' : 'Updated'} “${response.body?.display_name || response.body?.name || 'element'}”.`, 'success');
+    const action = savedAction(context.mode);
+    context.notify(`${action} “${response.body?.display_name || response.body?.name || 'element'}”.`, 'success');
     await context.refresh();
     close();
   } catch {
-    showEditorMessage(dialog, 'The element could not be saved because the server is unreachable.', 'error');
+    showEditorMessage(workspace, 'The element could not be saved because the server is unreachable.', 'error');
   } finally {
-    setEditorBusy(dialog, false);
+    setEditorBusy(workspace, false);
   }
 }
 
-async function validateDraft(form, dialog, payload) {
+function savedAction(mode) {
+  if (mode === 'import') return 'Imported';
+  return mode === 'create' ? 'Created' : 'Updated';
+}
+
+async function validateDraft(form, workspace, payload) {
   const response = await post(editorPath(form, '/validate'), { body: payload });
-  showValidation(dialog, response);
+  showValidation(workspace, response, form);
   return response.status === 200 && response.body?.valid === true;
 }
 
-function showConflict(dialog) {
-  showEditorMessage(dialog, 'This element changed after you opened it. Your draft was not saved. Review or copy it, then reload the latest version before editing again.', 'error');
-  dialog.querySelector('[data-editor-reload]').hidden = false;
+function showConflict(workspace) {
+  showEditorMessage(workspace, 'This element changed after you opened it. Your draft was not saved. Review or copy it, then reload the latest version before editing again.', 'error');
+  workspace.querySelector('[data-editor-reload]').hidden = false;
 }
 
-async function reloadEditor(form, dialog, context) {
-  setEditorBusy(dialog, true);
+async function reloadEditor(form, workspace, context) {
+  setEditorBusy(workspace, true);
   try {
     const response = await get(editorPath(form));
     if (response.status !== 200 || !response.body) {
-      showEditorMessage(dialog, responseDetail(response, 'The latest version could not be loaded.'), 'error');
-      return;
+      showEditorMessage(workspace, responseDetail(response, 'The latest version could not be loaded.'), 'error');
+      return false;
     }
     if (typeof response.etag !== 'string' || !response.etag) {
-      showEditorMessage(dialog, 'The latest version did not include an ETag, so editing remains blocked.', 'error');
-      return;
+      showEditorMessage(workspace, 'The latest version did not include an ETag, so editing remains blocked.', 'error');
+      return false;
     }
     context.element = { ...response.body, _etag: response.etag };
+    resetGuidedMetadata(form);
     form.elements.tags.value = Array.isArray(response.body.tags) ? response.body.tags.join(', ') : '';
-    form.elements.metadata.value = JSON.stringify(response.body.metadata ?? {}, null, 2);
+    form.elements.description.value = descriptionFrom(response.body);
+    setCustomMetadata(form, workspace, response.body.metadata, 'edit');
     form.elements.content.value = typeof response.body.content === 'string' ? response.body.content : '';
-    dialog.querySelector('[data-editor-reload]').hidden = true;
-    showEditorMessage(dialog, 'Latest version loaded. The previous draft was replaced only after your confirmation.', 'success');
+    populateGuidedMetadata(form, response.body.metadata ?? {}, response.body.type);
+    workspace.querySelector('[data-editor-reload]').hidden = true;
+    showEditorMessage(workspace, 'Latest version loaded. The previous draft was replaced only after your confirmation.', 'success');
+    return true;
   } finally {
-    setEditorBusy(dialog, false);
+    setEditorBusy(workspace, false);
   }
+}
+
+function updateTypeGuidance(form, workspace) {
+  const type = form.elements.type.value;
+  const guidance = TYPE_GUIDANCE[type] ?? TYPE_GUIDANCE.personas;
+  const instructionsRequired = guidance.instructionsRequired ? ' <small>Required</small>' : ' <small>Optional</small>';
+  const contentRequired = guidance.contentRequired ? ' <small>Required</small>' : ' <small>Optional</small>';
+  workspace.querySelector('[data-instructions-label]').innerHTML = escapeHtml(guidance.instructionsLabel) + instructionsRequired;
+  workspace.querySelector('[data-instructions-help]').textContent = guidance.instructionsHelp;
+  form.elements.instructions.placeholder = guidance.instructionsPlaceholder;
+  form.elements.instructions.required = guidance.instructionsRequired;
+  workspace.querySelector('[data-content-label]').innerHTML = escapeHtml(guidance.contentLabel) + contentRequired;
+  workspace.querySelector('[data-content-help]').textContent = guidance.contentHelp;
+  form.elements.content.placeholder = guidance.placeholder;
+  form.elements.content.required = guidance.contentRequired;
+  workspace.querySelector('[data-builder-overview]').innerHTML = `
+    <strong>Building a ${escapeHtml(guidance.label)}</strong>
+    <span>${escapeHtml(guidance.summary)} Complete the four sections below; only fields valid for this type are shown.</span>`;
+  workspace.querySelectorAll('[data-guided-type]').forEach(section => {
+    section.hidden = section.dataset.guidedType !== type;
+  });
+  if (type === 'ensembles' && !form.querySelector('[data-repeat-row="ensemble-elements"]')) {
+    addRepeatRow(workspace, 'ensemble-elements');
+  }
+}
+
+function wireBuilderControls(workspace) {
+  workspace.addEventListener('click', event => {
+    const add = event.target.closest('[data-add-row]');
+    if (add) {
+      addRepeatRow(workspace, add.dataset.addRow);
+      return;
+    }
+    const remove = event.target.closest('[data-remove-row]');
+    remove?.closest('[data-repeat-row]')?.remove();
+  });
+}
+
+function addRepeatRow(workspace, kind, values = {}, shouldFocus = true) {
+  const list = workspace.querySelector(`[data-repeat-list="${kind}"]`);
+  if (!list) return;
+  list.insertAdjacentHTML('beforeend', repeatRow(kind, values));
+  if (shouldFocus) list.lastElementChild?.querySelector('input')?.focus();
+}
+
+function repeatRow(kind, values) {
+  if (kind === 'ensemble-elements') return ensembleElementRow(values);
+  if (kind === 'template-variables') return definitionRow(kind, values, ['string', 'number', 'boolean', 'date', 'array', 'object']);
+  return definitionRow(kind, values, ['string', 'number', 'boolean', 'enum']);
+}
+
+function definitionRow(kind, values, types) {
+  const options = types.map(type => `<option value="${type}"${values.type === type ? ' selected' : ''}>${capitalize(type)}</option>`).join('');
+  return `
+    <div class="portfolio-repeat-row" data-repeat-row="${kind}">
+      <label><span>Name</span><input data-row-field="name" value="${escapeAttr(values.name ?? '')}" placeholder="topic"></label>
+      <label><span>Type</span><select data-row-field="type">${options}</select></label>
+      <label class="portfolio-repeat-grow"><span>Description</span><input data-row-field="description" value="${escapeAttr(values.description ?? '')}" placeholder="What this value controls"></label>
+      <label class="portfolio-repeat-check"><input data-row-field="required" type="checkbox"${values.required ? ' checked' : ''}><span>Required</span></label>
+      <button class="btn btn-ghost" data-remove-row type="button" aria-label="Remove row">Remove</button>
+    </div>`;
+}
+
+function ensembleElementRow(values) {
+  const typeOptions = ['persona', 'skill', 'template', 'agent', 'memory', 'ensemble'];
+  const roleOptions = ['primary', 'support', 'override', 'monitor'];
+  const activationOptions = ['always', 'on-demand', 'conditional'];
+  return `
+    <div class="portfolio-repeat-row portfolio-repeat-row--ensemble" data-repeat-row="ensemble-elements">
+      <label><span>Element name</span><input data-row-field="name" value="${escapeAttr(values.element_name ?? '')}" placeholder="technical-writer"></label>
+      <label><span>Type</span><select data-row-field="type">${rowOptions(typeOptions, values.element_type)}</select></label>
+      <label><span>Role</span><select data-row-field="role">${rowOptions(roleOptions, values.role)}</select></label>
+      <label><span>Activation</span><select data-row-field="activation">${rowOptions(activationOptions, values.activation)}</select></label>
+      <label><span>Priority</span><input data-row-field="priority" type="number" min="0" max="100" value="${escapeAttr(values.priority ?? 10)}"></label>
+      <label class="portfolio-repeat-grow"><span>Purpose</span><input data-row-field="purpose" value="${escapeAttr(values.purpose ?? '')}" placeholder="Why this element is included"></label>
+      <button class="btn btn-ghost" data-remove-row type="button" aria-label="Remove element">Remove</button>
+    </div>`;
+}
+
+function rowOptions(values, selected) {
+  return values.map(value => `<option value="${value}"${selected === value ? ' selected' : ''}>${capitalize(value.replaceAll('-', ' '))}</option>`).join('');
+}
+
+function populateGuidedMetadata(form, metadata, type) {
+  if (!metadata || typeof metadata !== 'object') return;
+  setFieldValue(form, 'author', metadata.author);
+  setFieldValue(form, 'version', metadata.version);
+  setFieldValue(form, 'triggers', joined(metadata.triggers));
+  setFieldValue(form, 'instructions', metadata.instructions);
+  const populators = {
+    personas: populatePersonaMetadata,
+    skills: populateSkillMetadata,
+    templates: populateTemplateMetadata,
+    agents: populateAgentMetadata,
+    memories: populateMemoryMetadata,
+    ensembles: populateEnsembleMetadata,
+  };
+  populators[type]?.(form, metadata);
+}
+
+function resetGuidedMetadata(form) {
+  for (const name of ['author', 'version', 'triggers', 'instructions']) setFieldValue(form, name, '');
+  form.querySelectorAll('[data-guided-type] input, [data-guided-type] textarea').forEach(field => {
+    if (field.type === 'checkbox') field.checked = field.defaultChecked;
+    else field.value = '';
+  });
+  form.querySelectorAll('[data-guided-type] select').forEach(field => { field.selectedIndex = 0; });
+  form.querySelectorAll('[data-repeat-list]').forEach(list => list.replaceChildren());
+}
+
+function populatePersonaMetadata(form, metadata) {
+  setFieldValue(form, 'persona_tone', metadata.tone);
+  setFieldValue(form, 'persona_voice', metadata.voice);
+  setFieldValue(form, 'persona_domain', metadata.domain);
+  setFieldValue(form, 'persona_expertise', joined(metadata.expertise));
+  setFieldValue(form, 'persona_communication_style', metadata.communication_style ?? metadata.communicationStyle);
+}
+
+function populateSkillMetadata(form, metadata) {
+  setFieldValue(form, 'skill_complexity', metadata.complexity);
+  setFieldValue(form, 'skill_domains', joined(metadata.domains));
+  setFieldValue(form, 'skill_prerequisites', joined(metadata.prerequisites));
+  setFieldValue(form, 'skill_category', metadata.category);
+  populateRows(form, 'skill-parameters', metadata.parameters);
+}
+
+function populateTemplateMetadata(form, metadata) {
+  setFieldValue(form, 'template_category', metadata.category);
+  setFieldValue(form, 'template_output_format', metadata.output_format ?? metadata.outputFormat);
+  populateRows(form, 'template-variables', metadata.variables);
+}
+
+function populateAgentMetadata(form, metadata) {
+  const goal = asRecord(metadata.goal);
+  const activates = asRecord(metadata.activates);
+  const tools = asRecord(metadata.tools);
+  const autonomy = asRecord(metadata.autonomy);
+  setFieldValue(form, 'agent_goal_template', goal.template);
+  setFieldValue(form, 'agent_success_criteria', lines(goal.successCriteria));
+  setFieldValue(form, 'agent_activates_personas', joined(activates.personas));
+  setFieldValue(form, 'agent_activates_skills', joined(activates.skills));
+  setFieldValue(form, 'agent_tools_allowed', joined(tools.allowed));
+  setFieldValue(form, 'agent_tools_denied', joined(tools.denied));
+  setFieldValue(form, 'agent_risk_tolerance', autonomy.riskTolerance);
+  setFieldValue(form, 'agent_max_steps', autonomy.maxAutonomousSteps);
+}
+
+function populateMemoryMetadata(form, metadata) {
+  setFieldValue(form, 'memory_privacy_level', metadata.privacyLevel);
+  setFieldValue(form, 'memory_type', metadata.memoryType);
+  setFieldValue(form, 'memory_retention_days', metadata.retentionDays);
+  setFieldValue(form, 'memory_max_entries', metadata.maxEntries);
+  setCheckbox(form, 'memory_searchable', metadata.searchable);
+  setCheckbox(form, 'memory_auto_load', metadata.autoLoad);
+}
+
+function populateEnsembleMetadata(form, metadata) {
+  setFieldValue(form, 'ensemble_activation_strategy', metadata.activationStrategy ?? metadata.activation_strategy);
+  setFieldValue(form, 'ensemble_conflict_resolution', metadata.conflictResolution ?? metadata.conflict_resolution);
+  setFieldValue(form, 'ensemble_context_sharing', metadata.contextSharing ?? metadata.context_sharing);
+  setCheckbox(form, 'ensemble_allow_nested', metadata.allowNested ?? metadata.allow_nested);
+  populateRows(form, 'ensemble-elements', metadata.elements);
+}
+
+function populateRows(form, kind, values) {
+  if (!Array.isArray(values) || !values.length) return;
+  const workspace = form.closest('[data-portfolio-authoring]');
+  const list = form.querySelector(`[data-repeat-list="${kind}"]`);
+  list?.replaceChildren();
+  values.forEach(value => addRepeatRow(workspace, kind, asRecord(value), false));
+}
+
+function setFieldValue(form, name, value) {
+  const field = form.elements[name];
+  if (field && (typeof value === 'string' || typeof value === 'number')) field.value = String(value);
+}
+
+function setCheckbox(form, name, value) {
+  if (typeof value === 'boolean' && form.elements[name]) form.elements[name].checked = value;
+}
+
+function joined(value) {
+  return Array.isArray(value) ? value.filter(item => typeof item === 'string').join(', ') : '';
+}
+
+function lines(value) {
+  return Array.isArray(value) ? value.filter(item => typeof item === 'string').join('\n') : '';
+}
+
+function wireImport(workspace, form, onDraft) {
+  const input = workspace.querySelector('[data-import-file]');
+  const dropZone = workspace.querySelector('[data-import-drop]');
+  if (!input || !dropZone) return;
+  const handleFile = async file => {
+    if (!file) return;
+    setEditorBusy(workspace, true);
+    try {
+      const draft = await parseElementFile(file);
+      onDraft(draft);
+      showEditorMessage(workspace, `Loaded “${file.name}”. Review the detected fields, then validate before importing.`, 'success');
+    } catch (error) {
+      showEditorMessage(workspace, error instanceof Error ? error.message : 'The selected file could not be read.', 'error', input);
+    } finally {
+      setEditorBusy(workspace, false);
+      input.value = '';
+    }
+  };
+  input.addEventListener('change', () => handleFile(input.files?.[0]));
+  for (const eventName of ['dragenter', 'dragover']) {
+    dropZone.addEventListener(eventName, event => {
+      event.preventDefault();
+      dropZone.classList.add('is-dragging');
+    });
+  }
+  for (const eventName of ['dragleave', 'drop']) {
+    dropZone.addEventListener(eventName, event => {
+      event.preventDefault();
+      dropZone.classList.remove('is-dragging');
+    });
+  }
+  dropZone.addEventListener('drop', event => handleFile(event.dataTransfer?.files?.[0]));
+}
+
+async function parseElementFile(file) {
+  if (file.size > IMPORT_FILE_LIMIT_BYTES) throw new Error('This file is larger than the 1 MB import limit.');
+  const extension = file.name.toLowerCase().split('.').pop();
+  if (!['md', 'markdown', 'yaml', 'yml', 'json'].includes(extension)) {
+    throw new Error('Choose a Markdown, YAML, or JSON Dollhouse element file.');
+  }
+  const source = await file.text();
+  if (!source.trim()) throw new Error('The selected file is empty.');
+  const parsed = parseImportedSource(source, extension);
+  return normalizeImportedDraft(parsed, source, file.name);
+}
+
+function parseImportedSource(source, extension) {
+  if (extension === 'md' || extension === 'markdown') return parseMarkdownImport(source);
+  if (extension === 'json') {
+    try {
+      return { record: JSON.parse(source), format: 'json' };
+    } catch {
+      throw new Error('This JSON file is not valid.');
+    }
+  }
+  return { record: loadYaml(source), format: 'yaml' };
+}
+
+function parseMarkdownImport(source) {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n)?([\s\S]*)$/u.exec(source);
+  if (!match) throw new Error('This Markdown file needs YAML frontmatter between opening and closing --- lines.');
+  return { record: loadYaml(match[1]), content: match[2], format: 'markdown' };
+}
+
+function loadYaml(source) {
+  if (!globalThis.jsyaml) throw new Error('YAML support is not available in this browser session.');
+  try {
+    return globalThis.jsyaml.load(source, { schema: globalThis.jsyaml.JSON_SCHEMA });
+  } catch {
+    throw new Error('This YAML file is not valid.');
+  }
+}
+
+function normalizeImportedDraft(parsed, originalSource, filename) {
+  const packageRecord = asRecord(parsed.record);
+  const portable = typeof packageRecord.exportVersion === 'string' && packageRecord.data !== undefined;
+  const nested = portable ? parsePortableData(packageRecord) : packageRecord;
+  const metadata = importedMetadata(nested);
+  const typeCandidate = portable ? packageRecord.elementType : nested.type ?? metadata.type;
+  const packageName = portable ? packageRecord.elementName : undefined;
+  const detectedType = normalizeType(typeCandidate);
+  const name = firstString(
+    packageName,
+    nested.name,
+    metadata.name,
+    filename.replace(/\.[^.]+$/u, ''),
+  );
+  const type = detectedType ?? 'personas';
+  const importedBody = importedContent({
+    type,
+    parsed,
+    nested,
+    metadata,
+    originalSource,
+    portable,
+    packageRecord,
+  });
+  const explicitInstructions = firstString(nested.instructions, metadata.instructions);
+  const legacyInstructionBody = parsed.format === 'markdown' &&
+    ['personas', 'skills', 'agents'].includes(type) &&
+    !explicitInstructions;
+  const instructions = legacyInstructionBody ? importedBody : explicitInstructions;
+  const content = legacyInstructionBody ? '' : importedBody;
+  const tags = importedTags(nested, metadata);
+  return {
+    type,
+    typeDetected: Boolean(detectedType),
+    name,
+    description: firstString(nested.description, metadata.description),
+    tags: tags.filter(tag => typeof tag === 'string'),
+    instructions,
+    metadata,
+    content,
+    filename,
+    format: parsed.format,
+  };
+}
+
+function importedTags(record, metadata) {
+  if (Array.isArray(record.tags)) return record.tags;
+  return Array.isArray(metadata.tags) ? metadata.tags : [];
+}
+
+function parsePortableData(packageRecord) {
+  const data = packageRecord.data;
+  if (data && typeof data === 'object') return asRecord(data);
+  if (typeof data !== 'string') throw new Error('This portable export does not contain readable element data.');
+  if (packageRecord.format === 'yaml') return asRecord(loadYaml(data));
+  try {
+    return asRecord(JSON.parse(data));
+  } catch {
+    throw new Error('The data inside this portable JSON export is not valid JSON.');
+  }
+}
+
+function importedMetadata(record) {
+  if (record.metadata && typeof record.metadata === 'object' && !Array.isArray(record.metadata)) {
+    const metadata = { ...record.metadata };
+    for (const [key, value] of Object.entries(record)) {
+      if (!IMPORT_ENVELOPE_KEYS.has(key) && metadata[key] === undefined) metadata[key] = value;
+    }
+    return metadata;
+  }
+  const metadata = { ...record };
+  for (const key of ['content', 'instructions', 'entries', 'stats', 'extensions', 'id', 'type']) delete metadata[key];
+  return metadata;
+}
+
+function importedContent({ type, parsed, nested, originalSource, portable, packageRecord }) {
+  if (type === 'memories') {
+    if (portable && typeof packageRecord.data === 'string') return packageRecord.data;
+    return originalSource;
+  }
+  if (typeof parsed.content === 'string') return parsed.content;
+  if (typeof nested.content === 'string') return nested.content;
+  return '';
+}
+
+function normalizeType(value) {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  const aliases = {
+    persona: 'personas',
+    skill: 'skills',
+    template: 'templates',
+    agent: 'agents',
+    memory: 'memories',
+    ensemble: 'ensembles',
+  };
+  const type = aliases[normalized] ?? normalized;
+  return TYPES.includes(type) ? type : null;
+}
+
+function applyImportedDraft(form, workspace, draft) {
+  const typeControl = form.querySelector(`[name="type"][value="${draft.type}"]`);
+  if (typeControl) typeControl.checked = true;
+  resetGuidedMetadata(form);
+  form.elements.name.value = draft.name;
+  form.elements.description.value = draft.description;
+  form.elements.tags.value = draft.tags.join(', ');
+  form.elements.instructions.value = draft.instructions;
+  setCustomMetadata(form, workspace, draft.metadata, 'import');
+  form.elements.content.value = draft.content;
+  populateGuidedMetadata(form, draft.metadata, draft.type);
+  workspace.querySelector('[data-editor-fields]').hidden = false;
+  workspace.querySelector('button[type="submit"]').disabled = false;
+  workspace.querySelector('[data-editor-validate]')?.removeAttribute('disabled');
+  const source = workspace.querySelector('[data-import-source]');
+  const typeStatus = draft.typeDetected
+    ? `${escapeHtml(TYPE_GUIDANCE[draft.type].label)} detected`
+    : 'Choose the correct element type';
+  source.hidden = false;
+  source.innerHTML = `<strong>${escapeHtml(draft.filename)}</strong><span>${escapeHtml(draft.format.toUpperCase())} · ${typeStatus}</span>`;
+  updateTypeGuidance(form, workspace);
+}
+
+function fieldForIssue(form, path) {
+  if (typeof path !== 'string') return null;
+  const field = path.split(/[.[\]]/u).find(Boolean);
+  return form.elements[field] instanceof HTMLElement ? form.elements[field] : null;
+}
+
+function formDraft(form) {
+  return [...new FormData(form).entries()].map(([key, value]) => `${key}:${formDraftValue(value)}`).join('|');
+}
+
+function formDraftValue(value) {
+  if (typeof value === 'string') return value;
+  return `${value.name}:${value.size}:${value.type}:${value.lastModified}`;
+}
+
+function firstString(...values) {
+  return values.find(value => typeof value === 'string' && value.trim())?.trim() ?? '';
+}
+
+function asRecord(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
 }
 
 async function deleteElement(element, { notify, refresh }) {
@@ -383,16 +1442,39 @@ function renderSyncStatus(dialog, job, fallback) {
   status.innerHTML = `<p><strong>${escapeHtml(capitalize(job.status || fallback || 'updated'))}</strong> · ${escapeHtml(job.direction || '')} · ${escapeHtml(job.conflict_policy || '')}</p>${error}${summary}`;
 }
 
-function setEditorBusy(dialog, busy) {
-  dialog.querySelectorAll('button').forEach(button => { button.disabled = busy; });
+function setEditorBusy(workspace, busy) {
+  const controls = workspace.querySelectorAll(
+    '[data-editor-validate], [data-editor-render], [data-editor-reload], button[type="submit"], [data-import-file]',
+  );
+  controls.forEach(control => {
+    if (busy && !control.disabled) {
+      control.dataset.busyDisabled = '1';
+      control.disabled = true;
+    } else if (!busy && control.dataset.busyDisabled) {
+      control.disabled = false;
+      delete control.dataset.busyDisabled;
+    }
+  });
 }
 
 function setSyncBusy(dialog, busy) {
   dialog.querySelectorAll('select, button[type="submit"]').forEach(control => { control.disabled = busy; });
 }
 
-function showEditorMessage(dialog, message, kind) {
-  dialog.querySelector('[data-editor-feedback]').innerHTML = `<p class="portfolio-message portfolio-message--${kind}">${escapeHtml(message)}</p>`;
+function showEditorMessage(workspace, message, kind, field = null) {
+  showEditorHtml(workspace, `<p class="portfolio-message portfolio-message--${kind}">${escapeHtml(message)}</p>`, field);
+}
+
+function showEditorHtml(workspace, html, field = null) {
+  const feedback = workspace.querySelector('[data-editor-feedback]');
+  feedback.innerHTML = html;
+  if (field instanceof HTMLElement) {
+    field.focus();
+    field.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }
+  if (feedback.querySelector('.portfolio-message--error')) {
+    feedback.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }
 }
 
 function responseDetail(response, fallback) {

--- a/src/web-console/ui/portfolio-authoring.js
+++ b/src/web-console/ui/portfolio-authoring.js
@@ -1,0 +1,474 @@
+/** Portfolio create/edit/delete and GitHub sync controls. */
+
+import { del, get, patch, post } from './api.js';
+
+const TYPES = ['personas', 'skills', 'templates', 'agents', 'memories', 'ensembles'];
+const TERMINAL_SYNC_STATES = new Set(['succeeded', 'failed']);
+const SYNC_POLL_INTERVAL_MS = 1_000;
+const SYNC_POLL_LIMIT = 60;
+
+export function createPortfolioAuthoring({ hasRoute, notify, refresh }) {
+  const capabilities = Object.freeze({
+    create: hasRoute('POST', '/me/portfolio/elements/:type'),
+    edit: hasRoute('PATCH', '/me/portfolio/elements/:type/:name'),
+    delete: hasRoute('DELETE', '/me/portfolio/elements/:type/:name'),
+    validate: hasRoute('POST', '/me/portfolio/elements/:type/:name/validate'),
+    render: hasRoute('POST', '/me/portfolio/elements/:type/:name/render'),
+    sync: hasRoute('POST', '/me/portfolio/sync') && hasRoute('GET', '/me/portfolio/sync/:job_id'),
+  });
+
+  return Object.freeze({
+    capabilities,
+    openCreate: () => openEditor({ mode: 'create', capabilities, notify, refresh }),
+    openEdit: element => openEditor({ mode: 'edit', element, capabilities, notify, refresh }),
+    deleteElement: element => deleteElement(element, { notify, refresh }),
+    openSync: () => openSync({ notify, refresh }),
+  });
+}
+
+async function openEditor(context) {
+  const previousFocus = document.activeElement;
+  const dialog = editorDialog(context);
+  document.body.appendChild(dialog);
+  document.body.classList.add('modal-open');
+  dialog.showModal();
+  focusElement(dialog.querySelector('[name="type"]'));
+
+  const close = () => {
+    if (dialog.open) dialog.close();
+    dialog.remove();
+    document.body.classList.remove('modal-open');
+    restoreFocus(previousFocus);
+  };
+  dialog.querySelector('[data-editor-close]').addEventListener('click', close);
+  dialog.addEventListener('cancel', event => { event.preventDefault(); close(); });
+  dialog.addEventListener('click', event => { if (event.target === dialog) close(); });
+
+  const form = dialog.querySelector('form');
+  form.addEventListener('submit', event => {
+    event.preventDefault();
+    saveEditor(form, dialog, context, close);
+  });
+  dialog.querySelector('[data-editor-validate]')?.addEventListener('click', () => validateEditor(form, dialog));
+  dialog.querySelector('[data-editor-render]')?.addEventListener('click', () => renderEditor(form, dialog));
+  dialog.querySelector('[data-editor-reload]')?.addEventListener('click', () => reloadEditor(form, dialog, context));
+}
+
+function editorDialog({ mode, element, capabilities }) {
+  const isEdit = mode === 'edit';
+  const dialog = document.createElement('dialog');
+  dialog.className = 'portfolio-editor';
+  dialog.setAttribute('aria-labelledby', 'portfolio-editor-title');
+  dialog.innerHTML = `
+    <form method="dialog" class="portfolio-editor-card" novalidate>
+      <header class="portfolio-editor-head">
+        <div>
+          <h2 id="portfolio-editor-title">${isEdit ? 'Edit element' : 'Create element'}</h2>
+          <p>${isEdit ? 'Changes use the element ETag, so a newer version cannot be overwritten.' : 'Create a validated element in your portfolio.'}</p>
+        </div>
+        <button class="security-close" data-editor-close type="button" aria-label="Close">&#x2715;</button>
+      </header>
+      <div class="portfolio-editor-body">
+        <div class="portfolio-form-grid">
+          <label class="portfolio-field"><span>Type</span>
+            <select name="type" ${isEdit ? 'disabled' : ''}>${typeOptions(element?.type)}</select>
+          </label>
+          <label class="portfolio-field"><span>Name</span>
+            <input name="name" required maxlength="200" value="${escapeAttr(element?.name ?? '')}" ${isEdit ? 'readonly' : ''}>
+          </label>
+          <label class="portfolio-field portfolio-field--wide"><span>Tags <small>(comma separated)</small></span>
+            <input name="tags" value="${escapeAttr((element?.tags ?? []).join(', '))}">
+          </label>
+          <label class="portfolio-field portfolio-field--wide"><span>Metadata <small>(JSON object)</small></span>
+            <textarea name="metadata" rows="7" spellcheck="false">${escapeHtml(JSON.stringify(element?.metadata ?? {}, null, 2))}</textarea>
+          </label>
+          <label class="portfolio-field portfolio-field--wide"><span>Content</span>
+            <textarea name="content" rows="14" required spellcheck="false">${escapeHtml(element?.content ?? '')}</textarea>
+          </label>
+        </div>
+        <div class="portfolio-editor-feedback" data-editor-feedback aria-live="polite"></div>
+        <section class="portfolio-preview" data-editor-preview hidden aria-label="Rendered preview"></section>
+      </div>
+      <footer class="portfolio-editor-actions">
+        ${capabilities.validate ? '<button class="btn btn-ghost" data-editor-validate type="button">Validate</button>' : ''}
+        ${isEdit && capabilities.render ? '<button class="btn btn-ghost" data-editor-render type="button">Preview</button>' : ''}
+        <button class="btn btn-ghost" data-editor-reload type="button" hidden>Reload latest</button>
+        <span class="portfolio-editor-spacer"></span>
+        <button class="btn btn-ghost" data-editor-close type="button">Cancel</button>
+        <button class="btn btn-primary" type="submit">${isEdit ? 'Save changes' : 'Create element'}</button>
+      </footer>
+    </form>`;
+  return dialog;
+}
+
+function typeOptions(selected) {
+  return TYPES.map(type => `<option value="${type}"${type === selected ? ' selected' : ''}>${capitalize(type)}</option>`).join('');
+}
+
+function editorPayload(form, includeName) {
+  const metadataText = form.elements.metadata.value.trim();
+  let metadata;
+  try {
+    metadata = metadataText ? JSON.parse(metadataText) : {};
+  } catch {
+    return { problem: 'Metadata must be valid JSON.' };
+  }
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return { problem: 'Metadata must be a JSON object.' };
+  }
+  const payload = {
+    tags: form.elements.tags.value.split(',').map(tag => tag.trim()).filter(Boolean),
+    metadata,
+    content: form.elements.content.value,
+  };
+  if (includeName) payload.name = form.elements.name.value.trim();
+  return { payload };
+}
+
+function editorPath(form, suffix = '') {
+  const type = encodeURIComponent(form.elements.type.value);
+  const name = encodeURIComponent(form.elements.name.value.trim());
+  return `/me/portfolio/elements/${type}/${name}${suffix}`;
+}
+
+async function validateEditor(form, dialog) {
+  if (!form.elements.name.value.trim()) {
+    showEditorMessage(dialog, 'Name is required.', 'error');
+    return false;
+  }
+  const parsed = editorPayload(form, false);
+  if (parsed.problem) return showEditorMessage(dialog, parsed.problem, 'error');
+  setEditorBusy(dialog, true);
+  try {
+    const response = await post(editorPath(form, '/validate'), { body: parsed.payload });
+    showValidation(dialog, response);
+    return response.status === 200 && response.body?.valid === true;
+  } catch {
+    showEditorMessage(dialog, 'Validation could not reach the server.', 'error');
+    return false;
+  } finally {
+    setEditorBusy(dialog, false);
+  }
+}
+
+function showValidation(dialog, response) {
+  if (response.status !== 200) {
+    showEditorMessage(dialog, responseDetail(response, 'Validation failed.'), 'error');
+    return;
+  }
+  const issues = Array.isArray(response.body?.issues) ? response.body.issues : [];
+  if (response.body?.valid) {
+    showEditorMessage(dialog, 'Validation passed.', 'success');
+    return;
+  }
+  const list = issues.map(issue => `<li><strong>${escapeHtml(issue.path || 'element')}</strong>: ${escapeHtml(issue.message || issue.code || 'Invalid value')}</li>`).join('');
+  dialog.querySelector('[data-editor-feedback]').innerHTML = `<div class="portfolio-message portfolio-message--error"><p>Fix these validation issues:</p><ul>${list}</ul></div>`;
+}
+
+async function renderEditor(form, dialog) {
+  const parsed = editorPayload(form, false);
+  if (parsed.problem) return showEditorMessage(dialog, parsed.problem, 'error');
+  setEditorBusy(dialog, true);
+  try {
+    const response = await post(editorPath(form, '/render'), { body: parsed.payload });
+    if (response.status !== 200 || typeof response.body?.preview !== 'string') {
+      showEditorMessage(dialog, responseDetail(response, 'Preview failed.'), 'error');
+      return;
+    }
+    const preview = dialog.querySelector('[data-editor-preview]');
+    preview.hidden = false;
+    preview.innerHTML = `<h3>Server preview</h3><pre>${escapeHtml(response.body.preview)}</pre>`;
+    showEditorMessage(dialog, 'Preview refreshed from the server.', 'success');
+  } catch {
+    showEditorMessage(dialog, 'Preview could not reach the server.', 'error');
+  } finally {
+    setEditorBusy(dialog, false);
+  }
+}
+
+async function saveEditor(form, dialog, context, close) {
+  const includeName = context.mode === 'create';
+  const parsed = editorPayload(form, includeName);
+  if (parsed.problem) return showEditorMessage(dialog, parsed.problem, 'error');
+  if (!form.elements.name.value.trim()) return showEditorMessage(dialog, 'Name is required.', 'error');
+  setEditorBusy(dialog, true);
+  try {
+    if (context.capabilities.validate) {
+      const valid = await validateDraft(form, dialog, parsed.payload);
+      if (!valid) return;
+    }
+    const response = includeName
+      ? await post(`/me/portfolio/elements/${encodeURIComponent(form.elements.type.value)}`, { body: parsed.payload })
+      : await patch(editorPath(form), { body: parsed.payload, ifMatch: context.element?._etag });
+    if (response.status === 412) {
+      showConflict(dialog);
+      return;
+    }
+    const expectedStatus = includeName ? 201 : 200;
+    if (response.status !== expectedStatus) {
+      showEditorMessage(dialog, responseDetail(response, 'The element could not be saved.'), 'error');
+      return;
+    }
+    context.notify(`${includeName ? 'Created' : 'Updated'} “${response.body?.display_name || response.body?.name || 'element'}”.`, 'success');
+    await context.refresh();
+    close();
+  } catch {
+    showEditorMessage(dialog, 'The element could not be saved because the server is unreachable.', 'error');
+  } finally {
+    setEditorBusy(dialog, false);
+  }
+}
+
+async function validateDraft(form, dialog, payload) {
+  const response = await post(editorPath(form, '/validate'), { body: payload });
+  showValidation(dialog, response);
+  return response.status === 200 && response.body?.valid === true;
+}
+
+function showConflict(dialog) {
+  showEditorMessage(dialog, 'This element changed after you opened it. Your draft was not saved. Review or copy it, then reload the latest version before editing again.', 'error');
+  dialog.querySelector('[data-editor-reload]').hidden = false;
+}
+
+async function reloadEditor(form, dialog, context) {
+  setEditorBusy(dialog, true);
+  try {
+    const response = await get(editorPath(form));
+    if (response.status !== 200 || !response.body) {
+      showEditorMessage(dialog, responseDetail(response, 'The latest version could not be loaded.'), 'error');
+      return;
+    }
+    if (typeof response.etag !== 'string' || !response.etag) {
+      showEditorMessage(dialog, 'The latest version did not include an ETag, so editing remains blocked.', 'error');
+      return;
+    }
+    context.element = { ...response.body, _etag: response.etag };
+    form.elements.tags.value = Array.isArray(response.body.tags) ? response.body.tags.join(', ') : '';
+    form.elements.metadata.value = JSON.stringify(response.body.metadata ?? {}, null, 2);
+    form.elements.content.value = typeof response.body.content === 'string' ? response.body.content : '';
+    dialog.querySelector('[data-editor-reload]').hidden = true;
+    showEditorMessage(dialog, 'Latest version loaded. The previous draft was replaced only after your confirmation.', 'success');
+  } finally {
+    setEditorBusy(dialog, false);
+  }
+}
+
+async function deleteElement(element, { notify, refresh }) {
+  const confirmed = await confirmDelete(element);
+  if (!confirmed) return;
+  try {
+    const response = await del(elementPath(element), { ifMatch: element._etag });
+    if (response.status === 412) {
+      notify('Delete stopped because this element changed. Reload it and review the latest version first.', 'warn');
+      await refresh();
+      return;
+    }
+    if (response.status !== 200) {
+      notify(responseDetail(response, 'The element could not be deleted.'), 'error');
+      return;
+    }
+    notify(`Deleted “${element.display_name || element.name}” permanently.`, 'success');
+    await refresh();
+  } catch {
+    notify('The element could not be deleted because the server is unreachable.', 'error');
+  }
+}
+
+function confirmDelete(element) {
+  const name = element.display_name || element.name;
+  return confirmDialog(`Permanently delete “${name}”? This cannot be undone.`, 'Delete permanently');
+}
+
+async function openSync({ notify, refresh }) {
+  const previousFocus = document.activeElement;
+  const dialog = syncDialog();
+  const controller = new AbortController();
+  document.body.appendChild(dialog);
+  document.body.classList.add('modal-open');
+  dialog.showModal();
+  focusElement(dialog.querySelector('[name="direction"]'));
+  const close = () => {
+    controller.abort();
+    if (dialog.open) dialog.close();
+    dialog.remove();
+    document.body.classList.remove('modal-open');
+    restoreFocus(previousFocus);
+  };
+  dialog.querySelectorAll('[data-sync-close]').forEach(button => button.addEventListener('click', close));
+  dialog.addEventListener('cancel', event => { event.preventDefault(); close(); });
+  dialog.addEventListener('click', event => { if (event.target === dialog) close(); });
+  dialog.querySelector('form').addEventListener('submit', event => {
+    event.preventDefault();
+    startSync(dialog, { notify, refresh, signal: controller.signal });
+  });
+}
+
+function syncDialog() {
+  const dialog = document.createElement('dialog');
+  dialog.className = 'portfolio-sync';
+  dialog.setAttribute('aria-labelledby', 'portfolio-sync-title');
+  dialog.innerHTML = `
+    <form method="dialog" class="portfolio-sync-card">
+      <header class="portfolio-editor-head">
+        <div><h2 id="portfolio-sync-title">Sync portfolio with GitHub</h2><p>Choose the direction and how conflicts should be handled.</p></div>
+        <button class="security-close" data-sync-close type="button" aria-label="Close">&#x2715;</button>
+      </header>
+      <div class="portfolio-editor-body portfolio-sync-fields">
+        <label class="portfolio-field"><span>Direction</span><select name="direction">
+          <option value="pull">Pull from GitHub</option><option value="push">Push to GitHub</option><option value="bidirectional">Bidirectional</option>
+        </select></label>
+        <label class="portfolio-field"><span>Conflict policy</span><select name="conflict_policy">
+          <option value="fail">Stop on conflict</option><option value="prefer_local">Prefer local</option><option value="prefer_remote">Prefer GitHub</option>
+        </select></label>
+        <div class="portfolio-sync-status" data-sync-status aria-live="polite">Ready to start.</div>
+      </div>
+      <footer class="portfolio-editor-actions"><button class="btn btn-ghost" data-sync-close type="button">Close</button><button class="btn btn-primary" type="submit">Start sync</button></footer>
+    </form>`;
+  return dialog;
+}
+
+async function startSync(dialog, context) {
+  const form = dialog.querySelector('form');
+  setSyncBusy(dialog, true);
+  try {
+    const response = await post('/me/portfolio/sync', { body: {
+      provider: 'github',
+      direction: form.elements.direction.value,
+      conflict_policy: form.elements.conflict_policy.value,
+    }, signal: context.signal });
+    if (response.status !== 202 || !response.body?.job_id) {
+      renderSyncStatus(dialog, response.body, responseDetail(response, 'Sync could not start.'));
+      setSyncBusy(dialog, false);
+      return;
+    }
+    renderSyncStatus(dialog, response.body, 'Sync queued.');
+    const result = await pollSync(dialog, response.body.job_id, context.signal);
+    if (result?.status === 'succeeded') {
+      context.notify('Portfolio sync completed.', 'success');
+      await context.refresh();
+    } else if (result?.status === 'failed') {
+      const errorSuffix = result.error_code ? ` (${result.error_code})` : '';
+      context.notify(`Portfolio sync failed${errorSuffix}.`, 'error');
+    }
+  } catch (error) {
+    if (error?.name !== 'AbortError') renderSyncStatus(dialog, null, 'Sync status could not reach the server.');
+  } finally {
+    setSyncBusy(dialog, false);
+  }
+}
+
+async function pollSync(dialog, jobId, signal) {
+  for (let attempt = 0; attempt < SYNC_POLL_LIMIT; attempt += 1) {
+    await delay(SYNC_POLL_INTERVAL_MS, signal);
+    const response = await get(`/me/portfolio/sync/${encodeURIComponent(jobId)}`, { signal });
+    if (response.status !== 200 || !response.body) {
+      renderSyncStatus(dialog, null, responseDetail(response, 'Could not read sync status.'));
+      return null;
+    }
+    renderSyncStatus(dialog, response.body);
+    if (TERMINAL_SYNC_STATES.has(response.body.status)) return response.body;
+  }
+  renderSyncStatus(dialog, null, 'Sync is still running. Close this dialog and check again later.');
+  return null;
+}
+
+function renderSyncStatus(dialog, job, fallback) {
+  const status = dialog.querySelector('[data-sync-status]');
+  if (!job) {
+    status.innerHTML = `<p class="portfolio-message portfolio-message--error">${escapeHtml(fallback)}</p>`;
+    return;
+  }
+  const summary = job.result_summary ? `<pre>${escapeHtml(JSON.stringify(job.result_summary, null, 2))}</pre>` : '';
+  const error = job.error_code ? `<p>Error: <code>${escapeHtml(job.error_code)}</code></p>` : '';
+  status.innerHTML = `<p><strong>${escapeHtml(capitalize(job.status || fallback || 'updated'))}</strong> · ${escapeHtml(job.direction || '')} · ${escapeHtml(job.conflict_policy || '')}</p>${error}${summary}`;
+}
+
+function setEditorBusy(dialog, busy) {
+  dialog.querySelectorAll('button').forEach(button => { button.disabled = busy; });
+}
+
+function setSyncBusy(dialog, busy) {
+  dialog.querySelectorAll('select, button[type="submit"]').forEach(control => { control.disabled = busy; });
+}
+
+function showEditorMessage(dialog, message, kind) {
+  dialog.querySelector('[data-editor-feedback]').innerHTML = `<p class="portfolio-message portfolio-message--${kind}">${escapeHtml(message)}</p>`;
+}
+
+function responseDetail(response, fallback) {
+  return typeof response.body?.detail === 'string' ? response.body.detail : fallback;
+}
+
+function elementPath(element) {
+  return `/me/portfolio/elements/${encodeURIComponent(element.type)}/${encodeURIComponent(element.name)}`;
+}
+
+function confirmDialog(message, confirmLabel) {
+  return new Promise(resolve => {
+    document.getElementById('portfolio-confirm')?.remove();
+    const previousFocus = document.activeElement;
+    const modal = document.createElement('div');
+    modal.className = 'confirm-modal';
+    modal.id = 'portfolio-confirm';
+    modal.innerHTML = `<div class="confirm-backdrop"></div><div class="confirm-card" role="dialog" aria-modal="true" aria-label="Confirm deletion"><p class="confirm-msg">${escapeHtml(message)}</p><div class="confirm-actions"><button class="btn btn-ghost" data-confirm="0" type="button">Cancel</button><button class="btn btn-primary portfolio-danger" data-confirm="1" type="button">${escapeHtml(confirmLabel)}</button></div></div>`;
+    document.body.appendChild(modal);
+    const buttons = [...modal.querySelectorAll('button')];
+    const done = value => {
+      modal.remove();
+      document.removeEventListener('keydown', onKey);
+      restoreFocus(previousFocus);
+      resolve(value);
+    };
+    const onKey = event => {
+      if (event.key === 'Escape') done(false);
+      if (event.key !== 'Tab') return;
+      event.preventDefault();
+      const active = document.activeElement;
+      const current = active instanceof HTMLButtonElement ? buttons.indexOf(active) : -1;
+      const offset = event.shiftKey ? -1 : 1;
+      buttons[(current + offset + buttons.length) % buttons.length].focus();
+    };
+    modal.querySelector('.confirm-backdrop').addEventListener('click', () => done(false));
+    modal.querySelector('[data-confirm="0"]').addEventListener('click', () => done(false));
+    modal.querySelector('[data-confirm="1"]').addEventListener('click', () => done(true));
+    document.addEventListener('keydown', onKey);
+    buttons[1].focus();
+  });
+}
+
+function delay(ms, signal) {
+  return new Promise((resolve, reject) => {
+    const done = () => {
+      signal.removeEventListener('abort', aborted);
+      resolve();
+    };
+    const aborted = () => {
+      globalThis.clearTimeout(timer);
+      const error = new Error('Sync polling aborted.');
+      error.name = 'AbortError';
+      reject(error);
+    };
+    const timer = globalThis.setTimeout(done, ms);
+    signal.addEventListener('abort', aborted, { once: true });
+  });
+}
+
+function restoreFocus(element) {
+  if (element instanceof HTMLElement && element.isConnected) element.focus();
+}
+
+function focusElement(element) {
+  if (element instanceof HTMLElement) element.focus();
+}
+
+function capitalize(value) {
+  return value ? value.charAt(0).toUpperCase() + value.slice(1) : '';
+}
+
+function escapeHtml(value) {
+  return String(value ?? '').replaceAll(/[&<>"']/g, character => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[character]));
+}
+
+function escapeAttr(value) {
+  return escapeHtml(value);
+}

--- a/src/web-console/ui/portfolio-authoring.js
+++ b/src/web-console/ui/portfolio-authoring.js
@@ -99,6 +99,8 @@ const GUIDED_METADATA_KEYS = new Set([
 const TERMINAL_SYNC_STATES = new Set(['succeeded', 'failed']);
 const SYNC_POLL_INTERVAL_MS = 1_000;
 const SYNC_POLL_LIMIT = 60;
+// The portfolio exposes one authoring workspace; opening another closes the
+// previous workspace and removes its document-level listeners first.
 let activeWorkspaceCleanup = null;
 
 export function createPortfolioAuthoring({ host, hasRoute, notify, refresh }) {
@@ -727,11 +729,12 @@ function definitionFromRow(row) {
 function ensembleElementFromRow(row) {
   const elementName = row.querySelector('[data-row-field="name"]').value.trim();
   if (!elementName) return null;
+  const priority = optionalNumber(row.querySelector('[data-row-field="priority"]').value.trim()) ?? 10;
   return compactRecord({
     element_name: elementName,
     element_type: row.querySelector('[data-row-field="type"]').value,
     role: row.querySelector('[data-row-field="role"]').value,
-    priority: Number(row.querySelector('[data-row-field="priority"]').value),
+    priority,
     activation: row.querySelector('[data-row-field="activation"]').value,
     purpose: row.querySelector('[data-row-field="purpose"]').value.trim(),
   });
@@ -891,6 +894,8 @@ async function reloadEditor(form, workspace, context) {
       showEditorMessage(workspace, 'The latest version did not include an ETag, so editing remains blocked.', 'error');
       return false;
     }
+    // Event handlers share this context, so replacing the element also advances
+    // the ETag used by every subsequent save in this editor.
     context.element = { ...response.body, _etag: response.etag };
     resetGuidedMetadata(form);
     form.elements.tags.value = Array.isArray(response.body.tags) ? response.body.tags.join(', ') : '';
@@ -1158,6 +1163,8 @@ function parseMarkdownImport(source) {
 }
 
 function loadYaml(source) {
+  // index.html loads the vendored js-yaml bundle before app.js. Keep the guard
+  // so direct module use fails with an actionable message instead of a TypeError.
   if (!globalThis.jsyaml) throw new Error('YAML support is not available in this browser session.');
   try {
     return globalThis.jsyaml.load(source, { schema: globalThis.jsyaml.JSON_SCHEMA });

--- a/src/web-console/ui/portfolio.js
+++ b/src/web-console/ui/portfolio.js
@@ -16,6 +16,7 @@
 
 import { get, post } from './api.js';
 import { noConsoleRoute } from './console-meta.js';
+import { createPortfolioAuthoring } from './portfolio-authoring.js';
 import { renderElementDetail } from './portfolio-detail.js';
 
 // Plural API type → singular CSS/display type (drives the --family colour lanes
@@ -46,16 +47,19 @@ const state = {
   collection: { status: 'idle', detail: '', elements: [], installEnabled: true },
   // Catalog paths installed this session, so their cards can flip to "Installed".
   installed: new Set(),
+  summary: null,
 };
 
 let host;
 let notify = () => {};
 let hasRoute = noConsoleRoute;
+let authoring;
 
 export async function init(panelEl, ctx = {}) {
   host = panelEl;
   notify = ctx.toast || notify;
   hasRoute = ctx.hasRoute || hasRoute;
+  authoring = createPortfolioAuthoring({ hasRoute, notify, refresh: refreshPortfolio });
   state.collection.installEnabled = hasRoute('POST', '/me/portfolio/from-collection');
   host.innerHTML = template();
   const collectionAvailable = hasRoute('GET', '/collection/elements');
@@ -69,6 +73,13 @@ export async function init(panelEl, ctx = {}) {
 
 function template() {
   return `
+  <div class="portfolio-command-bar">
+    <span class="portfolio-summary" id="pf-summary" aria-live="polite">Portfolio</span>
+    <div class="portfolio-command-actions">
+      ${authoring.capabilities.sync ? '<button class="btn btn-ghost" id="pf-sync" type="button">Sync with GitHub</button>' : ''}
+      ${authoring.capabilities.create ? '<button class="btn btn-primary" id="pf-create" type="button">Create element</button>' : ''}
+    </div>
+  </div>
   <div class="browse-controls">
     <div class="search-wrapper">
       <label for="pf-search" class="sr-only">Search elements</label>
@@ -120,13 +131,18 @@ function template() {
 async function load() {
   const grid = host.querySelector('#pf-grid');
   grid.innerHTML = '<li class="panel-placeholder">Loading portfolio…</li>';
-  const list = await get('/me/portfolio/elements');
+  const [list, summary] = await Promise.all([
+    get('/me/portfolio/elements'),
+    hasRoute('GET', '/me/portfolio') ? get('/me/portfolio') : Promise.resolve(null),
+  ]);
   if (list.status !== 200) {
     grid.innerHTML = `<li class="panel-placeholder">Couldn't load your portfolio (status ${list.status}).</li>`;
     return;
   }
   // Local portfolio elements are flagged so the LOCAL badge + Portfolio source filter work.
   state.elements = (list.body?.elements ?? []).filter(Boolean).map(el => ({ ...el, _local: true }));
+  state.summary = summary?.status === 200 ? summary.body : null;
+  renderSummary();
   paint();
   // The list DTO is lean; hydrate the rich card fields (description/author/
   // category) from each element's full detail — the legacy did the same. No
@@ -149,6 +165,7 @@ async function hydrateDetails() {
           const m = res.body.metadata ?? {};
           el.metadata = m;                 // keep the full stored frontmatter
           el.content = res.body.content;   // for the detail view (next increment)
+          el._etag = res.etag;
           el.description = str(m.description);
           el.author = str(m.author);
           el.category = str(m.category);
@@ -228,6 +245,16 @@ function mapCollectionElement(el) {
 // Repaint both the type-filter counts and the grid (use when the source or the
 // underlying element set changed; plain render() suffices for search/sort/view).
 function paint() { renderTypeFilters(); render(); }
+
+function renderSummary() {
+  const summary = host.querySelector('#pf-summary');
+  if (!summary) return;
+  const total = state.summary?.total_elements;
+  const plural = total === 1 ? '' : 's';
+  summary.textContent = Number.isSafeInteger(total)
+    ? `${total} portfolio element${plural}`
+    : 'Your portfolio';
+}
 
 function renderTypeFilters() {
   // Counts follow the active source, so the Collection tab shows catalog counts
@@ -312,6 +339,7 @@ function card(el) {
   const stale = el.validation_status && el.validation_status !== 'valid';
   const tagItems = (el.tags || []).slice(0, 5).map(t => `<li class="tag">${escapeHtml(t)}</li>`).join('');
   const isCollection = el.source === 'collection';
+  const actions = isCollection ? installAction(el) : portfolioCardActions(el);
   return `
   <article class="element-card" data-type="${escapeAttr(singular)}" data-key="${escapeAttr(el.type)}" data-name="${escapeAttr(el.name)}"
     ${isCollection && el.path ? `data-path="${escapeAttr(el.path)}"` : ''}
@@ -335,16 +363,20 @@ function card(el) {
         ${el.category ? `<span class="meta-category">${escapeHtml(el.category)}</span>` : ''}
         ${el.updated_at ? `<span class="meta-date">${formatDate(el.updated_at)}</span>` : ''}
       </div>
-      ${isCollection ? installAction(el) : `
-      <div class="card-actions">
-        <button class="card-download-btn" data-action="download" aria-label="Download ${escapeHtml(title(el))}" title="Download">&#10515;</button>
-      </div>`}
+      ${actions}
       ${el.tags?.length
         ? `<ul class="card-tags" aria-label="Tags">${tagItems}</ul>`
         : ''}
     </footer>
     <div class="card-inline-detail"></div>
   </article>`;
+}
+
+function portfolioCardActions(el) {
+  const edit = authoring.capabilities.edit
+    ? `<button class="card-download-btn" data-action="edit" aria-label="Edit ${escapeHtml(title(el))}" title="Edit">Edit</button>`
+    : '';
+  return `<div class="card-actions portfolio-card-edit">${edit}<button class="card-download-btn" data-action="download" aria-label="Download ${escapeHtml(title(el))}" title="Download">&#10515;</button></div>`;
 }
 
 // Version label for both the portfolio's numeric version and the collection's
@@ -396,6 +428,8 @@ function renderComponentSummary(el) {
 /* ── Controls ───────────────────────────────────────────────────────────── */
 
 function wireControls() {
+  host.querySelector('#pf-create')?.addEventListener('click', () => authoring.openCreate());
+  host.querySelector('#pf-sync')?.addEventListener('click', () => authoring.openSync());
   host.querySelector('#pf-search').addEventListener('input', (e) => { state.search = e.target.value; state.page = 1; render(); });
   host.querySelector('#pf-sort').addEventListener('change', (e) => { state.sort = e.target.value; render(); });
   host.querySelector('#pf-view').addEventListener('click', (e) => toggleGroup(e, '.view-btn', '#pf-view', v => { state.view = v; }));
@@ -429,6 +463,8 @@ function wireControls() {
     if (installBtn) { e.stopPropagation(); installCard(list[idx], installBtn); return; }   // install without opening
     const dlBtn = e.target.closest('[data-action="download"]');
     if (dlBtn) { e.stopPropagation(); downloadCard(list[idx], dlBtn); return; }   // download without opening
+    const editBtn = e.target.closest('[data-action="edit"]');
+    if (editBtn) { e.stopPropagation(); editCard(list[idx], editBtn); return; }
     openModal(list, idx);
   });
 }
@@ -458,6 +494,8 @@ function ensureModal() {
       </header>
       <div class="modal-toolbar">
         <button class="modal-action-btn modal-install-btn" data-act="install" hidden>&#8681; Install</button>
+        <button class="modal-action-btn modal-edit-btn" data-act="edit" hidden>Edit</button>
+        <button class="modal-action-btn modal-delete-btn portfolio-danger" data-act="delete" hidden>Delete</button>
         <button class="modal-action-btn" data-act="render">&#8644; Raw</button>
         <button class="modal-action-btn" data-act="copy">&#9112; Copy</button>
         <button class="modal-action-btn" data-act="download">&#10515; Download</button>
@@ -470,20 +508,21 @@ function ensureModal() {
       <div class="modal-body" id="pf-modal-body" tabindex="-1"></div>
     </div>`;
   document.body.appendChild(dlg);
-  dlg.addEventListener('click', (e) => { if (e.target === dlg) close(); });        // backdrop click
-  dlg.querySelector('#pf-modal-close').addEventListener('click', close);
+  dlg.addEventListener('click', (e) => { if (e.target === dlg) closeDetailModal(); });        // backdrop click
+  dlg.querySelector('#pf-modal-close').addEventListener('click', closeDetailModal);
   dlg.querySelector('.modal-toolbar').addEventListener('click', onToolbar);
-  function close() { dlg.close(); document.body.classList.remove('modal-open'); }
 }
 
 let modalList = [];
 let modalIdx = -1;
 let modalEl = null;
 let modalContent = '';
+let modalPreviousFocus = null;
 
 async function openModal(list, idx) {
   ensureModal();
   modalList = list; modalIdx = idx; modalEl = list[idx];
+  modalPreviousFocus = document.activeElement;
   const dlg = document.getElementById('pf-modal');
   const body = dlg.querySelector('#pf-modal-body');
   setHeader(modalEl);
@@ -499,7 +538,7 @@ async function openModal(list, idx) {
     body.innerHTML = `<p class="panel-placeholder">Couldn't load this element (status ${res.status}).</p>`;
     return;
   }
-  modalEl = { ...modalEl, ...res.body, metadata: res.body.metadata ?? {} };
+  modalEl = { ...modalEl, ...res.body, metadata: res.body.metadata ?? {}, _etag: res.etag };
   modalContent = typeof res.body.content === 'string' ? res.body.content : '';
   setHeader(modalEl);
   renderModalBody();
@@ -525,6 +564,10 @@ function setHeader(el) {
     installBtn.disabled = done;
     installBtn.textContent = done ? 'Installed ✓' : '⭳ Install';
   }
+  const local = el.source !== 'collection';
+  const safelyLoaded = Boolean(el._etag);
+  dlg.querySelector('.modal-edit-btn').hidden = !local || !safelyLoaded || !authoring.capabilities.edit;
+  dlg.querySelector('.modal-delete-btn').hidden = !local || !safelyLoaded || !authoring.capabilities.delete;
 }
 
 function renderModalBody() {
@@ -588,6 +631,7 @@ async function ensureLoaded(el) {
   if (res.status === 200 && res.body) {
     el.metadata = res.body.metadata ?? {};
     el.content = typeof res.body.content === 'string' ? res.body.content : '';
+    el._etag = res.etag;
   }
   return el;
 }
@@ -671,9 +715,14 @@ async function installFromModal(btn) {
 // the Portfolio tab shows the new element without a jarring full "Loading…".
 async function refreshPortfolio() {
   try {
-    const list = await get('/me/portfolio/elements');
+    const [list, summary] = await Promise.all([
+      get('/me/portfolio/elements'),
+      hasRoute('GET', '/me/portfolio') ? get('/me/portfolio') : Promise.resolve(null),
+    ]);
     if (list.status !== 200) return;
     state.elements = (list.body?.elements ?? []).filter(Boolean).map(el => ({ ...el, _local: true }));
+    state.summary = summary?.status === 200 ? summary.body : state.summary;
+    renderSummary();
     if (state.source !== 'collection') paint();
     hydrateDetails();
   } catch { /* leave the current portfolio view; the next full load will catch up */ }
@@ -692,11 +741,44 @@ function onToolbar(e) {
     downloadElement(modalEl);
   } else if (act === 'install') {
     installFromModal(btn);
+  } else if (act === 'edit') {
+    const element = modalEl;
+    closeDetailModal();
+    authoring.openEdit(element);
+  } else if (act === 'delete') {
+    const element = modalEl;
+    closeDetailModal();
+    authoring.deleteElement(element);
   } else if (act === 'prev' && modalIdx > 0) {
     openModal(modalList, modalIdx - 1);
   } else if (act === 'next' && modalIdx < modalList.length - 1) {
     openModal(modalList, modalIdx + 1);
   }
+}
+
+async function editCard(element, button) {
+  const prior = button.textContent;
+  button.disabled = true;
+  button.textContent = 'Loading…';
+  try {
+    await ensureLoaded(element);
+    if (!element._etag) {
+      notify('This element could not be opened for safe editing.', 'error');
+      return;
+    }
+    authoring.openEdit(element);
+  } finally {
+    button.disabled = false;
+    button.textContent = prior;
+  }
+}
+
+function closeDetailModal() {
+  const dialog = document.getElementById('pf-modal');
+  if (dialog?.open) dialog.close();
+  document.body.classList.remove('modal-open');
+  if (modalPreviousFocus instanceof HTMLElement && modalPreviousFocus.isConnected) modalPreviousFocus.focus();
+  modalPreviousFocus = null;
 }
 
 function toggleGroup(e, btnSel, groupSel, apply) {

--- a/src/web-console/ui/portfolio.js
+++ b/src/web-console/ui/portfolio.js
@@ -60,25 +60,35 @@ export async function init(panelEl, ctx = {}) {
   host = panelEl;
   notify = ctx.toast || notify;
   hasRoute = ctx.hasRoute || hasRoute;
-  authoring = createPortfolioAuthoring({ hasRoute, notify, refresh: refreshPortfolio });
+  authoring = createPortfolioAuthoring({ host, hasRoute, notify, refresh: refreshPortfolio });
   state.collection.installEnabled = hasRoute('POST', '/me/portfolio/from-collection');
   host.innerHTML = template();
   const collectionAvailable = hasRoute('GET', '/collection/elements');
   host.querySelector('#pf-source').hidden = !collectionAvailable;
   if (!collectionAvailable) state.source = 'portfolio';
   wireControls();
-  await load();
+  await Promise.all([
+    load(),
+    collectionAvailable ? loadCollection() : Promise.resolve(),
+  ]);
 }
 
 /* ── Markup ─────────────────────────────────────────────────────────────── */
 
 function template() {
   return `
+  <div data-portfolio-browser>
   <div class="portfolio-command-bar">
     <span class="portfolio-summary" id="pf-summary" aria-live="polite">Portfolio</span>
     <div class="portfolio-command-actions">
       ${authoring.capabilities.sync ? '<button class="btn btn-ghost" id="pf-sync" type="button">Sync with GitHub</button>' : ''}
-      ${authoring.capabilities.create ? '<button class="btn btn-primary" id="pf-create" type="button">Create element</button>' : ''}
+      ${authoring.capabilities.create ? `
+        <button class="portfolio-start-action" id="pf-create" type="button">
+          <strong>Create new</strong><span>Build an element with guided fields</span>
+        </button>
+        <button class="portfolio-start-action" id="pf-import" type="button">
+          <strong>Import file</strong><span>Review and add a local element file</span>
+        </button>` : ''}
     </div>
   </div>
   <div class="browse-controls">
@@ -124,7 +134,9 @@ function template() {
     <button class="pagination-btn" id="pf-prev" type="button">&#8249; Prev</button>
     <span class="pagination-info" id="pf-pageinfo"></span>
     <button class="pagination-btn" id="pf-next" type="button">Next &#8250;</button>
-  </nav>`;
+  </nav>
+  </div>
+  <section class="portfolio-workspace" data-portfolio-authoring hidden aria-label="Portfolio authoring"></section>`;
 }
 
 /* ── Data ───────────────────────────────────────────────────────────────── */
@@ -143,7 +155,6 @@ async function load() {
   // Local portfolio elements are flagged so the LOCAL badge + Portfolio source filter work.
   state.elements = (list.body?.elements ?? []).filter(Boolean).map(el => ({ ...el, _local: true }));
   state.summary = summary?.status === 200 ? summary.body : null;
-  renderSummary();
   paint();
   // The list DTO is lean; hydrate the rich card fields (description/author/
   // category) from each element's full detail — the legacy did the same. No
@@ -191,7 +202,7 @@ const COLLECTION_MAX_PAGES = 20;  // safety bound on the page walk
 async function loadCollection() {
   if (state.collection.status === 'loading') return;
   state.collection.status = 'loading';
-  render();
+  paint();
 
   const elements = [];
   let installEnabled = hasRoute('POST', '/me/portfolio/from-collection');
@@ -210,6 +221,16 @@ async function loadCollection() {
         return;
       }
       if (!body.has_more) break;
+      if (page === COLLECTION_MAX_PAGES) {
+        state.collection = {
+          status: 'degraded',
+          detail: `Only the first ${elements.length} collection elements could be loaded.`,
+          elements,
+          installEnabled,
+        };
+        paint();
+        return;
+      }
     }
     state.collection = { status: 'ok', detail: '', elements, installEnabled };
   } catch {
@@ -245,21 +266,58 @@ function mapCollectionElement(el) {
 
 // Repaint both the type-filter counts and the grid (use when the source or the
 // underlying element set changed; plain render() suffices for search/sort/view).
-function paint() { renderTypeFilters(); render(); }
+function paint() { renderSummary(); renderTypeFilters(); render(); }
 
 function renderSummary() {
   const summary = host.querySelector('#pf-summary');
   if (!summary) return;
-  const total = state.summary?.total_elements;
-  const plural = total === 1 ? '' : 's';
-  summary.textContent = Number.isSafeInteger(total)
-    ? `${total} portfolio element${plural}`
-    : 'Your portfolio';
+  if (state.source === 'portfolio') {
+    const total = state.summary?.total_elements;
+    summary.textContent = Number.isSafeInteger(total)
+      ? elementCount(total, 'portfolio')
+      : 'Your portfolio';
+    return;
+  }
+  if (state.source === 'collection') {
+    summary.textContent = collectionSummary();
+    return;
+  }
+  summary.textContent = allSourcesSummary();
+}
+
+function elementCount(total, qualifier = '') {
+  const prefix = qualifier ? `${qualifier} ` : '';
+  return `${total} ${prefix}element${total === 1 ? '' : 's'}`;
+}
+
+function collectionSummary() {
+  const { status, elements, detail } = state.collection;
+  if (status === 'idle' || status === 'loading') return 'Loading collection…';
+  if (status === 'error' || status === 'unavailable') return 'Collection unavailable';
+  if (status === 'degraded') {
+    return `${elementCount(elements.length, 'available collection')} · ${detail || 'Collection may be incomplete'}`;
+  }
+  return elementCount(elements.length, 'collection');
+}
+
+function allSourcesSummary() {
+  const { status, detail } = state.collection;
+  if (status === 'idle' || status === 'loading') {
+    return `${elementCount(state.elements.length, 'portfolio')} · Loading collection…`;
+  }
+  if (status === 'error' || status === 'unavailable') {
+    return `${elementCount(state.elements.length, 'portfolio')} · Collection unavailable`;
+  }
+  const total = sourceElements().length;
+  if (status === 'degraded') {
+    return `${elementCount(total, 'available')} · ${detail || 'Collection may be incomplete'}`;
+  }
+  return elementCount(total, 'total');
 }
 
 function renderTypeFilters() {
-  // Counts follow the active source, so the Collection tab shows catalog counts
-  // rather than the user's portfolio counts.
+  // Counts follow the active source. All combines the complete catalog and the
+  // user's portfolio rather than acting as a second Portfolio filter.
   const items = sourceElements();
   const counts = {};
   for (const el of items) counts[el.type] = (counts[el.type] ?? 0) + 1;
@@ -275,14 +333,14 @@ function renderTypeFilters() {
 }
 
 function sourceElements() {
-  // Collection tab draws from the lazily-loaded catalog; All/Portfolio draw from
-  // the user's local elements (identical today — everything local is portfolio).
-  return state.source === 'collection' ? state.collection.elements : state.elements;
+  if (state.source === 'collection') return state.collection.elements;
+  if (state.source === 'portfolio') return state.elements;
+  return [...state.collection.elements, ...state.elements];
 }
 
 function visibleElements() {
   const q = state.search.trim().toLowerCase();
-  let items = sourceElements().filter(el => state.type === 'all' || el.type === state.type);
+  let items = [...sourceElements()].filter(el => state.type === 'all' || el.type === state.type);
   if (q) {
     items = items.filter(el =>
       (el.name || '').toLowerCase().includes(q) ||
@@ -430,18 +488,20 @@ function renderComponentSummary(el) {
 
 function wireControls() {
   host.querySelector('#pf-create')?.addEventListener('click', () => authoring.openCreate());
+  host.querySelector('#pf-import')?.addEventListener('click', () => authoring.openImport());
   host.querySelector('#pf-sync')?.addEventListener('click', () => authoring.openSync());
   host.querySelector('#pf-search').addEventListener('input', (e) => { state.search = e.target.value; state.page = 1; render(); });
   host.querySelector('#pf-sort').addEventListener('change', (e) => { state.sort = e.target.value; render(); });
   host.querySelector('#pf-view').addEventListener('click', (e) => toggleGroup(e, '.view-btn', '#pf-view', v => { state.view = v; }));
   host.querySelector('#pf-source').addEventListener('click', (e) => toggleGroup(e, '.source-btn', '#pf-source', v => {
     state.source = v; state.page = 1;
+    renderSummary();
     renderTypeFilters(); // counts follow the active source
     // Lazy-load the catalog the first time the Collection tab is opened, and
     // re-try when the last attempt failed or came back empty-degraded —
     // otherwise a transient blip would brick the tab for the whole session.
     const cst = state.collection.status;
-    if (v === 'collection' && (cst === 'idle' || cst === 'error' ||
+    if ((v === 'all' || v === 'collection') && (cst === 'idle' || cst === 'error' ||
         (cst === 'degraded' && state.collection.elements.length === 0))) loadCollection();
   }));
   host.querySelector('#pf-type-filters').addEventListener('click', (e) => {
@@ -615,10 +675,11 @@ function rawSource(el) {
 }
 
 function downloadElement(el) {
-  const blob = new Blob([rawSource(el)], { type: 'text/markdown' });
+  const isMemory = el.type === 'memories';
+  const blob = new Blob([rawSource(el)], { type: isMemory ? 'application/yaml' : 'text/markdown' });
   const a = document.createElement('a');
   a.href = URL.createObjectURL(blob);
-  a.download = `${el.name}.md`;
+  a.download = `${el.name}${isMemory ? '.yaml' : '.md'}`;
   a.click();
   URL.revokeObjectURL(a.href);
 }

--- a/tests/integration/agents/AgentManager.dbState.test.ts
+++ b/tests/integration/agents/AgentManager.dbState.test.ts
@@ -1,3 +1,6 @@
+/// <reference types="node" />
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/globals';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -31,6 +34,35 @@ import {
 
 let dbAvailable = false;
 
+function createDbAgentManager(tempDir: string, tracker: ContextTracker): AgentManager {
+  const fileLockManager = new FileLockManager();
+  const fileOperations = new FileOperationsService(fileLockManager);
+  const metadataService = new MetadataService();
+  const portfolioManager = new PortfolioManager(fileOperations, { baseDir: tempDir });
+  const validationRegistry = new ValidationRegistry(
+    new ValidationService(),
+    new TriggerValidationService(),
+    metadataService,
+  );
+  const userIdResolver = createUserIdResolver(tracker);
+  const sessionIdResolver = createSessionIdResolver(tracker);
+
+  return new AgentManager({
+    portfolioManager,
+    fileLockManager,
+    baseDir: tempDir,
+    fileOperationsService: fileOperations,
+    validationRegistry,
+    serializationService: new SerializationService(),
+    metadataService,
+    eventDispatcher: new ElementEventDispatcher(),
+    storageLayerFactory: new DatabaseStorageLayerFactory(getTestDb(), userIdResolver),
+    stateStore: new DatabaseAgentStateStore(getTestDb(), userIdResolver, sessionIdResolver),
+    contextTracker: tracker,
+    getCurrentUserId: userIdResolver,
+  });
+}
+
 beforeAll(async () => {
   dbAvailable = await isDatabaseAvailable();
   if (!dbAvailable) {
@@ -57,35 +89,6 @@ describe('AgentManager DB-backed runtime state', () => {
     const userId = await ensureTestUser();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-manager-db-state-'));
     const tracker = new ContextTracker();
-    const userIdResolver = createUserIdResolver(tracker);
-    const sessionIdResolver = createSessionIdResolver(tracker);
-
-    const createManager = (): AgentManager => {
-      const fileLockManager = new FileLockManager();
-      const fileOperations = new FileOperationsService(fileLockManager);
-      const metadataService = new MetadataService();
-      const portfolioManager = new PortfolioManager(fileOperations, { baseDir: tempDir });
-      const validationRegistry = new ValidationRegistry(
-        new ValidationService(),
-        new TriggerValidationService(),
-        metadataService,
-      );
-
-      return new AgentManager({
-        portfolioManager,
-        fileLockManager,
-        baseDir: tempDir,
-        fileOperationsService: fileOperations,
-        validationRegistry,
-        serializationService: new SerializationService(),
-        metadataService,
-        eventDispatcher: new ElementEventDispatcher(),
-        storageLayerFactory: new DatabaseStorageLayerFactory(getTestDb(), userIdResolver),
-        stateStore: new DatabaseAgentStateStore(getTestDb(), userIdResolver, sessionIdResolver),
-        contextTracker: tracker,
-        getCurrentUserId: userIdResolver,
-      });
-    };
 
     const session = {
       userId,
@@ -98,7 +101,7 @@ describe('AgentManager DB-backed runtime state', () => {
 
     try {
       await tracker.runAsync({ type: 'test', timestamp: Date.now(), session }, async () => {
-        const manager = createManager();
+        const manager = createDbAgentManager(tempDir, tracker);
         const created = await manager.create(
           'db-state-agent',
           'Persists runtime state in Postgres',
@@ -134,7 +137,7 @@ describe('AgentManager DB-backed runtime state', () => {
           ]),
         );
 
-        const reloadedManager = createManager();
+        const reloadedManager = createDbAgentManager(tempDir, tracker);
         const reloaded = await reloadedManager.getAgentState({
           agentName: 'db-state-agent',
           includeDecisionHistory: true,
@@ -151,41 +154,68 @@ describe('AgentManager DB-backed runtime state', () => {
     }
   });
 
+  it('deletes DB-backed agents and their UUID-keyed runtime state by canonical filename', async () => {
+    if (!dbAvailable) return;
+
+    const userId = await ensureTestUser();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-manager-db-delete-'));
+    const tracker = new ContextTracker();
+    const session = {
+      userId,
+      sessionId: 'agent-manager-db-delete-test',
+      tenantId: null,
+      transport: 'http' as const,
+      createdAt: Date.now(),
+      roles: ['admin'],
+    };
+
+    try {
+      await tracker.runAsync({ type: 'test', timestamp: Date.now(), session }, async () => {
+        const manager = createDbAgentManager(tempDir, tracker);
+        const created = await manager.create(
+          'db-delete-agent',
+          'Deletes its runtime state with the element',
+          'Use the provided objective as the active goal.',
+          {
+            goal: {
+              template: '{objective}',
+              parameters: [{ name: 'objective', type: 'string', required: true }],
+            },
+          },
+        );
+        expect(created.success).toBe(true);
+        await manager.executeAgent('db-delete-agent', { objective: 'delete me' });
+
+        const beforeDelete = await withUserRead(getTestDb(), userId, (tx) =>
+          tx
+            .select({ agentId: agentStates.agentId })
+            .from(agentStates)
+            .where(eq(agentStates.userId, userId))
+        );
+        expect(beforeDelete).toHaveLength(1);
+
+        await manager.delete('db-delete-agent.md');
+
+        expect(await manager.read('db-delete-agent')).toBeNull();
+        const afterDelete = await withUserRead(getTestDb(), userId, (tx) =>
+          tx
+            .select({ agentId: agentStates.agentId })
+            .from(agentStates)
+            .where(eq(agentStates.userId, userId))
+        );
+        expect(afterDelete).toEqual([]);
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('isolates agent state between concurrent sessions for the same user and agent', async () => {
     if (!dbAvailable) return;
 
     const userId = await ensureTestUser();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-manager-db-state-isolation-'));
     const tracker = new ContextTracker();
-    const userIdResolver = createUserIdResolver(tracker);
-    const sessionIdResolver = createSessionIdResolver(tracker);
-
-    const createManager = (): AgentManager => {
-      const fileLockManager = new FileLockManager();
-      const fileOperations = new FileOperationsService(fileLockManager);
-      const metadataService = new MetadataService();
-      const portfolioManager = new PortfolioManager(fileOperations, { baseDir: tempDir });
-      const validationRegistry = new ValidationRegistry(
-        new ValidationService(),
-        new TriggerValidationService(),
-        metadataService,
-      );
-
-      return new AgentManager({
-        portfolioManager,
-        fileLockManager,
-        baseDir: tempDir,
-        fileOperationsService: fileOperations,
-        validationRegistry,
-        serializationService: new SerializationService(),
-        metadataService,
-        eventDispatcher: new ElementEventDispatcher(),
-        storageLayerFactory: new DatabaseStorageLayerFactory(getTestDb(), userIdResolver),
-        stateStore: new DatabaseAgentStateStore(getTestDb(), userIdResolver, sessionIdResolver),
-        contextTracker: tracker,
-        getCurrentUserId: userIdResolver,
-      });
-    };
 
     const sessionAlpha = {
       userId,
@@ -206,7 +236,7 @@ describe('AgentManager DB-backed runtime state', () => {
 
     try {
       await tracker.runAsync({ type: 'test', timestamp: Date.now(), session: sessionAlpha }, async () => {
-        const manager = createManager();
+        const manager = createDbAgentManager(tempDir, tracker);
         const created = await manager.create(
           'shared-state-agent',
           'Persists isolated runtime state in Postgres',
@@ -223,7 +253,7 @@ describe('AgentManager DB-backed runtime state', () => {
       });
 
       await tracker.runAsync({ type: 'test', timestamp: Date.now(), session: sessionBeta }, async () => {
-        const manager = createManager();
+        const manager = createDbAgentManager(tempDir, tracker);
         await manager.executeAgent('shared-state-agent', { objective: 'goal from beta' });
       });
 
@@ -250,7 +280,7 @@ describe('AgentManager DB-backed runtime state', () => {
       );
 
       await tracker.runAsync({ type: 'test', timestamp: Date.now(), session: sessionAlpha }, async () => {
-        const manager = createManager();
+        const manager = createDbAgentManager(tempDir, tracker);
         const state = await manager.getAgentState({ agentName: 'shared-state-agent' });
         expect(state.state.goals).toEqual(
           expect.arrayContaining([expect.objectContaining({ description: 'goal from alpha' })]),

--- a/tests/integration/web-console-e2e/harness/portfolioUiMock.ts
+++ b/tests/integration/web-console-e2e/harness/portfolioUiMock.ts
@@ -25,11 +25,13 @@ interface PortfolioElement {
 
 interface PortfolioUiMockOptions {
   readonly conflictOnFirstPatch?: boolean;
+  readonly includeCollection?: boolean;
   readonly omitEtagAfterConflict?: boolean;
   readonly syncOutcome?: 'succeeded' | 'failed';
 }
 
 export interface PortfolioUiMockState {
+  collectionReads: number;
   patchAttempts: number;
   deletes: number;
   syncReads: number;
@@ -41,11 +43,19 @@ export async function installPortfolioUiMock(
   options: PortfolioUiMockOptions = {},
 ): Promise<PortfolioUiMockState> {
   const state: PortfolioUiMockState = {
+    collectionReads: 0,
     patchAttempts: 0,
     deletes: 0,
     syncReads: 0,
     elements: [element('personas', 'alpha-persona', 'Original portfolio content.')],
   };
+  if (options.includeCollection) {
+    await page.route('**/api/v1/collection/elements**', async route => {
+      const pageNumber = Number(new URL(route.request().url()).searchParams.get('page') ?? '1');
+      state.collectionReads += 1;
+      await fulfill(route, 200, collectionPage(pageNumber));
+    });
+  }
   await page.route('**/api/v1/me/portfolio**', async route => {
     const request = route.request();
     const path = new URL(request.url()).pathname;
@@ -109,9 +119,11 @@ function postResponse(path: string, body: unknown, state: PortfolioUiMockState):
   if (path.endsWith('/validate')) {
     const candidate = asRecord(body);
     const content = typeof candidate.content === 'string' ? candidate.content : '';
-    return ok(content.trim()
+    const metadata = asRecord(candidate.metadata);
+    const instructions = typeof metadata.instructions === 'string' ? metadata.instructions : '';
+    return ok(content.trim() || instructions.trim()
       ? { valid: true, issues: [] }
-      : { valid: false, issues: [{ path: 'content', code: 'required', message: 'content is required.' }] });
+      : { valid: false, issues: [{ path: 'content', code: 'required', message: 'content or instructions are required.' }] });
   }
   if (path.endsWith('/render')) {
     const candidate = asRecord(body);
@@ -122,7 +134,14 @@ function postResponse(path: string, body: unknown, state: PortfolioUiMockState):
   const candidate = asRecord(body);
   const name = typeof candidate.name === 'string' ? candidate.name : '';
   const content = typeof candidate.content === 'string' ? candidate.content : '';
-  const created = element(decodeURIComponent(createMatch[1]), name, content);
+  const type = decodeURIComponent(createMatch[1]);
+  if (state.elements.some(item => item.type === type && item.name === name)) {
+    return {
+      status: 409,
+      body: { code: 'portfolio_element_exists', detail: 'An element with this type and name already exists.' },
+    };
+  }
+  const created = element(type, name, content);
   created.display_name = typeof candidate.display_name === 'string' ? candidate.display_name : null;
   created.metadata = asRecord(candidate.metadata);
   created.tags = Array.isArray(candidate.tags) ? candidate.tags.map(String) : [];
@@ -200,6 +219,44 @@ function counts(elements: PortfolioElement[]) {
   const result = Object.fromEntries(['personas', 'skills', 'templates', 'agents', 'memories', 'ensembles'].map(type => [type, 0]));
   for (const item of elements) result[item.type] += 1;
   return result;
+}
+
+function collectionPage(page: number) {
+  const fixtures = [
+    {
+      type: 'skills',
+      name: 'collection-skill',
+      display_name: 'Collection Skill',
+      description: 'A skill from the community collection.',
+      version: '1.0.0',
+      author: 'DollhouseMCP',
+      tags: ['collection', 'skill'],
+      path: 'library/skills/collection-skill.md',
+      source: 'collection',
+    },
+    {
+      type: 'templates',
+      name: 'collection-template',
+      display_name: 'Collection Template',
+      description: 'A template from the community collection.',
+      version: '1.0.0',
+      author: 'DollhouseMCP',
+      tags: ['collection', 'template'],
+      path: 'library/templates/collection-template.md',
+      source: 'collection',
+    },
+  ];
+  const index = Math.max(0, page - 1);
+  return {
+    elements: index < fixtures.length ? [fixtures[index]] : [],
+    total: fixtures.length,
+    page,
+    page_size: 1,
+    has_more: page < fixtures.length,
+    source_status: 'ok',
+    source_detail: null,
+    install_enabled: false,
+  };
 }
 
 function syncJob(status: string) {

--- a/tests/integration/web-console-e2e/harness/portfolioUiMock.ts
+++ b/tests/integration/web-console-e2e/harness/portfolioUiMock.ts
@@ -1,0 +1,243 @@
+import type { Page, Route } from '@playwright/test';
+
+import { mutationProtocolProblem, preconditionProblem } from './requestProtocolMock.js';
+
+const CREATE_PATH_PATTERN = /^\/api\/v1\/me\/portfolio\/elements\/([^/]+)$/u;
+const ELEMENT_PATH_PATTERN = /^\/api\/v1\/me\/portfolio\/elements\/([^/]+)\/([^/]+)$/u;
+
+interface MockResponse {
+  readonly status: number;
+  readonly body: unknown;
+  readonly etag?: string;
+}
+
+interface PortfolioElement {
+  type: string;
+  name: string;
+  display_name: string | null;
+  version: number;
+  updated_at: string;
+  validation_status: string;
+  tags: string[];
+  metadata: Record<string, unknown>;
+  content: string;
+}
+
+interface PortfolioUiMockOptions {
+  readonly conflictOnFirstPatch?: boolean;
+  readonly omitEtagAfterConflict?: boolean;
+  readonly syncOutcome?: 'succeeded' | 'failed';
+}
+
+export interface PortfolioUiMockState {
+  patchAttempts: number;
+  deletes: number;
+  syncReads: number;
+  elements: PortfolioElement[];
+}
+
+export async function installPortfolioUiMock(
+  page: Page,
+  options: PortfolioUiMockOptions = {},
+): Promise<PortfolioUiMockState> {
+  const state: PortfolioUiMockState = {
+    patchAttempts: 0,
+    deletes: 0,
+    syncReads: 0,
+    elements: [element('personas', 'alpha-persona', 'Original portfolio content.')],
+  };
+  await page.route('**/api/v1/me/portfolio**', async route => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    const method = request.method();
+    const response = responseFor(method, path, request.postDataJSON(), request.headers(), state, options);
+    await fulfill(route, response.status, response.body, response.etag);
+  });
+  return state;
+}
+
+function responseFor(
+  method: string,
+  path: string,
+  body: unknown,
+  headers: Readonly<Record<string, string>>,
+  state: PortfolioUiMockState,
+  options: PortfolioUiMockOptions,
+): MockResponse {
+  if (method === 'GET') {
+    return getResponse(
+      path,
+      state,
+      options.syncOutcome ?? 'succeeded',
+      options.omitEtagAfterConflict ?? false,
+    );
+  }
+  const protocolProblem = mutationProtocolProblem(headers);
+  if (protocolProblem) return protocolProblem;
+  if (method === 'POST') return postResponse(path, body, state);
+  if (method === 'PATCH') return patchResponse(path, body, headers, state, options.conflictOnFirstPatch ?? false);
+  if (method === 'DELETE') return deleteResponse(path, headers, state);
+  return missing();
+}
+
+function getResponse(
+  path: string,
+  state: PortfolioUiMockState,
+  syncOutcome: 'succeeded' | 'failed',
+  omitEtagAfterConflict: boolean,
+): MockResponse {
+  if (path === '/api/v1/me/portfolio') {
+    return ok({ total_elements: state.elements.length, counts_by_type: counts(state.elements), updated_at: new Date().toISOString() });
+  }
+  if (path === '/api/v1/me/portfolio/elements') {
+    return ok({ elements: state.elements.map(summary) });
+  }
+  if (path.startsWith('/api/v1/me/portfolio/sync/')) {
+    state.syncReads += 1;
+    const running = state.syncReads < 2;
+    return ok(syncJob(running ? 'running' : syncOutcome));
+  }
+  const found = findElement(path, state.elements);
+  if (!found) return missing();
+  return omitEtagAfterConflict && state.patchAttempts > 0
+    ? ok(found)
+    : { ...ok(found), etag: etag(found) };
+}
+
+function postResponse(path: string, body: unknown, state: PortfolioUiMockState): MockResponse {
+  if (path === '/api/v1/me/portfolio/sync') return { status: 202, body: syncJob('queued') };
+  if (path.endsWith('/validate')) {
+    const candidate = asRecord(body);
+    const content = typeof candidate.content === 'string' ? candidate.content : '';
+    return ok(content.trim()
+      ? { valid: true, issues: [] }
+      : { valid: false, issues: [{ path: 'content', code: 'required', message: 'content is required.' }] });
+  }
+  if (path.endsWith('/render')) {
+    const candidate = asRecord(body);
+    return ok({ type: 'personas', name: 'alpha-persona', preview: candidate.content ?? '' });
+  }
+  const createMatch = CREATE_PATH_PATTERN.exec(path);
+  if (!createMatch) return missing();
+  const candidate = asRecord(body);
+  const name = typeof candidate.name === 'string' ? candidate.name : '';
+  const content = typeof candidate.content === 'string' ? candidate.content : '';
+  const created = element(decodeURIComponent(createMatch[1]), name, content);
+  created.display_name = typeof candidate.display_name === 'string' ? candidate.display_name : null;
+  created.metadata = asRecord(candidate.metadata);
+  created.tags = Array.isArray(candidate.tags) ? candidate.tags.map(String) : [];
+  state.elements.push(created);
+  return { status: 201, body: created, etag: etag(created) };
+}
+
+function patchResponse(
+  path: string,
+  body: unknown,
+  headers: Readonly<Record<string, string>>,
+  state: PortfolioUiMockState,
+  conflictOnFirstPatch: boolean,
+): MockResponse {
+  state.patchAttempts += 1;
+  const current = findElement(path, state.elements);
+  if (!current) return missing();
+  if (conflictOnFirstPatch && state.patchAttempts === 1) {
+    current.content = 'Latest server content.';
+    current.version += 1;
+  }
+  const concurrencyProblem = preconditionProblem(headers, etag(current));
+  if (concurrencyProblem) return concurrencyProblem;
+  const candidate = asRecord(body);
+  current.content = typeof candidate.content === 'string' ? candidate.content : current.content;
+  current.display_name = typeof candidate.display_name === 'string' ? candidate.display_name : null;
+  current.metadata = asRecord(candidate.metadata);
+  current.tags = Array.isArray(candidate.tags) ? candidate.tags.map(String) : [];
+  current.version += 1;
+  return { status: 200, body: current, etag: etag(current) };
+}
+
+function deleteResponse(
+  path: string,
+  headers: Readonly<Record<string, string>>,
+  state: PortfolioUiMockState,
+): MockResponse {
+  const current = findElement(path, state.elements);
+  if (!current) return missing();
+  const concurrencyProblem = preconditionProblem(headers, etag(current));
+  if (concurrencyProblem) return concurrencyProblem;
+  state.deletes += 1;
+  state.elements = state.elements.filter(item => item !== current);
+  return ok({ deleted: true, type: current.type, name: current.name, version: current.version, deleted_at: new Date().toISOString() });
+}
+
+function findElement(path: string, elements: PortfolioElement[]): PortfolioElement | null {
+  const match = ELEMENT_PATH_PATTERN.exec(path);
+  if (!match) return null;
+  const type = decodeURIComponent(match[1]);
+  const name = decodeURIComponent(match[2]);
+  return elements.find(item => item.type === type && item.name === name) ?? null;
+}
+
+function element(type: string, name: string, content: string): PortfolioElement {
+  return {
+    type,
+    name,
+    display_name: null,
+    version: 1,
+    updated_at: new Date().toISOString(),
+    validation_status: 'valid',
+    tags: ['e2e'],
+    metadata: { description: 'Portfolio browser acceptance fixture.' },
+    content,
+  };
+}
+
+function summary(item: PortfolioElement) {
+  const { metadata: _metadata, content: _content, ...value } = item;
+  return value;
+}
+
+function counts(elements: PortfolioElement[]) {
+  const result = Object.fromEntries(['personas', 'skills', 'templates', 'agents', 'memories', 'ensembles'].map(type => [type, 0]));
+  for (const item of elements) result[item.type] += 1;
+  return result;
+}
+
+function syncJob(status: string) {
+  return {
+    job_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    status,
+    direction: 'pull',
+    conflict_policy: 'fail',
+    status_url: '/api/v1/me/portfolio/sync/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    created_at: new Date().toISOString(),
+    started_at: status === 'queued' ? null : new Date().toISOString(),
+    completed_at: ['succeeded', 'failed'].includes(status) ? new Date().toISOString() : null,
+    result_summary: status === 'succeeded' ? { pulled: 1 } : null,
+    error_code: status === 'failed' ? 'github_sync_failed' : null,
+  };
+}
+
+function etag(item: PortfolioElement) {
+  return `"mock-${item.type}-${item.name}-v${item.version}"`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+async function fulfill(route: Route, status: number, body: unknown, etagValue?: string) {
+  await route.fulfill({
+    status,
+    contentType: 'application/json',
+    headers: etagValue ? { etag: etagValue } : undefined,
+    body: JSON.stringify(body),
+  });
+}
+
+function ok(body: unknown): MockResponse {
+  return { status: 200, body };
+}
+
+function missing(): MockResponse {
+  return { status: 404, body: { code: 'portfolio_element_not_found', detail: 'Element was not found.' } };
+}

--- a/tests/integration/web-console-e2e/harness/portfolioUiMock.ts
+++ b/tests/integration/web-console-e2e/harness/portfolioUiMock.ts
@@ -4,6 +4,7 @@ import { mutationProtocolProblem, preconditionProblem } from './requestProtocolM
 
 const CREATE_PATH_PATTERN = /^\/api\/v1\/me\/portfolio\/elements\/([^/]+)$/u;
 const ELEMENT_PATH_PATTERN = /^\/api\/v1\/me\/portfolio\/elements\/([^/]+)\/([^/]+)$/u;
+const VALIDATE_PATH_PATTERN = /^\/api\/v1\/me\/portfolio\/elements\/([^/]+)\/[^/]+\/validate$/u;
 
 interface MockResponse {
   readonly status: number;
@@ -118,12 +119,7 @@ function postResponse(path: string, body: unknown, state: PortfolioUiMockState):
   if (path === '/api/v1/me/portfolio/sync') return { status: 202, body: syncJob('queued') };
   if (path.endsWith('/validate')) {
     const candidate = asRecord(body);
-    const content = typeof candidate.content === 'string' ? candidate.content : '';
-    const metadata = asRecord(candidate.metadata);
-    const instructions = typeof metadata.instructions === 'string' ? metadata.instructions : '';
-    return ok(content.trim() || instructions.trim()
-      ? { valid: true, issues: [] }
-      : { valid: false, issues: [{ path: 'content', code: 'required', message: 'content or instructions are required.' }] });
+    return ok(mockValidation(path, candidate));
   }
   if (path.endsWith('/render')) {
     const candidate = asRecord(body);
@@ -147,6 +143,30 @@ function postResponse(path: string, body: unknown, state: PortfolioUiMockState):
   created.tags = Array.isArray(candidate.tags) ? candidate.tags.map(String) : [];
   state.elements.push(created);
   return { status: 201, body: created, etag: etag(created) };
+}
+
+function mockValidation(path: string, candidate: Record<string, unknown>): unknown {
+  const match = VALIDATE_PATH_PATTERN.exec(path);
+  const type = match ? decodeURIComponent(match[1]) : '';
+  const content = typeof candidate.content === 'string' ? candidate.content.trim() : '';
+  const metadata = asRecord(candidate.metadata);
+  const instructions = typeof metadata.instructions === 'string' ? metadata.instructions.trim() : '';
+  const requiresContent = type === 'templates' || type === 'memories';
+  const requiresInstructionsOrContent = type === 'personas' || type === 'skills';
+  const hasAgentDefinition = type === 'agents' && metadata.goal !== undefined;
+  const hasEnsembleDefinition = type === 'ensembles' && Array.isArray(metadata.elements) && metadata.elements.length > 0;
+  const valid = Boolean(content)
+    || requiresInstructionsOrContent && Boolean(instructions)
+    || !requiresContent && !requiresInstructionsOrContent && (
+      Boolean(instructions) || hasAgentDefinition || hasEnsembleDefinition
+    );
+  return valid
+    ? { valid: true, issues: [] }
+    : { valid: false, issues: [{ path: 'content', code: 'required', message: validationMessage(requiresContent) }] };
+}
+
+function validationMessage(requiresContent: boolean): string {
+  return requiresContent ? 'content is required.' : 'content or metadata.instructions is required.';
 }
 
 function patchResponse(

--- a/tests/integration/web-console-e2e/harness/requestProtocolMock.ts
+++ b/tests/integration/web-console-e2e/harness/requestProtocolMock.ts
@@ -1,0 +1,61 @@
+export interface ProtocolProblem {
+  readonly status: number;
+  readonly body: unknown;
+}
+
+export function mutationProtocolProblem(
+  headers: Readonly<Record<string, string>>,
+): ProtocolProblem | null {
+  if (headers['x-console-request'] !== '1') {
+    return forbidden('The console request marker is required.');
+  }
+
+  const cookieToken = cookieValue(headers.cookie, 'dh_csrf');
+  if (!cookieToken || headers['x-csrf-token'] !== cookieToken) {
+    return forbidden('The CSRF token is missing or does not match the cookie.');
+  }
+
+  if (!headers['idempotency-key']) {
+    return {
+      status: 400,
+      body: { code: 'idempotency_key_required', detail: 'An Idempotency-Key header is required.' },
+    };
+  }
+
+  return null;
+}
+
+export function preconditionProblem(
+  headers: Readonly<Record<string, string>>,
+  currentEtag: string,
+): ProtocolProblem | null {
+  const ifMatch = headers['if-match'];
+  if (!ifMatch) {
+    return {
+      status: 428,
+      body: { code: 'precondition_required', detail: 'An If-Match header is required.' },
+    };
+  }
+  if (ifMatch !== currentEtag) {
+    return {
+      status: 412,
+      body: { code: 'precondition_failed', detail: 'The resource changed.' },
+    };
+  }
+  return null;
+}
+
+function cookieValue(cookieHeader: string | undefined, name: string): string | null {
+  const prefix = `${name}=`;
+  const match = cookieHeader?.split(';').map(part => part.trim()).find(part => part.startsWith(prefix));
+  if (!match) return null;
+  try {
+    return decodeURIComponent(match.slice(prefix.length));
+  } catch {
+    return null;
+  }
+}
+
+function forbidden(detail: string): ProtocolProblem {
+  return { status: 403, body: { code: 'csrf_failed', detail } };
+}

--- a/tests/integration/web-console-e2e/harness/selfServiceUiMock.ts
+++ b/tests/integration/web-console-e2e/harness/selfServiceUiMock.ts
@@ -1,0 +1,119 @@
+import type { Page, Route } from '@playwright/test';
+
+import { mutationProtocolProblem, preconditionProblem } from './requestProtocolMock.js';
+
+export interface SelfServiceUiMockState {
+  displayName: string | null;
+  theme: unknown;
+  settingsWrites: number;
+}
+
+export async function installSelfServiceUiMock(
+  page: Page,
+  options: { conflictOnFirstSettingsWrite?: boolean; initialTheme?: unknown } = {},
+): Promise<SelfServiceUiMockState> {
+  const state: SelfServiceUiMockState = {
+    displayName: 'E2E Admin',
+    theme: options.initialTheme ?? 'light',
+    settingsWrites: 0,
+  };
+  let settingsVersion = 1;
+  await page.route('**/api/v1/me/profile', route => handleProfile(route, state));
+  await page.route('**/api/v1/me/settings**', async route => {
+    const request = route.request();
+    const method = request.method();
+    if (method === 'GET') {
+      await fulfill(route, 200, settings(state, settingsVersion), settingsEtag(settingsVersion));
+      return;
+    }
+    const protocolProblem = mutationProtocolProblem(request.headers());
+    if (protocolProblem) {
+      await fulfill(route, protocolProblem.status, protocolProblem.body);
+      return;
+    }
+    state.settingsWrites += 1;
+    if (options.conflictOnFirstSettingsWrite && state.settingsWrites === 1) {
+      state.theme = 'dark';
+      settingsVersion += 1;
+    }
+    const concurrencyProblem = preconditionProblem(request.headers(), settingsEtag(settingsVersion));
+    if (concurrencyProblem) {
+      await fulfill(route, concurrencyProblem.status, concurrencyProblem.body);
+      return;
+    }
+    if (method === 'PUT') {
+      const body = request.postDataJSON() as { value?: unknown } | null;
+      state.theme = typeof body?.value === 'string' ? body.value : null;
+    } else if (method === 'DELETE') {
+      state.theme = null;
+    }
+    settingsVersion += 1;
+    await fulfill(route, 200, {
+      key: 'display_config.theme',
+      value: state.theme,
+      updated_at: Date.now(),
+      etag: settingsEtag(settingsVersion),
+    }, settingsEtag(settingsVersion));
+  });
+  return state;
+}
+
+async function handleProfile(route: Route, state: SelfServiceUiMockState) {
+  const request = route.request();
+  if (request.method() === 'PATCH') {
+    const protocolProblem = mutationProtocolProblem(request.headers());
+    if (protocolProblem) {
+      await fulfill(route, protocolProblem.status, protocolProblem.body);
+      return;
+    }
+    const body = request.postDataJSON() as { display_name?: unknown } | null;
+    state.displayName = typeof body?.display_name === 'string' ? body.display_name : null;
+  }
+  await fulfill(route, 200, profile(state));
+}
+
+function profile(state: SelfServiceUiMockState) {
+  return {
+    user_id: '22222222-2222-4222-8222-222222222222',
+    primary_sub: 'local_e2e_admin',
+    username: 'e2e_admin',
+    display_name: state.displayName,
+    email: 'e2e@example.test',
+    email_verified: true,
+    auth_methods: ['password'],
+    roles: ['admin'],
+    created_at: new Date().toISOString(),
+    last_login_at: new Date().toISOString(),
+  };
+}
+
+function settings(state: SelfServiceUiMockState, version: number) {
+  return {
+    github_config: {},
+    sync_config: {},
+    autoload_config: {},
+    retention_config: {},
+    wizard_config: {},
+    display_config: state.theme === null ? {} : { theme: state.theme },
+    collection_config: {},
+    auto_activate_config: {},
+    source_priority_config: {},
+    user_identity_config: {},
+    config_version: version,
+    updated_at: Date.now(),
+    etag: settingsEtag(version),
+  };
+}
+
+function settingsEtag(version: number) {
+  return `W/"settings-${version}"`;
+}
+
+async function fulfill(route: Route, status: number, body: unknown, etag?: string) {
+  await route.fulfill({
+    status,
+    contentType: 'application/json',
+    headers: etag ? { etag } : undefined,
+    body: JSON.stringify(body),
+  });
+}

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -21,16 +21,52 @@ const CONFIRM_ACTION = '[data-confirm="1"]';
 const ACCOUNT_MENU = '#site-account';
 const EDITOR_FEEDBACK = '[data-editor-feedback]';
 const EDITOR_CONTENT = '.portfolio-editor [name="content"]';
+const EDITOR_INSTRUCTIONS = '.portfolio-editor [name="instructions"]';
+const EDITOR_SUBMIT = '.portfolio-editor button[type="submit"]';
+const EDITOR_VALIDATE = '[data-editor-validate]';
+const AUTHORING_WORKSPACE = '[data-portfolio-authoring]';
 const THEME_SELECT = '#account-theme-form [name="theme"]';
 const BULK_SESSION_ACTION = '#sess-revoke-others';
 const AUTH_ME_URL = '**/api/v1/auth/me';
 const ADMIN_USER_SESSIONS_URL = '**/api/v1/admin/accounts/users/*/sessions';
+
+interface TextFileFixture {
+  readonly name: string;
+  readonly mimeType: string;
+  readonly content: string;
+}
+
+async function setTextInputFile(page: Page, selector: string, file: TextFileFixture): Promise<void> {
+  await page.locator(selector).evaluate((element, fixture) => {
+    if (!(element instanceof HTMLInputElement)) throw new Error('File fixture target must be an input element.');
+    const transfer = new DataTransfer();
+    transfer.items.add(new File([fixture.content], fixture.name, { type: fixture.mimeType }));
+    element.files = transfer.files;
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+  }, file);
+}
 
 async function filterManifestRoutes(page: Page, unavailableRoutes: ReadonlySet<string>): Promise<void> {
   await page.route(MANIFEST_URL, async route => {
     const response = await route.fetch();
     const manifest = await response.json() as { routes: Array<{ method: string; path: string }> };
     const routes = manifest.routes.filter(item => !unavailableRoutes.has(`${item.method} ${item.path}`));
+    await route.fulfill({ response, json: { ...manifest, routes } });
+  });
+}
+
+async function includeManifestRoutes(
+  page: Page,
+  additionalRoutes: ReadonlyArray<{ readonly method: string; readonly path: string }>,
+): Promise<void> {
+  await page.route(MANIFEST_URL, async route => {
+    const response = await route.fetch();
+    const manifest = await response.json() as { routes: Array<{ method: string; path: string }> };
+    const routeKeys = new Set(manifest.routes.map(item => `${item.method} ${item.path}`));
+    const routes = [
+      ...manifest.routes,
+      ...additionalRoutes.filter(item => !routeKeys.has(`${item.method} ${item.path}`)),
+    ];
     await route.fulfill({ response, json: { ...manifest, routes } });
   });
 }
@@ -137,25 +173,79 @@ test('console UI serves its asset graph and boots from server metadata', async (
   await expect(page.locator('#sec-enroll')).toHaveCount(0);
 });
 
+test('All combines every collection page with the portfolio and reports source totals', async ({ page }) => {
+  await includeManifestRoutes(page, [
+    { method: 'GET', path: '/api/v1/collection/elements' },
+    { method: 'GET', path: '/api/v1/collection/elements/:type/:name' },
+  ]);
+  const mock = await installPortfolioUiMock(page, { includeCollection: true });
+  await loginFromConsole(page);
+
+  await expect(page.locator('#pf-source')).toBeVisible();
+  await expect(page.locator('#pf-summary')).toHaveText('3 total elements');
+  await expect(page.locator('#pf-count')).toHaveText('3 elements');
+  await expect(page.locator('#pf-grid .element-card')).toHaveCount(3);
+  await expect(page.locator('#pf-grid .source-badge-collection')).toHaveCount(2);
+  await expect(page.locator('#pf-grid .source-badge', { hasText: 'LOCAL' })).toHaveCount(1);
+  await expect(page.locator('#pf-type-filters [data-key="personas"] .filter-count')).toHaveText('1');
+  await expect(page.locator('#pf-type-filters [data-key="skills"] .filter-count')).toHaveText('1');
+  await expect(page.locator('#pf-type-filters [data-key="templates"] .filter-count')).toHaveText('1');
+  expect(mock.collectionReads).toBe(2);
+
+  await page.locator('#pf-source [data-source="portfolio"]').click();
+  await expect(page.locator('#pf-summary')).toHaveText('1 portfolio element');
+  await expect(page.locator('#pf-grid .element-card')).toHaveCount(1);
+
+  await page.locator('#pf-source [data-source="collection"]').click();
+  await expect(page.locator('#pf-summary')).toHaveText('2 collection elements');
+  await expect(page.locator('#pf-grid .element-card')).toHaveCount(2);
+
+  await page.locator('#pf-source [data-source="all"]').click();
+  await page.locator('#pf-search').fill('Collection Skill');
+  await expect(page.locator('#pf-count')).toHaveText('1 element');
+  await expect(page.locator('#pf-grid .element-card')).toHaveCount(1);
+  await expect(page.locator('#pf-grid .card-title')).toHaveText('Collection Skill');
+});
+
 test('portfolio authoring validates drafts, preserves conflicts, and confirms hard deletion', async ({ page }) => {
   const mock = await installPortfolioUiMock(page, { conflictOnFirstPatch: true });
   await loginFromConsole(page);
 
+  await expect(page.locator('.portfolio-start-action')).toHaveCount(2);
+  await expect(page.locator('#pf-create')).toContainText('Create new');
+  await expect(page.locator('#pf-import')).toContainText('Import file');
   await page.locator('#pf-create').click();
-  await page.locator('[data-editor-validate]').click();
+  await expect(page.locator(AUTHORING_WORKSPACE)).toBeVisible();
+  await expect(page.locator('.portfolio-type-choice')).toHaveCount(6);
+  await expect(page.locator('[data-builder-overview]')).toContainText('Building a Persona');
+  await expect(page.locator('.portfolio-editor [name="metadata"]')).toBeHidden();
+  await page.locator('[data-custom-metadata] summary').click();
+  await expect(page.locator('[data-custom-metadata-enable]')).toBeVisible();
+  await page.locator('[data-custom-metadata-enable]').click();
+  await page.locator('.portfolio-editor [name="metadata"]').fill('{');
+  await expect(page.locator('[data-custom-metadata-status]')).toContainText('must be valid JSON');
+  await page.locator('.portfolio-editor [name="metadata"]').fill('{"custom_note":"preserve me"}');
+  await expect(page.locator('[data-custom-metadata-status]')).toContainText('Valid JSON object');
+  await page.locator(EDITOR_VALIDATE).click();
   await expect(page.locator(EDITOR_FEEDBACK)).toContainText('Name is required');
+  await expect(page.locator(EDITOR_FEEDBACK)).toBeInViewport();
   await page.locator('.portfolio-editor [name="name"]').fill('browser-created');
-  await page.locator('[data-editor-validate]').click();
-  await expect(page.locator(EDITOR_FEEDBACK)).toContainText('content is required');
-  await page.locator(EDITOR_CONTENT).fill('Created through the browser.');
-  await page.locator('[data-editor-validate]').click();
+  await page.locator(EDITOR_VALIDATE).click();
+  await expect(page.locator(EDITOR_FEEDBACK)).toContainText('Description is required');
+  await page.locator('.portfolio-editor [name="description"]').fill('A guided browser-created persona.');
+  await page.locator(EDITOR_VALIDATE).click();
+  await expect(page.locator(EDITOR_FEEDBACK)).toContainText('Behavioral instructions are required');
+  await page.locator(EDITOR_INSTRUCTIONS).fill('You are a careful browser-created persona.');
+  await page.locator(EDITOR_CONTENT).fill('Optional reference material.');
+  await page.locator(EDITOR_VALIDATE).click();
   await expect(page.locator(EDITOR_FEEDBACK)).toContainText('Validation passed');
-  await page.locator('.portfolio-editor button[type="submit"]').click();
+  await page.locator(EDITOR_SUBMIT).click();
   await expect(page.locator('[data-name="browser-created"]')).toBeVisible();
+  expect(mock.elements.find(item => item.name === 'browser-created')?.metadata.custom_note).toBe('preserve me');
 
   await page.locator('[data-name="alpha-persona"] [data-action="edit"]').click();
   await page.locator(EDITOR_CONTENT).fill('Unsaved browser draft.');
-  await page.locator('.portfolio-editor button[type="submit"]').click();
+  await page.locator(EDITOR_SUBMIT).click();
   await expect(page.locator(EDITOR_FEEDBACK)).toContainText('changed after you opened it');
   await expect(page.locator('[data-editor-reload]')).toBeVisible();
   await page.locator('[data-editor-reload]').click();
@@ -173,13 +263,75 @@ test('portfolio authoring validates drafts, preserves conflicts, and confirms ha
   expect(mock.deletes).toBe(1);
 });
 
+test('portfolio imports a reviewed file without silently overwriting a duplicate', async ({ page }) => {
+  const mock = await installPortfolioUiMock(page);
+  await loginFromConsole(page);
+  const file = {
+    name: 'imported-skill.md',
+    mimeType: 'text/markdown',
+    content: `---
+name: Imported Skill
+type: skill
+description: Imported from a local Dollhouse file.
+tags:
+  - imported
+  - browser
+custom_policy: reviewed
+---
+
+Follow the reviewed skill instructions.`,
+  };
+
+  await page.locator('#pf-import').click();
+  await expect(page.locator('[data-import-drop]')).toBeVisible();
+  await setTextInputFile(page, '[data-import-file]', file);
+  await expect(page.locator('[data-import-source]')).toContainText('Skill detected');
+  await expect(page.locator('[name="type"][value="skills"]')).toBeChecked();
+  await expect(page.locator('.portfolio-editor [name="name"]')).toHaveValue('Imported Skill');
+  await expect(page.locator('.portfolio-editor [name="description"]')).toHaveValue('Imported from a local Dollhouse file.');
+  await expect.poll(async () => (await page.locator(EDITOR_INSTRUCTIONS).inputValue()).trim())
+    .toBe('Follow the reviewed skill instructions.');
+  await expect(page.locator(EDITOR_CONTENT)).toHaveValue('');
+  await expect(page.locator('[data-custom-metadata-notice]')).toContainText('1 additional metadata field');
+  await expect(page.locator('[data-custom-metadata-notice]')).toContainText('will be preserved');
+  await expect(page.locator('.portfolio-editor [name="metadata"]')).toHaveValue(/"custom_policy": "reviewed"/u);
+  await page.locator(EDITOR_VALIDATE).click();
+  await expect(page.locator(EDITOR_FEEDBACK)).toContainText('ready to save');
+  await page.locator(EDITOR_SUBMIT).click();
+  await expect(page.locator('[data-name="Imported Skill"]')).toBeVisible();
+  expect(mock.elements.filter(item => item.type === 'skills' && item.name === 'Imported Skill')).toHaveLength(1);
+  expect(mock.elements.find(item => item.type === 'skills' && item.name === 'Imported Skill')?.metadata.custom_policy)
+    .toBe('reviewed');
+
+  await page.locator('#pf-import').click();
+  await setTextInputFile(page, '[data-import-file]', file);
+  await page.locator(EDITOR_SUBMIT).click();
+  await expect(page.locator(EDITOR_FEEDBACK)).toContainText('Nothing was overwritten');
+  expect(mock.elements.filter(item => item.type === 'skills' && item.name === 'Imported Skill')).toHaveLength(1);
+
+  await page.locator('.portfolio-editor [data-editor-close]').last().click();
+  await page.locator('#portfolio-confirm [data-confirm="1"]').click();
+  await expect(page.locator(AUTHORING_WORKSPACE)).toBeHidden();
+  await expect(page.locator('#pf-grid')).toBeVisible();
+});
+
+test('portfolio create cancel leaves the workspace without saving', async ({ page }) => {
+  await installPortfolioUiMock(page);
+  await loginFromConsole(page);
+
+  await page.locator('#pf-create').click();
+  await page.locator('.portfolio-editor [data-editor-close]').last().click();
+  await expect(page.locator(AUTHORING_WORKSPACE)).toBeHidden();
+  await expect(page.locator('#pf-grid')).toBeVisible();
+});
+
 test('portfolio editor stays blocked when conflict reload omits its ETag', async ({ page }) => {
   await installPortfolioUiMock(page, { conflictOnFirstPatch: true, omitEtagAfterConflict: true });
   await loginFromConsole(page);
 
   await page.locator('[data-name="alpha-persona"] [data-action="edit"]').click();
   await page.locator(EDITOR_CONTENT).fill('Draft that must not overwrite newer content.');
-  await page.locator('.portfolio-editor button[type="submit"]').click();
+  await page.locator(EDITOR_SUBMIT).click();
   await page.locator('[data-editor-reload]').click();
 
   await expect(page.locator(EDITOR_FEEDBACK)).toContainText('did not include an ETag');
@@ -217,7 +369,7 @@ test('portfolio write controls disappear when the manifest omits write routes', 
   ]));
   await loginFromConsole(page);
   await expect(page.locator('#pf-grid')).toBeVisible();
-  await expect(page.locator('#pf-create, #pf-sync, [data-action="edit"]')).toHaveCount(0);
+  await expect(page.locator('#pf-create, #pf-import, #pf-sync, [data-action="edit"]')).toHaveCount(0);
   await page.locator('[data-name="alpha-persona"]').click();
   await expect(page.locator('.modal-edit-btn')).toBeHidden();
   await expect(page.locator('.modal-delete-btn')).toBeHidden();

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -19,6 +19,7 @@ const SESSIONS_TAB = '.console-tab[data-tab="sessions"]';
 const SESSION_DETAIL_HEADER = '#session-detail-header';
 const CONFIRM_ACTION = '[data-confirm="1"]';
 const ACCOUNT_MENU = '#site-account';
+const PORTFOLIO_CREATE = '#pf-create';
 const EDITOR_FEEDBACK = '[data-editor-feedback]';
 const EDITOR_CONTENT = '.portfolio-editor [name="content"]';
 const EDITOR_INSTRUCTIONS = '.portfolio-editor [name="instructions"]';
@@ -212,9 +213,9 @@ test('portfolio authoring validates drafts, preserves conflicts, and confirms ha
   await loginFromConsole(page);
 
   await expect(page.locator('.portfolio-start-action')).toHaveCount(2);
-  await expect(page.locator('#pf-create')).toContainText('Create new');
+  await expect(page.locator(PORTFOLIO_CREATE)).toContainText('Create new');
   await expect(page.locator('#pf-import')).toContainText('Import file');
-  await page.locator('#pf-create').click();
+  await page.locator(PORTFOLIO_CREATE).click();
   await expect(page.locator(AUTHORING_WORKSPACE)).toBeVisible();
   await expect(page.locator('.portfolio-type-choice')).toHaveCount(6);
   await expect(page.locator('[data-builder-overview]')).toContainText('Building a Persona');
@@ -261,6 +262,81 @@ test('portfolio authoring validates drafts, preserves conflicts, and confirms ha
   await page.locator('#portfolio-confirm [data-confirm="1"]').click();
   await expect(page.locator('[data-name="alpha-persona"]')).toHaveCount(0);
   expect(mock.deletes).toBe(1);
+});
+
+test('portfolio guided authoring serializes agent and ensemble settings', async ({ page }) => {
+  const mock = await installPortfolioUiMock(page);
+  await loginFromConsole(page);
+
+  await page.locator(PORTFOLIO_CREATE).click();
+  await page.locator('.portfolio-editor [name="type"][value="agents"]').check();
+  await page.locator('.portfolio-editor [name="name"]').fill('guided-agent');
+  await page.locator('.portfolio-editor [name="description"]').fill('An agent configured through guided fields.');
+  await page.locator(EDITOR_INSTRUCTIONS).fill('Coordinate the selected elements and tools.');
+  await page.locator('.portfolio-editor [name="agent_goal_template"]').fill('Research {topic} and recommend a path.');
+  await page.locator('.portfolio-editor [name="agent_success_criteria"]').fill('Sources are cited\nTradeoffs are explicit');
+  await page.locator('.portfolio-editor [name="agent_activates_personas"]').fill('technical-writer, reviewer');
+  await page.locator('.portfolio-editor [name="agent_activates_skills"]').fill('web-research');
+  await page.locator('.portfolio-editor [name="agent_tools_allowed"]').fill('search, fetch');
+  await page.locator('.portfolio-editor [name="agent_tools_denied"]').fill('shell');
+  await page.locator('.portfolio-editor [name="agent_risk_tolerance"]').selectOption('conservative');
+  await page.locator('.portfolio-editor [name="agent_max_steps"]').fill('12');
+  await page.locator(EDITOR_SUBMIT).click();
+  await expect(page.locator('[data-name="guided-agent"]')).toBeVisible();
+
+  expect(mock.elements.find(item => item.name === 'guided-agent')?.metadata).toMatchObject({
+    goal: {
+      template: 'Research {topic} and recommend a path.',
+      parameters: [],
+      successCriteria: ['Sources are cited', 'Tradeoffs are explicit'],
+    },
+    activates: {
+      personas: ['technical-writer', 'reviewer'],
+      skills: ['web-research'],
+    },
+    tools: {
+      allowed: ['search', 'fetch'],
+      denied: ['shell'],
+    },
+    autonomy: {
+      riskTolerance: 'conservative',
+      maxAutonomousSteps: 12,
+    },
+  });
+
+  await page.locator(PORTFOLIO_CREATE).click();
+  await page.locator('.portfolio-editor [name="type"][value="ensembles"]').check();
+  await page.locator('.portfolio-editor [name="name"]').fill('guided-ensemble');
+  await page.locator('.portfolio-editor [name="description"]').fill('An ensemble configured through guided fields.');
+  await page.locator(EDITOR_INSTRUCTIONS).fill('Coordinate the ensemble members in priority order.');
+  await page.locator('.portfolio-editor [name="ensemble_activation_strategy"]').selectOption('priority');
+  await page.locator('.portfolio-editor [name="ensemble_conflict_resolution"]').selectOption('merge');
+  await page.locator('.portfolio-editor [name="ensemble_context_sharing"]').selectOption('selective');
+  await page.locator('.portfolio-editor [name="ensemble_allow_nested"]').check();
+  const elementRow = page.locator('[data-repeat-row="ensemble-elements"]');
+  await elementRow.locator('[data-row-field="name"]').fill('technical-writer');
+  await elementRow.locator('[data-row-field="type"]').selectOption('persona');
+  await elementRow.locator('[data-row-field="role"]').selectOption('primary');
+  await elementRow.locator('[data-row-field="activation"]').selectOption('always');
+  await elementRow.locator('[data-row-field="priority"]').fill('');
+  await elementRow.locator('[data-row-field="purpose"]').fill('Draft the final response.');
+  await page.locator(EDITOR_SUBMIT).click();
+  await expect(page.locator('[data-name="guided-ensemble"]')).toBeVisible();
+
+  expect(mock.elements.find(item => item.name === 'guided-ensemble')?.metadata).toMatchObject({
+    activationStrategy: 'priority',
+    conflictResolution: 'merge',
+    contextSharing: 'selective',
+    allowNested: true,
+    elements: [{
+      element_name: 'technical-writer',
+      element_type: 'persona',
+      role: 'primary',
+      priority: 10,
+      activation: 'always',
+      purpose: 'Draft the final response.',
+    }],
+  });
 });
 
 test('portfolio imports a reviewed file without silently overwriting a duplicate', async ({ page }) => {
@@ -319,7 +395,7 @@ test('portfolio create cancel leaves the workspace without saving', async ({ pag
   await installPortfolioUiMock(page);
   await loginFromConsole(page);
 
-  await page.locator('#pf-create').click();
+  await page.locator(PORTFOLIO_CREATE).click();
   await page.locator('.portfolio-editor [data-editor-close]').last().click();
   await expect(page.locator(AUTHORING_WORKSPACE)).toBeHidden();
   await expect(page.locator('#pf-grid')).toBeVisible();

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -23,6 +23,7 @@ const PORTFOLIO_CREATE = '#pf-create';
 const EDITOR_FEEDBACK = '[data-editor-feedback]';
 const EDITOR_CONTENT = '.portfolio-editor [name="content"]';
 const EDITOR_INSTRUCTIONS = '.portfolio-editor [name="instructions"]';
+const EDITOR_METADATA = '.portfolio-editor [name="metadata"]';
 const EDITOR_SUBMIT = '.portfolio-editor button[type="submit"]';
 const EDITOR_VALIDATE = '[data-editor-validate]';
 const AUTHORING_WORKSPACE = '[data-portfolio-authoring]';
@@ -219,13 +220,13 @@ test('portfolio authoring validates drafts, preserves conflicts, and confirms ha
   await expect(page.locator(AUTHORING_WORKSPACE)).toBeVisible();
   await expect(page.locator('.portfolio-type-choice')).toHaveCount(6);
   await expect(page.locator('[data-builder-overview]')).toContainText('Building a Persona');
-  await expect(page.locator('.portfolio-editor [name="metadata"]')).toBeHidden();
+  await expect(page.locator(EDITOR_METADATA)).toBeHidden();
   await page.locator('[data-custom-metadata] summary').click();
   await expect(page.locator('[data-custom-metadata-enable]')).toBeVisible();
   await page.locator('[data-custom-metadata-enable]').click();
-  await page.locator('.portfolio-editor [name="metadata"]').fill('{');
+  await page.locator(EDITOR_METADATA).fill('{');
   await expect(page.locator('[data-custom-metadata-status]')).toContainText('must be valid JSON');
-  await page.locator('.portfolio-editor [name="metadata"]').fill('{"custom_note":"preserve me"}');
+  await page.locator(EDITOR_METADATA).fill('{"custom_note":"preserve me"}');
   await expect(page.locator('[data-custom-metadata-status]')).toContainText('Valid JSON object');
   await page.locator(EDITOR_VALIDATE).click();
   await expect(page.locator(EDITOR_FEEDBACK)).toContainText('Name is required');
@@ -237,7 +238,6 @@ test('portfolio authoring validates drafts, preserves conflicts, and confirms ha
   await page.locator(EDITOR_VALIDATE).click();
   await expect(page.locator(EDITOR_FEEDBACK)).toContainText('Behavioral instructions are required');
   await page.locator(EDITOR_INSTRUCTIONS).fill('You are a careful browser-created persona.');
-  await page.locator(EDITOR_CONTENT).fill('Optional reference material.');
   await page.locator(EDITOR_VALIDATE).click();
   await expect(page.locator(EDITOR_FEEDBACK)).toContainText('Validation passed');
   await page.locator(EDITOR_SUBMIT).click();
@@ -370,7 +370,7 @@ Follow the reviewed skill instructions.`,
   await expect(page.locator(EDITOR_CONTENT)).toHaveValue('');
   await expect(page.locator('[data-custom-metadata-notice]')).toContainText('1 additional metadata field');
   await expect(page.locator('[data-custom-metadata-notice]')).toContainText('will be preserved');
-  await expect(page.locator('.portfolio-editor [name="metadata"]')).toHaveValue(/"custom_policy": "reviewed"/u);
+  await expect(page.locator(EDITOR_METADATA)).toHaveValue(/"custom_policy": "reviewed"/u);
   await page.locator(EDITOR_VALIDATE).click();
   await expect(page.locator(EDITOR_FEEDBACK)).toContainText('ready to save');
   await page.locator(EDITOR_SUBMIT).click();
@@ -389,6 +389,47 @@ Follow the reviewed skill instructions.`,
   await page.locator('#portfolio-confirm [data-confirm="1"]').click();
   await expect(page.locator(AUTHORING_WORKSPACE)).toBeHidden();
   await expect(page.locator('#pf-grid')).toBeVisible();
+});
+
+test('portfolio import keeps legacy instructions but strips internal extensions', async ({ page }) => {
+  const mock = await installPortfolioUiMock(page);
+  await loginFromConsole(page);
+  const file = {
+    name: 'legacy-agent.json',
+    mimeType: 'application/json',
+    content: JSON.stringify({
+      type: 'agent',
+      name: 'legacy-extension-agent',
+      content: '',
+      metadata: {
+        description: 'An agent imported from a legacy JSON export.',
+        custom_policy: 'preserve this',
+        goal: {
+          template: 'Review {topic} and report findings.',
+          parameters: [],
+        },
+      },
+      extensions: {
+        instructions: 'Use the imported legacy operating instructions.',
+        runtime_state: 'do not import',
+      },
+    }),
+  };
+
+  await page.locator('#pf-import').click();
+  await setTextInputFile(page, '[data-import-file]', file);
+  await expect(page.locator('[name="type"][value="agents"]')).toBeChecked();
+  await expect(page.locator(EDITOR_INSTRUCTIONS)).toHaveValue('Use the imported legacy operating instructions.');
+  await expect(page.locator(EDITOR_METADATA)).toHaveValue(/"custom_policy": "preserve this"/u);
+  await expect(page.locator(EDITOR_METADATA)).not.toHaveValue(/extensions|runtime_state/u);
+  await expect(page.locator('[data-custom-metadata-notice]')).toContainText('1 additional metadata field');
+  await page.locator(EDITOR_SUBMIT).click();
+  await expect(page.locator('[data-name="legacy-extension-agent"]')).toBeVisible();
+
+  const imported = mock.elements.find(item => item.name === 'legacy-extension-agent');
+  expect(imported?.metadata.custom_policy).toBe('preserve this');
+  expect(imported?.metadata.instructions).toBe('Use the imported legacy operating instructions.');
+  expect(imported?.metadata).not.toHaveProperty('extensions');
 });
 
 test('portfolio create cancel leaves the workspace without saving', async ({ page }) => {

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -6,6 +6,8 @@ import { test, expect, type Page } from '@playwright/test';
 import { TOTP, Secret } from 'otpauth';
 
 import { SEED_PASSWORD } from '../harness/seed.js';
+import { installPortfolioUiMock } from '../harness/portfolioUiMock.js';
+import { installSelfServiceUiMock } from '../harness/selfServiceUiMock.js';
 import { installSessionUiMock } from '../harness/sessionUiMock.js';
 import { BASE_URL } from '../setup/provision.js';
 
@@ -14,6 +16,11 @@ const OPERATE = '/api/v1/admin/operate/health';
 const MANIFEST_URL = '**/api/v1/me/manifest';
 const SESSIONS_TAB = '.console-tab[data-tab="sessions"]';
 const SESSION_DETAIL_HEADER = '#session-detail-header';
+const CONFIRM_ACTION = '[data-confirm="1"]';
+const ACCOUNT_MENU = '#site-account';
+const EDITOR_FEEDBACK = '[data-editor-feedback]';
+const EDITOR_CONTENT = '.portfolio-editor [name="content"]';
+const THEME_SELECT = '#account-theme-form [name="theme"]';
 
 async function filterManifestRoutes(page: Page, unavailableRoutes: ReadonlySet<string>): Promise<void> {
   await page.route(MANIFEST_URL, async route => {
@@ -103,10 +110,144 @@ test('console UI serves its asset graph and boots from server metadata', async (
   await expect(page.locator('[data-revoke-console], [data-disconnect-mcp]')).toHaveCount(0);
   await expect(page.locator('#sess-revoke-others')).toHaveText('Sign out other console sessions');
 
-  await page.locator('#site-account').click();
+  await page.locator(ACCOUNT_MENU).click();
   await page.locator('#account-security').click();
   await expect(page.locator('#security-modal')).toBeVisible();
   await expect(page.locator('#sec-enroll')).toHaveCount(0);
+});
+
+test('portfolio authoring validates drafts, preserves conflicts, and confirms hard deletion', async ({ page }) => {
+  const mock = await installPortfolioUiMock(page, { conflictOnFirstPatch: true });
+  await loginFromConsole(page);
+
+  await page.locator('#pf-create').click();
+  await page.locator('[data-editor-validate]').click();
+  await expect(page.locator(EDITOR_FEEDBACK)).toContainText('Name is required');
+  await page.locator('.portfolio-editor [name="name"]').fill('browser-created');
+  await page.locator('[data-editor-validate]').click();
+  await expect(page.locator(EDITOR_FEEDBACK)).toContainText('content is required');
+  await page.locator(EDITOR_CONTENT).fill('Created through the browser.');
+  await page.locator('[data-editor-validate]').click();
+  await expect(page.locator(EDITOR_FEEDBACK)).toContainText('Validation passed');
+  await page.locator('.portfolio-editor button[type="submit"]').click();
+  await expect(page.locator('[data-name="browser-created"]')).toBeVisible();
+
+  await page.locator('[data-name="alpha-persona"] [data-action="edit"]').click();
+  await page.locator(EDITOR_CONTENT).fill('Unsaved browser draft.');
+  await page.locator('.portfolio-editor button[type="submit"]').click();
+  await expect(page.locator(EDITOR_FEEDBACK)).toContainText('changed after you opened it');
+  await expect(page.locator('[data-editor-reload]')).toBeVisible();
+  await page.locator('[data-editor-reload]').click();
+  await expect(page.locator(EDITOR_CONTENT)).toHaveValue('Latest server content.');
+  await page.locator('.portfolio-editor [data-editor-close]').first().click();
+
+  await page.locator('[data-name="alpha-persona"]').click();
+  await page.locator('.modal-delete-btn').click();
+  await page.locator('#portfolio-confirm [data-confirm="0"]').click();
+  expect(mock.deletes).toBe(0);
+  await page.locator('[data-name="alpha-persona"]').click();
+  await page.locator('.modal-delete-btn').click();
+  await page.locator('#portfolio-confirm [data-confirm="1"]').click();
+  await expect(page.locator('[data-name="alpha-persona"]')).toHaveCount(0);
+  expect(mock.deletes).toBe(1);
+});
+
+test('portfolio editor stays blocked when conflict reload omits its ETag', async ({ page }) => {
+  await installPortfolioUiMock(page, { conflictOnFirstPatch: true, omitEtagAfterConflict: true });
+  await loginFromConsole(page);
+
+  await page.locator('[data-name="alpha-persona"] [data-action="edit"]').click();
+  await page.locator(EDITOR_CONTENT).fill('Draft that must not overwrite newer content.');
+  await page.locator('.portfolio-editor button[type="submit"]').click();
+  await page.locator('[data-editor-reload]').click();
+
+  await expect(page.locator(EDITOR_FEEDBACK)).toContainText('did not include an ETag');
+  await expect(page.locator('[data-editor-reload]')).toBeVisible();
+  await expect(page.locator(EDITOR_CONTENT)).toHaveValue('Draft that must not overwrite newer content.');
+});
+
+test('portfolio sync reports successful and failed terminal jobs', async ({ page }) => {
+  const success = await installPortfolioUiMock(page);
+  await loginFromConsole(page);
+  await page.locator('#pf-sync').click();
+  await page.locator('.portfolio-sync button[type="submit"]').click();
+  await expect(page.locator('[data-sync-status]')).toContainText('Succeeded', { timeout: 5_000 });
+  expect(success.syncReads).toBeGreaterThanOrEqual(2);
+
+  await page.unroute('**/api/v1/me/portfolio**');
+  const failed = await installPortfolioUiMock(page, { syncOutcome: 'failed' });
+  await page.locator('[data-sync-close]').first().click();
+  await page.locator('#pf-sync').click();
+  await page.locator('.portfolio-sync button[type="submit"]').click();
+  await expect(page.locator('[data-sync-status]')).toContainText('github_sync_failed', { timeout: 5_000 });
+  expect(failed.syncReads).toBeGreaterThanOrEqual(2);
+});
+
+test('portfolio write controls disappear when the manifest omits write routes', async ({ page }) => {
+  await installPortfolioUiMock(page);
+  await filterManifestRoutes(page, new Set([
+    'POST /api/v1/me/portfolio/sync',
+    'GET /api/v1/me/portfolio/sync/:job_id',
+    'POST /api/v1/me/portfolio/elements/:type',
+    'PATCH /api/v1/me/portfolio/elements/:type/:name',
+    'DELETE /api/v1/me/portfolio/elements/:type/:name',
+    'POST /api/v1/me/portfolio/elements/:type/:name/validate',
+    'POST /api/v1/me/portfolio/elements/:type/:name/render',
+  ]));
+  await loginFromConsole(page);
+  await expect(page.locator('#pf-grid')).toBeVisible();
+  await expect(page.locator('#pf-create, #pf-sync, [data-action="edit"]')).toHaveCount(0);
+  await page.locator('[data-name="alpha-persona"]').click();
+  await expect(page.locator('.modal-edit-btn')).toBeHidden();
+  await expect(page.locator('.modal-delete-btn')).toBeHidden();
+});
+
+test('profile and allowlisted appearance settings persist without overwriting stale state', async ({ page }) => {
+  const mock = await installSelfServiceUiMock(page, { conflictOnFirstSettingsWrite: true });
+  await loginFromConsole(page);
+  await page.locator(ACCOUNT_MENU).click();
+  await page.locator('#account-settings').click();
+
+  await page.locator('#account-profile-form [name="display_name"]').fill('Browser Admin');
+  await page.locator('#account-profile-form button[type="submit"]').click();
+  await expect(page.locator(ACCOUNT_MENU)).toHaveText('Browser Admin');
+
+  await page.locator(THEME_SELECT).selectOption('light');
+  await page.locator('#account-theme-form button[type="submit"]').click();
+  await expect(page.locator('[data-theme-feedback]')).toContainText('not saved');
+  await expect(page.locator(THEME_SELECT)).toHaveValue('dark');
+  await page.locator(THEME_SELECT).selectOption('light');
+  await page.locator('#account-theme-form button[type="submit"]').click();
+  await expect(page.locator('[data-theme-feedback]')).toContainText('Appearance saved');
+
+  await page.locator('[data-account-close]').last().click();
+  await page.reload();
+  await page.locator('#console-shell').waitFor({ state: 'visible' });
+  await page.locator(ACCOUNT_MENU).click();
+  await page.locator('#account-settings').click();
+  await expect(page.locator('#account-profile-form [name="display_name"]')).toHaveValue('Browser Admin');
+  await expect(page.locator(THEME_SELECT)).toHaveValue('light');
+  expect(mock.settingsWrites).toBe(2);
+});
+
+test('appearance settings preserve unsupported backend values until explicitly reset', async ({ page }) => {
+  const mock = await installSelfServiceUiMock(page, { initialTheme: 'system' });
+  await loginFromConsole(page);
+  await page.locator(ACCOUNT_MENU).click();
+  await page.locator('#account-settings').click();
+
+  const theme = page.locator(THEME_SELECT);
+  await expect(theme).toBeDisabled();
+  await expect(theme).toHaveValue('__unsupported_saved_theme__');
+  await expect(page.locator('[data-theme-feedback]')).toContainText('not supported');
+  await expect(page.locator('#account-theme-form button[type="submit"]')).toBeDisabled();
+  expect(mock.settingsWrites).toBe(0);
+
+  await page.locator('#account-theme-form [data-theme-reset]').click();
+  await expect(theme).toBeEnabled();
+  await expect(theme).toHaveValue('light');
+  expect(mock.theme).toBeNull();
+  expect(mock.settingsWrites).toBe(1);
 });
 
 test('owned session workspace handles HITL, snapshots, polling cleanup, and termination acknowledgement', async ({ page }) => {
@@ -127,7 +268,7 @@ test('owned session workspace handles HITL, snapshots, polling cleanup, and term
 
   const deleteApproval = approvals.filter({ hasText: 'delete_element' });
   await deleteApproval.locator('[data-approval-action="deny"]').click();
-  await page.locator('[data-confirm="1"]').click();
+  await page.locator(CONFIRM_ACTION).click();
   await expect(deleteApproval).toContainText('denied');
 
   await page.locator('#session-activation-form select[name="type"]').selectOption('skills');
@@ -136,7 +277,7 @@ test('owned session workspace handles HITL, snapshots, polling cleanup, and term
   await expect(page.locator('.session-detail-panel--activations')).toContainText('beta-skill');
 
   await page.locator('[data-deactivate-name="beta-skill"]').click();
-  await page.locator('[data-confirm="1"]').click();
+  await page.locator(CONFIRM_ACTION).click();
   await expect(page.locator('.session-detail-panel--activations')).toContainText('No elements are active for this session.');
 
   await page.locator('[data-execution-id]').click();
@@ -151,7 +292,7 @@ test('owned session workspace handles HITL, snapshots, polling cleanup, and term
   await page.locator(SESSIONS_TAB).click();
   await expect(page.locator(SESSION_DETAIL_HEADER)).toContainText('Claude Code 1.2.3');
   await page.locator('[data-session-disconnect]').click();
-  await page.locator('[data-confirm="1"]').click();
+  await page.locator(CONFIRM_ACTION).click();
   await expect(page.locator(SESSION_DETAIL_HEADER)).toContainText('Session unavailable');
   expect(mock.commandReads).toBeGreaterThanOrEqual(2);
 });
@@ -163,7 +304,7 @@ test('session termination keeps a failed acknowledgement visible', async ({ page
   await page.locator('[data-inspect-mcp]').click();
 
   await page.locator('[data-session-disconnect]').click();
-  await page.locator('[data-confirm="1"]').click();
+  await page.locator(CONFIRM_ACTION).click();
 
   await expect(page.locator('.session-command-status')).toContainText('Waiting for the owning replica');
   expect(mock.commandReads).toBe(1);
@@ -184,7 +325,7 @@ test('bulk session termination reports command acknowledgement accurately', asyn
   await page.locator(SESSIONS_TAB).click();
 
   await page.locator('#sess-revoke-others').click();
-  await page.locator('[data-confirm="1"]').click();
+  await page.locator(CONFIRM_ACTION).click();
 
   await expect(page.locator('#sessions-command-summary')).toContainText('1 disconnect(s) acknowledged.');
   expect(mock.commandReads).toBeGreaterThanOrEqual(2);

--- a/tests/integration/web-console-e2e/specs/me-portfolio.e2e-spec.ts
+++ b/tests/integration/web-console-e2e/specs/me-portfolio.e2e-spec.ts
@@ -1,3 +1,5 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
 import { setupWorld, type World } from '../harness/world.js';
 
 let world: World;
@@ -65,6 +67,83 @@ describe('/me/portfolio element authoring (write routes enabled)', () => {
       expect(JSON.stringify(afterEdit.body)).toContain(fixture.preserved);
       expect(afterEdit.body.tags).toEqual(['edited-all-types']);
       const deleted = await world.clients.userA.delete(`${typeBase}/${fixture.name}`, { ifMatch: edited.etag });
+      expect(deleted.status).toBe(200);
+    }
+  });
+
+  it('persists guided metadata when reference content is optional', async () => {
+    const fixtures = [
+      {
+        type: 'personas',
+        name: 'guided-empty-content-persona',
+        metadata: {
+          description: 'Guided persona',
+          instructions: 'You are a careful guided persona.',
+        },
+      },
+      {
+        type: 'skills',
+        name: 'guided-empty-content-skill',
+        metadata: {
+          description: 'Guided skill',
+          instructions: 'Follow the guided procedure in order.',
+        },
+      },
+      {
+        type: 'agents',
+        name: 'guided-empty-content-agent',
+        metadata: {
+          description: 'Guided agent',
+          instructions: 'Work incrementally and verify each result.',
+          goal: {
+            template: 'Research {topic} and recommend a path.',
+            parameters: [],
+          },
+        },
+      },
+      {
+        type: 'ensembles',
+        name: 'guided-empty-content-ensemble',
+        metadata: {
+          description: 'Guided ensemble',
+          instructions: 'Coordinate the configured elements.',
+          activationStrategy: 'priority',
+          conflictResolution: 'merge',
+          contextSharing: 'selective',
+          allowNested: false,
+          elements: [{
+            element_name: 'guided-empty-content-persona',
+            element_type: 'persona',
+            role: 'primary',
+            priority: 10,
+            activation: 'always',
+          }],
+        },
+      },
+    ] as const;
+
+    for (const fixture of fixtures) {
+      const typeBase = `/api/v1/me/portfolio/elements/${fixture.type}`;
+      const created = await world.clients.userA.post(typeBase, {
+        body: {
+          name: fixture.name,
+          metadata: fixture.metadata,
+          tags: ['guided'],
+        },
+      });
+      expect(created.status).toBe(201);
+
+      const read = await world.clients.userA.get(`${typeBase}/${fixture.name}`);
+      expect(read.status).toBe(200);
+      expect(read.body).toMatchObject({
+        type: fixture.type,
+        name: fixture.name,
+        tags: ['guided'],
+      });
+      expect(JSON.stringify(read.body.metadata)).toContain(fixture.metadata.description);
+      expect(read.body.metadata.instructions).toBe(fixture.metadata.instructions);
+
+      const deleted = await world.clients.userA.delete(`${typeBase}/${fixture.name}`, { ifMatch: read.etag });
       expect(deleted.status).toBe(200);
     }
   });

--- a/tests/integration/web-console-e2e/specs/me-portfolio.e2e-spec.ts
+++ b/tests/integration/web-console-e2e/specs/me-portfolio.e2e-spec.ts
@@ -36,6 +36,39 @@ describe('/me/portfolio reads', () => {
 });
 
 describe('/me/portfolio element authoring (write routes enabled)', () => {
+  it('creates, edits, and deletes every supported portfolio type', async () => {
+    const fixtures = [
+      { type: 'personas', name: 'alpha-all-types-persona', content: 'Persona instructions.', preserved: 'Persona instructions.', metadata: { description: 'Persona' } },
+      { type: 'skills', name: 'alpha-all-types-skill', content: 'Skill instructions.', preserved: 'Skill instructions.', metadata: { description: 'Skill' } },
+      { type: 'templates', name: 'alpha-all-types-template', content: 'Hello {{name}}', preserved: 'Hello {{name}}', metadata: { description: 'Template' } },
+      { type: 'agents', name: 'alpha-all-types-agent', content: 'Agent instructions.', preserved: 'Agent instructions.', metadata: { description: 'Agent', goal: 'Assist carefully' } },
+      { type: 'memories', name: 'alpha-all-types-memory', content: 'entries:\n  - content: Remember the alpha test.', preserved: 'Remember the alpha test.', metadata: { description: 'Memory' } },
+      { type: 'ensembles', name: 'alpha-all-types-ensemble', content: 'Alpha ensemble.', preserved: '"elements":[]', metadata: { description: 'Ensemble', elements: [] } },
+    ] as const;
+
+    for (const fixture of fixtures) {
+      const typeBase = `/api/v1/me/portfolio/elements/${fixture.type}`;
+      const created = await world.clients.userA.post(typeBase, {
+        body: { name: fixture.name, content: fixture.content, metadata: fixture.metadata, tags: ['all-types'] },
+      });
+      expect(created.status).toBe(201);
+      const read = await world.clients.userA.get(`${typeBase}/${fixture.name}`);
+      expect(read.status).toBe(200);
+      expect(read.body).toMatchObject({ type: fixture.type, name: fixture.name });
+      const edited = await world.clients.userA.patch(`${typeBase}/${fixture.name}`, {
+        body: { tags: ['edited-all-types'] },
+        ifMatch: read.etag,
+      });
+      expect(edited.status).toBe(200);
+      const afterEdit = await world.clients.userA.get(`${typeBase}/${fixture.name}`);
+      expect(afterEdit.status).toBe(200);
+      expect(JSON.stringify(afterEdit.body)).toContain(fixture.preserved);
+      expect(afterEdit.body.tags).toEqual(['edited-all-types']);
+      const deleted = await world.clients.userA.delete(`${typeBase}/${fixture.name}`, { ifMatch: edited.etag });
+      expect(deleted.status).toBe(200);
+    }
+  });
+
   it('full CRUD round-trip: create -> read -> validate -> render -> edit -> delete', async () => {
     // create
     const created = await world.clients.userA.post(base, {
@@ -154,6 +187,26 @@ describe('/me/portfolio element authoring (write routes enabled)', () => {
     // cleanup
     const read = await world.clients.userA.get(`${base}/precond-persona`);
     if (read.status === 200) await world.clients.userA.delete(`${base}/precond-persona`, { ifMatch: read.etag });
+  });
+
+  it('rejects stale ETags for both update and hard delete', async () => {
+    const name = 'stale-etag-persona';
+    const created = await world.clients.userA.post(base, { body: { name, content: 'first', metadata: {} } });
+    expect(created.status).toBe(201);
+    const updated = await world.clients.userA.patch(`${base}/${name}`, {
+      body: { content: 'second' },
+      ifMatch: created.etag,
+    });
+    expect(updated.status).toBe(200);
+    const staleUpdate = await world.clients.userA.patch(`${base}/${name}`, {
+      body: { content: 'third' },
+      ifMatch: created.etag,
+    });
+    expect(staleUpdate.status).toBe(412);
+    const staleDelete = await world.clients.userA.delete(`${base}/${name}`, { ifMatch: created.etag });
+    expect(staleDelete.status).toBe(412);
+    const cleanup = await world.clients.userA.delete(`${base}/${name}`, { ifMatch: updated.etag });
+    expect(cleanup.status).toBe(200);
   });
 });
 

--- a/tests/integration/web-console-e2e/specs/me-profile-settings.e2e-spec.ts
+++ b/tests/integration/web-console-e2e/specs/me-profile-settings.e2e-spec.ts
@@ -1,3 +1,5 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
 import { setupWorld, type World } from '../harness/world.js';
 
 let world: World;

--- a/tests/unit/elements/agents/AgentManager.test.ts
+++ b/tests/unit/elements/agents/AgentManager.test.ts
@@ -3,8 +3,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
-import * as path from 'path';
-import * as os from 'os';
+import { randomUUID } from 'node:crypto';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // Mock the security modules before importing anything that uses them
 jest.mock('../../../../src/security/fileLockManager.js');
@@ -13,14 +14,13 @@ jest.mock('../../../../src/utils/logger.js');
 jest.mock('../../../../src/services/FileOperationsService.js');
 
 // Import after mocking
-import { AgentManager } from '../../../../src/elements/agents/AgentManager.js';
 import { Agent } from '../../../../src/elements/agents/Agent.js';
 import { ElementType } from '../../../../src/portfolio/types.js';
 import { FileLockManager } from '../../../../src/security/fileLockManager.js';
 import { SecurityMonitor } from '../../../../src/security/securityMonitor.js';
 import { DollhouseContainer } from '../../../../src/di/Container.js';
-import { PortfolioManager } from '../../../../src/portfolio/PortfolioManager.js';
-import { FileOperationsService } from '../../../../src/services/FileOperationsService.js';
+import type { PortfolioManager } from '../../../../src/portfolio/PortfolioManager.js';
+import type { FileOperationsService } from '../../../../src/services/FileOperationsService.js';
 import { createTestMetadataService, TestableAgentManager } from '../../../helpers/di-mocks.js';
 import type { MetadataService } from '../../../../src/services/MetadataService.js';
 import { ValidationRegistry } from '../../../../src/services/validation/ValidationRegistry.js';
@@ -32,6 +32,21 @@ import { SECURITY_LIMITS } from '../../../../src/security/constants.js';
 import { createTestStorageFactory } from '../../../helpers/createTestStorageFactory.js';
 
 const metadataService: MetadataService = createTestMetadataService();
+const TEST_AGENT_NAME = 'test-agent';
+const STATE_FILE_SUFFIX = '.state.yaml';
+
+function asAsyncRead(
+  implementation: (filePath: string) => string
+): FileOperationsService['readFile'] {
+  return (filePath) => Promise.resolve().then(() => implementation(filePath));
+}
+
+function requireLoadedAgent(agent: Agent | null): Agent {
+  if (!agent) {
+    throw new Error('Expected agent to load');
+  }
+  return agent;
+}
 
 describe('AgentManager', () => {
   let agentManager: TestableAgentManager;
@@ -52,7 +67,7 @@ describe('AgentManager', () => {
 
     // Create temporary test directory
 
-    testDir = path.join(os.tmpdir(), 'agent-test-' + Math.random().toString(36).substring(7));
+    testDir = path.join(os.tmpdir(), `agent-test-${randomUUID()}`);
     portfolioPath = testDir;
     
     mockPortfolioManager = {
@@ -65,21 +80,21 @@ describe('AgentManager', () => {
     container.register<PortfolioManager>('PortfolioManager', () => mockPortfolioManager as any);
     container.register<FileLockManager>('FileLockManager', () => new FileLockManager());
     
-    const mockFileOperations: any = {
-      createDirectory: jest.fn().mockResolvedValue(undefined),
-      exists: jest.fn().mockResolvedValue(false),
-      readFile: jest.fn().mockResolvedValue(''),
-      writeFile: jest.fn().mockResolvedValue(undefined),
-      deleteFile: jest.fn().mockResolvedValue(undefined),
-      listDirectory: jest.fn().mockResolvedValue([]),
-      resolvePath: jest.fn((p: string) => path.resolve(portfolioPath, p)),
-      validatePath: jest.fn().mockReturnValue(true),
-      createFileExclusive: jest.fn().mockResolvedValue(true)
+      const mockFileOperations: any = {
+        createDirectory: jest.fn<FileOperationsService['createDirectory']>().mockResolvedValue(),
+        exists: jest.fn<FileOperationsService['exists']>().mockResolvedValue(false),
+        readFile: jest.fn<FileOperationsService['readFile']>().mockResolvedValue(''),
+        writeFile: jest.fn<FileOperationsService['writeFile']>().mockResolvedValue(),
+        deleteFile: jest.fn<FileOperationsService['deleteFile']>().mockResolvedValue(),
+        listDirectory: jest.fn<FileOperationsService['listDirectory']>().mockResolvedValue([]),
+        resolvePath: jest.fn<FileOperationsService['resolvePath']>((p: string) => path.resolve(portfolioPath, p)),
+        validatePath: jest.fn<FileOperationsService['validatePath']>().mockReturnValue(true),
+        createFileExclusive: jest.fn<FileOperationsService['createFileExclusive']>().mockResolvedValue(true)
     };
     // BaseElementManager.load uses readElementFile. Wire dynamically so tests
     // that reassign readFile via mockResolvedValue still flow through.
     mockFileOperations.readElementFile = jest.fn((...args: unknown[]) => mockFileOperations.readFile(...args));
-    container.register<FileOperationsService>('FileOperationsService', () => mockFileOperations as any);
+    container.register<FileOperationsService>('FileOperationsService', () => mockFileOperations);
 
     // Register DI services
     container.register('SerializationService', () => new SerializationService());
@@ -103,7 +118,7 @@ describe('AgentManager', () => {
     storageLayerFactory: createTestStorageFactory(),
     }));
 
-    agentManager = container.resolve<AgentManager>('AgentManager');
+    agentManager = container.resolve<TestableAgentManager>('AgentManager');
     _fileLockManager = container.resolve<FileLockManager>('FileLockManager');
     fileOperationsService = container.resolve<FileOperationsService>('FileOperationsService') as jest.Mocked<FileOperationsService>;
 
@@ -116,7 +131,7 @@ describe('AgentManager', () => {
   });
 
   describe('Initialization', () => {
-    it('should create agents directory structure', async () => {
+    it('should create agents directory structure', () => {
       expect(fileOperationsService.createDirectory).toHaveBeenCalledTimes(2); // agents dir + state dir
     });
   });
@@ -124,7 +139,7 @@ describe('AgentManager', () => {
   describe('Create', () => {
     it('should create a new agent', async () => {
       const result = await agentManager.create(
-        'test-agent',
+        TEST_AGENT_NAME,
         'A test agent',
         'Agent instructions here',
         {
@@ -134,7 +149,7 @@ describe('AgentManager', () => {
       );
 
       expect(result.success).toBe(true);
-      expect(result.message).toContain('test-agent');
+      expect(result.message).toContain(TEST_AGENT_NAME);
       expect(result.element).toBeInstanceOf(Agent);
       expect(fileOperationsService.createFileExclusive).toHaveBeenCalledWith(
         expect.stringContaining('test-agent.md'),
@@ -281,7 +296,7 @@ describe('AgentManager', () => {
   });
 
   describe('Read', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       fileOperationsService.readFile.mockResolvedValue(`---
 name: test-agent
 type: agent
@@ -298,10 +313,10 @@ Agent instructions here`);
     });
 
     it('should read an existing agent', async () => {
-      const agent = await agentManager.read('test-agent');
+      const agent = await agentManager.read(TEST_AGENT_NAME);
 
       expect(agent).not.toBeNull();
-      expect(agent?.metadata.name).toBe('test-agent');
+      expect(agent?.metadata.name).toBe(TEST_AGENT_NAME);
       expect(agent?.extensions?.decisionFramework).toBe('rule_based');
     });
 
@@ -321,8 +336,8 @@ Agent instructions here`);
 
     it('should load agent state if available', async () => {
       // Mock both agent file and state file
-      fileOperationsService.readFile.mockImplementation(async (path: string) => {
-          if (path.includes('.state.yaml')) {
+      fileOperationsService.readFile.mockImplementation(asAsyncRead((path: string) => {
+          if (path.includes(STATE_FILE_SUFFIX)) {
             // Return state file content in YAML frontmatter format
             return `---
 goals:
@@ -343,9 +358,9 @@ type: agent
 ---
 Content`;
           }
-        });
+        }));
 
-      const agent = await agentManager.read('test-agent');
+      const agent = await agentManager.read(TEST_AGENT_NAME);
       const state = agent?.getState();
 
       // Note: sessionCount is stored as string in YAML and parsed back as number
@@ -362,7 +377,7 @@ description: Old description
 ---
 Content`);
 
-      const success = await agentManager.update('test-agent', {
+      const success = await agentManager.update(TEST_AGENT_NAME, {
         description: 'New description',
         specializations: ['updated', 'skills']
       });
@@ -387,7 +402,7 @@ Content`);
 
     it('should save agent state if dirty', async () => {
       // Create a mock agent with dirty state
-      const agent = new Agent({ name: 'test-agent' }, metadataService);
+      const agent = new Agent({ name: TEST_AGENT_NAME }, metadataService);
       agent.addGoal({ description: 'New goal' }); // This makes state dirty
 
       // Mock the read to return our agent
@@ -399,7 +414,7 @@ Content`);
       // Mock the manager's read method to return our agent
       jest.spyOn(agentManager, 'read').mockImplementation(() => Promise.resolve(agent));
 
-      await agentManager.update('test-agent', {});
+      await agentManager.update(TEST_AGENT_NAME, {});
 
       // Should have written both the agent file and state file
       expect(fileOperationsService.writeFile).toHaveBeenCalledTimes(2);
@@ -407,7 +422,7 @@ Content`);
 
     it('should not call saveAgentState when state is not dirty (Issue #123)', async () => {
       // Create a fresh agent WITHOUT making any state changes
-      const agent = new Agent({ name: 'test-agent' }, metadataService);
+      const agent = new Agent({ name: TEST_AGENT_NAME }, metadataService);
       // Note: NOT calling addGoal, recordDecision, or any state-modifying method
       // so needsStatePersistence() should return false
 
@@ -420,7 +435,7 @@ Content`);
       // Mock the manager's read method to return our fresh (clean) agent
       jest.spyOn(agentManager, 'read').mockImplementation(() => Promise.resolve(agent));
 
-      await agentManager.update('test-agent', { description: 'Updated description' });
+      await agentManager.update(TEST_AGENT_NAME, { description: 'Updated description' });
 
       // Should have written ONLY the agent file, NOT the state file
       // because needsStatePersistence() returns false for clean state
@@ -435,7 +450,7 @@ Content`);
     it('should delete agent and state files', async () => {
       fileOperationsService.exists.mockResolvedValue(true);
 
-      await agentManager.delete('test-agent');
+      await agentManager.delete(TEST_AGENT_NAME);
 
       expect(fileOperationsService.deleteFile).toHaveBeenCalledTimes(2); // Main file + state file
       expect(fileOperationsService.deleteFile).toHaveBeenCalledWith(
@@ -445,7 +460,7 @@ Content`);
       );
       expect(fileOperationsService.deleteFile).toHaveBeenCalledWith(
         expect.stringContaining('test-agent.state.yaml'),
-        'agents',
+        ElementType.AGENT,
         expect.objectContaining({ source: 'AgentManager.delete (state file)' })
       );
     });
@@ -453,7 +468,7 @@ Content`);
     it('should log security event on deletion', async () => {
       fileOperationsService.exists.mockResolvedValue(true);
 
-      await agentManager.delete('test-agent');
+      await agentManager.delete(TEST_AGENT_NAME);
 
       // Security logging is now handled by FileOperationsService, but BaseElementManager might still log high-level events?
       // Actually, BaseElementManager.delete calls super.delete which calls fileOperations.deleteFile.
@@ -482,7 +497,7 @@ Content`);
       // Configure the mock to return agent files
       mockPortfolioManager.listElements.mockResolvedValue(['agent1.md', 'agent2.md']);
 
-      fileOperationsService.readFile.mockImplementation(async (path: any) => {
+      fileOperationsService.readFile.mockImplementation(asAsyncRead((path: any) => {
         if (path.includes('agent1')) {
           return `---
 name: agent1
@@ -494,7 +509,7 @@ name: agent2
 ---
 Content`;
         }
-      });
+      }));
 
       const agents = await agentManager.list();
 
@@ -532,7 +547,7 @@ Content`;
       expect(agentManager.validatePath('../traversal')).toBe(false);
       expect(agentManager.validatePath('~/home')).toBe(false);
       expect(agentManager.validatePath('/absolute/path')).toBe(false);
-      expect(agentManager.validatePath('C:\\windows')).toBe(false);
+      expect(agentManager.validatePath(String.raw`C:\windows`)).toBe(false);
     });
   });
 
@@ -581,6 +596,8 @@ This is the agent content.`;
 
       expect(agent.metadata.name).toBe('markdown-agent');
       expect(agent.extensions?.decisionFramework).toBe('programmatic');
+      expect(agent.instructions).toContain('This is the agent content.');
+      await expect(agentManager.exportElement(agent, 'markdown')).resolves.toContain('This is the agent content.');
     });
 
     it('should export agent to JSON', async () => {
@@ -621,7 +638,7 @@ This is the agent content.`;
         sessionCount: 1
       };
 
-      await agentManager.exposedSaveAgentState('test-agent', state as any);
+      await agentManager.exposedSaveAgentState(TEST_AGENT_NAME, state as any);
 
       // Check that the path contains the expected components (cross-platform)
       const firstCallArgs = (fileOperationsService.writeFile as jest.Mock).mock.calls[0];
@@ -640,15 +657,15 @@ This is the agent content.`;
         sessionCount: 1
       };
 
-      await expect(agentManager.exposedSaveAgentState('test-agent', hugeState as any))
+      await expect(agentManager.exposedSaveAgentState(TEST_AGENT_NAME, hugeState as any))
         .rejects.toThrow('exceeds allowed size');
     });
 
     it('should cache loaded state', async () => {
       let callCount = 0;
-      fileOperationsService.readFile.mockImplementation(async (path: string) => {
+      fileOperationsService.readFile.mockImplementation(asAsyncRead((path: string) => {
           callCount++;
-          if (path.includes('.state.yaml')) {
+          if (path.includes(STATE_FILE_SUFFIX)) {
             return `---
 goals: []
 decisions: []
@@ -662,17 +679,17 @@ name: test-agent
 ---
 Content`;
           }
-        });
+        }));
 
       // First read: element is not cached, so both the agent file and its
       // .state.yaml sidecar are read from disk (callCount = 2).
-      await agentManager.read('test-agent');
+      await agentManager.read(TEST_AGENT_NAME);
       expect(callCount).toBe(2);
 
       // Second read: the element cache (populated by BaseElementManager.load())
       // serves the agent, and its already-hydrated state is returned as-is —
       // neither file is re-read. This is the desired steady-state behavior.
-      await agentManager.read('test-agent');
+      await agentManager.read(TEST_AGENT_NAME);
       expect(callCount).toBe(2);
 
       // Force an element-cache miss by clearing the base-class LRU. The state
@@ -680,7 +697,7 @@ Content`;
       // so the next read should re-fetch the agent file but reuse the cached
       // AgentState, confirming the two layers are separate.
       agentManager.clearCache();
-      await agentManager.read('test-agent');
+      await agentManager.read(TEST_AGENT_NAME);
       expect(callCount).toBe(3); // +1 agent file read; state came from stateCache
     });
 
@@ -697,7 +714,7 @@ Content`;
         stateVersion: 1
       };
 
-      await agentManager.exposedSaveAgentState('test-agent', state as any);
+      await agentManager.exposedSaveAgentState(TEST_AGENT_NAME, state as any);
 
       // Verify that withLock was called with the correct resource identifier
       expect(withLockSpy).toHaveBeenCalledWith(
@@ -751,8 +768,8 @@ Content`;
 
       // Execute concurrent saves
       await Promise.all([
-        agentManager.exposedSaveAgentState('test-agent', state1 as any).then(() => executionOrder.push(1)),
-        agentManager.exposedSaveAgentState('test-agent', state2 as any).then(() => executionOrder.push(2))
+        agentManager.exposedSaveAgentState(TEST_AGENT_NAME, state1 as any).then(() => executionOrder.push(1)),
+        agentManager.exposedSaveAgentState(TEST_AGENT_NAME, state2 as any).then(() => executionOrder.push(2))
       ]);
 
       // Both should complete successfully (serialized by lock)
@@ -801,8 +818,8 @@ Content`);
     describe('Corruption Recovery', () => {
       it('should handle malformed YAML state file gracefully', async () => {
         // Mock agent file to exist
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             // Return malformed YAML (unclosed brace, invalid syntax)
             return `---
 goals: [
@@ -814,11 +831,11 @@ decisions: []
 name: test-agent
 ---
 Content`;
-        });
+        }));
 
         // Should not throw - graceful degradation returns null for corrupt state
         // Agent should still load, just without persisted state
-        const agent = await agentManager.read('test-agent');
+        const agent = await agentManager.read(TEST_AGENT_NAME);
 
         // Agent loads but state is default (no goals from corrupt file)
         expect(agent).not.toBeNull();
@@ -826,8 +843,8 @@ Content`;
       });
 
       it('should handle truncated state file', async () => {
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             // Truncated YAML - incomplete content
             return `---
 goals:
@@ -839,16 +856,16 @@ goals:
 name: test-agent
 ---
 Content`;
-        });
+        }));
 
         // Should handle gracefully
-        const agent = await agentManager.read('test-agent');
+        const agent = await agentManager.read(TEST_AGENT_NAME);
         expect(agent).not.toBeNull();
       });
 
       it('should handle state file with invalid stateVersion type', async () => {
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             return `---
 goals: []
 decisions: []
@@ -862,9 +879,9 @@ stateVersion: "not-a-number"
 name: test-agent
 ---
 Content`;
-        });
+        }));
 
-        const agent = await agentManager.read('test-agent');
+        const agent = await agentManager.read(TEST_AGENT_NAME);
         expect(agent).not.toBeNull();
 
         // stateVersion should be coerced or defaulted, not NaN
@@ -877,8 +894,8 @@ Content`;
        * normalizeLoadedState() defaults missing goals/decisions to empty arrays.
        */
       it('should default missing goals/decisions arrays in state file', async () => {
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             // Missing goals, decisions, context - only has sessionCount and lastActive
             return `---
 lastActive: 2025-01-01T00:00:00Z
@@ -890,9 +907,9 @@ stateVersion: 1
 name: test-agent
 ---
 Content`;
-        });
+        }));
 
-        const agent = await agentManager.read('test-agent');
+        const agent = await agentManager.read(TEST_AGENT_NAME);
         expect(agent).not.toBeNull();
 
         // CORRECT BEHAVIOR: Missing fields should be defaulted to empty arrays
@@ -905,8 +922,8 @@ Content`;
       });
 
       it('should handle state file with invalid date format', async () => {
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             return `---
 goals: []
 decisions: []
@@ -920,10 +937,10 @@ stateVersion: 1
 name: test-agent
 ---
 Content`;
-        });
+        }));
 
         // Should handle gracefully
-        const agent = await agentManager.read('test-agent');
+        const agent = await agentManager.read(TEST_AGENT_NAME);
         expect(agent).not.toBeNull();
       });
     });
@@ -946,7 +963,7 @@ Content`;
         };
 
         // Should succeed without throwing
-        await expect(agentManager.exposedSaveAgentState('test-agent', state as any))
+        await expect(agentManager.exposedSaveAgentState(TEST_AGENT_NAME, state as any))
           .resolves.not.toThrow();
       });
 
@@ -964,7 +981,7 @@ Content`;
           stateVersion: 1
         };
 
-        await expect(agentManager.exposedSaveAgentState('test-agent', state as any))
+        await expect(agentManager.exposedSaveAgentState(TEST_AGENT_NAME, state as any))
           .rejects.toThrow('exceeds allowed size');
       });
 
@@ -994,14 +1011,14 @@ Content`;
         };
 
         // Should succeed - 50 small goals is under size limit
-        await expect(agentManager.exposedSaveAgentState('test-agent', state as any))
+        await expect(agentManager.exposedSaveAgentState(TEST_AGENT_NAME, state as any))
           .resolves.not.toThrow();
       });
     });
 
     describe('State Version Rollback on Failed Save', () => {
       it('should not increment stateVersion when write fails', async () => {
-        const agent = new Agent({ name: 'test-agent' }, metadataService);
+        const agent = new Agent({ name: TEST_AGENT_NAME }, metadataService);
         const initialVersion = agent.getState().stateVersion;
 
         // Add a goal - with Option C fix, version does NOT increment during operation
@@ -1014,7 +1031,7 @@ Content`;
         fileOperationsService.writeFile.mockRejectedValueOnce(new Error('Disk full'));
 
         // Attempt save - should fail
-        await expect(agentManager.exposedSaveAgentState('test-agent', agent.getState() as any))
+        await expect(agentManager.exposedSaveAgentState(TEST_AGENT_NAME, agent.getState() as any))
           .rejects.toThrow('Disk full');
 
         // FIX (Issue #123): Version should NOT have incremented because save failed
@@ -1031,7 +1048,7 @@ Content`;
        * This test verifies the Option C pattern is working correctly.
        */
       it('stateVersion should only increment on successful save', async () => {
-        const agent = new Agent({ name: 'test-agent' }, metadataService);
+        const agent = new Agent({ name: TEST_AGENT_NAME }, metadataService);
         const initialVersion = agent.getState().stateVersion;
         expect(initialVersion).toBe(1);
 
@@ -1044,24 +1061,24 @@ Content`;
         expect(agent.getState().stateVersion).toBe(1); // Will fail with current bug
 
         // Mock successful save
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             const error = new Error('ENOENT') as NodeJS.ErrnoException;
             error.code = 'ENOENT';
             throw error;
           }
           return `---\nname: test-agent\n---\nContent`;
-        });
+        }));
 
         // Save should increment version
-        await agentManager.exposedSaveAgentState('test-agent', agent.getState() as any);
+        await agentManager.exposedSaveAgentState(TEST_AGENT_NAME, agent.getState() as any);
 
         // After successful save, version should be 2
         // Note: The agent object won't automatically update - this tests the pattern
       });
 
       it('should not increment stateVersion when size validation fails', async () => {
-        const agent = new Agent({ name: 'test-agent' }, metadataService);
+        const agent = new Agent({ name: TEST_AGENT_NAME }, metadataService);
         const initialVersion = agent.getState().stateVersion;
 
         // Add goal - with Option C fix, version does NOT change during operation
@@ -1077,7 +1094,7 @@ Content`;
         };
 
         // Attempt save - should fail due to size
-        await expect(agentManager.exposedSaveAgentState('test-agent', oversizedState as any))
+        await expect(agentManager.exposedSaveAgentState(TEST_AGENT_NAME, oversizedState as any))
           .rejects.toThrow('exceeds allowed size');
 
         // FIX (Issue #123): Version should NOT have changed because save failed
@@ -1086,8 +1103,8 @@ Content`;
 
       it('should not persist stateVersion increment when version conflict occurs', async () => {
         // Setup: Load an agent with version 1
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             return `---
 goals: []
 decisions: []
@@ -1101,7 +1118,7 @@ stateVersion: 5
 name: test-agent
 ---
 Content`;
-        });
+        }));
 
         // Create a state with lower version (simulating stale state)
         const staleState = {
@@ -1114,7 +1131,7 @@ Content`;
         };
 
         // Attempt to save stale state - should fail with version conflict
-        await expect(agentManager.exposedSaveAgentState('test-agent', staleState as any))
+        await expect(agentManager.exposedSaveAgentState(TEST_AGENT_NAME, staleState as any))
           .rejects.toThrow('State version conflict');
 
         // Verify no write occurred
@@ -1124,8 +1141,8 @@ Content`;
 
     describe('Issue #697: V2 Field Normalization on Load', () => {
       it('should normalize goals (plural) to goal on load', async () => {
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             const error = new Error('ENOENT') as NodeJS.ErrnoException;
             error.code = 'ENOENT';
             throw error;
@@ -1141,20 +1158,20 @@ goals:
       required: true
 ---
 Agent with plural goals field`;
-        });
+        }));
 
         const agent = await agentManager.read('plural-goal-agent');
         expect(agent).not.toBeNull();
         // goal should be set from goals
-        expect((agent!.metadata as any).goal).toBeDefined();
-        expect((agent!.metadata as any).goal.template).toBe('Do {{task}}');
+        expect((requireLoadedAgent(agent).metadata as any).goal).toBeDefined();
+        expect((requireLoadedAgent(agent).metadata as any).goal.template).toBe('Do {{task}}');
         // goals (plural) should be removed
-        expect((agent!.metadata as any).goals).toBeUndefined();
+        expect((requireLoadedAgent(agent).metadata as any).goals).toBeUndefined();
       });
 
       it('should not clobber existing goal when goals (plural) also present', async () => {
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             const error = new Error('ENOENT') as NodeJS.ErrnoException;
             error.code = 'ENOENT';
             throw error;
@@ -1168,19 +1185,19 @@ goals:
   template: "Legacy {{task}}"
 ---
 Agent with both goal and goals`;
-        });
+        }));
 
         const agent = await agentManager.read('both-goal-agent');
         expect(agent).not.toBeNull();
         // Original goal should be preserved
-        expect((agent!.metadata as any).goal.template).toBe('Primary {{task}}');
+        expect((requireLoadedAgent(agent).metadata as any).goal.template).toBe('Primary {{task}}');
         // goals should be cleaned up
-        expect((agent!.metadata as any).goals).toBeUndefined();
+        expect((requireLoadedAgent(agent).metadata as any).goals).toBeUndefined();
       });
 
       it('should normalize maxSteps to maxAutonomousSteps inside autonomy', async () => {
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             const error = new Error('ENOENT') as NodeJS.ErrnoException;
             error.code = 'ENOENT';
             throw error;
@@ -1193,18 +1210,18 @@ autonomy:
   riskTolerance: moderate
 ---
 Agent with maxSteps shorthand`;
-        });
+        }));
 
         const agent = await agentManager.read('maxsteps-agent');
         expect(agent).not.toBeNull();
-        const autonomy = (agent!.metadata as any).autonomy;
+        const autonomy = (requireLoadedAgent(agent).metadata as any).autonomy;
         expect(autonomy.maxAutonomousSteps).toBe(5);
         expect(autonomy.maxSteps).toBeUndefined();
       });
 
       it('should promote root-level riskTolerance into autonomy block', async () => {
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             const error = new Error('ENOENT') as NodeJS.ErrnoException;
             error.code = 'ENOENT';
             throw error;
@@ -1215,18 +1232,18 @@ type: agent
 riskTolerance: conservative
 ---
 Agent with root-level riskTolerance`;
-        });
+        }));
 
         const agent = await agentManager.read('root-risk-agent');
         expect(agent).not.toBeNull();
-        const autonomy = (agent!.metadata as any).autonomy;
+        const autonomy = (requireLoadedAgent(agent).metadata as any).autonomy;
         expect(autonomy).toBeDefined();
         expect(autonomy.riskTolerance).toBe('conservative');
       });
 
       it('should promote root-level maxAutonomousSteps into autonomy block', async () => {
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             const error = new Error('ENOENT') as NodeJS.ErrnoException;
             error.code = 'ENOENT';
             throw error;
@@ -1237,19 +1254,19 @@ type: agent
 maxAutonomousSteps: 10
 ---
 Agent with root-level maxAutonomousSteps`;
-        });
+        }));
 
         const agent = await agentManager.read('root-steps-agent');
         expect(agent).not.toBeNull();
-        const autonomy = (agent!.metadata as any).autonomy;
+        const autonomy = (requireLoadedAgent(agent).metadata as any).autonomy;
         expect(autonomy).toBeDefined();
         expect(autonomy.maxAutonomousSteps).toBe(10);
-        expect((agent!.metadata as any).maxAutonomousSteps).toBeUndefined();
+        expect((requireLoadedAgent(agent).metadata as any).maxAutonomousSteps).toBeUndefined();
       });
 
       it('should not clobber existing autonomy.riskTolerance with root-level value', async () => {
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             const error = new Error('ENOENT') as NodeJS.ErrnoException;
             error.code = 'ENOENT';
             throw error;
@@ -1263,11 +1280,11 @@ autonomy:
   maxAutonomousSteps: 3
 ---
 Agent with both root and nested riskTolerance`;
-        });
+        }));
 
         const agent = await agentManager.read('noclobber-agent');
         expect(agent).not.toBeNull();
-        const autonomy = (agent!.metadata as any).autonomy;
+        const autonomy = (requireLoadedAgent(agent).metadata as any).autonomy;
         // Nested value should win
         expect(autonomy.riskTolerance).toBe('conservative');
         expect(autonomy.maxAutonomousSteps).toBe(3);
@@ -1277,8 +1294,8 @@ Agent with both root and nested riskTolerance`;
     describe('Version Conflict Detection', () => {
       it('should detect version conflict when disk version is higher', async () => {
         // Mock disk state with version 10
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             return `---
 goals: []
 decisions: []
@@ -1292,7 +1309,7 @@ stateVersion: 10
 name: test-agent
 ---
 Content`;
-        });
+        }));
 
         // Try to save with version 5 (stale)
         const staleState = {
@@ -1304,14 +1321,14 @@ Content`;
           stateVersion: 5
         };
 
-        await expect(agentManager.exposedSaveAgentState('test-agent', staleState as any))
+        await expect(agentManager.exposedSaveAgentState(TEST_AGENT_NAME, staleState as any))
           .rejects.toThrow(/State version conflict.*current version is 10.*attempted to save version 5/);
       });
 
       it('should allow save when disk version matches attempted version', async () => {
         // Mock disk state with version 5
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             return `---
 goals: []
 decisions: []
@@ -1325,7 +1342,7 @@ stateVersion: 5
 name: test-agent
 ---
 Content`;
-        });
+        }));
 
         // Save with version 5 (matches disk) - should increment to 6
         // Note: Current implementation allows equal versions (not just greater)
@@ -1339,14 +1356,14 @@ Content`;
         };
 
         // Should succeed - versions match
-        await expect(agentManager.exposedSaveAgentState('test-agent', matchingState as any))
+        await expect(agentManager.exposedSaveAgentState(TEST_AGENT_NAME, matchingState as any))
           .resolves.not.toThrow();
       });
 
       it('should allow save when disk version is lower (normal progression)', async () => {
         // Mock disk state with version 3
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             return `---
 goals: []
 decisions: []
@@ -1360,7 +1377,7 @@ stateVersion: 3
 name: test-agent
 ---
 Content`;
-        });
+        }));
 
         // Save with version 5 (higher than disk 3) - normal case
         const newerState = {
@@ -1373,14 +1390,14 @@ Content`;
         };
 
         // Should succeed
-        await expect(agentManager.exposedSaveAgentState('test-agent', newerState as any))
+        await expect(agentManager.exposedSaveAgentState(TEST_AGENT_NAME, newerState as any))
           .resolves.not.toThrow();
       });
 
       it('should handle first save when no state file exists', async () => {
         // Mock: no state file exists (ENOENT)
-        fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-          if (filePath.includes('.state.yaml')) {
+        fileOperationsService.readFile.mockImplementation(asAsyncRead((filePath: string) => {
+          if (filePath.includes(STATE_FILE_SUFFIX)) {
             const error = new Error('ENOENT') as NodeJS.ErrnoException;
             error.code = 'ENOENT';
             throw error;
@@ -1389,7 +1406,7 @@ Content`;
 name: test-agent
 ---
 Content`;
-        });
+        }));
 
         const newState = {
           goals: [{ id: 'goal_1', description: 'First goal', status: 'pending' }],
@@ -1401,7 +1418,7 @@ Content`;
         };
 
         // Should succeed - no existing state to conflict with
-        await expect(agentManager.exposedSaveAgentState('test-agent', newState as any))
+        await expect(agentManager.exposedSaveAgentState(TEST_AGENT_NAME, newState as any))
           .resolves.not.toThrow();
       });
     });

--- a/tests/unit/elements/ensembles/EnsembleManager.test.ts
+++ b/tests/unit/elements/ensembles/EnsembleManager.test.ts
@@ -16,7 +16,7 @@ jest.mock('../../../../src/utils/logger.js');
 import { EnsembleManager } from '../../../../src/elements/ensembles/EnsembleManager.js';
 import { resolveElementTypes } from '../../../../src/utils/elementTypeResolver.js';
 import { Ensemble } from '../../../../src/elements/ensembles/Ensemble.js';
-import { EnsembleMetadata } from '../../../../src/elements/ensembles/types.js';
+import type { EnsembleMetadata } from '../../../../src/elements/ensembles/types.js';
 import { ElementType } from '../../../../src/portfolio/types.js';
 import { FileLockManager } from '../../../../src/security/fileLockManager.js';
 import { FileOperationsService } from '../../../../src/services/FileOperationsService.js';
@@ -29,6 +29,16 @@ import { ValidationService } from '../../../../src/services/validation/Validatio
 import { ElementEventDispatcher } from '../../../../src/events/ElementEventDispatcher.js';
 import { createTestStorageFactory } from '../../../helpers/createTestStorageFactory.js';
 import { logger } from '../../../../src/utils/logger.js';
+
+const LEGACY_SKILL_NAME = 'legacy-skill';
+
+function atomicReadFileMock(manager: FileLockManager): jest.MockedFunction<FileLockManager['atomicReadFile']> {
+  return manager.atomicReadFile as jest.MockedFunction<FileLockManager['atomicReadFile']>;
+}
+
+function atomicWriteFileMock(manager: FileLockManager): jest.MockedFunction<FileLockManager['atomicWriteFile']> {
+  return manager.atomicWriteFile as jest.MockedFunction<FileLockManager['atomicWriteFile']>;
+}
 
 describe('EnsembleManager', () => {
   let ensembleManager: EnsembleManager;
@@ -76,7 +86,7 @@ describe('EnsembleManager', () => {
     jest.clearAllMocks();
 
     // Set default mock implementations
-    fileLockManager.atomicWriteFile = jest.fn(() => Promise.resolve(undefined)) as any;
+    fileLockManager.atomicWriteFile = jest.fn(() => Promise.resolve()) as any;
     fileLockManager.atomicReadFile = jest.fn(() => Promise.resolve('')) as any;
     fileLockManager.withLock = jest.fn((resource: string, operation: () => Promise<any>) => operation()) as any;
     (SecurityMonitor as any).logSecurityEvent = jest.fn();
@@ -113,11 +123,11 @@ describe('EnsembleManager', () => {
       expect(ensemble).toBeInstanceOf(Ensemble);
       expect(ensemble.metadata.name).toBe('Test Ensemble');
       expect(ensemble.metadata.activationStrategy).toBe('sequential');
-      expect(ensemble.metadata.elements.length).toBe(1);
+      expect(ensemble.metadata.elements).toHaveLength(1);
 
       // CRITICAL: Verify file was saved to disk
       expect(fileLockManager.atomicWriteFile).toHaveBeenCalled();
-      const writeCall = (fileLockManager.atomicWriteFile as jest.Mock).mock.calls[0];
+      const writeCall = atomicWriteFileMock(fileLockManager).mock.calls[0];
       const [actualPath, content] = writeCall as [string, string];
 
       // Verify the filename
@@ -146,7 +156,7 @@ describe('EnsembleManager', () => {
         description: 'Testing legacy field migration',
         elements: [
           {
-            name: 'legacy-skill',  // Legacy field
+            name: LEGACY_SKILL_NAME,  // Legacy field
             type: 'skill',         // Legacy field
             role: 'primary',
             priority: 80,
@@ -158,9 +168,9 @@ describe('EnsembleManager', () => {
       const ensemble = await ensembleManager.create(metadata);
 
       expect(ensemble).toBeInstanceOf(Ensemble);
-      expect(ensemble.metadata.elements.length).toBe(1);
+      expect(ensemble.metadata.elements).toHaveLength(1);
       // Verify migration happened - element should have element_name/element_type
-      expect(ensemble.metadata.elements[0].element_name).toBe('legacy-skill');
+      expect(ensemble.metadata.elements[0].element_name).toBe(LEGACY_SKILL_NAME);
       expect(ensemble.metadata.elements[0].element_type).toBe('skill');
     });
 
@@ -170,7 +180,7 @@ describe('EnsembleManager', () => {
         name: 'Legacy Parse Ensemble',
         elements: [
           {
-            name: 'legacy-skill',
+            name: LEGACY_SKILL_NAME,
             type: 'skill',
             role: 'primary',
             priority: 80,
@@ -201,7 +211,7 @@ describe('EnsembleManager', () => {
         description: 'Testing bounded legacy warnings',
         elements: [
           {
-            name: 'legacy-skill',
+            name: LEGACY_SKILL_NAME,
             type: 'skill',
             role: 'primary',
             priority: 80,
@@ -223,7 +233,7 @@ describe('EnsembleManager', () => {
         name: 'Legacy Resettable Warning Ensemble',
         elements: [
           {
-            name: 'legacy-skill',
+            name: LEGACY_SKILL_NAME,
             type: 'skill',
             role: 'primary',
             priority: 80,
@@ -264,6 +274,7 @@ describe('EnsembleManager', () => {
       const yamlContent = `---
 name: Imported Ensemble
 description: Imported from YAML
+instructions: Coordinate the imported elements.
 activationStrategy: all
 conflictResolution: priority
 elements:
@@ -287,8 +298,15 @@ This is ensemble documentation.
 
       expect(ensemble.metadata.name).toBe('Imported Ensemble');
       expect(ensemble.metadata.activationStrategy).toBe('all');
-      expect(ensemble.metadata.elements.length).toBe(2);
+      expect(ensemble.metadata.elements).toHaveLength(2);
       expect(ensemble.metadata.elements[0].element_name).toBe('element1');
+      expect(ensemble.instructions).toBe('Coordinate the imported elements.');
+      expect(ensemble.metadata.instructions).toBeUndefined();
+      expect(ensemble.content).toContain('This is ensemble documentation.');
+
+      const exported = await ensembleManager.exportElement(ensemble, 'yaml');
+      expect(exported).toContain('instructions: Coordinate the imported elements.');
+      expect(exported).toContain('This is ensemble documentation.');
     });
 
     it('should import ensemble from JSON', async () => {
@@ -367,14 +385,14 @@ This is ensemble documentation.
       const fullPath = path.join(portfolioPath, 'ensembles', filePath);
 
       // Mock successful save
-      (fileLockManager.atomicWriteFile as jest.Mock).mockResolvedValueOnce(undefined);
+      atomicWriteFileMock(fileLockManager).mockImplementationOnce(() => Promise.resolve());
 
       await ensembleManager.save(ensemble, filePath);
 
-      const calls = (fileLockManager.atomicWriteFile as jest.Mock).mock.calls;
+      const calls = atomicWriteFileMock(fileLockManager).mock.calls;
       expect(calls.length).toBeGreaterThan(0);
 
-      const [actualPath, content, options] = calls[calls.length - 1] as [string, string, { encoding: string }];
+      const [actualPath, content, options] = calls.at(-1) as [string, string, { encoding: string }];
 
       // Normalize paths for cross-platform comparison (handles /var → /private/var on macOS)
       // Since the file hasn't been written yet (mocked), normalize parent directories
@@ -417,13 +435,13 @@ Test instructions.
       await fs.writeFile(fullPath, fileContent, 'utf-8');
 
       // Mock file read
-      (fileLockManager.atomicReadFile as jest.Mock).mockResolvedValueOnce(fileContent);
+      atomicReadFileMock(fileLockManager).mockResolvedValueOnce(fileContent);
 
       const ensemble = await ensembleManager.load(filePath);
 
       expect(ensemble.metadata.name).toBe('Load Test');
       expect(ensemble.metadata.activationStrategy).toBe('priority');
-      expect(ensemble.metadata.elements.length).toBe(1);
+      expect(ensemble.metadata.elements).toHaveLength(1);
       expect(ensemble.metadata.elements[0].element_name).toBe('loaded-element');
     });
 
@@ -448,9 +466,8 @@ elements:
       const fullPath = path.join(portfolioPath, 'ensembles', filePath);
       await fs.writeFile(fullPath, fileContent, 'utf-8');
       mockPortfolioManager.listElements.mockResolvedValue([filePath]);
-      (fileLockManager.atomicReadFile as jest.Mock).mockImplementation(async (targetPath: string) =>
-        fs.readFile(targetPath, 'utf-8')
-      );
+      atomicReadFileMock(fileLockManager).mockImplementation((targetPath: string) =>
+        fs.readFile(targetPath, 'utf-8'));
 
       await ensembleManager.load(filePath);
       await ensembleManager.load(filePath);
@@ -479,9 +496,8 @@ elements:
       const fullPath = path.join(portfolioPath, 'ensembles', filePath);
       await fs.writeFile(fullPath, fileContent, 'utf-8');
       mockPortfolioManager.listElements.mockResolvedValue([filePath]);
-      (fileLockManager.atomicReadFile as jest.Mock).mockImplementation(async (targetPath: string) =>
-        fs.readFile(targetPath, 'utf-8')
-      );
+      atomicReadFileMock(fileLockManager).mockImplementation((targetPath: string) =>
+        fs.readFile(targetPath, 'utf-8'));
 
       const result = await ensembleManager.repairLegacyElementFields();
 
@@ -497,9 +513,9 @@ elements:
         ]
       });
 
-      const writes = (fileLockManager.atomicWriteFile as jest.Mock).mock.calls;
+      const writes = atomicWriteFileMock(fileLockManager).mock.calls;
       expect(writes.length).toBeGreaterThan(0);
-      const [, content] = writes[writes.length - 1] as [string, string];
+      const [, content] = writes.at(-1) as [string, string];
       const contentLines = content.split('\n').map((line) => line.trim());
       expect(content).toContain('element_name: repair-skill');
       expect(content).toContain('element_type: skill');
@@ -625,7 +641,7 @@ elements:
       const yamlContent = `---
 name: Too Many Elements
 elements:
-${tooManyElements.map(e => `  - name: ${e.element_name}
+${tooManyElements.map(e => `  - name: ${e.name}
     type: ${e.element_type}
     role: ${e.role}
     priority: ${e.priority}
@@ -715,7 +731,7 @@ elements:
     it('should resolve element_type when found in exactly one manager', async () => {
       const mockManagers = {
         skillManager: { findByName: jest.fn<(name: string) => Promise<any>>().mockResolvedValue({ metadata: { name: 'found-skill' } }) },
-        templateManager: { findByName: jest.fn<(name: string) => Promise<any>>().mockResolvedValue(undefined) },
+        templateManager: { findByName: jest.fn<(name: string) => Promise<any>>().mockReturnValue(Promise.resolve()) },
       };
 
       const elements = [
@@ -747,8 +763,8 @@ elements:
 
     it('should report elements not found in any manager', async () => {
       const mockManagers = {
-        skillManager: { findByName: jest.fn<(name: string) => Promise<any>>().mockResolvedValue(undefined) },
-        templateManager: { findByName: jest.fn<(name: string) => Promise<any>>().mockResolvedValue(undefined) },
+        skillManager: { findByName: jest.fn<(name: string) => Promise<any>>().mockReturnValue(Promise.resolve()) },
+        templateManager: { findByName: jest.fn<(name: string) => Promise<any>>().mockReturnValue(Promise.resolve()) },
       };
 
       const elements = [
@@ -762,7 +778,7 @@ elements:
 
     it('should resolve persona via findPersona method', async () => {
       const mockManagers = {
-        skillManager: { findByName: jest.fn<(name: string) => Promise<any>>().mockResolvedValue(undefined) },
+        skillManager: { findByName: jest.fn<(name: string) => Promise<any>>().mockReturnValue(Promise.resolve()) },
         personaManager: { findPersona: jest.fn<(name: string) => any>().mockReturnValue({ metadata: { name: 'my-persona' } }) },
       };
 
@@ -777,10 +793,11 @@ elements:
 
     it('should handle mixed elements: some with type, some needing resolution', async () => {
       const mockManagers = {
-        skillManager: { findByName: jest.fn<(name: string) => Promise<any>>().mockResolvedValue(undefined) },
-        templateManager: { findByName: jest.fn<(name: string) => Promise<any>>().mockImplementation(async (name: string) => {
-          return name === 'found-template' ? { metadata: { name: 'found-template' } } : undefined;
-        }) },
+        skillManager: { findByName: jest.fn<(name: string) => Promise<any>>().mockReturnValue(Promise.resolve()) },
+        templateManager: {
+          findByName: jest.fn<(name: string) => Promise<any>>().mockImplementation((name: string) =>
+            Promise.resolve(name === 'found-template' ? { metadata: { name: 'found-template' } } : undefined)),
+        },
       };
 
       const elements = [
@@ -816,7 +833,7 @@ elements:
     it('should validate resolved types against canonical element type map', async () => {
       const mockManagers = {
         skillManager: { findByName: jest.fn<(name: string) => Promise<any>>().mockResolvedValue({ metadata: { name: 'valid-skill' } }) },
-        templateManager: { findByName: jest.fn<(name: string) => Promise<any>>().mockResolvedValue(undefined) },
+        templateManager: { findByName: jest.fn<(name: string) => Promise<any>>().mockReturnValue(Promise.resolve()) },
       };
 
       const elements = [
@@ -887,7 +904,7 @@ elements: []
       // Use mockImplementation to return based on filename for deterministic ordering
       // BaseElementManager.list() uses Promise.all() which executes in parallel,
       // so mockResolvedValueOnce may return in unpredictable order
-      (fileLockManager.atomicReadFile as jest.Mock).mockImplementation((filePath: string) => {
+      atomicReadFileMock(fileLockManager).mockImplementation((filePath: string) => {
         if (filePath.includes('ensemble1')) return Promise.resolve(fileContent1);
         if (filePath.includes('ensemble2')) return Promise.resolve(fileContent2);
         return Promise.reject(new Error('Unknown file'));
@@ -895,7 +912,7 @@ elements: []
 
       const ensembles = await ensembleManager.list();
 
-      expect(ensembles.length).toBe(2);
+      expect(ensembles).toHaveLength(2);
       expect(ensembles[0].metadata.name).toBe('Ensemble 1');
       expect(ensembles[1].metadata.name).toBe('Ensemble 2');
     });
@@ -985,25 +1002,25 @@ elements:
       // Write initial file and warm the cache
       await fs.writeFile(filePath, originalContent, 'utf-8');
       mockPortfolioManager.listElements.mockResolvedValue([fileName]);
-      (fileLockManager.atomicReadFile as jest.Mock).mockResolvedValue(originalContent);
+      atomicReadFileMock(fileLockManager).mockResolvedValue(originalContent);
 
       // list() triggers a scan that stores the mtime and populates the LRU cache
       const initial = await ensembleManager.list();
-      expect(initial[0].metadata.elements.length).toBe(2);
+      expect(initial[0].metadata.elements).toHaveLength(2);
 
       // Simulate external edit: overwrite file on disk (changing mtime) and update mock
       await fs.writeFile(filePath, updatedContent, 'utf-8');
       // Advance mtime explicitly to guarantee the scan sees a change
       const futureTime = new Date(Date.now() + 5000);
       await fs.utimes(filePath, futureTime, futureTime);
-      (fileLockManager.atomicReadFile as jest.Mock).mockResolvedValue(updatedContent);
+      atomicReadFileMock(fileLockManager).mockResolvedValue(updatedContent);
 
       // activateEnsemble must call scanAndEvict() so the LRU entry is flushed
       const result = await ensembleManager.activateEnsemble('DQM Stack');
 
       expect(result.success).toBe(true);
       // Without the fix, this returns 2 (stale cache). With the fix, it returns 3.
-      expect(result.ensemble?.metadata.elements.length).toBe(3);
+      expect(result.ensemble?.metadata.elements).toHaveLength(3);
     });
 
     it('should not return stale data on repeated activate-deactivate-activate cycle', async () => {
@@ -1016,12 +1033,12 @@ elements:
 
       await fs.writeFile(filePath, v1, 'utf-8');
       mockPortfolioManager.listElements.mockResolvedValue([fileName]);
-      (fileLockManager.atomicReadFile as jest.Mock).mockResolvedValue(v1);
+      atomicReadFileMock(fileLockManager).mockResolvedValue(v1);
       await ensembleManager.list();
 
       // First activation: should get v1 (1 element)
       const r1 = await ensembleManager.activateEnsemble('Cycle Ensemble');
-      expect(r1.ensemble?.metadata.elements.length).toBe(1);
+      expect(r1.ensemble?.metadata.elements).toHaveLength(1);
 
       await ensembleManager.deactivateEnsemble('Cycle Ensemble');
 
@@ -1029,11 +1046,11 @@ elements:
       await fs.writeFile(filePath, v2, 'utf-8');
       const futureTime = new Date(Date.now() + 5000);
       await fs.utimes(filePath, futureTime, futureTime);
-      (fileLockManager.atomicReadFile as jest.Mock).mockResolvedValue(v2);
+      atomicReadFileMock(fileLockManager).mockResolvedValue(v2);
 
       // Second activation: must NOT serve stale 1-element cache
       const r2 = await ensembleManager.activateEnsemble('Cycle Ensemble');
-      expect(r2.ensemble?.metadata.elements.length).toBe(2);
+      expect(r2.ensemble?.metadata.elements).toHaveLength(2);
     });
   });
 
@@ -1050,13 +1067,15 @@ elements:
       expect(ensemble.metadata.name).toBe('Body Test');
 
       // Verify the written content includes a markdown body
-      const writeCall = (fileLockManager.atomicWriteFile as jest.Mock).mock.calls[
-        (fileLockManager.atomicWriteFile as jest.Mock).mock.calls.length - 1
-      ];
+      const writeCall = atomicWriteFileMock(fileLockManager).mock.calls.at(
+        -1
+      );
       const [, content] = writeCall as [string, string];
 
       // File should have content after the closing ---
-      expect(content).toMatch(/---\s*\n[\s\S]+\n---\s*\n[\s\S]+/);
+      const closingDelimiter = content.indexOf('\n---\n');
+      expect(closingDelimiter).toBeGreaterThan(0);
+      expect(content.slice(closingDelimiter + 5).trim()).not.toBe('');
       expect(content).toContain('Body Test');
     });
 
@@ -1083,7 +1102,7 @@ elements:
 `;
       const ensemblesDir = path.join(portfolioPath, 'ensembles');
       await fs.writeFile(path.join(ensemblesDir, 'legacy-ensemble.md'), fileContent, 'utf-8');
-      (fileLockManager.atomicReadFile as jest.Mock).mockResolvedValueOnce(fileContent);
+      atomicReadFileMock(fileLockManager).mockResolvedValueOnce(fileContent);
 
       // Should load without throwing
       const loaded = await ensembleManager.load('legacy-ensemble.md');
@@ -1112,7 +1131,7 @@ elements:
 `;
       const ensemblesDir = path.join(portfolioPath, 'ensembles');
       await fs.writeFile(path.join(ensemblesDir, 'emdash-ensemble.md'), fileContent, 'utf-8');
-      (fileLockManager.atomicReadFile as jest.Mock).mockResolvedValueOnce(fileContent);
+      atomicReadFileMock(fileLockManager).mockResolvedValueOnce(fileContent);
 
       const loaded = await ensembleManager.load('emdash-ensemble.md');
       expect(loaded.metadata.description).toContain('—');

--- a/tests/unit/web-console/modules/PortfolioModule.test.ts
+++ b/tests/unit/web-console/modules/PortfolioModule.test.ts
@@ -87,7 +87,7 @@ function userIntegration(overrides: Partial<UserIntegrationRecord> = {}): UserIn
   return {
     id: INTEGRATION_ID,
     userId: USER_ID,
-    provider: 'github',
+    provider: 'github' as UserIntegrationRecord['provider'],
     externalAccountLabel: 'alice',
     externalInstallationId: 'installation-123',
     authorizedPermissions: {
@@ -601,7 +601,9 @@ describe('PortfolioModule', () => {
 
     await expect(update.handler(consoleRequest({
       params: { type: 'skills', name: REVIEW_HELPER_NAME },
-      headers: { 'if-match': [REVIEW_HELPER_V3_ETAG] },
+      // Node may expose a repeated header as an array even though ConsoleRequest's
+      // normalized public type is string-valued; exercise that defensive path.
+      headers: { 'if-match': [REVIEW_HELPER_V3_ETAG] } as unknown as ConsoleRequest['headers'],
       body: { content: '# Array header' },
     }))).resolves.toMatchObject({
       status: 200,
@@ -820,6 +822,51 @@ describe('PortfolioModule', () => {
       version: 3,
       content: '# Review Helper\nOwner private content.',
     });
+  });
+
+  it('applies element-type content requirements to guided drafts', async () => {
+    const { module } = moduleFixture([]);
+    const validate = findRoute(module.routes, ELEMENT_VALIDATE_PATH, 'POST');
+    const contentOptional = [
+      { type: 'personas', metadata: { instructions: 'Act as a careful reviewer.' } },
+      { type: 'skills', metadata: { instructions: 'Review the input in ordered steps.' } },
+      { type: 'agents', metadata: { goal: { template: 'Review {topic}', parameters: [] } } },
+      {
+        type: 'ensembles',
+        metadata: {
+          elements: [{
+            element_name: 'review-helper',
+            element_type: 'skill',
+            role: 'primary',
+            priority: 10,
+            activation: 'always',
+          }],
+        },
+      },
+    ] as const;
+
+    for (const fixture of contentOptional) {
+      await expect(validate.handler(consoleRequest({
+        params: { type: fixture.type, name: `guided-${fixture.type}` },
+        body: { content: '', metadata: fixture.metadata },
+      }))).resolves.toEqual({
+        status: 200,
+        body: { valid: true, issues: [] },
+      });
+    }
+
+    for (const type of ['templates', 'memories']) {
+      await expect(validate.handler(consoleRequest({
+        params: { type, name: `empty-${type}` },
+        body: { content: '', metadata: {} },
+      }))).resolves.toMatchObject({
+        status: 200,
+        body: {
+          valid: false,
+          issues: [expect.objectContaining({ path: 'content', code: 'required' })],
+        },
+      });
+    }
   });
 
   it('starts portfolio sync jobs only for connected integrations with sufficient permissions', async () => {


### PR DESCRIPTION
## Summary

Adds guided portfolio self-service and account settings to the web console, allowing users to browse, create, import, edit, validate, and manage elements without needing to understand their underlying file formats.

## What changed

- Combines the complete Collection catalog and user Portfolio in the All view with accurate totals and filters.
- Adds guided Create and file-import workflows for personas, skills, templates, agents, memories, and ensembles.
- Adds type-specific field guidance, validation, previews, safe editing, deletion, and GitHub sync controls.
- Preserves unmapped metadata during imports and edits while keeping raw JSON behind optional developer controls.
- Adds profile display-name and saved-theme settings.
- Protects writes with ETags, explicit conflict handling, duplicate-import protection, and capability-aware controls.
- Aligns AgentManager create/import serialization and database-backed deletion behavior with portfolio authoring.

## Test coverage

- Covers combined Collection and Portfolio browsing, filtering, pagination, and totals.
- Covers guided creation, local file imports, metadata preservation, validation, cancellation, conflicts, and deletion.
- Covers account profile and appearance settings, including unsupported saved values and stale-write protection.
- Covers AgentManager content handling and database-backed state deletion.
- Covers capability gating when portfolio write routes are unavailable.

## Verification

- Build, script type-check, ESLint, local Sonar lint, and `git diff --check` passed.
- AgentManager tests passed: 59 unit and 3 PostgreSQL integration.
- Console tests passed: 9 authenticated browser and 23 API E2E.
- Manual headed-browser review completed successfully.

## Scope

This change primarily adds web-console UI assets and test coverage, with targeted AgentManager production changes needed by portfolio authoring. It does not add API routes, database schemas, migrations, dependencies, or lockfile changes.