### PR TITLE
feat(web-console): add operations control workspace

### DIFF
--- a/src/web-console/modules/operations/OperationsConfig.ts
+++ b/src/web-console/modules/operations/OperationsConfig.ts
@@ -191,7 +191,7 @@ export class OperatorConfigurationService {
       sensitivity: definition.sensitivity,
       mutability: definition.mutability,
       value_schema: definition.schema,
-      effective_at: metadata.pendingRestart ? null : metadata.effectiveAt ?? effectiveAt(config),
+      effective_at: metadata.pendingRestart ? null : metadata.effectiveAt,
       pending_restart: metadata.pendingRestart,
       etag: settingEtag(config, definition),
     };
@@ -291,7 +291,6 @@ function settingEtag(config: OperatorConfig, definition: OperatorConfigSettingDe
     sensitivity: definition.sensitivity,
     configured: definition.sensitivity === 'secret_write_only' ? isConfiguredSecret(value) : undefined,
     value: definition.sensitivity === 'secret_write_only' ? undefined : value,
-    updatedAt: config.updatedAt,
     metadata: configMetadata(config, definition.key),
   };
   const digest = createHash('sha256').update(canonicalJson(payload)).digest('base64url').slice(0, 32);
@@ -325,10 +324,6 @@ function setConfigMetadata(
     : {};
   root[key] = metadata;
   config.defaultsConfig[CONFIG_METADATA_KEY] = root;
-}
-
-function effectiveAt(config: OperatorConfig): string | null {
-  return config.updatedAt > 0 ? new Date(config.updatedAt).toISOString() : null;
 }
 
 function isConfiguredSecret(value: unknown): boolean {

--- a/src/web-console/ui/admin-metrics.js
+++ b/src/web-console/ui/admin-metrics.js
@@ -13,6 +13,8 @@
  */
 
 import { get } from './api.js';
+import { isAbortError } from './polling.js';
+import { escapeHtml } from './operations-ui.js';
 
 const REFRESH_MS = 10000;
 // A multi-instance source with this many instances renders as a full-width
@@ -23,38 +25,65 @@ let host;
 let notify = () => {};
 let timer = null;
 let tabActive = true;
+let sectionActive = false;
+let tabName = 'operations';
+let loadController;
 
 const state = { snapshot: null, meta: null, loading: true, error: false, disabled: false, autoRefresh: false };
 
-export async function init(panelEl, ctx = {}) {
+export function init(panelEl, ctx = {}) {
   host = panelEl;
   notify = ctx.toast || notify;
+  tabName = ctx.tabName || tabName;
   host.innerHTML = shell();
-  host.querySelector('#am-refresh').addEventListener('click', () => load());
+  host.querySelector('#am-refresh').addEventListener('click', () => refresh());
   host.querySelector('#am-auto').addEventListener('change', (e) => { state.autoRefresh = e.target.checked; syncTimer(); });
-  await load();
   globalThis.addEventListener('dh:tab-activated', onTabActivated);
-  document.addEventListener('visibilitychange', syncTimer);
+  document.addEventListener('visibilitychange', onDocumentVisibilityChanged);
+  return Object.freeze({
+    refresh,
+    setVisible(visible) {
+      sectionActive = visible;
+      if (visible) refresh();
+      else abortLoad();
+      syncTimer();
+    },
+  });
 }
 
-async function load() {
-  state.loading = true;
+async function refresh(externalSignal) {
+  abortLoad();
+  const controller = new AbortController();
+  loadController = controller;
+  const abort = () => controller.abort();
+  externalSignal?.addEventListener('abort', abort, { once: true });
+  state.loading = !state.snapshot;
   state.error = false;
   renderBody();
-  const res = await get('/admin/operate/metrics/system?latest=true').catch(() => null);
-  if (!res || res.status !== 200 || !res.body) {
+  try {
+    const res = await get('/admin/operate/metrics/system?latest=true', { signal: controller.signal });
+    if (res.status !== 200 || !res.body) {
+      state.error = true;
+      state.loading = false;
+      renderBody();
+      return;
+    }
+    const snapshots = Array.isArray(res.body.items) ? res.body.items : [];
+    state.snapshot = snapshots.length > 0 ? snapshots.at(-1) : null;
+    state.meta = { newest: res.body.newest_available, nextCursor: res.body.page?.next_cursor ?? null };
+    state.disabled = snapshots.length === 0; // empty result = collection disabled or nothing captured yet
+    state.loading = false;
+    state.error = false;
+    renderBody();
+  } catch (error) {
+    if (isAbortError(error)) return;
     state.error = true;
     state.loading = false;
     renderBody();
-    return;
+  } finally {
+    externalSignal?.removeEventListener('abort', abort);
+    if (loadController === controller) loadController = undefined;
   }
-  const snapshots = Array.isArray(res.body.snapshots) ? res.body.snapshots : [];
-  state.snapshot = snapshots.length > 0 ? snapshots[snapshots.length - 1] : null;
-  state.meta = { newest: res.body.newest_available, total: res.body.total };
-  state.disabled = snapshots.length === 0; // empty result = collection disabled or nothing captured yet
-  state.loading = false;
-  state.error = false;
-  renderBody();
 }
 
 /* ── Markup ─────────────────────────────────────────────────────────────── */
@@ -62,7 +91,7 @@ async function load() {
 function shell() {
   return `
   <div class="metrics-status-bar">
-    <span class="metrics-scope-label">System metrics</span>
+    <span class="metrics-scope-label">In-process metrics</span>
     <span class="metrics-checked" id="am-checked"></span>
     <div class="metrics-bar-actions">
       <label class="metrics-auto"><input type="checkbox" id="am-auto"> Auto-refresh</label>
@@ -79,7 +108,7 @@ function renderBody() {
   if (checked) checked.textContent = state.snapshot && !state.loading ? `as of ${relAgo(state.snapshot.timestamp)}` : '';
 
   if (state.loading) { body.innerHTML = '<div class="metrics-loading">Loading system metrics…</div>'; return; }
-  if (state.error) { body.innerHTML = '<div class="metrics-loading">Couldn\'t load system metrics. Admin elevation is required.</div>'; return; }
+  if (state.error && !state.snapshot) { body.innerHTML = '<div class="metrics-loading">Couldn\'t load system metrics. Admin elevation is required.</div>'; return; }
   if (state.disabled || !state.snapshot) {
     body.innerHTML = '<div class="metrics-loading">No metrics captured. Server-side metrics collection may be disabled (DOLLHOUSE_METRICS_ENABLED).</div>';
     return;
@@ -88,17 +117,23 @@ function renderBody() {
   const metrics = Array.isArray(state.snapshot.metrics) ? state.snapshot.metrics : [];
   const errors = Array.isArray(state.snapshot.errors) ? state.snapshot.errors : [];
   const sources = groupBySource(metrics);
+  const errorAlert = errors.length
+    ? `<div class="metrics-alert metrics-alert--warn">${errors.map(escapeHtml).join('<br>')}</div>`
+    : '';
+  const staleAlert = state.error
+    ? '<div class="metrics-alert metrics-alert--warn">System metrics could not be refreshed. Showing the last successful snapshot.</div>'
+    : '';
 
   const overview = `<div class="metrics-stat-grid">
         ${stat(formatNumber(metrics.length), 'Metrics')}
         ${stat(formatNumber(sources.length), 'Sources')}
         ${stat(formatNumber(errors.length), 'Collector errors')}
         ${stat(`${round(Number(state.snapshot.duration_ms || 0))}ms`, 'Collection time')}
-      </div>${errors.length ? `<div class="metrics-alert metrics-alert--warn">${errors.map(escapeHtml).join('<br>')}</div>` : ''}`;
+      </div>${errorAlert}`;
 
   body.innerHTML = `
     <div class="metrics-dashboard">
-      ${overviewCard(overview)}
+      ${staleAlert}${overviewCard(overview)}
       ${sources.map(s => sourceCard(s.source, s.badge, s.matrix ? sourceMatrix(s.metrics) : sourceTable(s.metrics), s.wide)).join('')}
     </div>`;
 }
@@ -213,17 +248,23 @@ function sourceMatrix(metrics) {
   for (const m of metrics) { const k = instanceKeyOf(m); if (!seen.has(k)) { seen.add(k); instances.push(k); } }
   const names = [...new Set(metrics.map(m => m.name))].sort((a, b) => a.localeCompare(b));
   const cell = new Map();
-  for (const m of metrics) cell.set(`${m.name} ${instanceKeyOf(m)}`, m);
+  for (const metric of metrics) {
+    const instance = instanceKeyOf(metric);
+    if (!cell.has(metric.name)) cell.set(metric.name, new Map());
+    cell.get(metric.name).set(instance, metric);
+  }
 
-  const head = `<tr><th>Metric</th>${instances.map(i => `<th class="metrics-num">${escapeHtml(i)}</th>`).join('')}</tr>`;
+  const columnHeaders = instances.map(i => `<th class="metrics-num">${escapeHtml(i)}</th>`).join('');
+  const head = `<tr><th>Metric</th>${columnHeaders}</tr>`;
   const rows = names.map(name => {
     const sample = metrics.find(m => m.name === name);
     const unit = sample && sample.unit !== 'bytes' ? sample.unit : '';
     const cells = instances.map(i => {
-      const m = cell.get(`${name} ${i}`);
+      const m = cell.get(name)?.get(i);
       return m ? `<td class="metrics-num">${matrixCell(m)}</td>` : '<td class="metrics-num metrics-dim">—</td>';
     }).join('');
-    return `<tr><td>${escapeHtml(name)}${unit ? ` <span class="metrics-unit">${escapeHtml(unit)}</span>` : ''}</td>${cells}</tr>`;
+    const unitMarkup = unit ? ` <span class="metrics-unit">${escapeHtml(unit)}</span>` : '';
+    return `<tr><td>${escapeHtml(name)}${unitMarkup}</td>${cells}</tr>`;
   }).join('');
   return `<div class="metrics-matrix-wrap"><table class="metrics-table metrics-matrix"><thead>${head}</thead><tbody>${rows}</tbody></table></div>`;
 }
@@ -245,15 +286,26 @@ function stat(value, label) {
 /* ── Polling ────────────────────────────────────────────────────────────── */
 
 function syncTimer() {
-  const shouldRun = state.autoRefresh && tabActive && !document.hidden;
-  if (shouldRun && !timer) timer = setInterval(load, REFRESH_MS);
+  const shouldRun = state.autoRefresh && tabActive && sectionActive && !document.hidden;
+  if (shouldRun && !timer) timer = setInterval(refresh, REFRESH_MS);
   else if (!shouldRun && timer) { clearInterval(timer); timer = null; }
 }
 
 function onTabActivated(e) {
-  tabActive = e.detail?.name === 'admin-metrics';
-  if (tabActive) load();
+  tabActive = e.detail?.name === tabName;
+  if (tabActive && sectionActive) refresh();
   syncTimer();
+}
+
+function onDocumentVisibilityChanged() {
+  if (document.hidden) abortLoad();
+  else if (tabActive && sectionActive) refresh();
+  syncTimer();
+}
+
+function abortLoad() {
+  loadController?.abort();
+  loadController = undefined;
 }
 
 /* ── Helpers ────────────────────────────────────────────────────────────── */
@@ -285,9 +337,4 @@ function relAgo(ts) {
   const m = Math.floor(s / 60);
   if (m < 60) return `${m}m ago`;
   return `${Math.floor(m / 60)}h ago`;
-}
-
-function escapeHtml(s) {
-  if (s === null || s === undefined) return '';
-  return String(s).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;');
 }

--- a/src/web-console/ui/admin-metrics.js
+++ b/src/web-console/ui/admin-metrics.js
@@ -22,24 +22,17 @@ const REFRESH_MS = 10000;
 const WIDE_INSTANCE_THRESHOLD = 7;
 
 let host;
-let notify = () => {};
 let timer = null;
-let tabActive = true;
 let sectionActive = false;
-let tabName = 'operations';
 let loadController;
 
 const state = { snapshot: null, meta: null, loading: true, error: false, disabled: false, autoRefresh: false };
 
-export function init(panelEl, ctx = {}) {
+export function init(panelEl) {
   host = panelEl;
-  notify = ctx.toast || notify;
-  tabName = ctx.tabName || tabName;
   host.innerHTML = shell();
   host.querySelector('#am-refresh').addEventListener('click', () => refresh());
   host.querySelector('#am-auto').addEventListener('change', (e) => { state.autoRefresh = e.target.checked; syncTimer(); });
-  globalThis.addEventListener('dh:tab-activated', onTabActivated);
-  document.addEventListener('visibilitychange', onDocumentVisibilityChanged);
   return Object.freeze({
     refresh,
     setVisible(visible) {
@@ -144,7 +137,7 @@ function renderBody() {
 // instead of a long, repetitive flat list.
 function instanceKeyOf(m) {
   const labels = m.labels || {};
-  const keys = Object.keys(labels).sort();
+  const keys = Object.keys(labels).sort((left, right) => left.localeCompare(right));
   return keys.length ? keys.map(k => labels[k]).join(' · ') : '(default)';
 }
 
@@ -286,21 +279,9 @@ function stat(value, label) {
 /* ── Polling ────────────────────────────────────────────────────────────── */
 
 function syncTimer() {
-  const shouldRun = state.autoRefresh && tabActive && sectionActive && !document.hidden;
+  const shouldRun = state.autoRefresh && sectionActive && !document.hidden;
   if (shouldRun && !timer) timer = setInterval(refresh, REFRESH_MS);
   else if (!shouldRun && timer) { clearInterval(timer); timer = null; }
-}
-
-function onTabActivated(e) {
-  tabActive = e.detail?.name === tabName;
-  if (tabActive && sectionActive) refresh();
-  syncTimer();
-}
-
-function onDocumentVisibilityChanged() {
-  if (document.hidden) abortLoad();
-  else if (tabActive && sectionActive) refresh();
-  syncTimer();
 }
 
 function abortLoad() {

--- a/src/web-console/ui/app.js
+++ b/src/web-console/ui/app.js
@@ -54,9 +54,17 @@ const TAB_MODULES = {
     load: () => import('./logs.js'),
     requiredRoutes: [['GET', '/me/logs']],
   },
-  'admin-metrics': {
-    load: () => import('./admin-metrics.js'),
-    requiredRoutes: [['GET', '/admin/operate/metrics/system']],
+  operations: {
+    load: () => import('./operations.js'),
+    requiredRoutes: [],
+    requiredAnyRoutes: [
+      ['GET', '/admin/operate/health'],
+      ['GET', '/admin/operate/config'],
+      ['GET', '/admin/operate/logs'],
+      ['GET', '/admin/operate/metrics'],
+      ['GET', '/admin/operate/metrics/system'],
+      ['GET', '/admin/operate/sessions'],
+    ],
   },
   integrations: {
     load: () => import('./integrations.js'),
@@ -95,7 +103,7 @@ function activateTab(name) {
 
 function ensureTabModule(name) {
   const definition = TAB_MODULES[name];
-  if (!definition || !consoleMetadata?.hasRoutes(definition.requiredRoutes)) return Promise.resolve();
+  if (!tabDefinitionAvailable(definition, consoleMetadata)) return Promise.resolve();
   if (tabModulePromises.has(name)) return tabModulePromises.get(name);
   const panel = document.getElementById(`tab-${name}`);
   const loading = (async () => {
@@ -120,7 +128,7 @@ function configureAvailableTabs(metadata) {
   consoleMetadata = metadata;
   document.querySelectorAll('.console-tab').forEach(tab => {
     const definition = TAB_MODULES[tab.dataset.tab];
-    const available = !!definition && metadata.hasRoutes(definition.requiredRoutes);
+    const available = tabDefinitionAvailable(definition, metadata);
     tab.dataset.featureAvailable = String(available);
     tab.hidden = !available || !!tab.dataset.adminCap;
   });
@@ -130,6 +138,12 @@ function configureAvailableTabs(metadata) {
   if (accountSettings) {
     accountSettings.hidden = !metadata.hasRoute('GET', '/me/profile') && !metadata.hasRoute('GET', '/me/settings');
   }
+}
+
+function tabDefinitionAvailable(definition, metadata) {
+  if (!definition || !metadata?.hasRoutes(definition.requiredRoutes)) return false;
+  if (!definition.requiredAnyRoutes) return true;
+  return definition.requiredAnyRoutes.some(([method, path]) => metadata.hasRoute(method, path));
 }
 
 function showNoAvailableFeatures() {

--- a/src/web-console/ui/index.html
+++ b/src/web-console/ui/index.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="console.css">
   <link rel="stylesheet" href="logs.css">
   <link rel="stylesheet" href="admin-metrics.css">
+  <link rel="stylesheet" href="operations.css">
   <link rel="stylesheet" href="integrations.css">
   <link rel="stylesheet" href="portfolio-actions.css">
 </head>
@@ -66,7 +67,7 @@
           <button class="console-tab" data-tab="integrations" hidden>Integrations</button>
           <!-- Admin-only: each revealed by app.js only while elevated AND holding the matching capability. -->
           <button class="console-tab console-tab--admin" data-tab="users" data-admin-cap="console:admin:accounts" hidden>Users</button>
-          <button class="console-tab console-tab--admin" data-tab="admin-metrics" data-admin-cap="console:admin:operate" hidden>Metrics</button>
+          <button class="console-tab console-tab--admin" data-tab="operations" data-admin-cap="console:admin:operate" hidden>Operations</button>
         </nav>
       </div>
     </header>
@@ -90,8 +91,8 @@
       <section id="tab-users" class="tab-panel" hidden aria-label="User administration">
         <div class="panel-placeholder">Loading users…</div>
       </section>
-      <section id="tab-admin-metrics" class="tab-panel" hidden aria-label="System metrics">
-        <div class="panel-placeholder">Loading system metrics…</div>
+      <section id="tab-operations" class="tab-panel" hidden aria-label="Operations">
+        <div class="panel-placeholder">Loading operations…</div>
       </section>
     </main>
   </div>

--- a/src/web-console/ui/operations-config.js
+++ b/src/web-console/ui/operations-config.js
@@ -7,7 +7,6 @@ import { escapeAttr, escapeHtml, responseDetail } from './operations-ui.js';
 export function createOperatorConfigView(ctx = {}) {
   let container;
   let items = [];
-  let loading = false;
   let requestController;
   let requestVersion = 0;
 
@@ -19,21 +18,15 @@ export function createOperatorConfigView(ctx = {}) {
       container.addEventListener('click', onClick);
     },
     async load(signal) {
-      if (loading) return;
-      loading = true;
       const version = ++requestVersion;
-      try {
-        const response = await get('/admin/operate/config', { signal });
-        if (version !== requestVersion) return;
-        if (response.status !== 200 || !Array.isArray(response.body?.items)) {
-          showLoadProblem(responseDetail(response, 'Operator configuration could not be loaded.'));
-          return;
-        }
-        items = response.body.items;
-        render();
-      } finally {
-        loading = false;
+      const response = await get('/admin/operate/config', { signal });
+      if (version !== requestVersion) return;
+      if (response.status !== 200 || !Array.isArray(response.body?.items)) {
+        showLoadProblem(responseDetail(response, 'Operator configuration could not be loaded.'));
+        return;
       }
+      items = response.body.items;
+      render();
     },
     showError(message) {
       const grid = container?.querySelector('.operations-config-grid');

--- a/src/web-console/ui/operations-config.js
+++ b/src/web-console/ui/operations-config.js
@@ -1,0 +1,289 @@
+/** Definition-driven operator configuration editor. */
+
+import { get, put } from './api.js';
+import { isAbortError } from './polling.js';
+import { escapeAttr, escapeHtml, responseDetail } from './operations-ui.js';
+
+export function createOperatorConfigView(ctx = {}) {
+  let container;
+  let items = [];
+  let loading = false;
+  let requestController;
+  let requestVersion = 0;
+
+  return Object.freeze({
+    mount(panel) {
+      container = panel;
+      container.innerHTML = '<div class="operations-state">Loading operator configuration…</div>';
+      container.addEventListener('submit', onSubmit);
+      container.addEventListener('click', onClick);
+    },
+    async load(signal) {
+      if (loading) return;
+      loading = true;
+      const version = ++requestVersion;
+      try {
+        const response = await get('/admin/operate/config', { signal });
+        if (version !== requestVersion) return;
+        if (response.status !== 200 || !Array.isArray(response.body?.items)) {
+          showLoadProblem(responseDetail(response, 'Operator configuration could not be loaded.'));
+          return;
+        }
+        items = response.body.items;
+        render();
+      } finally {
+        loading = false;
+      }
+    },
+    showError(message) {
+      const grid = container?.querySelector('.operations-config-grid');
+      if (!grid) {
+        renderState(message, 'warn');
+        return;
+      }
+      container.querySelector('[data-config-refresh-warning]')?.remove();
+      grid.insertAdjacentHTML(
+        'beforebegin',
+        `<p class="operations-inline-message operations-inline-message--warn" data-config-refresh-warning>${escapeHtml(message)}</p>`,
+      );
+    },
+    setVisible(nextVisible) {
+      if (!nextVisible) abortRequest();
+    },
+  });
+
+  async function onSubmit(event) {
+    const form = event.target.closest('[data-config-form]');
+    if (!form) return;
+    event.preventDefault();
+    const key = form.dataset.configForm;
+    const item = items.find(candidate => candidate.key === key);
+    if (!item) return;
+    const parsed = readValue(form, item);
+    if (parsed.problem) {
+      showFormMessage(form, parsed.problem, 'error');
+      return;
+    }
+    if (!item.etag) {
+      showFormMessage(form, 'This setting has no ETag, so editing remains blocked.', 'error');
+      return;
+    }
+    setBusy(form, true);
+    try {
+      const response = await put(`/admin/operate/config/${encodeURIComponent(key)}`, {
+        body: { value: parsed.value },
+        ifMatch: item.etag,
+      });
+      if (response.status === 412) {
+        showFormMessage(form, 'This setting changed elsewhere. Your value was not saved. Reload the latest setting before trying again.', 'error', true);
+        return;
+      }
+      if (response.status !== 200 || !response.body) {
+        showFormMessage(form, responseDetail(response, 'The setting could not be saved.'), 'error');
+        return;
+      }
+      replaceItem(response.body);
+      renderCard(key);
+      ctx.toast?.(`Saved ${key}.`, 'success');
+    } catch {
+      showFormMessage(form, 'The setting could not reach the server.', 'error');
+    } finally {
+      setBusy(form, false);
+    }
+  }
+
+  function onClick(event) {
+    const reload = event.target.closest('[data-config-reload]');
+    if (reload) reloadSetting(reload.dataset.configReload);
+  }
+
+  async function reloadSetting(key) {
+    const form = container.querySelector(`[data-config-form="${CSS.escape(key)}"]`);
+    if (form) setBusy(form, true);
+    abortRequest();
+    const controller = new AbortController();
+    requestController = controller;
+    const version = ++requestVersion;
+    try {
+      const response = await get(`/admin/operate/config/${encodeURIComponent(key)}`, { signal: controller.signal });
+      if (version !== requestVersion) return;
+      if (response.status !== 200 || !response.body) {
+        if (form) showFormMessage(form, responseDetail(response, 'The latest setting could not be loaded.'), 'error', true);
+        return;
+      }
+      const etag = response.etag || response.body.etag;
+      if (!etag) {
+        if (form) showFormMessage(form, 'The latest setting did not include an ETag, so editing remains blocked.', 'error', true);
+        return;
+      }
+      replaceItem({ ...response.body, etag });
+      renderCard(key);
+    } catch (error) {
+      if (isAbortError(error)) return;
+      if (form) showFormMessage(form, 'The latest setting could not reach the server.', 'error', true);
+    } finally {
+      if (requestController === controller) requestController = undefined;
+      if (form?.isConnected) setBusy(form, false);
+    }
+  }
+
+  function replaceItem(next) {
+    const index = items.findIndex(item => item.key === next.key);
+    if (index >= 0) items[index] = next;
+  }
+
+  function render() {
+    if (items.length === 0) {
+      renderState('No operator configuration keys are available.');
+      return;
+    }
+    container.innerHTML = `<div class="operations-section-heading"><div><h3>Configuration</h3><p>Only schema-registered settings are exposed. Secret values are write-only.</p></div></div>
+      <div class="operations-config-grid">${items.map(item => configCard(item, canWrite(ctx))).join('')}</div>`;
+  }
+
+  function renderCard(key) {
+    const item = items.find(candidate => candidate.key === key);
+    const form = container.querySelector(`[data-config-form="${CSS.escape(key)}"]`);
+    if (!item || !form) return;
+    form.outerHTML = configCard(item, canWrite(ctx));
+  }
+
+  function renderState(message, kind = 'neutral') {
+    container.innerHTML = `<div class="operations-state operations-state--${kind}">${escapeHtml(message)}</div>`;
+  }
+
+  function showLoadProblem(message) {
+    if (items.length > 0) {
+      const grid = container.querySelector('.operations-config-grid');
+      container.querySelector('[data-config-refresh-warning]')?.remove();
+      grid?.insertAdjacentHTML(
+        'beforebegin',
+        `<p class="operations-inline-message operations-inline-message--warn" data-config-refresh-warning>${escapeHtml(message)} Showing the last successful snapshot.</p>`,
+      );
+    } else {
+      renderState(message, 'error');
+    }
+  }
+
+  function abortRequest() {
+    requestController?.abort();
+    requestController = undefined;
+    requestVersion += 1;
+  }
+}
+
+function configCard(item, writeAvailable) {
+  const readOnly = item.mutability === 'read_only';
+  const missingEtag = typeof item.etag !== 'string' || !item.etag;
+  const disabled = readOnly || missingEtag || !writeAvailable;
+  const sensitivity = item.sensitivity === 'secret_write_only' ? 'Write-only secret' : 'Operator visible';
+  let restart = mutabilityBadge(item.mutability);
+  if (item.pending_restart) restart = '<span class="operations-badge operations-badge--warn">Restart pending</span>';
+  if (!writeAvailable) restart = '<span class="operations-badge">Not writable in this deployment</span>';
+  const configuredLabel = item.configured ? 'Configured' : 'Not configured';
+  const configured = item.sensitivity === 'secret_write_only'
+    ? `<span class="operations-config-state">${configuredLabel}</span>`
+    : '';
+  return `<form class="operations-card operations-config-card" data-config-form="${escapeAttr(item.key)}" data-locked="${disabled}">
+    <header><div><h3><code>${escapeHtml(item.key)}</code></h3><p>${escapeHtml(sensitivity)}</p></div>${restart}</header>
+    ${configControl(item, disabled)}
+    <div class="operations-config-meta">Schema v${Number(item.schema_version || 0)} · ${escapeHtml(effectiveLabel(item))}</div>
+    <div class="operations-inline-feedback" data-config-feedback aria-live="polite"></div>
+    <footer>${configured}<span></span><button class="btn btn-ghost" data-config-reload="${escapeAttr(item.key)}" type="button" hidden>Reload latest</button><button class="btn btn-primary" type="submit" ${disabled ? 'disabled' : ''}>Save</button></footer>
+  </form>`;
+}
+
+function configControl(item, disabled) {
+  const schema = item.value_schema || {};
+  const disabledAttribute = disabled ? 'disabled' : '';
+  if (schema.type === 'boolean') return booleanControl(item, disabledAttribute);
+  if (schema.type === 'object') return objectControl(item, disabledAttribute);
+  return scalarControl(item, schema, disabledAttribute);
+}
+
+function booleanControl(item, disabledAttribute) {
+  const secret = item.sensitivity === 'secret_write_only';
+  const secretPlaceholder = secret
+    ? '<option value="" selected disabled>Choose a replacement value</option>'
+    : '';
+  const trueSelected = !secret && item.value === true ? ' selected' : '';
+  const falseSelected = !secret && item.value === false ? ' selected' : '';
+  return `<label class="operations-field"><span>Value</span><select name="value" ${disabledAttribute}>${secretPlaceholder}<option value="true"${trueSelected}>Enabled</option><option value="false"${falseSelected}>Disabled</option></select></label>`;
+}
+
+function objectControl(item, disabledAttribute) {
+  const secret = item.sensitivity === 'secret_write_only';
+  const value = secret ? '' : JSON.stringify(item.value ?? {}, null, 2);
+  const placeholder = secret && item.configured ? 'Enter a replacement JSON value' : '';
+  return `<label class="operations-field"><span>JSON value</span><textarea name="value" rows="6" spellcheck="false" placeholder="${escapeAttr(placeholder)}" ${disabledAttribute}>${escapeHtml(value)}</textarea></label>`;
+}
+
+function scalarControl(item, schema, disabledAttribute) {
+  const inputType = item.sensitivity === 'secret_write_only' ? 'password' : 'text';
+  const numeric = schema.type === 'integer' || schema.type === 'number';
+  const type = numeric ? 'number' : inputType;
+  const step = schema.type === 'integer' ? ' step="1"' : '';
+  const minimum = typeof schema.minimum === 'number' ? ` min="${schema.minimum}"` : '';
+  const maximum = typeof schema.maximum === 'number' ? ` max="${schema.maximum}"` : '';
+  const value = item.sensitivity === 'secret_write_only' ? '' : item.value ?? '';
+  const placeholder = item.sensitivity === 'secret_write_only' && item.configured ? 'Enter a replacement value' : '';
+  return `<label class="operations-field"><span>Value</span><input name="value" type="${type}" value="${escapeAttr(value)}" placeholder="${escapeAttr(placeholder)}"${step}${minimum}${maximum} ${disabledAttribute}></label>`;
+}
+
+function readValue(form, item) {
+  const raw = form.elements.value.value;
+  const type = item.value_schema?.type;
+  if (item.sensitivity === 'secret_write_only' && !raw) return { problem: 'Enter a new secret value before saving.' };
+  if (type === 'boolean') return { value: raw === 'true' };
+  if (type === 'integer') {
+    const value = Number(raw);
+    return Number.isSafeInteger(value) ? { value } : { problem: 'Value must be an integer.' };
+  }
+  if (type === 'number') {
+    const value = Number(raw);
+    return Number.isFinite(value) ? { value } : { problem: 'Value must be a finite number.' };
+  }
+  if (type === 'object') {
+    try {
+      const value = JSON.parse(raw);
+      return value && typeof value === 'object' && !Array.isArray(value)
+        ? { value }
+        : { problem: 'Value must be a JSON object.' };
+    } catch {
+      return { problem: 'Value must be valid JSON.' };
+    }
+  }
+  return { value: raw };
+}
+
+function mutabilityBadge(mutability) {
+  if (mutability === 'restart_required') return '<span class="operations-badge">Restart required</span>';
+  if (mutability === 'read_only') return '<span class="operations-badge">Read only</span>';
+  return '<span class="operations-badge operations-badge--ok">Dynamic</span>';
+}
+
+function canWrite(ctx) {
+  return ctx.hasRoute?.('PUT', '/admin/operate/config/:key') === true;
+}
+
+function effectiveLabel(item) {
+  if (item.pending_restart) return 'not effective until restart';
+  if (!item.effective_at) return 'effective state unavailable';
+  const date = new Date(item.effective_at);
+  return Number.isNaN(date.getTime()) ? 'effective state unavailable' : `effective ${date.toLocaleString()}`;
+}
+
+function setBusy(form, busy) {
+  form.setAttribute('aria-busy', String(busy));
+  const locked = form.dataset.locked === 'true';
+  form.querySelectorAll('input, select, textarea, button').forEach(control => {
+    if (control.matches('[data-config-reload]')) control.disabled = busy;
+    else control.disabled = busy || locked;
+  });
+}
+
+function showFormMessage(form, message, kind, showReload = false) {
+  const feedback = form.querySelector('[data-config-feedback]');
+  feedback.innerHTML = `<p class="operations-inline-message operations-inline-message--${kind}">${escapeHtml(message)}</p>`;
+  form.querySelector('[data-config-reload]').hidden = !showReload;
+}

--- a/src/web-console/ui/operations-sessions.js
+++ b/src/web-console/ui/operations-sessions.js
@@ -1,0 +1,415 @@
+/** Privacy-reduced, cross-user runtime session control for elevated operators. */
+
+import { del, get } from './api.js';
+import { isAbortError, pollUntilTerminal } from './polling.js';
+import { createCursorPager, escapeAttr, escapeHtml, formatTimestamp } from './operations-ui.js';
+
+const COMMAND_POLL_INTERVAL_MS = 500;
+const COMMAND_POLL_TIMEOUT_MS = 10_000;
+
+export function createOperationalSessionsView(ctx = {}) {
+  let container;
+  let items = [];
+  let hasSnapshot = false;
+  const pager = createCursorPager();
+  let selectedSession;
+  let visible = false;
+  const commands = new Map();
+  let commandPoll;
+  let listController;
+  let detailController;
+  let listVersion = 0;
+  let detailVersion = 0;
+  const filters = { userId: '', status: '' };
+
+  return Object.freeze({
+    mount(panel) {
+      container = panel;
+      container.innerHTML = sessionShell();
+      container.querySelector('[data-operational-session-filters]').addEventListener('submit', applyFilters);
+      container.addEventListener('click', onClick);
+    },
+    async load(signal) {
+      const version = ++listVersion;
+      const response = await get(sessionListPath(filters, pager.cursor()), { signal });
+      if (version !== listVersion) return;
+      if (response.status !== 200 || !response.body) {
+        showListProblem('Runtime sessions could not be loaded.');
+        return;
+      }
+      items = Array.isArray(response.body.items) ? response.body.items : [];
+      pager.apply(response.body.page);
+      hasSnapshot = true;
+      renderList();
+    },
+    showError(message) {
+      showListProblem(message);
+    },
+    setVisible(nextVisible) {
+      visible = nextVisible;
+      if (!visible) {
+        abortListRequest();
+        abortDetailRequest();
+        stopCommandPolling();
+        return;
+      }
+      resumeSelectedCommand();
+    },
+  });
+
+  function applyFilters(event) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    filters.userId = form.elements.user_id.value.trim();
+    filters.status = form.elements.status.value;
+    pager.reset();
+    loadFromUi();
+  }
+
+  function onClick(event) {
+    const inspect = event.target.closest('[data-operational-session-id]');
+    if (inspect) {
+      loadDetail(inspect.dataset.operationalSessionId);
+      return;
+    }
+    if (event.target.closest('[data-operational-session-close]')) {
+      stopCommandPolling();
+      selectedSession = undefined;
+      renderDetail();
+      return;
+    }
+    if (event.target.closest('[data-operational-session-terminate]')) {
+      confirmTermination();
+      return;
+    }
+    if (event.target.closest('[data-session-next]') && pager.moveNext()) {
+      loadFromUi();
+      return;
+    }
+    if (event.target.closest('[data-session-previous]') && pager.movePrevious()) {
+      loadFromUi();
+    }
+  }
+
+  async function loadFromUi() {
+    abortListRequest();
+    const controller = new AbortController();
+    listController = controller;
+    const version = ++listVersion;
+    if (!hasSnapshot) renderListState('Loading runtime sessions…');
+    try {
+      const response = await get(sessionListPath(filters, pager.cursor()), { signal: controller.signal });
+      if (version !== listVersion) return;
+      if (response.status !== 200 || !response.body) {
+        showListProblem('Runtime sessions could not be loaded.');
+        return;
+      }
+      items = Array.isArray(response.body.items) ? response.body.items : [];
+      pager.apply(response.body.page);
+      hasSnapshot = true;
+      renderList();
+    } catch (error) {
+      if (!isAbortError(error)) showListProblem('Runtime sessions could not reach the server.');
+    } finally {
+      if (listController === controller) listController = undefined;
+    }
+  }
+
+  async function loadDetail(sessionId) {
+    abortDetailRequest();
+    stopCommandPolling();
+    const controller = new AbortController();
+    detailController = controller;
+    const version = ++detailVersion;
+    renderDetailState('Loading runtime session…');
+    try {
+      const response = await get(`/admin/operate/sessions/${encodeURIComponent(sessionId)}`, { signal: controller.signal });
+      if (version !== detailVersion) return;
+      if (response.status !== 200 || !response.body) {
+        selectedSession = undefined;
+        renderDetailState('This runtime session ended, expired, or is not available to this operator.', 'neutral');
+        return;
+      }
+      selectedSession = response.body;
+      renderDetail();
+      resumeSelectedCommand();
+    } catch (error) {
+      if (isAbortError(error)) return;
+      selectedSession = undefined;
+      renderDetailState('The runtime session could not reach the server.', 'error');
+    } finally {
+      if (detailController === controller) detailController = undefined;
+    }
+  }
+
+  async function confirmTermination() {
+    if (!selectedSession) return;
+    const confirmed = await confirmDialog(
+      `Terminate runtime session ${selectedSession.session_id}? The owning client will be disconnected.`,
+      'Terminate session',
+    );
+    if (!confirmed) return;
+    await terminateSelectedSession();
+  }
+
+  async function terminateSelectedSession() {
+    const sessionId = selectedSession?.session_id;
+    if (!sessionId) return;
+    setDetailBusy(true);
+    try {
+      const response = await del(`/admin/operate/sessions/${encodeURIComponent(sessionId)}`);
+      if (response.status !== 202 || !response.body?.command_id) {
+        showCommandMessage('The termination command was not accepted.', 'error');
+        return;
+      }
+      const command = { ...response.body, session_id: sessionId, status: 'pending' };
+      commands.set(sessionId, command);
+      renderCommandStatus();
+      pollCommand(sessionId, command.command_id);
+    } catch {
+      showCommandMessage('The termination command could not reach the server.', 'error');
+    } finally {
+      setDetailBusy(false);
+    }
+  }
+
+  async function pollCommand(sessionId, commandId) {
+    if (!visible) return;
+    if (commandPoll?.sessionId === sessionId && commandPoll.commandId === commandId) return;
+    stopCommandPolling();
+    const controller = new AbortController();
+    commandPoll = { sessionId, commandId, controller };
+    try {
+      const result = await pollUntilTerminal(
+        signal => readCommand(commandId, signal),
+        {
+          signal: controller.signal,
+          intervalMs: COMMAND_POLL_INTERVAL_MS,
+          timeoutMs: COMMAND_POLL_TIMEOUT_MS,
+          onUpdate: next => updateCommand(sessionId, commandId, next),
+        },
+      );
+      if (result.timedOut && isSelectedSession(sessionId)) {
+        showCommandMessage('The command is still pending. Status checks will resume when this section is reopened.', 'warn');
+      }
+      if (result.status?.status === 'terminated' || result.status?.status === 'already_absent') {
+        items = items.filter(item => item.session_id !== sessionId);
+        renderList();
+      }
+    } catch (error) {
+      if (!isAbortError(error) && isSelectedSession(sessionId)) {
+        showCommandMessage('The termination acknowledgement could not be read.', 'error');
+      }
+    } finally {
+      if (commandPoll?.controller === controller) commandPoll = undefined;
+    }
+  }
+
+  function updateCommand(sessionId, commandId, next) {
+    if (next?.command_id && next.command_id !== commandId) return;
+    commands.set(sessionId, { ...next, command_id: commandId, session_id: sessionId });
+    if (isSelectedSession(sessionId)) renderCommandStatus();
+  }
+
+  function renderList() {
+    const target = container.querySelector('[data-operational-session-list]');
+    const count = container.querySelector('[data-operational-session-count]');
+    count.textContent = `${items.length} allowlisted session${items.length === 1 ? '' : 's'} in this page.`;
+    target.innerHTML = items.length === 0
+      ? '<div class="operations-state">No runtime sessions match these filters.</div>'
+      : items.map(item => sessionCard(item, canInspect(ctx))).join('');
+    container.querySelector('[data-session-previous]').disabled = !pager.hasPrevious();
+    container.querySelector('[data-session-next]').disabled = !pager.nextCursor();
+    container.querySelector('[data-session-list-warning]')?.remove();
+  }
+
+  function renderListState(message, kind = 'neutral') {
+    const target = container.querySelector('[data-operational-session-list]');
+    target.innerHTML = `<div class="operations-state operations-state--${kind}">${escapeHtml(message)}</div>`;
+  }
+
+  function renderDetail() {
+    const target = container.querySelector('[data-operational-session-detail]');
+    if (!selectedSession) {
+      target.innerHTML = '<div class="operations-state">Select a runtime session to inspect its allowlisted metadata.</div>';
+      return;
+    }
+    const command = commands.get(selectedSession.session_id);
+    target.innerHTML = detailMarkup(selectedSession, canTerminate(ctx), command?.status === 'pending');
+    renderCommandStatus();
+  }
+
+  function renderDetailState(message, kind = 'neutral') {
+    const target = container.querySelector('[data-operational-session-detail]');
+    target.innerHTML = `<div class="operations-state operations-state--${kind}">${escapeHtml(message)}</div>`;
+  }
+
+  function renderCommandStatus() {
+    const target = container.querySelector('[data-operational-command-status]');
+    const command = selectedSession ? commands.get(selectedSession.session_id) : undefined;
+    if (!target || !command) return;
+    const presentation = commandPresentation(command);
+    target.innerHTML = `<p class="operations-inline-message operations-inline-message--${presentation.kind}">${escapeHtml(presentation.message)}</p>`;
+  }
+
+  function showCommandMessage(message, kind) {
+    const target = container.querySelector('[data-operational-command-status]');
+    if (target) target.innerHTML = `<p class="operations-inline-message operations-inline-message--${kind}">${escapeHtml(message)}</p>`;
+  }
+
+  function setDetailBusy(busy) {
+    const button = container.querySelector('[data-operational-session-terminate]');
+    if (button) button.disabled = busy;
+  }
+
+  function showListProblem(message) {
+    if (!hasSnapshot) {
+      renderListState(message, 'error');
+      return;
+    }
+    container.querySelector('[data-session-list-warning]')?.remove();
+    container.querySelector('[data-operational-session-list]')?.insertAdjacentHTML(
+      'beforebegin',
+      `<p class="operations-inline-message operations-inline-message--warn" data-session-list-warning>${escapeHtml(message)} Showing the last successful snapshot.</p>`,
+    );
+  }
+
+  function resumeSelectedCommand() {
+    const sessionId = selectedSession?.session_id;
+    const command = sessionId ? commands.get(sessionId) : undefined;
+    if (sessionId && command?.status === 'pending') pollCommand(sessionId, command.command_id);
+  }
+
+  function isSelectedSession(sessionId) {
+    return selectedSession?.session_id === sessionId;
+  }
+
+  function stopCommandPolling() {
+    commandPoll?.controller.abort();
+    commandPoll = undefined;
+  }
+
+  function abortListRequest() {
+    listController?.abort();
+    listController = undefined;
+    listVersion += 1;
+  }
+
+  function abortDetailRequest() {
+    detailController?.abort();
+    detailController = undefined;
+    detailVersion += 1;
+  }
+}
+
+async function readCommand(commandId, signal) {
+  const response = await get(`/admin/operate/sessions/commands/${encodeURIComponent(commandId)}`, { signal });
+  if (response.status !== 200 || !response.body) throw new Error('Command status unavailable.');
+  return response.body;
+}
+
+function sessionShell() {
+  return `<div class="operations-section-heading"><div><h3>Runtime sessions</h3><p>Cross-user operational metadata only. Private account and session content is never displayed.</p></div></div>
+    <form class="operations-filter-bar" data-operational-session-filters>
+      <label><span>User UUID</span><input name="user_id" maxlength="64" placeholder="Optional exact UUID"></label>
+      <label><span>Status</span><select name="status"><option value="">All statuses</option><option value="active">Active</option><option value="closing">Closing</option></select></label>
+      <button class="btn btn-primary" type="submit">Apply filters</button>
+    </form>
+    <p class="operations-checked" data-operational-session-count aria-live="polite"></p>
+    <div class="operations-session-layout">
+      <div><div class="operations-session-list" data-operational-session-list><div class="operations-state">Loading runtime sessions…</div></div>
+        <div class="operations-pagination"><button class="btn btn-ghost" data-session-previous type="button" disabled>Previous</button><button class="btn btn-ghost" data-session-next type="button" disabled>Next</button></div></div>
+      <aside class="operations-card operations-session-detail" data-operational-session-detail><div class="operations-state">Select a runtime session to inspect its allowlisted metadata.</div></aside>
+    </div>`;
+}
+
+function sessionCard(session, inspectAvailable) {
+  const client = clientLabel(session.client_info);
+  const openingTag = inspectAvailable
+    ? `<button class="operations-card operations-session-card" data-operational-session-id="${escapeAttr(session.session_id)}" type="button">`
+    : '<article class="operations-card operations-session-card">';
+  const closingTag = inspectAvailable ? '</button>' : '</article>';
+  return `${openingTag}
+    <span><strong>${escapeHtml(client)}</strong><small>${escapeHtml(session.transport)}</small></span>
+    <span><code>${escapeHtml(session.account_correlation_id)}</code><small>${escapeHtml(session.replica_id)}</small></span>
+    <span class="operations-status">${escapeHtml(session.status)}</span>
+    <span><strong>${Number(session.request_count || 0).toLocaleString()}</strong><small>requests · ${Number(session.error_count || 0).toLocaleString()} errors</small></span>
+    <span><strong>${escapeHtml(formatTimestamp(session.last_active_at))}</strong><small>last active</small></span>
+  ${closingTag}`;
+}
+
+function detailMarkup(session, terminateAvailable, commandPending) {
+  const disabled = commandPending ? ' disabled' : '';
+  const terminate = terminateAvailable
+    ? `<button class="btn btn-primary" data-operational-session-terminate type="button"${disabled}>Terminate session</button>`
+    : '';
+  return `<header><div><p class="operations-eyebrow">Runtime session</p><h3>${escapeHtml(clientLabel(session.client_info))}</h3></div><button class="btn btn-ghost" data-operational-session-close type="button">Close</button></header>
+    <dl class="operations-detail-list">
+      ${detailRow('Session ID', session.session_id)}
+      ${detailRow('Account correlation', session.account_correlation_id)}
+      ${detailRow('Replica', session.replica_id)}
+      ${detailRow('Status', session.status)}
+      ${detailRow('Transport', session.transport)}
+      ${detailRow('Created', formatTimestamp(session.created_at))}
+      ${detailRow('Last active', formatTimestamp(session.last_active_at))}
+      ${detailRow('Lease until', formatTimestamp(session.lease_until))}
+      ${detailRow('Requests', Number(session.request_count || 0).toLocaleString())}
+      ${detailRow('Errors', Number(session.error_count || 0).toLocaleString())}
+    </dl>
+    <div data-operational-command-status aria-live="polite"></div>
+    <footer>${terminate}</footer>`;
+}
+
+function detailRow(label, value) {
+  return `<div><dt>${escapeHtml(label)}</dt><dd><code>${escapeHtml(value ?? '—')}</code></dd></div>`;
+}
+
+function sessionListPath(filters, cursor) {
+  const params = new URLSearchParams({ limit: '50' });
+  if (filters.userId) params.set('user_id', filters.userId);
+  if (filters.status) params.set('status', filters.status);
+  if (cursor) params.set('cursor', cursor);
+  return `/admin/operate/sessions?${params.toString()}`;
+}
+
+function canTerminate(ctx) {
+  return ctx.hasRoute?.('DELETE', '/admin/operate/sessions/:session_id') === true;
+}
+
+function canInspect(ctx) {
+  return ctx.hasRoute?.('GET', '/admin/operate/sessions/:session_id') === true;
+}
+
+function clientLabel(clientInfo) {
+  if (!clientInfo) return 'Unknown client';
+  return [clientInfo.name, clientInfo.version].filter(Boolean).join(' ') || 'Unknown client';
+}
+
+function commandPresentation(command) {
+  if (command.status === 'terminated') return { kind: 'success', message: 'The owning replica acknowledged termination.' };
+  if (command.status === 'already_absent') return { kind: 'success', message: 'The session was already absent when the command was processed.' };
+  if (command.status === 'failed') {
+    const code = command.error_code ? ` (${command.error_code})` : '';
+    return { kind: 'error', message: `Termination failed${code}.` };
+  }
+  return { kind: 'warn', message: 'Waiting for the owning replica to acknowledge termination…' };
+}
+
+function confirmDialog(message, confirmLabel) {
+  return new Promise(resolve => {
+    document.getElementById('operations-confirm')?.remove();
+    const modal = document.createElement('div');
+    modal.id = 'operations-confirm';
+    modal.className = 'confirm-modal';
+    modal.innerHTML = `<div class="confirm-backdrop"></div><div class="confirm-card" role="dialog" aria-modal="true" aria-label="Confirm operator action"><p class="confirm-msg">${escapeHtml(message)}</p><div class="confirm-actions"><button class="btn btn-ghost" data-confirm="0" type="button">Cancel</button><button class="btn btn-primary" data-confirm="1" type="button">${escapeHtml(confirmLabel)}</button></div></div>`;
+    document.body.appendChild(modal);
+    const close = confirmed => {
+      modal.remove();
+      resolve(confirmed);
+    };
+    modal.querySelector('.confirm-backdrop').addEventListener('click', () => close(false));
+    modal.querySelector('[data-confirm="0"]').addEventListener('click', () => close(false));
+    modal.querySelector('[data-confirm="1"]').addEventListener('click', () => close(true));
+    modal.querySelector('[data-confirm="1"]').focus();
+  });
+}

--- a/src/web-console/ui/operations-telemetry.js
+++ b/src/web-console/ui/operations-telemetry.js
@@ -133,7 +133,7 @@ export function createOperationalMetricsView(ctx = {}) {
         <section class="operations-system-metrics" data-system-metrics></section>`;
       const systemHost = container.querySelector('[data-system-metrics]');
       if (ctx.hasRoute?.('GET', '/admin/operate/metrics/system')) {
-        systemMetrics = initSystemMetrics(systemHost, { ...ctx, tabName: 'operations' });
+        systemMetrics = initSystemMetrics(systemHost);
       } else {
         systemHost.hidden = true;
       }

--- a/src/web-console/ui/operations-telemetry.js
+++ b/src/web-console/ui/operations-telemetry.js
@@ -1,0 +1,227 @@
+/** Operator-safe log and metric snapshots. SSE routes are finite exports, so UI refresh uses GET polling. */
+
+import { get } from './api.js';
+import { init as initSystemMetrics } from './admin-metrics.js';
+import { isAbortError } from './polling.js';
+import { createCursorPager, escapeAttr, escapeHtml, formatTimestamp, responseDetail } from './operations-ui.js';
+
+export function createOperationalLogsView() {
+  let container;
+  let items = [];
+  let hasSnapshot = false;
+  const pager = createCursorPager();
+  let requestController;
+  let requestVersion = 0;
+  const filters = { level: '', subsystem: '', event: '' };
+
+  return Object.freeze({
+    mount(panel) {
+      container = panel;
+      container.innerHTML = logShell();
+      container.querySelector('[data-operational-log-filters]').addEventListener('submit', applyFilters);
+      container.addEventListener('click', onClick);
+    },
+    async load(signal) {
+      const version = ++requestVersion;
+      const response = await get(logPath(filters, pager.cursor()), { signal });
+      if (version !== requestVersion) return;
+      if (response.status !== 200 || !response.body) {
+        showLogProblem(responseDetail(response, 'Operational logs could not be loaded.'));
+        return;
+      }
+      items = Array.isArray(response.body.items) ? response.body.items : [];
+      pager.apply(response.body.page);
+      hasSnapshot = true;
+      renderLogs();
+    },
+    showError(message) {
+      showLogProblem(message);
+    },
+    setVisible(visible) {
+      if (!visible) abortRequest();
+    },
+  });
+
+  function applyFilters(event) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    filters.level = form.elements.level.value;
+    filters.subsystem = form.elements.subsystem.value.trim();
+    filters.event = form.elements.event.value.trim();
+    pager.reset();
+    loadFromUi();
+  }
+
+  function onClick(event) {
+    if (event.target.closest('[data-log-next]') && pager.moveNext()) {
+      loadFromUi();
+    }
+    if (event.target.closest('[data-log-previous]') && pager.movePrevious()) {
+      loadFromUi();
+    }
+  }
+
+  async function loadFromUi() {
+    abortRequest();
+    const controller = new AbortController();
+    requestController = controller;
+    const version = ++requestVersion;
+    if (!hasSnapshot) renderLogState('Loading operational logs…');
+    try {
+      const response = await get(logPath(filters, pager.cursor()), { signal: controller.signal });
+      if (version !== requestVersion) return;
+      if (response.status !== 200 || !response.body) {
+        showLogProblem(responseDetail(response, 'Operational logs could not be loaded.'));
+        return;
+      }
+      items = Array.isArray(response.body.items) ? response.body.items : [];
+      pager.apply(response.body.page);
+      hasSnapshot = true;
+      renderLogs();
+    } catch (error) {
+      if (!isAbortError(error)) showLogProblem('Operational logs could not reach the server.');
+    } finally {
+      if (requestController === controller) requestController = undefined;
+    }
+  }
+
+  function renderLogs() {
+    const body = container.querySelector('[data-operational-log-body]');
+    const status = container.querySelector('[data-operational-log-status]');
+    status.textContent = `${items.length} allowlisted event${items.length === 1 ? '' : 's'} in this page.`;
+    body.innerHTML = items.length === 0
+      ? '<div class="operations-state">No operational events match these filters.</div>'
+      : `<div class="operations-table-wrap"><table class="operations-table"><thead><tr><th>Time</th><th>Level</th><th>Subsystem</th><th>Event</th><th>Session / account</th><th>Result</th></tr></thead><tbody>${items.map(logRow).join('')}</tbody></table></div>`;
+    container.querySelector('[data-log-previous]').disabled = !pager.hasPrevious();
+    container.querySelector('[data-log-next]').disabled = !pager.nextCursor();
+    container.querySelector('[data-operational-log-warning]')?.remove();
+  }
+
+  function renderLogState(message, kind = 'neutral') {
+    container.querySelector('[data-operational-log-body]').innerHTML = `<div class="operations-state operations-state--${kind}">${escapeHtml(message)}</div>`;
+  }
+
+  function showLogProblem(message) {
+    if (!hasSnapshot) {
+      renderLogState(message, 'error');
+      return;
+    }
+    container.querySelector('[data-operational-log-warning]')?.remove();
+    container.querySelector('[data-operational-log-body]')?.insertAdjacentHTML(
+      'beforebegin',
+      `<p class="operations-inline-message operations-inline-message--warn" data-operational-log-warning>${escapeHtml(message)} Showing the last successful snapshot.</p>`,
+    );
+  }
+
+  function abortRequest() {
+    requestController?.abort();
+    requestController = undefined;
+    requestVersion += 1;
+  }
+}
+
+export function createOperationalMetricsView(ctx = {}) {
+  let container;
+  let systemMetrics;
+  let lastBody;
+
+  return Object.freeze({
+    mount(panel) {
+      container = panel;
+      container.innerHTML = `<div class="operations-section-heading"><div><h3>Metrics</h3><p>Allowlisted activity aggregates and in-process server snapshots.</p></div></div>
+        <section class="operations-card operations-operational-metrics"><header><h3>Operational activity</h3></header><div data-operational-metrics-body><div class="operations-state">Loading operational metrics…</div></div></section>
+        <section class="operations-system-metrics" data-system-metrics></section>`;
+      const systemHost = container.querySelector('[data-system-metrics]');
+      if (ctx.hasRoute?.('GET', '/admin/operate/metrics/system')) {
+        systemMetrics = initSystemMetrics(systemHost, { ...ctx, tabName: 'operations' });
+      } else {
+        systemHost.hidden = true;
+      }
+    },
+    async load(signal) {
+      if (!ctx.hasRoute?.('GET', '/admin/operate/metrics')) return;
+      const response = await get('/admin/operate/metrics', { signal });
+      if (response.status !== 200 || !response.body) {
+        showMetricProblem(responseDetail(response, 'Operational metrics could not be loaded.'));
+        return;
+      }
+      lastBody = response.body;
+      renderMetrics(response.body);
+    },
+    showError(message) {
+      showMetricProblem(message);
+    },
+    setVisible(visible) {
+      systemMetrics?.setVisible(visible);
+    },
+    async refresh(signal) {
+      await Promise.all([
+        this.load(signal),
+        systemMetrics?.refresh(signal),
+      ]);
+    },
+  });
+
+  function renderMetrics(body) {
+    const metrics = Array.isArray(body.metrics) ? body.metrics : [];
+    const target = container.querySelector('[data-operational-metrics-body]');
+    container.querySelector('[data-operational-metrics-warning]')?.remove();
+    if (metrics.length === 0) {
+      target.innerHTML = '<div class="operations-state">No operational activity metrics are available.</div>';
+      return;
+    }
+    target.innerHTML = `<div class="operations-table-wrap"><table class="operations-table"><thead><tr><th>Metric</th><th>Kind</th><th>Value</th><th>Dimensions</th></tr></thead><tbody>${metrics.map(metricRow).join('')}</tbody></table></div><p class="operations-checked">Checked ${escapeHtml(formatTimestamp(body.checked_at))}</p>`;
+  }
+
+  function renderMetricState(message, kind) {
+    const target = container?.querySelector('[data-operational-metrics-body]');
+    if (target) target.innerHTML = `<div class="operations-state operations-state--${kind}">${escapeHtml(message)}</div>`;
+  }
+
+  function showMetricProblem(message) {
+    if (!lastBody) {
+      renderMetricState(message, 'error');
+      return;
+    }
+    container.querySelector('[data-operational-metrics-warning]')?.remove();
+    container.querySelector('[data-operational-metrics-body]')?.insertAdjacentHTML(
+      'beforebegin',
+      `<p class="operations-inline-message operations-inline-message--warn" data-operational-metrics-warning>${escapeHtml(message)} Showing the last successful snapshot.</p>`,
+    );
+  }
+}
+
+function logShell() {
+  return `<div class="operations-section-heading"><div><h3>Operational logs</h3><p>Allowlisted event metadata only; prompt and portfolio content are never included.</p></div></div>
+    <form class="operations-filter-bar" data-operational-log-filters>
+      <label><span>Level</span><select name="level"><option value="">All levels</option><option value="debug">Debug</option><option value="info">Info</option><option value="warn">Warning</option><option value="error">Error</option></select></label>
+      <label><span>Subsystem</span><input name="subsystem" maxlength="64" placeholder="runtime"></label>
+      <label><span>Event</span><input name="event" maxlength="128" placeholder="session.started"></label>
+      <button class="btn btn-primary" type="submit">Apply filters</button>
+    </form>
+    <p class="operations-checked" data-operational-log-status aria-live="polite"></p>
+    <div data-operational-log-body><div class="operations-state">Loading operational logs…</div></div>
+    <div class="operations-pagination"><button class="btn btn-ghost" data-log-previous type="button" disabled>Previous</button><button class="btn btn-ghost" data-log-next type="button" disabled>Next</button></div>`;
+}
+
+function logPath(filters, cursor) {
+  const params = new URLSearchParams({ limit: '50' });
+  if (filters.level) params.set('level', filters.level);
+  if (filters.subsystem) params.set('subsystem', filters.subsystem);
+  if (filters.event) params.set('event', filters.event);
+  if (cursor) params.set('cursor', cursor);
+  return `/admin/operate/logs?${params.toString()}`;
+}
+
+function logRow(item) {
+  const correlation = item.session_id || item.account_correlation_id || '—';
+  const result = item.error_code || (item.status_code ? `HTTP ${item.status_code}` : '—');
+  return `<tr><td>${escapeHtml(formatTimestamp(item.ts))}</td><td><span class="operations-log-level operations-log-level--${escapeAttr(item.level)}">${escapeHtml(item.level)}</span></td><td><code>${escapeHtml(item.subsystem)}</code></td><td><code>${escapeHtml(item.event)}</code></td><td><code>${escapeHtml(correlation)}</code></td><td><code>${escapeHtml(result)}</code></td></tr>`;
+}
+
+function metricRow(metric) {
+  const dimensions = metric.dimensions && typeof metric.dimensions === 'object'
+    ? Object.entries(metric.dimensions).map(([key, value]) => `${key}=${value}`).join(' · ')
+    : '';
+  return `<tr><td><code>${escapeHtml(metric.name)}</code><br><small>${escapeHtml(metric.unit)}</small></td><td>${escapeHtml(metric.kind)}</td><td class="operations-number">${Number(metric.value || 0).toLocaleString()}</td><td>${escapeHtml(dimensions || '—')}</td></tr>`;
+}

--- a/src/web-console/ui/operations-ui.js
+++ b/src/web-console/ui/operations-ui.js
@@ -1,0 +1,60 @@
+/** Shared, operator-safe presentation and cursor helpers. */
+
+export function createCursorPager() {
+  let page = {};
+  const history = [];
+
+  return Object.freeze({
+    apply(nextPage) {
+      page = nextPage && typeof nextPage === 'object' ? nextPage : {};
+    },
+    reset() {
+      page = {};
+      history.length = 0;
+    },
+    cursor() {
+      return page.cursor;
+    },
+    nextCursor() {
+      return page.next_cursor;
+    },
+    hasPrevious() {
+      return history.length > 0;
+    },
+    moveNext() {
+      if (!page.next_cursor) return false;
+      history.push(page.cursor ?? null);
+      page = { cursor: page.next_cursor };
+      return true;
+    },
+    movePrevious() {
+      if (history.length === 0) return false;
+      page = { cursor: history.pop() };
+      return true;
+    },
+  });
+}
+
+export function responseDetail(response, fallback) {
+  return typeof response?.body?.detail === 'string' ? response.body.detail : fallback;
+}
+
+export function formatTimestamp(value) {
+  if (!value) return 'unknown';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 'unknown' : date.toLocaleString();
+}
+
+export function escapeHtml(value) {
+  return String(value ?? '').replaceAll(/[&<>"']/g, character => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[character]));
+}
+
+export function escapeAttr(value) {
+  return escapeHtml(value);
+}

--- a/src/web-console/ui/operations.css
+++ b/src/web-console/ui/operations.css
@@ -85,9 +85,14 @@
 .operations-health-grid,
 .operations-config-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 20rem), 1fr));
   gap: 1rem;
   margin-top: 1rem;
+}
+.operations-health-grid {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 20rem), 1fr));
+}
+.operations-config-grid {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 24rem), 1fr));
 }
 .operations-health-card { box-shadow: none; }
 .operations-health-card header { border-left: 0.25rem solid var(--teal); }
@@ -133,11 +138,37 @@
 .operations-inline-message--error { color: #b42318; }
 .operations-inline-message--success { color: var(--teal); }
 
-.operations-config-card { box-shadow: none; }
+.operations-config-card {
+  min-width: 0;
+  box-shadow: none;
+}
+.operations-config-card > header {
+  align-items: flex-start;
+}
+.operations-config-card > header > div {
+  min-width: 0;
+}
+.operations-config-card h3 {
+  min-width: 0;
+  font-size: var(--step-1);
+  line-height: 1.25;
+}
+.operations-config-card h3 code {
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+.operations-config-card > header > .operations-badge {
+  flex: 0 0 auto;
+}
 .operations-config-card > .operations-field { margin: 1rem; }
 .operations-config-meta,
 .operations-inline-feedback { margin: 0 1rem 1rem; color: var(--ink-500); font-size: var(--step--1); }
-.operations-config-card footer { display: grid; grid-template-columns: auto 1fr auto auto; }
+.operations-config-card footer {
+  flex-wrap: wrap;
+}
+.operations-config-card footer > span:empty {
+  flex: 1 1 1rem;
+}
 
 .operations-field,
 .operations-filter-bar label {
@@ -229,7 +260,7 @@ button.operations-session-card:hover { border-color: var(--signal); }
   .operations-header,
   .operations-section-heading { align-items: flex-start; flex-direction: column; }
   .operations-filter-bar { grid-template-columns: 1fr; }
-  .operations-config-card footer { grid-template-columns: 1fr; }
+  .operations-config-card > header { flex-direction: column; }
   .operations-session-card { grid-template-columns: 1fr; }
   .operations-detail-list > div { grid-template-columns: 1fr; gap: 0.2rem; }
 }

--- a/src/web-console/ui/operations.css
+++ b/src/web-console/ui/operations.css
@@ -1,0 +1,235 @@
+.operations-header,
+.operations-section-heading,
+.operations-card > header,
+.operations-card > footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.operations-header {
+  padding: clamp(1rem, 2vw, 1.75rem) var(--gutter);
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--paper-strong) 82%, var(--surface-1));
+}
+
+.operations-header h2,
+.operations-section-heading h3,
+.operations-card h3 { margin: 0; }
+.operations-header p,
+.operations-section-heading p,
+.operations-card p { margin: 0.25rem 0 0; color: var(--ink-500); }
+
+.operations-eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--step--1);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--signal) !important;
+}
+
+.operations-nav {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.65rem var(--gutter);
+  overflow-x: auto;
+  border-bottom: 1px solid var(--line);
+}
+
+.operations-nav-button {
+  appearance: none;
+  border: 0;
+  border-radius: var(--radius-sm);
+  padding: 0.55rem 0.85rem;
+  color: var(--ink-500);
+  background: transparent;
+  font: 600 var(--step--1) var(--font-mono);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.operations-nav-button:hover { color: var(--ink-900); background: var(--surface-1); }
+.operations-nav-button.active { color: var(--paper-strong); background: var(--ink-900); }
+
+.operations-panel { padding: clamp(1rem, 2vw, 1.75rem) var(--gutter) 3rem; }
+.operations-section-heading { margin-bottom: 1rem; }
+
+.operations-card {
+  background: var(--paper-strong);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-soft);
+}
+.operations-card > header,
+.operations-card > footer { padding: 0.9rem 1rem; }
+.operations-card > header { border-bottom: 1px solid var(--line); }
+.operations-card > footer { border-top: 1px solid var(--line); }
+
+.operations-summary-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.2rem;
+  border: 1px solid var(--line);
+  border-left: 0.3rem solid var(--teal);
+  border-radius: var(--radius-md);
+  background: var(--paper-strong);
+}
+.operations-summary-card h3 { margin: 0; }
+.operations-summary-card > span { color: var(--ink-500); font: var(--step--1) var(--font-mono); }
+.operations-summary-card--degraded,
+.operations-summary-card--not-ready { border-left-color: var(--accent); }
+.operations-summary-card--unavailable { border-left-color: #b42318; }
+
+.operations-health-grid,
+.operations-config-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 20rem), 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.operations-health-card { box-shadow: none; }
+.operations-health-card header { border-left: 0.25rem solid var(--teal); }
+.operations-health-card--degraded header,
+.operations-health-card--not-ready header { border-left-color: var(--accent); }
+.operations-health-card--unavailable header { border-left-color: #b42318; }
+.operations-health-card > p,
+.operations-health-card > ul { margin: 1rem; }
+
+.operations-status,
+.operations-badge,
+.operations-config-state,
+.operations-log-level {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.18rem 0.5rem;
+  font: 600 var(--step--1) var(--font-mono);
+  text-transform: capitalize;
+  white-space: nowrap;
+}
+.operations-badge--ok { color: var(--teal); }
+.operations-badge--warn { color: var(--accent); }
+
+.operations-state {
+  padding: 2rem 1rem;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius-md);
+  color: var(--ink-500);
+  text-align: center;
+}
+.operations-state--error { color: #b42318; border-color: currentColor; }
+.operations-state--warn { color: var(--accent); border-color: currentColor; }
+
+.operations-inline-message {
+  padding: 0.55rem 0.7rem;
+  border-radius: var(--radius-sm);
+  background: var(--surface-1);
+  font-size: var(--step--1);
+}
+.operations-inline-message--warn { color: var(--accent); }
+.operations-inline-message--error { color: #b42318; }
+.operations-inline-message--success { color: var(--teal); }
+
+.operations-config-card { box-shadow: none; }
+.operations-config-card > .operations-field { margin: 1rem; }
+.operations-config-meta,
+.operations-inline-feedback { margin: 0 1rem 1rem; color: var(--ink-500); font-size: var(--step--1); }
+.operations-config-card footer { display: grid; grid-template-columns: auto 1fr auto auto; }
+
+.operations-field,
+.operations-filter-bar label {
+  display: grid;
+  gap: 0.35rem;
+  font: var(--step--1) var(--font-mono);
+  color: var(--ink-500);
+}
+.operations-field input,
+.operations-field select,
+.operations-field textarea,
+.operations-filter-bar input,
+.operations-filter-bar select {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 0.55rem 0.65rem;
+  color: var(--ink-900);
+  background: var(--paper-strong);
+  font: var(--step--1) var(--font-mono);
+}
+
+.operations-filter-bar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr)) auto;
+  align-items: end;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  padding: 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-1);
+}
+
+.operations-table-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: var(--radius-md); }
+.operations-table { width: 100%; border-collapse: collapse; font: var(--step--1) var(--font-mono); }
+.operations-table th,
+.operations-table td { padding: 0.65rem 0.75rem; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+.operations-table th { color: var(--ink-500); background: var(--surface-1); white-space: nowrap; }
+.operations-table tr:last-child td { border-bottom: 0; }
+.operations-number { text-align: right !important; font-variant-numeric: tabular-nums; }
+.operations-log-level--error { color: #b42318; }
+.operations-log-level--warn { color: var(--accent); }
+
+.operations-checked { margin: 0.75rem 0; color: var(--ink-500); font: var(--step--1) var(--font-mono); }
+.operations-pagination { display: flex; justify-content: flex-end; gap: 0.5rem; margin-top: 0.75rem; }
+.operations-system-metrics { margin-top: 1rem; }
+.operations-system-metrics .metrics-dashboard { padding-inline: 0; }
+
+.operations-session-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(20rem, 0.8fr);
+  gap: 1rem;
+  align-items: start;
+}
+.operations-session-list { display: grid; gap: 0.65rem; }
+.operations-session-card {
+  display: grid;
+  grid-template-columns: 1.2fr 1.4fr auto 0.8fr 1fr;
+  gap: 0.75rem;
+  align-items: center;
+  width: 100%;
+  padding: 0.75rem;
+  color: var(--ink-900);
+  text-align: left;
+}
+button.operations-session-card { cursor: pointer; }
+button.operations-session-card:hover { border-color: var(--signal); }
+.operations-session-card span { display: grid; gap: 0.2rem; min-width: 0; }
+.operations-session-card small { color: var(--ink-500); overflow-wrap: anywhere; }
+.operations-session-card code { overflow-wrap: anywhere; }
+.operations-session-detail { position: sticky; top: 1rem; box-shadow: none; }
+.operations-session-detail > .operations-state { border: 0; }
+.operations-detail-list { display: grid; gap: 0; margin: 0; padding: 0.5rem 1rem; }
+.operations-detail-list > div { display: grid; grid-template-columns: 8.5rem minmax(0, 1fr); gap: 0.75rem; padding: 0.5rem 0; border-bottom: 1px solid var(--line); }
+.operations-detail-list > div:last-child { border-bottom: 0; }
+.operations-detail-list dt { color: var(--ink-500); }
+.operations-detail-list dd { margin: 0; overflow-wrap: anywhere; }
+.operations-session-detail [data-operational-command-status] { padding: 0 1rem 1rem; }
+
+@media (max-width: 70rem) {
+  .operations-session-layout { grid-template-columns: 1fr; }
+  .operations-session-detail { position: static; }
+  .operations-session-card { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 40rem) {
+  .operations-header,
+  .operations-section-heading { align-items: flex-start; flex-direction: column; }
+  .operations-filter-bar { grid-template-columns: 1fr; }
+  .operations-config-card footer { grid-template-columns: 1fr; }
+  .operations-session-card { grid-template-columns: 1fr; }
+  .operations-detail-list > div { grid-template-columns: 1fr; gap: 0.2rem; }
+}

--- a/src/web-console/ui/operations.js
+++ b/src/web-console/ui/operations.js
@@ -1,0 +1,245 @@
+/** Capability-gated operator workspace for deployment health and control. */
+
+import { get } from './api.js';
+import { createVisiblePoller, isAbortError } from './polling.js';
+import { createOperatorConfigView } from './operations-config.js';
+import { createOperationalLogsView, createOperationalMetricsView } from './operations-telemetry.js';
+import { createOperationalSessionsView } from './operations-sessions.js';
+import { escapeHtml, formatTimestamp, responseDetail } from './operations-ui.js';
+
+const REFRESH_INTERVAL_MS = 10_000;
+
+let host;
+let tabVisible = true;
+let elevationActive = true;
+let activeSection;
+let poller;
+let oneShotController;
+let views = new Map();
+
+export function init(panelEl, ctx = {}) {
+  host = panelEl;
+  const hasRoute = ctx.hasRoute || (() => false);
+  const definitions = sectionDefinitions(hasRoute, ctx);
+  views = new Map(definitions.map(definition => [definition.id, definition]));
+  host.innerHTML = shell(definitions);
+  wireNavigation();
+  globalThis.addEventListener('dh:tab-activated', onTabActivated);
+  globalThis.addEventListener('dh:elevation-changed', onElevationChanged);
+  document.addEventListener('visibilitychange', onDocumentVisibilityChanged);
+
+  if (definitions.length === 0) {
+    host.querySelector('#operations-content').innerHTML = '<div class="panel-placeholder">No operator features are available in this deployment.</div>';
+    return;
+  }
+  for (const definition of definitions) {
+    const panel = host.querySelector(`[data-operations-panel="${definition.id}"]`);
+    definition.view.mount(panel);
+  }
+  selectSection(definitions[0].id);
+}
+
+function sectionDefinitions(hasRoute, ctx) {
+  const definitions = [];
+  if (hasRoute('GET', '/admin/operate/health')) {
+    definitions.push({ id: 'health', label: 'Health', poll: true, view: createHealthView(ctx) });
+  }
+  if (hasRoute('GET', '/admin/operate/config')) {
+    definitions.push({ id: 'config', label: 'Configuration', poll: false, view: createOperatorConfigView(ctx) });
+  }
+  if (hasRoute('GET', '/admin/operate/logs')) {
+    definitions.push({ id: 'logs', label: 'Logs', poll: true, view: createOperationalLogsView(ctx) });
+  }
+  if (hasRoute('GET', '/admin/operate/metrics') || hasRoute('GET', '/admin/operate/metrics/system')) {
+    definitions.push({ id: 'metrics', label: 'Metrics', poll: true, view: createOperationalMetricsView(ctx) });
+  }
+  if (hasRoute('GET', '/admin/operate/sessions')) {
+    definitions.push({ id: 'sessions', label: 'Sessions', poll: true, view: createOperationalSessionsView(ctx) });
+  }
+  return definitions;
+}
+
+function shell(definitions) {
+  const navigation = definitions.map(definition =>
+    `<button class="operations-nav-button" data-operations-nav="${definition.id}" type="button">${definition.label}</button>`).join('');
+  const panels = definitions.map(definition =>
+    `<section class="operations-panel" data-operations-panel="${definition.id}" aria-label="${definition.label}" hidden></section>`).join('');
+  return `
+    <header class="operations-header">
+      <div><p class="operations-eyebrow">Elevated operator workspace</p><h2>Operations</h2><p>Allowlisted deployment health, configuration, telemetry, and runtime control.</p></div>
+      <button class="btn btn-ghost" id="operations-refresh" type="button">&#x21bb; Refresh</button>
+    </header>
+    <nav class="operations-nav" aria-label="Operations sections">${navigation}</nav>
+    <div id="operations-content">${panels}</div>`;
+}
+
+function wireNavigation() {
+  host.querySelectorAll('[data-operations-nav]').forEach(button => {
+    button.addEventListener('click', () => selectSection(button.dataset.operationsNav));
+  });
+  host.querySelector('#operations-refresh')?.addEventListener('click', () => refreshActiveSection());
+}
+
+function selectSection(sectionId) {
+  const definition = views.get(sectionId);
+  if (!definition) return;
+  activeSection = sectionId;
+  host.querySelectorAll('[data-operations-nav]').forEach(button => {
+    const selected = button.dataset.operationsNav === sectionId;
+    button.classList.toggle('active', selected);
+    button.setAttribute('aria-current', selected ? 'page' : 'false');
+  });
+  host.querySelectorAll('[data-operations-panel]').forEach(panel => {
+    panel.hidden = panel.dataset.operationsPanel !== sectionId;
+  });
+  syncViewVisibility();
+  startActivePolling(true);
+}
+
+function startActivePolling(immediate) {
+  stopActiveWork();
+  const definition = views.get(activeSection);
+  if (!definition || !operationsVisible()) return;
+  if (!definition.poll) {
+    if (immediate) loadOnce(definition);
+    return;
+  }
+  poller = createVisiblePoller(
+    signal => definition.view.load(signal),
+    { intervalMs: REFRESH_INTERVAL_MS, onError: handleRefreshError },
+  );
+  poller.start({ immediate });
+}
+
+function refreshActiveSection() {
+  const definition = views.get(activeSection);
+  if (!definition || !operationsVisible()) return;
+  if (definition.view.refresh) {
+    loadOnce(definition, definition.view.refresh);
+  } else if (definition.poll) {
+    poller?.refresh();
+  } else {
+    loadOnce(definition);
+  }
+}
+
+function onTabActivated(event) {
+  tabVisible = event.detail?.name === 'operations';
+  syncLifecycle();
+}
+
+function onElevationChanged(event) {
+  elevationActive = event.detail?.active === true;
+  syncLifecycle();
+}
+
+function onDocumentVisibilityChanged() {
+  syncLifecycle();
+}
+
+function syncLifecycle() {
+  syncViewVisibility();
+  if (operationsVisible()) startActivePolling(true);
+  else stopActiveWork();
+}
+
+function syncViewVisibility() {
+  const visible = operationsVisible();
+  views.forEach(item => item.view.setVisible?.(item.id === activeSection && visible));
+}
+
+function operationsVisible() {
+  return tabVisible && elevationActive && !document.hidden;
+}
+
+function stopActiveWork() {
+  poller?.stop();
+  poller = undefined;
+  oneShotController?.abort();
+  oneShotController = undefined;
+}
+
+function loadOnce(definition, task = definition.view.load) {
+  oneShotController?.abort();
+  const controller = new AbortController();
+  oneShotController = controller;
+  Promise.resolve(task.call(definition.view, controller.signal))
+    .catch(handleRefreshError)
+    .finally(() => {
+      if (oneShotController === controller) oneShotController = undefined;
+    });
+}
+
+function handleRefreshError(error) {
+  if (isAbortError(error)) return;
+  const definition = views.get(activeSection);
+  definition?.view.showError?.('The current operator snapshot could not be refreshed.');
+}
+
+function createHealthView(ctx) {
+  let container;
+  let lastBody;
+  return Object.freeze({
+    mount(panel) {
+      container = panel;
+      container.innerHTML = '<div class="operations-state">Loading deployment health…</div>';
+    },
+    async load(signal) {
+      const response = await get('/admin/operate/health', { signal });
+      if ((response.status !== 200 && response.status !== 503) || !response.body) {
+        showState(container, responseDetail(response, 'Deployment health could not be loaded.'), 'error');
+        return;
+      }
+      lastBody = response.body;
+      renderHealth(container, lastBody);
+    },
+    showError(message) {
+      if (lastBody) renderHealth(container, lastBody, message);
+      else showState(container, message, 'error');
+      ctx.toast?.(message, 'warn');
+    },
+  });
+}
+
+function renderHealth(container, health, staleMessage = '') {
+  const components = Array.isArray(health.components) ? health.components : [];
+  const checked = formatTimestamp(health.checked_at);
+  const stale = staleMessage ? `<p class="operations-inline-message operations-inline-message--warn">${escapeHtml(staleMessage)}</p>` : '';
+  container.innerHTML = `${stale}
+    <div class="operations-summary-card operations-summary-card--${statusClass(health.status)}">
+      <div><p class="operations-eyebrow">Deployment status</p><h3>${escapeHtml(statusLabel(health.status))}</h3></div>
+      <span>Checked ${escapeHtml(checked)}</span>
+    </div>
+    <div class="operations-health-grid">${components.map(healthComponent).join('')}</div>`;
+}
+
+function healthComponent(component) {
+  const codes = Array.isArray(component.failure_codes) ? component.failure_codes : [];
+  const codeItems = codes.map(code => `<li><code>${escapeHtml(code)}</code></li>`).join('');
+  const failures = codes.length > 0
+    ? `<ul>${codeItems}</ul>`
+    : '<p>No reported failures.</p>';
+  return `<article class="operations-card operations-health-card operations-health-card--${statusClass(component.status)}">
+    <header><h3>${escapeHtml(componentLabel(component.component))}</h3><span class="operations-status">${escapeHtml(statusLabel(component.status))}</span></header>
+    ${failures}
+  </article>`;
+}
+
+function componentLabel(value) {
+  return String(value || 'component').replaceAll('_', ' ').replaceAll(/\b\w/g, character => character.toUpperCase());
+}
+
+function statusLabel(value) {
+  if (value === 'ok') return 'Healthy';
+  if (value === 'degraded') return 'Degraded';
+  if (value === 'not_ready') return 'Not ready';
+  return 'Unavailable';
+}
+
+function statusClass(value) {
+  return value === 'ok' || value === 'degraded' || value === 'not_ready' ? value.replace('_', '-') : 'unavailable';
+}
+
+function showState(container, message, kind = 'neutral') {
+  container.innerHTML = `<div class="operations-state operations-state--${kind}">${escapeHtml(message)}</div>`;
+}

--- a/tests/integration/web-console-e2e/harness/operationsUiMock.ts
+++ b/tests/integration/web-console-e2e/harness/operationsUiMock.ts
@@ -26,6 +26,7 @@ interface ConfigState {
 type CommandOutcome = 'terminated' | 'already_absent' | 'failed';
 
 interface OperationsUiMockOptions {
+  readonly configListDelayMs?: number;
   readonly conflictOnFirstConfigWrite?: boolean;
   readonly commandOutcome?: CommandOutcome;
   readonly detailUnavailable?: boolean;
@@ -39,6 +40,7 @@ interface RuntimeState {
 }
 
 export interface OperationsUiMockState {
+  configReads: number;
   configPutAttempts: number;
   configWrites: number;
   commandReads: number;
@@ -61,6 +63,7 @@ export async function installOperationsUiMock(
   options: OperationsUiMockOptions = {},
 ): Promise<OperationsUiMockState> {
   const state: OperationsUiMockState = {
+    configReads: 0,
     configPutAttempts: 0,
     configWrites: 0,
     commandReads: 0,
@@ -83,6 +86,7 @@ export async function installOperationsUiMock(
   };
   const runtime: RuntimeState = {
     options: {
+      configListDelayMs: options.configListDelayMs ?? 0,
       conflictOnFirstConfigWrite: options.conflictOnFirstConfigWrite ?? true,
       commandOutcome: options.commandOutcome ?? 'terminated',
       detailUnavailable: options.detailUnavailable ?? false,
@@ -96,7 +100,17 @@ export async function installOperationsUiMock(
     const request = route.request();
     const path = new URL(request.url()).pathname;
     const response = responseFor(request.method(), path, request.postDataJSON(), request.headers(), state, config, runtime);
-    await fulfill(route, response);
+    const delayedConfigRead = request.method() === 'GET'
+      && path === '/api/v1/admin/operate/config'
+      && state.configReads === 1
+      && runtime.options.configListDelayMs > 0;
+    if (delayedConfigRead) await delay(runtime.options.configListDelayMs);
+    try {
+      await fulfill(route, response);
+    } catch (error) {
+      if (!delayedConfigRead) throw error;
+      // The lifecycle regression intentionally navigates away while this request is pending.
+    }
   });
   return state;
 }
@@ -129,7 +143,10 @@ function staticGetResponse(path: string, state: OperationsUiMockState, config: C
     state.healthReads += 1;
     return { status: 503, body: health() };
   }
-  if (path === '/api/v1/admin/operate/config') return ok({ items: configItems(config) });
+  if (path === '/api/v1/admin/operate/config') {
+    state.configReads += 1;
+    return ok({ items: configItems(config) });
+  }
   if (path === `/api/v1/admin/operate/config/${CONFIG_KEY}`) return configResponse(CONFIG_KEY, config);
   if (path === `/api/v1/admin/operate/config/${SIBLING_CONFIG_KEY}`) return configResponse(SIBLING_CONFIG_KEY, config);
   if (path === '/api/v1/admin/operate/logs') {
@@ -454,6 +471,12 @@ async function fulfill(route: Route, response: MockResponse): Promise<void> {
     contentType: 'application/json',
     headers: response.etag ? { etag: response.etag } : undefined,
     body: JSON.stringify(response.body),
+  });
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, milliseconds);
   });
 }
 

--- a/tests/integration/web-console-e2e/harness/operationsUiMock.ts
+++ b/tests/integration/web-console-e2e/harness/operationsUiMock.ts
@@ -1,0 +1,470 @@
+import type { Page, Route } from '@playwright/test';
+
+import { mutationProtocolProblem, preconditionProblem } from './requestProtocolMock.js';
+
+export const OPERATIONAL_SESSION_ID = '77777777-7777-4777-8777-777777777777';
+export const SECOND_OPERATIONAL_SESSION_ID = '66666666-6666-4666-8666-666666666666';
+export const OPERATIONS_PRIVATE_MARKER = 'private-prompt-must-not-render';
+
+const COMMAND_ID = '88888888-8888-4888-8888-888888888888';
+const SECOND_COMMAND_ID = '55555555-5555-4555-8555-555555555555';
+const CONFIG_KEY = 'enhanced_index.enabled';
+const SIBLING_CONFIG_KEY = 'enhanced_index.max_cache_entries';
+const REPLICA_ID = 'replica-browser';
+
+interface MockResponse {
+  readonly status: number;
+  readonly body: unknown;
+  readonly etag?: string;
+}
+
+interface ConfigState {
+  enabled: { value: boolean; version: number };
+  maxCacheEntries: { value: number; version: number };
+}
+
+type CommandOutcome = 'terminated' | 'already_absent' | 'failed';
+
+interface OperationsUiMockOptions {
+  readonly conflictOnFirstConfigWrite?: boolean;
+  readonly commandOutcome?: CommandOutcome;
+  readonly detailUnavailable?: boolean;
+  readonly includeSecondSession?: boolean;
+}
+
+interface RuntimeState {
+  readonly options: Required<OperationsUiMockOptions>;
+  readonly commandReads: Map<string, number>;
+  readonly terminatedSessionIds: Set<string>;
+}
+
+export interface OperationsUiMockState {
+  configPutAttempts: number;
+  configWrites: number;
+  commandReads: number;
+  terminated: boolean;
+  configValue: boolean;
+  maxCacheEntries: number;
+  healthReads: number;
+  logReads: number;
+  metricsReads: number;
+  systemMetricsReads: number;
+  sessionReads: number;
+  detailReads: number;
+  failNextLogRead: boolean;
+  failNextMetricsRead: boolean;
+  failNextSessionRead: boolean;
+}
+
+export async function installOperationsUiMock(
+  page: Page,
+  options: OperationsUiMockOptions = {},
+): Promise<OperationsUiMockState> {
+  const state: OperationsUiMockState = {
+    configPutAttempts: 0,
+    configWrites: 0,
+    commandReads: 0,
+    terminated: false,
+    configValue: true,
+    maxCacheEntries: 1000,
+    healthReads: 0,
+    logReads: 0,
+    metricsReads: 0,
+    systemMetricsReads: 0,
+    sessionReads: 0,
+    detailReads: 0,
+    failNextLogRead: false,
+    failNextMetricsRead: false,
+    failNextSessionRead: false,
+  };
+  const config: ConfigState = {
+    enabled: { value: true, version: 1 },
+    maxCacheEntries: { value: 1000, version: 1 },
+  };
+  const runtime: RuntimeState = {
+    options: {
+      conflictOnFirstConfigWrite: options.conflictOnFirstConfigWrite ?? true,
+      commandOutcome: options.commandOutcome ?? 'terminated',
+      detailUnavailable: options.detailUnavailable ?? false,
+      includeSecondSession: options.includeSecondSession ?? false,
+    },
+    commandReads: new Map(),
+    terminatedSessionIds: new Set(),
+  };
+
+  await page.route('**/api/v1/admin/operate/**', async route => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    const response = responseFor(request.method(), path, request.postDataJSON(), request.headers(), state, config, runtime);
+    await fulfill(route, response);
+  });
+  return state;
+}
+
+function responseFor(
+  method: string,
+  path: string,
+  body: unknown,
+  headers: Readonly<Record<string, string>>,
+  state: OperationsUiMockState,
+  config: ConfigState,
+  runtime: RuntimeState,
+): MockResponse {
+  if (method === 'GET') return getResponse(path, state, config, runtime);
+  const protocolProblem = mutationProtocolProblem(headers);
+  if (protocolProblem) return protocolProblem;
+  if (method === 'PUT') return putConfig(path, body, headers, state, config, runtime);
+  if (method === 'DELETE') return terminateSession(path, runtime);
+  return missing('Operator route was not found.');
+}
+
+function getResponse(path: string, state: OperationsUiMockState, config: ConfigState, runtime: RuntimeState): MockResponse {
+  const staticResponse = staticGetResponse(path, state, config);
+  if (staticResponse) return staticResponse;
+  return sessionGetResponse(path, state, runtime);
+}
+
+function staticGetResponse(path: string, state: OperationsUiMockState, config: ConfigState): MockResponse | null {
+  if (path === '/api/v1/admin/operate/health') {
+    state.healthReads += 1;
+    return { status: 503, body: health() };
+  }
+  if (path === '/api/v1/admin/operate/config') return ok({ items: configItems(config) });
+  if (path === `/api/v1/admin/operate/config/${CONFIG_KEY}`) return configResponse(CONFIG_KEY, config);
+  if (path === `/api/v1/admin/operate/config/${SIBLING_CONFIG_KEY}`) return configResponse(SIBLING_CONFIG_KEY, config);
+  if (path === '/api/v1/admin/operate/logs') {
+    state.logReads += 1;
+    if (state.failNextLogRead) {
+      state.failNextLogRead = false;
+      return unavailable('Operational logs are temporarily unavailable.');
+    }
+    return ok(logPage());
+  }
+  if (path === '/api/v1/admin/operate/metrics') {
+    state.metricsReads += 1;
+    if (state.failNextMetricsRead) {
+      state.failNextMetricsRead = false;
+      return unavailable('Operational metrics are temporarily unavailable.');
+    }
+    return ok(operationalMetrics());
+  }
+  if (path === '/api/v1/admin/operate/metrics/system') {
+    state.systemMetricsReads += 1;
+    return ok(systemMetrics());
+  }
+  return null;
+}
+
+function sessionGetResponse(path: string, state: OperationsUiMockState, runtime: RuntimeState): MockResponse {
+  if (path === '/api/v1/admin/operate/sessions') return sessionListResponse(state, runtime);
+  const sessionId = sessionIdFromDetailPath(path);
+  if (sessionId) return sessionDetailResponse(sessionId, state, runtime);
+  const commandId = commandIdFromPath(path);
+  if (commandId) return commandResponse(commandId, state, runtime);
+  return missing('Operator resource was not found.');
+}
+
+function sessionListResponse(state: OperationsUiMockState, runtime: RuntimeState): MockResponse {
+  state.sessionReads += 1;
+  if (state.failNextSessionRead) {
+    state.failNextSessionRead = false;
+    return unavailable('Runtime sessions are temporarily unavailable.');
+  }
+  const sessionIds = runtime.options.includeSecondSession
+    ? [OPERATIONAL_SESSION_ID, SECOND_OPERATIONAL_SESSION_ID]
+    : [OPERATIONAL_SESSION_ID];
+  const items = sessionIds
+    .filter(sessionId => !runtime.terminatedSessionIds.has(sessionId))
+    .map(runtimeSession);
+  return ok({ items, page: pageEnvelope() });
+}
+
+function sessionDetailResponse(sessionId: string, state: OperationsUiMockState, runtime: RuntimeState): MockResponse {
+  state.detailReads += 1;
+  if (runtime.options.detailUnavailable || runtime.terminatedSessionIds.has(sessionId)) {
+    return missing('This session belongs to another account.');
+  }
+  return ok(runtimeSession(sessionId));
+}
+
+function commandResponse(commandId: string, state: OperationsUiMockState, runtime: RuntimeState): MockResponse {
+  state.commandReads += 1;
+  const reads = (runtime.commandReads.get(commandId) ?? 0) + 1;
+  runtime.commandReads.set(commandId, reads);
+  const status = reads === 1 ? 'pending' : runtime.options.commandOutcome;
+  const targetSessionId = sessionIdForCommand(commandId);
+  if (status === 'terminated' || status === 'already_absent') {
+    runtime.terminatedSessionIds.add(targetSessionId);
+    if (targetSessionId === OPERATIONAL_SESSION_ID) state.terminated = true;
+  }
+  return ok(commandStatus(commandId, status));
+}
+
+function putConfig(
+  path: string,
+  body: unknown,
+  headers: Readonly<Record<string, string>>,
+  state: OperationsUiMockState,
+  config: ConfigState,
+  runtime: RuntimeState,
+): MockResponse {
+  const key = decodeConfigKey(path);
+  if (!key) return missing('Configuration key was not found.');
+  state.configPutAttempts += 1;
+  const target = configTarget(key, config);
+  if (state.configPutAttempts === 1 && runtime.options.conflictOnFirstConfigWrite) target.version += 1;
+  const concurrencyProblem = preconditionProblem(headers, configEtag(key, config));
+  if (concurrencyProblem) return concurrencyProblem;
+  const candidate = asRecord(body);
+  if (key === CONFIG_KEY && typeof candidate.value === 'boolean') {
+    config.enabled.value = candidate.value;
+    state.configValue = candidate.value;
+  } else if (key === SIBLING_CONFIG_KEY && typeof candidate.value === 'number') {
+    config.maxCacheEntries.value = candidate.value;
+    state.maxCacheEntries = candidate.value;
+  } else {
+    return { status: 422, body: { code: 'invalid_config_value', detail: 'Value does not match the setting schema.' } };
+  }
+  target.version += 1;
+  state.configWrites += 1;
+  return configResponse(key, config);
+}
+
+function terminateSession(path: string, runtime: RuntimeState): MockResponse {
+  const sessionId = sessionIdFromDetailPath(path);
+  if (!sessionId || runtime.terminatedSessionIds.has(sessionId)) {
+    return missing('Runtime session was not found.');
+  }
+  const commandId = commandIdForSession(sessionId);
+  return {
+    status: 202,
+    body: {
+      session_id: sessionId,
+      command_id: commandId,
+      target_replica_id: REPLICA_ID,
+      reason: 'operator_terminated',
+      status: 'accepted',
+    },
+  };
+}
+
+function health() {
+  const checkedAt = new Date().toISOString();
+  return {
+    status: 'degraded',
+    checked_at: checkedAt,
+    components: [
+      { component: 'database', status: 'ok', checked_at: checkedAt, failure_codes: [] },
+      { component: 'runtime_control', status: 'degraded', checked_at: checkedAt, failure_codes: ['runtime_ack_delayed'] },
+    ],
+  };
+}
+
+function configItems(config: ConfigState) {
+  return [
+    configSetting(CONFIG_KEY, config),
+    configSetting(SIBLING_CONFIG_KEY, config),
+    {
+      key: 'license.key',
+      schema_version: 1,
+      sensitivity: 'secret_write_only',
+      mutability: 'restart_required',
+      value_schema: { type: 'string', min_length: 1, max_length: 4096 },
+      effective_at: null,
+      pending_restart: true,
+      configured: true,
+      etag: '"license-key-v1"',
+    },
+    {
+      key: 'private.feature_enabled',
+      schema_version: 1,
+      sensitivity: 'secret_write_only',
+      mutability: 'dynamic',
+      value_schema: { type: 'boolean' },
+      effective_at: null,
+      pending_restart: false,
+      configured: true,
+      value: true,
+      etag: '"private-feature-v1"',
+    },
+    {
+      key: 'private.provider_options',
+      schema_version: 1,
+      sensitivity: 'secret_write_only',
+      mutability: 'dynamic',
+      value_schema: { type: 'object' },
+      effective_at: null,
+      pending_restart: false,
+      configured: true,
+      value: { token: OPERATIONS_PRIVATE_MARKER },
+      etag: '"private-provider-v1"',
+    },
+  ];
+}
+
+function configSetting(key: string, config: ConfigState) {
+  const enabled = key === CONFIG_KEY;
+  const target = configTarget(key, config);
+  return {
+    key,
+    schema_version: 1,
+    sensitivity: 'public_admin',
+    mutability: 'dynamic',
+    value_schema: enabled
+      ? { type: 'boolean' }
+      : { type: 'integer', minimum: 0, maximum: 100000 },
+    effective_at: new Date().toISOString(),
+    pending_restart: false,
+    value: target.value,
+    etag: configEtag(key, config),
+  };
+}
+
+function configResponse(key: string, config: ConfigState): MockResponse {
+  const setting = configSetting(key, config);
+  return { status: 200, body: setting, etag: setting.etag };
+}
+
+function configEtag(key: string, config: ConfigState) {
+  return `"operator-config-${key}-v${configTarget(key, config).version}"`;
+}
+
+function configTarget(key: string, config: ConfigState) {
+  return key === CONFIG_KEY ? config.enabled : config.maxCacheEntries;
+}
+
+function decodeConfigKey(path: string): string | null {
+  const prefix = '/api/v1/admin/operate/config/';
+  if (!path.startsWith(prefix)) return null;
+  const key = decodeURIComponent(path.slice(prefix.length));
+  return key === CONFIG_KEY || key === SIBLING_CONFIG_KEY ? key : null;
+}
+
+function logPage() {
+  return {
+    items: [{
+      ts: new Date().toISOString(),
+      level: 'warn',
+      subsystem: 'runtime',
+      event: 'runtime.command.delayed',
+      correlation_id: 'correlation-browser',
+      account_correlation_id: '99999999-9999-4999-8999-999999999999',
+      session_id: OPERATIONAL_SESSION_ID,
+      replica: REPLICA_ID,
+      duration_ms: 125,
+      status_code: 202,
+      error_code: null,
+      message: OPERATIONS_PRIVATE_MARKER,
+    }],
+    page: pageEnvelope(),
+  };
+}
+
+function operationalMetrics() {
+  return {
+    checked_at: new Date().toISOString(),
+    metrics: [{
+      name: 'runtime.commands.pending',
+      kind: 'gauge',
+      value: 1,
+      unit: 'commands',
+      dimensions: { subsystem: 'runtime', replica: REPLICA_ID },
+    }],
+  };
+}
+
+function systemMetrics() {
+  const timestamp = new Date().toISOString();
+  return {
+    items: [{
+      id: 'browser-snapshot',
+      timestamp,
+      duration_ms: 3,
+      metrics: [{ name: 'cache.hits', source: 'enhanced-index', unit: 'count', type: 'counter', value: 42 }],
+      errors: [],
+    }],
+    page: { limit: 50, cursor: null, next_cursor: null },
+    oldest_available: timestamp,
+    newest_available: timestamp,
+  };
+}
+
+function runtimeSession(sessionId: string) {
+  const now = new Date();
+  const second = sessionId === SECOND_OPERATIONAL_SESSION_ID;
+  return {
+    session_id: sessionId,
+    transport: 'streamable-http',
+    client_info: { name: second ? 'Second Browser Client' : 'Browser MCP Client', version: '4.2.0' },
+    created_at: new Date(now.getTime() - 60_000).toISOString(),
+    last_active_at: now.toISOString(),
+    status: 'active',
+    account_correlation_id: '99999999-9999-4999-8999-999999999999',
+    replica_id: REPLICA_ID,
+    request_count: 12,
+    error_count: 1,
+    lease_until: new Date(now.getTime() + 300_000).toISOString(),
+    private_prompt: OPERATIONS_PRIVATE_MARKER,
+  };
+}
+
+function commandStatus(commandId: string, status: 'pending' | CommandOutcome) {
+  return {
+    command_id: commandId,
+    status,
+    acknowledged_at: status === 'pending' ? null : new Date().toISOString(),
+    replica_id: status === 'pending' ? null : REPLICA_ID,
+    error_code: status === 'failed' ? 'session_termination_failed' : null,
+  };
+}
+
+function sessionIdFromDetailPath(path: string): string | null {
+  const prefix = '/api/v1/admin/operate/sessions/';
+  if (!path.startsWith(prefix) || path.includes('/commands/')) return null;
+  const sessionId = decodeURIComponent(path.slice(prefix.length));
+  return sessionId === OPERATIONAL_SESSION_ID || sessionId === SECOND_OPERATIONAL_SESSION_ID ? sessionId : null;
+}
+
+function commandIdFromPath(path: string): string | null {
+  const prefix = '/api/v1/admin/operate/sessions/commands/';
+  if (!path.startsWith(prefix)) return null;
+  const commandId = decodeURIComponent(path.slice(prefix.length));
+  return commandId === COMMAND_ID || commandId === SECOND_COMMAND_ID ? commandId : null;
+}
+
+function commandIdForSession(sessionId: string): string {
+  return sessionId === OPERATIONAL_SESSION_ID ? COMMAND_ID : SECOND_COMMAND_ID;
+}
+
+function sessionIdForCommand(commandId: string): string {
+  return commandId === COMMAND_ID ? OPERATIONAL_SESSION_ID : SECOND_OPERATIONAL_SESSION_ID;
+}
+
+function pageEnvelope() {
+  return { limit: 50, cursor: null, next_cursor: null };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+async function fulfill(route: Route, response: MockResponse): Promise<void> {
+  await route.fulfill({
+    status: response.status,
+    contentType: 'application/json',
+    headers: response.etag ? { etag: response.etag } : undefined,
+    body: JSON.stringify(response.body),
+  });
+}
+
+function ok(body: unknown): MockResponse {
+  return { status: 200, body };
+}
+
+function missing(detail: string): MockResponse {
+  return { status: 404, body: { code: 'not_found', detail } };
+}
+
+function unavailable(detail: string): MockResponse {
+  return { status: 503, body: { code: 'temporarily_unavailable', detail } };
+}

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -9,6 +9,11 @@ import { SEED_PASSWORD } from '../harness/seed.js';
 import { installPortfolioUiMock } from '../harness/portfolioUiMock.js';
 import { installSelfServiceUiMock } from '../harness/selfServiceUiMock.js';
 import { installSessionUiMock } from '../harness/sessionUiMock.js';
+import {
+  installOperationsUiMock,
+  OPERATIONS_PRIVATE_MARKER,
+  SECOND_OPERATIONAL_SESSION_ID,
+} from '../harness/operationsUiMock.js';
 import { BASE_URL } from '../setup/provision.js';
 
 const USER = 'e2e_admin';
@@ -21,6 +26,10 @@ const ACCOUNT_MENU = '#site-account';
 const EDITOR_FEEDBACK = '[data-editor-feedback]';
 const EDITOR_CONTENT = '.portfolio-editor [name="content"]';
 const THEME_SELECT = '#account-theme-form [name="theme"]';
+const OPERATIONS_TAB = '.console-tab[data-tab="operations"]';
+const SUBMIT_BUTTON = 'button[type="submit"]';
+const OPERATIONS_SESSIONS_NAV = '[data-operations-nav="sessions"]';
+const OPERATIONAL_SESSION_CARD = '[data-operational-session-id]';
 
 async function filterManifestRoutes(page: Page, unavailableRoutes: ReadonlySet<string>): Promise<void> {
   await page.route(MANIFEST_URL, async route => {
@@ -64,6 +73,16 @@ async function loginFromConsole(page: Page): Promise<void> {
   await Promise.all([page.waitForLoadState('networkidle'), page.click('button[value="login"]')]);
   await approveClientConsentIfShown(page);
   await page.locator('#console-shell').waitFor({ state: 'visible' });
+}
+
+async function openMockOperations(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    globalThis.dispatchEvent(new CustomEvent('dh:elevation-changed', {
+      detail: { active: true, capabilities: ['console:admin:operate'] },
+    }));
+  });
+  await expect(page.locator(OPERATIONS_TAB)).toBeVisible();
+  await page.locator(OPERATIONS_TAB).click();
 }
 
 test('console UI serves its asset graph and boots from server metadata', async ({ page }) => {
@@ -200,6 +219,169 @@ test('portfolio write controls disappear when the manifest omits write routes', 
   await page.locator('[data-name="alpha-persona"]').click();
   await expect(page.locator('.modal-edit-btn')).toBeHidden();
   await expect(page.locator('.modal-delete-btn')).toBeHidden();
+});
+
+test('operations remains usable when a partial deployment omits health', async ({ page }) => {
+  await installOperationsUiMock(page);
+  await filterManifestRoutes(page, new Set([
+    'GET /api/v1/admin/operate/health',
+    'PUT /api/v1/admin/operate/config/:key',
+  ]));
+  await loginFromConsole(page);
+
+  await page.evaluate(() => {
+    globalThis.dispatchEvent(new CustomEvent('dh:elevation-changed', {
+      detail: { active: true, capabilities: ['console:admin:operate'] },
+    }));
+  });
+  await expect(page.locator(OPERATIONS_TAB)).toBeVisible();
+  await page.locator(OPERATIONS_TAB).click();
+  await expect(page.locator('[data-operations-nav="health"]')).toHaveCount(0);
+  await expect(page.locator('[data-operations-nav="config"]')).toBeVisible();
+  await page.locator('[data-operations-nav="config"]').click();
+  await expect(page.locator('[data-config-form="enhanced_index.enabled"]')).toBeVisible();
+  await expect(page.locator('[data-config-form="enhanced_index.enabled"]')).toContainText('Not writable in this deployment');
+  await expect(page.locator('[data-config-form="enhanced_index.enabled"] select')).toBeDisabled();
+});
+
+test('operations requires its capability and stops polling when privilege or visibility is lost', async ({ page }) => {
+  const mock = await installOperationsUiMock(page);
+  await loginFromConsole(page);
+
+  await page.evaluate(() => {
+    globalThis.dispatchEvent(new CustomEvent('dh:elevation-changed', {
+      detail: { active: true, capabilities: ['console:admin:accounts'] },
+    }));
+  });
+  await expect(page.locator(OPERATIONS_TAB)).toBeHidden();
+
+  await page.clock.install();
+  await openMockOperations(page);
+  await expect.poll(() => mock.healthReads).toBeGreaterThan(0);
+  const beforeStepDown = mock.healthReads;
+  await page.evaluate(() => {
+    globalThis.dispatchEvent(new CustomEvent('dh:elevation-changed', {
+      detail: { active: false, capabilities: [] },
+    }));
+  });
+  await page.clock.fastForward(11_000);
+  expect(mock.healthReads, 'step-down aborts and stops operator polling').toBe(beforeStepDown);
+
+  await openMockOperations(page);
+  await expect.poll(() => mock.healthReads).toBeGreaterThan(beforeStepDown);
+  const beforeHidden = mock.healthReads;
+  await page.evaluate(() => {
+    Object.defineProperty(globalThis.document, 'hidden', { configurable: true, value: true });
+    globalThis.document.dispatchEvent(new Event('visibilitychange'));
+  });
+  await page.clock.fastForward(11_000);
+  expect(mock.healthReads, 'background tabs do not poll operator routes').toBe(beforeHidden);
+});
+
+test('operator configuration preserves sibling drafts, per-setting concurrency, badges, and secret privacy', async ({ page }) => {
+  const mock = await installOperationsUiMock(page, { conflictOnFirstConfigWrite: false });
+  await loginFromConsole(page);
+  await openMockOperations(page);
+  await page.locator('[data-operations-nav="config"]').click();
+
+  const enabled = page.locator('[data-config-form="enhanced_index.enabled"]');
+  const sibling = page.locator('[data-config-form="enhanced_index.max_cache_entries"]');
+  const license = page.locator('[data-config-form="license.key"]');
+  await expect(enabled).toContainText('Dynamic');
+  await expect(enabled).toContainText('effective');
+  await expect(license).toContainText('Restart pending');
+  await expect(license).toContainText('not effective until restart');
+  await expect(page.locator('[data-config-form="private.feature_enabled"] select')).toHaveValue('');
+  await expect(page.locator('[data-config-form="private.provider_options"] textarea')).toHaveValue('');
+  await expect(page.locator('#tab-operations')).not.toContainText(OPERATIONS_PRIVATE_MARKER);
+
+  await sibling.locator('input[name="value"]').fill('2048');
+  await enabled.locator('select[name="value"]').selectOption('false');
+  await enabled.locator(SUBMIT_BUTTON).click();
+  await expect.poll(() => mock.configWrites).toBe(1);
+  await expect(sibling.locator('input[name="value"]')).toHaveValue('2048');
+  await sibling.locator(SUBMIT_BUTTON).click();
+  await expect.poll(() => mock.configWrites).toBe(2);
+  expect(mock.maxCacheEntries).toBe(2048);
+  await expect(sibling.locator('[data-config-feedback]')).not.toContainText('changed elsewhere');
+});
+
+test('operations refresh includes embedded metrics and section changes stop its auto-refresh', async ({ page }) => {
+  const mock = await installOperationsUiMock(page);
+  await loginFromConsole(page);
+  await openMockOperations(page);
+  await page.clock.install();
+  await page.locator('[data-operations-nav="metrics"]').click();
+  await expect.poll(() => mock.metricsReads).toBeGreaterThan(0);
+  await expect.poll(() => mock.systemMetricsReads).toBeGreaterThan(0);
+
+  const operationalBeforeRefresh = mock.metricsReads;
+  const systemBeforeRefresh = mock.systemMetricsReads;
+  await page.locator('#operations-refresh').click();
+  await expect.poll(() => mock.metricsReads).toBeGreaterThan(operationalBeforeRefresh);
+  await expect.poll(() => mock.systemMetricsReads).toBeGreaterThan(systemBeforeRefresh);
+
+  await page.locator('#am-auto').check();
+  await page.locator('[data-operations-nav="health"]').click();
+  const systemBeforeSectionChange = mock.systemMetricsReads;
+  await page.clock.fastForward(11_000);
+  expect(mock.systemMetricsReads, 'embedded metrics stop when their Operations section is hidden').toBe(systemBeforeSectionChange);
+});
+
+test('operations retains the last session snapshot through a transient refresh failure', async ({ page }) => {
+  const mock = await installOperationsUiMock(page);
+  await loginFromConsole(page);
+  await openMockOperations(page);
+  await page.locator(OPERATIONS_SESSIONS_NAV).click();
+  await expect(page.locator(OPERATIONAL_SESSION_CARD)).toBeVisible();
+
+  mock.failNextSessionRead = true;
+  await page.locator('#operations-refresh').click();
+  await expect(page.locator('[data-session-list-warning]')).toContainText('last successful snapshot');
+  await expect(page.locator(OPERATIONAL_SESSION_CARD)).toBeVisible();
+});
+
+test('session termination acknowledgements stay bound to their originating session', async ({ page }) => {
+  const mock = await installOperationsUiMock(page, { includeSecondSession: true });
+  await loginFromConsole(page);
+  await openMockOperations(page);
+  await page.locator(OPERATIONS_SESSIONS_NAV).click();
+  await page.locator(OPERATIONAL_SESSION_CARD).first().click();
+  await page.locator('[data-operational-session-terminate]').click();
+  await page.locator(CONFIRM_ACTION).click();
+  await expect.poll(() => mock.commandReads).toBe(1);
+
+  await page.locator(`[data-operational-session-id="${SECOND_OPERATIONAL_SESSION_ID}"]`).click();
+  await expect(page.locator('[data-operational-session-detail]')).toContainText('Second Browser Client');
+  await page.waitForTimeout(700);
+  await expect(page.locator('[data-operational-command-status]')).toBeEmpty();
+  await expect(page.locator(`[data-operational-session-id="${SECOND_OPERATIONAL_SESSION_ID}"]`)).toBeVisible();
+});
+
+for (const outcome of ['already_absent', 'failed'] as const) {
+  test(`session termination renders the ${outcome} terminal outcome`, async ({ page }) => {
+    await installOperationsUiMock(page, { commandOutcome: outcome });
+    await loginFromConsole(page);
+    await openMockOperations(page);
+    await page.locator(OPERATIONS_SESSIONS_NAV).click();
+    await page.locator(OPERATIONAL_SESSION_CARD).click();
+    await page.locator('[data-operational-session-terminate]').click();
+    await page.locator(CONFIRM_ACTION).click();
+
+    const expected = outcome === 'already_absent' ? 'already absent' : 'Termination failed';
+    await expect(page.locator('[data-operational-command-status]')).toContainText(expected);
+  });
+}
+
+test('unavailable operator session detail uses a cross-user-neutral message', async ({ page }) => {
+  await installOperationsUiMock(page, { detailUnavailable: true });
+  await loginFromConsole(page);
+  await openMockOperations(page);
+  await page.locator(OPERATIONS_SESSIONS_NAV).click();
+  await page.locator(OPERATIONAL_SESSION_CARD).click();
+
+  await expect(page.locator('[data-operational-session-detail]')).toContainText('ended, expired, or is not available');
+  await expect(page.locator('[data-operational-session-detail]')).not.toContainText('another account');
 });
 
 test('profile and allowlisted appearance settings persist without overwriting stale state', async ({ page }) => {
@@ -370,7 +552,7 @@ test('console auth lifecycle: login -> enroll TOTP -> step-up -> step-down -> lo
   const secretText = (await page.locator('code').first().innerText()).trim().replaceAll(/\s+/g, '');
   const totp = new TOTP({ secret: Secret.fromBase32(secretText) });
   await page.fill('input[name="code"]', totp.generate());
-  await Promise.all([page.waitForLoadState('networkidle'), page.click('button[type="submit"]')]);
+  await Promise.all([page.waitForLoadState('networkidle'), page.click(SUBMIT_BUTTON)]);
 
   // 4. STEP-UP for the operate capability (may re-prompt password, then TOTP)
   await page.goto(
@@ -384,7 +566,7 @@ test('console auth lifecycle: login -> enroll TOTP -> step-up -> step-down -> lo
   }
   if (await page.locator('input[name="code"]').count()) {
     await page.fill('input[name="code"]', totp.generate());
-    await Promise.all([page.waitForLoadState('networkidle'), page.click('button[type="submit"]')]);
+    await Promise.all([page.waitForLoadState('networkidle'), page.click(SUBMIT_BUTTON)]);
   }
   await approveClientConsentIfShown(page);
 
@@ -394,6 +576,7 @@ test('console auth lifecycle: login -> enroll TOTP -> step-up -> step-down -> lo
   // The Users surface gets its role list and grants from /me/role-catalog.
   const catalogResponse = await page.request.get(`${BASE_URL}/api/v1/me/role-catalog`);
   const catalog = await catalogResponse.json() as { roles: string[] };
+  const operationsMock = await installOperationsUiMock(page);
   await filterManifestRoutes(page, new Set([
     'GET /api/v1/me/portfolio/elements',
     'GET /api/v1/me/sessions',
@@ -408,11 +591,51 @@ test('console auth lifecycle: login -> enroll TOTP -> step-up -> step-down -> lo
   await expect(page.locator('[data-role-toggle]')).toHaveCount(catalog.roles.length);
   await page.locator('#ua-drawer-close').click();
 
+  // The Operations workspace keeps configuration concurrency-safe, renders
+  // only allowlisted telemetry, and follows async runtime termination to ack.
+  await page.locator(OPERATIONS_TAB).click();
+  await expect(page.locator('[data-operations-panel="health"]')).toContainText('Degraded');
+  await expect(page.locator('[data-operations-panel="health"]')).toContainText('runtime_ack_delayed');
+
+  await page.locator('[data-operations-nav="config"]').click();
+  const configForm = page.locator('[data-config-form="enhanced_index.enabled"]');
+  await expect(page.locator('[data-config-form="license.key"] input')).toHaveValue('');
+  await configForm.locator('select[name="value"]').selectOption('false');
+  await configForm.locator(SUBMIT_BUTTON).click();
+  await expect(configForm.locator('[data-config-feedback]')).toContainText('changed elsewhere');
+  expect(operationsMock.configWrites).toBe(0);
+  await configForm.locator('[data-config-reload]').click();
+  await page.locator('[data-config-form="enhanced_index.enabled"] select[name="value"]').selectOption('false');
+  await page.locator('[data-config-form="enhanced_index.enabled"] button[type="submit"]').click();
+  await expect.poll(() => operationsMock.configWrites).toBe(1);
+  expect(operationsMock.configValue).toBe(false);
+
+  await page.locator('[data-operations-nav="logs"]').click();
+  await expect(page.locator('[data-operational-log-body]')).toContainText('runtime.command.delayed');
+  await expect(page.locator('#tab-operations')).not.toContainText(OPERATIONS_PRIVATE_MARKER);
+
+  await page.locator('[data-operations-nav="metrics"]').click();
+  await expect(page.locator('[data-operational-metrics-body]')).toContainText('runtime.commands.pending');
+  await expect(page.locator('[data-system-metrics]')).toContainText('cache.hits');
+
+  await page.locator(OPERATIONS_SESSIONS_NAV).click();
+  await page.locator(OPERATIONAL_SESSION_CARD).click();
+  await expect(page.locator('[data-operational-session-detail]')).toContainText('replica-browser');
+  await expect(page.locator('#tab-operations')).not.toContainText(OPERATIONS_PRIVATE_MARKER);
+  await page.locator('[data-operational-session-terminate]').click();
+  await page.locator(CONFIRM_ACTION).click();
+  await expect(page.locator('[data-operational-command-status]')).toContainText('acknowledged termination');
+  expect(operationsMock.commandReads).toBeGreaterThanOrEqual(2);
+  expect(operationsMock.terminated).toBe(true);
+
   // 6. STEP-DOWN hides the privileged panel even when no non-admin tab exists.
   await page.locator('#exit-btn').click();
   await expect(page.locator('#console-empty-state')).toBeVisible();
   await expect(page.locator('#tab-users')).toBeHidden();
   await expect(page.locator('.console-tab[data-tab="users"]')).toBeHidden();
+  await expect(page.locator('#tab-operations')).toBeHidden();
+  await expect(page.locator(OPERATIONS_TAB)).toBeHidden();
+  await page.unroute('**/api/v1/admin/operate/**');
   expect(await status(page, OPERATE), 'admin gated again after step-down').toBe(401);
 
   // 7. LOGOUT ends the session

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -35,7 +35,10 @@ const AUTHORING_WORKSPACE = '[data-portfolio-authoring]';
 const THEME_SELECT = '#account-theme-form [name="theme"]';
 const OPERATIONS_TAB = '.console-tab[data-tab="operations"]';
 const SUBMIT_BUTTON = 'button[type="submit"]';
+const OPERATIONS_HEALTH_NAV = '[data-operations-nav="health"]';
+const OPERATIONS_CONFIG_NAV = '[data-operations-nav="config"]';
 const OPERATIONS_SESSIONS_NAV = '[data-operations-nav="sessions"]';
+const ENABLED_CONFIG_FORM = '[data-config-form="enhanced_index.enabled"]';
 const OPERATIONAL_SESSION_CARD = '[data-operational-session-id]';
 const BULK_SESSION_ACTION = '#sess-revoke-others';
 const USER_DRAWER = '.ua-drawer';
@@ -527,12 +530,12 @@ test('operations remains usable when a partial deployment omits health', async (
   });
   await expect(page.locator(OPERATIONS_TAB)).toBeVisible();
   await page.locator(OPERATIONS_TAB).click();
-  await expect(page.locator('[data-operations-nav="health"]')).toHaveCount(0);
-  await expect(page.locator('[data-operations-nav="config"]')).toBeVisible();
-  await page.locator('[data-operations-nav="config"]').click();
-  await expect(page.locator('[data-config-form="enhanced_index.enabled"]')).toBeVisible();
-  await expect(page.locator('[data-config-form="enhanced_index.enabled"]')).toContainText('Not writable in this deployment');
-  await expect(page.locator('[data-config-form="enhanced_index.enabled"] select')).toBeDisabled();
+  await expect(page.locator(OPERATIONS_HEALTH_NAV)).toHaveCount(0);
+  await expect(page.locator(OPERATIONS_CONFIG_NAV)).toBeVisible();
+  await page.locator(OPERATIONS_CONFIG_NAV).click();
+  await expect(page.locator(ENABLED_CONFIG_FORM)).toBeVisible();
+  await expect(page.locator(ENABLED_CONFIG_FORM)).toContainText('Not writable in this deployment');
+  await expect(page.locator(`${ENABLED_CONFIG_FORM} select`)).toBeDisabled();
 });
 
 test('operations requires its capability and stops polling when privilege or visibility is lost', async ({ page }) => {
@@ -573,9 +576,9 @@ test('operator configuration preserves sibling drafts, per-setting concurrency, 
   const mock = await installOperationsUiMock(page, { conflictOnFirstConfigWrite: false });
   await loginFromConsole(page);
   await openMockOperations(page);
-  await page.locator('[data-operations-nav="config"]').click();
+  await page.locator(OPERATIONS_CONFIG_NAV).click();
 
-  const enabled = page.locator('[data-config-form="enhanced_index.enabled"]');
+  const enabled = page.locator(ENABLED_CONFIG_FORM);
   const sibling = page.locator('[data-config-form="enhanced_index.max_cache_entries"]');
   const license = page.locator('[data-config-form="license.key"]');
   await expect(enabled).toContainText('Dynamic');
@@ -597,6 +600,20 @@ test('operator configuration preserves sibling drafts, per-setting concurrency, 
   await expect(sibling.locator('[data-config-feedback]')).not.toContainText('changed elsewhere');
 });
 
+test('operator configuration restarts loading after rapid section navigation', async ({ page }) => {
+  const mock = await installOperationsUiMock(page, { configListDelayMs: 500 });
+  await loginFromConsole(page);
+  await openMockOperations(page);
+  await page.locator(OPERATIONS_CONFIG_NAV).click();
+  await expect.poll(() => mock.configReads).toBe(1);
+
+  await page.locator(OPERATIONS_HEALTH_NAV).click();
+  await page.locator(OPERATIONS_CONFIG_NAV).click();
+
+  await expect.poll(() => mock.configReads).toBe(2);
+  await expect(page.locator(ENABLED_CONFIG_FORM)).toBeVisible();
+});
+
 test('operations refresh includes embedded metrics and section changes stop its auto-refresh', async ({ page }) => {
   const mock = await installOperationsUiMock(page);
   await loginFromConsole(page);
@@ -613,10 +630,25 @@ test('operations refresh includes embedded metrics and section changes stop its 
   await expect.poll(() => mock.systemMetricsReads).toBeGreaterThan(systemBeforeRefresh);
 
   await page.locator('#am-auto').check();
-  await page.locator('[data-operations-nav="health"]').click();
+  await page.locator(OPERATIONS_HEALTH_NAV).click();
   const systemBeforeSectionChange = mock.systemMetricsReads;
   await page.clock.fastForward(11_000);
   expect(mock.systemMetricsReads, 'embedded metrics stop when their Operations section is hidden').toBe(systemBeforeSectionChange);
+});
+
+test('embedded system metrics refresh once when returning to Operations', async ({ page }) => {
+  const mock = await installOperationsUiMock(page);
+  await loginFromConsole(page);
+  await openMockOperations(page);
+  await page.locator('[data-operations-nav="metrics"]').click();
+  await expect.poll(() => mock.systemMetricsReads).toBeGreaterThan(0);
+
+  await page.locator('.console-tab[data-tab="portfolio"]').click();
+  const readsBeforeReturn = mock.systemMetricsReads;
+  await page.locator(OPERATIONS_TAB).click();
+  await expect.poll(() => mock.systemMetricsReads).toBe(readsBeforeReturn + 1);
+  await page.waitForTimeout(100);
+  expect(mock.systemMetricsReads, 'the parent lifecycle performs only one refresh').toBe(readsBeforeReturn + 1);
 });
 
 test('operations retains the last session snapshot through a transient refresh failure', async ({ page }) => {
@@ -919,16 +951,16 @@ test('console auth lifecycle: login -> enroll TOTP -> step-up -> step-down -> lo
   await expect(page.locator('[data-operations-panel="health"]')).toContainText('Degraded');
   await expect(page.locator('[data-operations-panel="health"]')).toContainText('runtime_ack_delayed');
 
-  await page.locator('[data-operations-nav="config"]').click();
-  const configForm = page.locator('[data-config-form="enhanced_index.enabled"]');
+  await page.locator(OPERATIONS_CONFIG_NAV).click();
+  const configForm = page.locator(ENABLED_CONFIG_FORM);
   await expect(page.locator('[data-config-form="license.key"] input')).toHaveValue('');
   await configForm.locator('select[name="value"]').selectOption('false');
   await configForm.locator(SUBMIT_BUTTON).click();
   await expect(configForm.locator('[data-config-feedback]')).toContainText('changed elsewhere');
   expect(operationsMock.configWrites).toBe(0);
   await configForm.locator('[data-config-reload]').click();
-  await page.locator('[data-config-form="enhanced_index.enabled"] select[name="value"]').selectOption('false');
-  await page.locator('[data-config-form="enhanced_index.enabled"] button[type="submit"]').click();
+  await page.locator(`${ENABLED_CONFIG_FORM} select[name="value"]`).selectOption('false');
+  await page.locator(`${ENABLED_CONFIG_FORM} button[type="submit"]`).click();
   await expect.poll(() => operationsMock.configWrites).toBe(1);
   expect(operationsMock.configValue).toBe(false);
 

--- a/tests/unit/web-console/modules/OperationsConfig.test.ts
+++ b/tests/unit/web-console/modules/OperationsConfig.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { InMemoryOperatorConfigStore } from '../../../../src/storage/operatorConfig/InMemoryOperatorConfigStore.js';
+import {
+  OperatorConfigurationService,
+  projectOperatorConfigSetting,
+} from '../../../../src/web-console/index.js';
+
+const NOW = new Date('2026-07-21T12:00:00.000Z');
+const ENABLED_KEY = 'enhanced_index.enabled';
+const PORT_KEY = 'console.port';
+
+describe('OperatorConfigurationService setting concurrency', () => {
+  it('keeps a sibling ETag valid when a different setting changes', async () => {
+    const service = new OperatorConfigurationService(
+      new InMemoryOperatorConfigStore(),
+      undefined,
+      () => NOW,
+    );
+    const siblingBefore = projectOperatorConfigSetting((await service.getConfig(PORT_KEY)).body);
+    const changedBefore = projectOperatorConfigSetting((await service.getConfig(ENABLED_KEY)).body);
+
+    await expect(service.updateConfig({
+      key: ENABLED_KEY,
+      ifMatch: changedBefore.etag,
+      body: { value: true },
+    })).resolves.toMatchObject({ status: 200 });
+
+    const siblingAfter = projectOperatorConfigSetting((await service.getConfig(PORT_KEY)).body);
+    expect(siblingAfter.etag).toBe(siblingBefore.etag);
+    await expect(service.updateConfig({
+      key: PORT_KEY,
+      ifMatch: siblingBefore.etag,
+      body: { value: 3100 },
+    })).resolves.toMatchObject({ status: 200 });
+  });
+});

--- a/tests/unit/web-console/modules/OperationsConfig.test.ts
+++ b/tests/unit/web-console/modules/OperationsConfig.test.ts
@@ -4,13 +4,27 @@ import { InMemoryOperatorConfigStore } from '../../../../src/storage/operatorCon
 import {
   OperatorConfigurationService,
   projectOperatorConfigSetting,
+  type OperatorConfigSettingDefinition,
 } from '../../../../src/web-console/index.js';
 
 const NOW = new Date('2026-07-21T12:00:00.000Z');
 const ENABLED_KEY = 'enhanced_index.enabled';
+const LICENSE_KEY = 'license.key';
 const PORT_KEY = 'console.port';
+const READ_ONLY_KEY = 'deployment.region';
+const READ_ONLY_DEFINITIONS: readonly OperatorConfigSettingDefinition[] = [{
+  key: READ_ONLY_KEY,
+  section: 'defaultsConfig',
+  path: ['region'],
+  schema: { type: 'string', min_length: 1 },
+  schemaVersion: 1,
+  sensitivity: 'public_admin',
+  mutability: 'read_only',
+  requiredCapability: 'console:admin:operate',
+  defaultValue: 'us-east-1',
+}];
 
-describe('OperatorConfigurationService setting concurrency', () => {
+describe('OperatorConfigurationService', () => {
   it('keeps a sibling ETag valid when a different setting changes', async () => {
     const service = new OperatorConfigurationService(
       new InMemoryOperatorConfigStore(),
@@ -33,5 +47,73 @@ describe('OperatorConfigurationService setting concurrency', () => {
       ifMatch: siblingBefore.etag,
       body: { value: 3100 },
     })).resolves.toMatchObject({ status: 200 });
+  });
+
+  it('records effective state and rotates the changed dynamic setting ETag', async () => {
+    const service = new OperatorConfigurationService(
+      new InMemoryOperatorConfigStore(),
+      undefined,
+      () => NOW,
+    );
+    const before = projectOperatorConfigSetting((await service.getConfig(ENABLED_KEY)).body);
+
+    const result = await service.updateConfig({
+      key: ENABLED_KEY,
+      ifMatch: before.etag,
+      body: { value: true },
+    });
+    const updated = projectOperatorConfigSetting(result.body);
+
+    expect(result.status).toBe(200);
+    expect(updated).toMatchObject({
+      key: ENABLED_KEY,
+      value: true,
+      effective_at: NOW.toISOString(),
+      pending_restart: false,
+    });
+    expect(updated.etag).not.toBe(before.etag);
+  });
+
+  it('rejects malformed and oversized mutations without changing stored configuration', async () => {
+    const store = new InMemoryOperatorConfigStore();
+    const service = new OperatorConfigurationService(store);
+    const initial = await store.load();
+    const enabled = projectOperatorConfigSetting((await service.getConfig(ENABLED_KEY)).body);
+    const license = projectOperatorConfigSetting((await service.getConfig(LICENSE_KEY)).body);
+
+    await expect(service.updateConfig({
+      key: ENABLED_KEY,
+      ifMatch: enabled.etag,
+      body: {},
+    })).resolves.toMatchObject({
+      status: 422,
+      body: { code: 'validation_failed', detail: 'Request body must be an object with a value field.' },
+    });
+    await expect(service.updateConfig({
+      key: LICENSE_KEY,
+      ifMatch: license.etag,
+      body: { value: 'x'.repeat(64 * 1024 + 1) },
+    })).resolves.toMatchObject({
+      status: 422,
+      body: { code: 'validation_failed', detail: 'Operator configuration value exceeds the maximum size.' },
+    });
+    await expect(store.load()).resolves.toEqual(initial);
+  });
+
+  it('rejects updates to read-only definitions without changing stored configuration', async () => {
+    const store = new InMemoryOperatorConfigStore();
+    const service = new OperatorConfigurationService(store, READ_ONLY_DEFINITIONS);
+    const initial = await store.load();
+    const setting = projectOperatorConfigSetting((await service.getConfig(READ_ONLY_KEY)).body);
+
+    await expect(service.updateConfig({
+      key: READ_ONLY_KEY,
+      ifMatch: setting.etag,
+      body: { value: 'us-west-2' },
+    })).resolves.toMatchObject({
+      status: 409,
+      body: { code: 'config_read_only' },
+    });
+    await expect(store.load()).resolves.toEqual(initial);
   });
 });


### PR DESCRIPTION
## Summary

Adds an elevated Operations workspace to the web console for monitoring deployment health, managing allowlisted configuration, inspecting operational telemetry, and controlling runtime sessions.

## What changed

- Adds a capability- and route-gated Operations tab with Health, Configuration, Logs, Metrics, and Sessions sections.
- Adds a schema-driven configuration editor with dynamic, restart-required, read-only, and write-only secret handling.
- Protects configuration writes with per-setting ETags, explicit conflict recovery, pending-restart indicators, and effective-state reporting.
- Keeps sibling configuration ETags stable when another setting changes.
- Adds privacy-filtered operational logs, activity metrics, and system metrics.
- Adds cross-user runtime-session inspection and confirmed termination with asynchronous command-status feedback.
- Stops polling when Operations is inactive, elevation ends, or the browser tab is hidden.
- Preserves the last successful snapshot through transient refresh failures.
- Adapts to partially available deployments by rendering only the Operations sections and controls advertised by the server.
- Adds responsive configuration cards with contained setting names and consistent controls.

## Test coverage

- Covers Operations capability gating and partial deployments.
- Covers elevation loss, browser visibility, section changes, and polling cleanup.
- Covers configuration drafts, per-setting concurrency, conflicts, mutability badges, and secret privacy.
- Covers operational metrics refresh and embedded system-metrics lifecycle behavior.
- Covers session inspection, stale snapshots, termination outcomes, and command acknowledgements remaining bound to the correct session.
- Covers privacy-neutral handling for unavailable or cross-user session details.

## Verification

- Build, ESLint, local Sonar lint, and `git diff --check` passed.
- Operations configuration unit and console API E2E tests passed: 4/4 and 135/135.
- Authenticated browser suite passed: 28/28, with the focused configuration test rerun after the final layout change.
- Manual headed-browser review completed successfully.

## Scope

This change primarily adds web-console UI assets and browser coverage. It includes a targeted Operations configuration correction so ETags and effective timestamps remain specific to each setting. It does not add API routes, database schemas, migrations, dependencies, or lockfile changes.
