### PR TITLE
feat(web-console): add custom integration authoring

### DIFF
--- a/src/web-console/ui/integration-descriptors.js
+++ b/src/web-console/ui/integration-descriptors.js
@@ -19,10 +19,12 @@ export function createIntegrationDescriptorManager(options) {
     descriptors: [],
     loading: false,
     error: false,
+    truncated: false,
     mode: 'list',
     editing: null,
     spec: null,
     operations: [],
+    specVersion: 0,
   };
 
   manager.host.addEventListener('click', event => onClick(manager, event));
@@ -30,14 +32,16 @@ export function createIntegrationDescriptorManager(options) {
   manager.host.addEventListener('change', event => onChange(manager, event));
 
   return {
-    setDescriptors(descriptors, error = false) {
+    setDescriptors(descriptors, error = false, truncated = false) {
       manager.descriptors = descriptors;
       manager.error = error;
+      manager.truncated = truncated;
       if (manager.mode === 'list') render(manager);
     },
     show() {
       manager.mode = 'list';
       manager.editing = null;
+      manager.specVersion += 1;
       render(manager);
     },
   };
@@ -66,6 +70,7 @@ function renderList(manager) {
       ${canCreate ? '<button class="btn btn-primary" data-descriptor-create type="button">Add integration</button>' : ''}
     </div>
     ${manager.error ? '<div class="int-notice int-notice--error">Custom integrations could not be loaded.</div>' : ''}
+    ${manager.truncated ? '<div class="int-notice">This list is too long to show in full. Some custom integrations are not shown.</div>' : ''}
     ${descriptorList(manager)}`;
 }
 
@@ -303,7 +308,7 @@ function specSummary(manager) {
   if (!manager.spec) return '<div class="int-notice">No API definition has been imported yet.</div>';
   return `
     <div class="int-spec-summary">
-      <strong>${manager.spec.operation_count} operations discovered</strong>
+      <strong>${discoveredSummary(manager.spec.operation_count)}</strong>
       <span>${formatBytes(manager.spec.spec_bytes)} · hash ${escapeHtml(manager.spec.spec_hash.slice(0, 12))}</span>
     </div>`;
 }
@@ -346,6 +351,7 @@ async function onClick(manager, event) {
     manager.editing = null;
     manager.spec = null;
     manager.operations = [];
+    manager.specVersion += 1;
     render(manager);
     return;
   }
@@ -557,6 +563,11 @@ function promotedOperationIds(descriptor) {
   return new Set(Array.isArray(operations) ? operations.filter(entry => typeof entry === 'string') : []);
 }
 
+function discoveredSummary(count) {
+  const plural = count === 1 ? '' : 's';
+  return `${count} operation${plural} discovered`;
+}
+
 function promotionSummary(count) {
   if (count === 0) return 'No operations are exposed as their own tools.';
   const plural = count === 1 ? '' : 's';
@@ -596,12 +607,16 @@ async function openSpec(manager, id) {
   manager.loading = true;
   manager.spec = null;
   manager.operations = [];
+  // Leaving and re-entering this screen leaves the previous fetches in flight; without a
+  // generation check a late response would overwrite whatever is on screen by then.
+  const version = ++manager.specVersion;
   render(manager);
   const path = `${DESCRIPTORS_PATH}/${encodeURIComponent(id)}/spec`;
   const [specResponse, operationsResponse] = await Promise.all([
     get(path).catch(() => null),
     get(`${path}/operations`).catch(() => null),
   ]);
+  if (version !== manager.specVersion) return;
   manager.spec = specResponse?.status === 200 ? specResponse.body : null;
   manager.operations = operationsResponse?.status === 200 && Array.isArray(operationsResponse.body?.operations)
     ? operationsResponse.body.operations
@@ -654,8 +669,11 @@ function parseSpec(text) {
   try {
     value = JSON.parse(text);
   } catch {
+    // Without this the optional call yields undefined rather than throwing, and a missing YAML
+    // parser is reported as malformed content.
+    if (!globalThis.jsyaml) throw new Error('YAML support did not load. Paste the definition as JSON instead.');
     try {
-      value = globalThis.jsyaml?.load(text);
+      value = globalThis.jsyaml.load(text);
     } catch {
       throw new Error('The API definition is not valid JSON or YAML.');
     }
@@ -696,6 +714,9 @@ function staticStrategyLabel(descriptor) {
   return descriptor.static_api_key?.injection?.location === 'basic' ? 'Basic authentication' : 'API key';
 }
 
+// Deliberately narrower than the connect modal's same-named helper: this form survives a failed
+// save so the operator can correct it, and wiping every input would discard their whole descriptor.
+// Only the secrets are cleared.
 function clearCredentialFields(form) {
   for (const input of form?.querySelectorAll('input[type="password"]') ?? []) input.value = '';
 }

--- a/src/web-console/ui/integration-descriptors.js
+++ b/src/web-console/ui/integration-descriptors.js
@@ -1,0 +1,721 @@
+/**
+ * Owner-scoped custom integration descriptor authoring.
+ *
+ * Secrets are write-only: this module never copies a client secret into state
+ * and clears/removes every credential field as soon as a request completes.
+ */
+
+import { del, get, patch, post, put } from './api.js';
+import { confirmDialog, escapeHtml } from './ui-utils.js';
+
+const DESCRIPTORS_PATH = '/me/integrations/descriptors';
+
+export function createIntegrationDescriptorManager(options) {
+  const manager = {
+    host: options.host,
+    notify: options.notify,
+    hasRoute: options.hasRoute,
+    onChanged: options.onChanged,
+    descriptors: [],
+    loading: false,
+    error: false,
+    mode: 'list',
+    editing: null,
+    spec: null,
+    operations: [],
+  };
+
+  manager.host.addEventListener('click', event => onClick(manager, event));
+  manager.host.addEventListener('submit', event => onSubmit(manager, event));
+  manager.host.addEventListener('change', event => onChange(manager, event));
+
+  return {
+    setDescriptors(descriptors, error = false) {
+      manager.descriptors = descriptors;
+      manager.error = error;
+      if (manager.mode === 'list') render(manager);
+    },
+    show() {
+      manager.mode = 'list';
+      manager.editing = null;
+      render(manager);
+    },
+  };
+}
+
+function render(manager) {
+  if (manager.mode === 'edit') {
+    renderEditor(manager);
+    return;
+  }
+  if (manager.mode === 'spec') {
+    renderSpec(manager);
+    return;
+  }
+  renderList(manager);
+}
+
+function renderList(manager) {
+  const canCreate = manager.hasRoute('POST', DESCRIPTORS_PATH);
+  manager.host.innerHTML = `
+    <div class="int-section-head">
+      <div>
+        <h2>Custom integrations</h2>
+        <p>Define an API once, then connect your account from the Connections view.</p>
+      </div>
+      ${canCreate ? '<button class="btn btn-primary" data-descriptor-create type="button">Add integration</button>' : ''}
+    </div>
+    ${manager.error ? '<div class="int-notice int-notice--error">Custom integrations could not be loaded.</div>' : ''}
+    ${descriptorList(manager)}`;
+}
+
+function descriptorList(manager) {
+  if (manager.descriptors.length === 0) {
+    return '<div class="int-empty"><strong>No custom integrations yet.</strong><span>Add an OAuth or API-key service to get started.</span></div>';
+  }
+  return `<div class="int-descriptor-list">${manager.descriptors.map(descriptorCard).join('')}</div>`;
+}
+
+function descriptorCard(descriptor) {
+  const editable = descriptor.ownership === 'byo';
+  const strategy = descriptor.auth_strategy === 'static_api_key'
+    ? staticStrategyLabel(descriptor)
+    : 'OAuth 2.0';
+  return `
+    <article class="int-descriptor-card">
+      <div class="int-descriptor-main">
+        <div class="int-card-name">${escapeHtml(descriptor.display_name)}</div>
+        <div class="int-provider-id">${escapeHtml(descriptor.provider)}</div>
+        <div class="int-caps">
+          <span class="int-cap">${escapeHtml(descriptor.category)}</span>
+          <span class="int-cap">${escapeHtml(strategy)}</span>
+          <span class="int-cap">${editable ? 'Custom' : 'Curated'}</span>
+        </div>
+        <div class="int-meta">${escapeHtml(descriptor.api_hosts.join(', '))}</div>
+      </div>
+      <div class="int-actions int-actions--compact">
+        ${editable ? descriptorActions(descriptor) : '<span class="int-meta">Managed by this deployment</span>'}
+      </div>
+    </article>`;
+}
+
+function descriptorActions(descriptor) {
+  const id = escapeHtml(descriptor.id);
+  return `
+    <button class="btn btn-ghost" data-descriptor-spec="${id}" type="button">API definition</button>
+    <button class="btn btn-ghost" data-descriptor-edit="${id}" type="button">Edit</button>
+    <button class="btn btn-ghost int-danger" data-descriptor-delete="${id}" type="button">Delete</button>`;
+}
+
+function renderEditor(manager) {
+  const descriptor = manager.editing;
+  const editing = Boolean(descriptor);
+  const strategy = descriptor?.auth_strategy ?? 'oauth2_authorization_code';
+  const oauth = descriptor?.oauth ?? {};
+  const injection = descriptor?.static_api_key?.injection ?? {};
+  const remoteMcp = asObject(descriptor?.operation_promotion).remoteMcp ?? {};
+  manager.host.innerHTML = `
+    <div class="int-editor">
+      <div class="int-section-head">
+        <div>
+          <button class="int-back" data-descriptor-back type="button">← Custom integrations</button>
+          <h2>${editing ? 'Edit integration' : 'Add integration'}</h2>
+          <p>Describe the service and how DollhouseMCP should authenticate with it.</p>
+        </div>
+      </div>
+      <form id="int-descriptor-form" class="int-form">
+        <section class="int-form-section">
+          <h3>Identity</h3>
+          <div class="int-form-grid">
+            ${field('Display name', 'display_name', descriptor?.display_name ?? '', 'Example: Acme Tasks', true)}
+            ${field('Provider ID', 'provider', descriptor?.provider ?? '', 'lowercase-name', true, editing)}
+            ${field('Category', 'category', descriptor?.category ?? '', 'Example: Project management', true)}
+            ${field('Allowed API hosts', 'api_hosts', descriptor?.api_hosts?.join(', ') ?? '', 'api.example.com, uploads.example.com', true)}
+          </div>
+          <p class="int-field-help">Provider IDs use lowercase letters, numbers, and hyphens. Hosts must be exact API hostnames; URLs and paths are not accepted.</p>
+        </section>
+        <section class="int-form-section">
+          <h3>Authentication</h3>
+          <label class="int-field">
+            <span>Method</span>
+            <select name="auth_strategy">
+              <option value="oauth2_authorization_code" ${strategy === 'oauth2_authorization_code' ? 'selected' : ''}>OAuth 2.0 authorization code</option>
+              <option value="static_api_key" ${strategy === 'static_api_key' ? 'selected' : ''}>API key or Basic authentication</option>
+            </select>
+            <small>Users provide their own account credential when they click Connect.</small>
+          </label>
+          <div data-auth-fields>${strategyFields(strategy, oauth, injection, descriptor?.has_client_secret)}</div>
+        </section>
+        <details class="int-advanced"${asObject(remoteMcp).serverUrl ? ' open' : ''}>
+          <summary>Connect a remote MCP server</summary>
+          <p class="int-field-help">
+            Most integrations leave this empty. Use it only when this service publishes its own MCP
+            server, and you want its tools available alongside the API operations imported below.
+          </p>
+          <div class="int-form-grid">
+            ${field('MCP server URL', 'remote_mcp_url', asObject(remoteMcp).serverUrl ?? '', 'https://api.example.com/mcp', false, false, 'url')}
+            ${field('Tools to expose', 'remote_mcp_tools', joinList(asObject(remoteMcp).tools), 'search, create_task')}
+          </div>
+          <p class="int-field-help">
+            The URL must use HTTPS, and its hostname must also be listed in Allowed API hosts above.
+            Only the tools you name here are exposed; the rest of the server stays unavailable.
+          </p>
+        </details>
+        <div class="int-form-error" role="alert" data-form-error></div>
+        <div class="int-form-actions">
+          <button class="btn btn-ghost" data-descriptor-back type="button">Cancel</button>
+          <button class="btn btn-primary" type="submit">${editing ? 'Save changes' : 'Create integration'}</button>
+        </div>
+      </form>
+    </div>`;
+}
+
+function strategyFields(strategy, oauth, injection, hasClientSecret = false) {
+  if (strategy === 'static_api_key') return staticFields(injection);
+  return `
+    <div class="int-form-grid int-auth-fields">
+      ${field('OAuth client ID', 'oauth_client_id', oauth.client_id ?? '', 'Client ID from the provider', true)}
+      ${secretField('OAuth client secret', 'oauth_client_secret', hasClientSecret)}
+      ${field('Authorization URL', 'oauth_authorization_url', oauth.authorization_url ?? '', 'https://provider.example/oauth/authorize', true, false, 'url')}
+      ${field('Token URL', 'oauth_token_url', oauth.token_url ?? '', 'https://provider.example/oauth/token', true, false, 'url')}
+      ${field('Scopes', 'oauth_scopes', Array.isArray(oauth.scopes) ? oauth.scopes.join(' ') : '', 'read write profile')}
+      ${selectField('PKCE support', 'oauth_pkce', [
+        ['required', 'Required'],
+        ['supported', 'Supported'],
+        ['unsupported', 'Not supported'],
+      ], oauth.pkce ?? 'required')}
+      ${selectField('Refresh tokens', 'oauth_refresh', [
+        ['none', 'None'],
+        ['static', 'Static'],
+        ['rotating', 'Rotating'],
+      ], oauth.refresh ?? 'none')}
+    </div>
+    <p class="int-field-help">The client secret is write-only. Leave it blank while editing to keep the currently stored secret.</p>
+    <details class="int-advanced int-auth-advanced">
+      <summary>Provider-specific OAuth settings</summary>
+      <p class="int-field-help">
+        Standard OAuth 2.0 providers need none of these. Fill them in only when the provider's own
+        setup guide asks for something below.
+      </p>
+      <div class="int-form-grid">
+        ${field('Token revocation URL', 'oauth_revocation_url', readText(oauth.token_exchange, 'revocationUrl'), 'https://provider.example/oauth/revoke', false, false, 'url')}
+        ${selectField('Client authentication', 'oauth_client_auth', [
+          ['body', 'Send client ID and secret in the request body'],
+          ['basic', 'Send them as an HTTP Basic header'],
+          ['none', 'Send neither (public client)'],
+        ], readText(oauth.token_exchange, 'clientAuth') || 'body')}
+        ${field('Account name field', 'oauth_account_field', accountLabelField(oauth.account_label), 'email')}
+      </div>
+      <p class="int-field-help">
+        Account name field: which value from the provider's token response to show as the connected
+        account, for example <code>email</code> or <code>login</code>. Leave blank to show no name.
+      </p>
+      <label class="int-field">
+        <span>Extra authorization parameters</span>
+        <textarea name="oauth_authorization_params" rows="3" spellcheck="false" placeholder="audience=https://api.example.com&#10;prompt=consent">${escapeHtml(paramLines(oauth.token_exchange))}</textarea>
+        <small>One <code>name=value</code> per line, added to the authorization URL. Some providers require an audience, tenant, or prompt value here.</small>
+      </label>
+    </details>`;
+}
+
+function staticFields(injection) {
+  const location = injection.location ?? 'header';
+  return `
+    <div class="int-form-grid int-auth-fields">
+      ${selectField('Credential type', 'static_location', [
+        ['header', 'API key in a header'],
+        ['query', 'API key in a query parameter'],
+        ['basic', 'Username and password (Basic)'],
+      ], location)}
+      ${field('Header or parameter name', 'static_name', location === 'basic' ? 'Authorization' : (injection.name ?? 'Authorization'), 'Authorization', true, location === 'basic')}
+      ${field('Value prefix', 'static_prefix', injection.value_prefix ?? '', 'Example: Bearer ')}
+    </div>
+    <p class="int-field-help">This defines where a user’s credential is placed in API requests. The credential itself is collected later when they connect.</p>`;
+}
+
+function field(label, name, value, placeholder, required = false, disabled = false, type = 'text') {
+  return `
+    <label class="int-field">
+      <span>${escapeHtml(label)}</span>
+      <input type="${type}" name="${name}" value="${escapeHtml(value)}" placeholder="${escapeHtml(placeholder)}"${required ? ' required' : ''}${disabled ? ' disabled' : ''}>
+    </label>`;
+}
+
+function secretField(label, name, hasSecret) {
+  return `
+    <label class="int-field">
+      <span>${escapeHtml(label)}</span>
+      <input type="password" name="${name}" value="" autocomplete="new-password" placeholder="${hasSecret ? 'Stored — leave blank to keep' : 'Client secret from the provider'}">
+    </label>`;
+}
+
+function selectField(label, name, choices, selected) {
+  return `
+    <label class="int-field">
+      <span>${escapeHtml(label)}</span>
+      <select name="${name}">
+        ${choices.map(([value, text]) => `<option value="${value}" ${value === selected ? 'selected' : ''}>${escapeHtml(text)}</option>`).join('')}
+      </select>
+    </label>`;
+}
+
+function renderSpec(manager) {
+  const descriptor = manager.editing;
+  manager.host.innerHTML = `
+    <div class="int-editor">
+      <div class="int-section-head">
+        <div>
+          <button class="int-back" data-descriptor-back type="button">← Custom integrations</button>
+          <h2>${escapeHtml(descriptor.display_name)} API definition</h2>
+          <p>Import an OpenAPI document to discover the operations this integration can use.</p>
+        </div>
+      </div>
+      ${specSummary(manager)}
+      <form id="int-spec-form" class="int-form">
+        <section class="int-form-section">
+          <h3>Import OpenAPI</h3>
+          <label class="int-field">
+            <span>Choose a JSON or YAML file</span>
+            <input type="file" name="spec_file" accept=".json,.yaml,.yml,application/json,application/yaml,text/yaml">
+          </label>
+          <label class="int-field">
+            <span>Or paste JSON or YAML</span>
+            <textarea name="spec_text" rows="11" spellcheck="false" placeholder="openapi: 3.0.3&#10;info:&#10;  title: Example API&#10;  version: 1.0.0"></textarea>
+          </label>
+          ${field('Source URL (optional)', 'source_url', manager.spec?.source_url ?? '', 'https://docs.example.com/openapi.yaml', false, false, 'url')}
+          <p class="int-field-help">The server validates size, structure, hosts, and supported operations before storing the definition.</p>
+        </section>
+        <div class="int-form-error" role="alert" data-form-error></div>
+        <div class="int-form-actions">
+          <button class="btn btn-ghost" data-descriptor-back type="button">Done</button>
+          <button class="btn btn-primary" type="submit">Import definition</button>
+        </div>
+      </form>
+      ${operationList(manager)}
+    </div>`;
+  manager.host.querySelector('[name="spec_file"]')?.addEventListener('change', event => {
+    void readSelectedSpec(manager, event.currentTarget);
+  });
+}
+
+function specSummary(manager) {
+  if (manager.loading) return '<div class="int-notice">Loading the current API definition…</div>';
+  if (!manager.spec) return '<div class="int-notice">No API definition has been imported yet.</div>';
+  return `
+    <div class="int-spec-summary">
+      <strong>${manager.spec.operation_count} operations discovered</strong>
+      <span>${formatBytes(manager.spec.spec_bytes)} · hash ${escapeHtml(manager.spec.spec_hash.slice(0, 12))}</span>
+    </div>`;
+}
+
+function operationList(manager) {
+  if (manager.operations.length === 0) return '';
+  const promoted = promotedOperationIds(manager.editing);
+  return `
+    <form id="int-promotion-form" class="int-operations">
+      <h3>Discovered operations</h3>
+      <p class="int-field-help">
+        Tick an operation to give it its own named tool, so an assistant can call it directly.
+        Everything imported stays usable either way — unticked operations are still reachable
+        through this integration's general-purpose request tool.
+      </p>
+      <div class="int-operation-list">
+        ${manager.operations.map(operation => `
+          <label class="int-operation">
+            <input type="checkbox" name="promoted" value="${escapeHtml(operation.operation_id)}"${promoted.has(operation.operation_id) ? ' checked' : ''}>
+            <span class="int-method int-method--${escapeHtml(operation.read_write_class)}">${escapeHtml(operation.method)}</span>
+            <div>
+              <strong>${escapeHtml(operation.operation_id)}</strong>
+              <code>${escapeHtml(operation.path)}</code>
+              ${operation.summary ? `<p>${escapeHtml(operation.summary)}</p>` : ''}
+            </div>
+          </label>`).join('')}
+      </div>
+      <div class="int-form-error" role="alert" data-form-error></div>
+      <div class="int-form-actions">
+        <button class="btn btn-primary" type="submit">Save selected tools</button>
+      </div>
+    </form>`;
+}
+
+async function onClick(manager, event) {
+  const button = event.target.closest('button');
+  if (!button || !manager.host.contains(button)) return;
+  if (button.dataset.descriptorBack !== undefined) {
+    manager.mode = 'list';
+    manager.editing = null;
+    manager.spec = null;
+    manager.operations = [];
+    render(manager);
+    return;
+  }
+  if (button.dataset.descriptorCreate !== undefined) {
+    manager.editing = null;
+    manager.mode = 'edit';
+    render(manager);
+    return;
+  }
+  if (button.dataset.descriptorEdit) {
+    manager.editing = findDescriptor(manager, button.dataset.descriptorEdit);
+    manager.mode = 'edit';
+    render(manager);
+    return;
+  }
+  if (button.dataset.descriptorDelete) await removeDescriptor(manager, button.dataset.descriptorDelete);
+  if (button.dataset.descriptorSpec) await openSpec(manager, button.dataset.descriptorSpec);
+}
+
+function onChange(manager, event) {
+  if (event.target.name === 'auth_strategy') {
+    const fields = manager.host.querySelector('[data-auth-fields]');
+    if (fields) fields.innerHTML = strategyFields(event.target.value, {}, {});
+  }
+  if (event.target.name === 'static_location') {
+    const form = event.target.form;
+    const name = form?.elements.namedItem('static_name');
+    if (name instanceof HTMLInputElement) {
+      name.disabled = event.target.value === 'basic';
+      if (name.disabled) name.value = 'Authorization';
+    }
+  }
+}
+
+async function onSubmit(manager, event) {
+  if (event.target.id === 'int-descriptor-form') {
+    event.preventDefault();
+    await saveDescriptor(manager, event.target);
+  }
+  if (event.target.id === 'int-spec-form') {
+    event.preventDefault();
+    await saveSpec(manager, event.target);
+  }
+  if (event.target.id === 'int-promotion-form') {
+    event.preventDefault();
+    await savePromotedOperations(manager, event.target);
+  }
+}
+
+// Promoting operations is a partial edit of operation_promotion, but the API replaces the whole
+// object when the key is sent — so the remote MCP configuration has to be carried through here.
+async function savePromotedOperations(manager, form) {
+  const error = form.querySelector('[data-form-error]');
+  const submit = form.querySelector('[type="submit"]');
+  setBusy(submit, true);
+  clearError(error);
+  try {
+    const promotion = { ...asObject(manager.editing?.operation_promotion) };
+    const operations = new FormData(form).getAll('promoted').map(String);
+    if (operations.length > 0) promotion.operations = operations;
+    else delete promotion.operations;
+    const response = await patch(`${DESCRIPTORS_PATH}/${encodeURIComponent(manager.editing.id)}`, {
+      body: { operation_promotion: promotion },
+    });
+    if (response.status !== 200) {
+      throw new Error(problemDetail(response, 'The selected tools could not be saved.'));
+    }
+    manager.editing = response.body ?? manager.editing;
+    manager.notify(promotionSummary(operations.length), 'success');
+    await manager.onChanged();
+  } catch (error_) {
+    showError(error, error_);
+  } finally {
+    setBusy(submit, false);
+  }
+}
+
+async function saveDescriptor(manager, form) {
+  const error = form.querySelector('[data-form-error]');
+  const submit = form.querySelector('[type="submit"]');
+  setBusy(submit, true);
+  clearError(error);
+  try {
+    const payload = descriptorPayload(new FormData(form), manager.editing);
+    const path = manager.editing ? `${DESCRIPTORS_PATH}/${encodeURIComponent(manager.editing.id)}` : DESCRIPTORS_PATH;
+    const response = manager.editing
+      ? await patch(path, { body: payload })
+      : await post(path, { body: payload });
+    if (response.status !== (manager.editing ? 200 : 201)) {
+      throw new Error(problemDetail(response, 'The integration could not be saved.'));
+    }
+    clearCredentialFields(form);
+    manager.notify(manager.editing ? 'Integration updated.' : 'Integration created.', 'success');
+    manager.mode = 'list';
+    manager.editing = null;
+    await manager.onChanged();
+  } catch (error_) {
+    showError(error, error_);
+  } finally {
+    clearCredentialFields(form);
+    setBusy(submit, false);
+  }
+}
+
+function descriptorPayload(data, existing) {
+  const strategy = String(data.get('auth_strategy') ?? '');
+  const payload = {
+    display_name: requiredValue(data, 'display_name'),
+    category: requiredValue(data, 'category'),
+    auth_strategy: strategy,
+    api_hosts: splitValues(data.get('api_hosts'), /[\s,]+/),
+    operation_promotion: promotionPayload(data, existing),
+  };
+  if (!existing) payload.provider = requiredValue(data, 'provider');
+  if (strategy === 'oauth2_authorization_code') {
+    payload.oauth = oauthPayload(data);
+    payload.static_api_key = null;
+  } else {
+    payload.oauth = null;
+    payload.static_api_key = staticPayload(data);
+  }
+  return payload;
+}
+
+function oauthPayload(data) {
+  const oauth = {
+    client_id: requiredValue(data, 'oauth_client_id'),
+    authorization_url: requiredValue(data, 'oauth_authorization_url'),
+    token_url: requiredValue(data, 'oauth_token_url'),
+    scopes: splitValues(data.get('oauth_scopes'), /[\s,]+/),
+    pkce: requiredValue(data, 'oauth_pkce'),
+    refresh: requiredValue(data, 'oauth_refresh'),
+    token_exchange: tokenExchangePayload(data),
+    account_label: accountLabelPayload(data),
+  };
+  const secret = stringValue(data.get('oauth_client_secret'));
+  if (secret) oauth.client_secret = secret;
+  return oauth;
+}
+
+function staticPayload(data) {
+  const location = requiredValue(data, 'static_location');
+  return {
+    injection: {
+      location,
+      name: location === 'basic' ? 'Authorization' : requiredValue(data, 'static_name'),
+      value_prefix: stringValue(data.get('static_prefix')) || null,
+    },
+  };
+}
+
+// The editor form no longer edits which operations are promoted — that moved to the API definition
+// screen, where the operation IDs actually exist — so carry the existing selection through unchanged.
+function promotionPayload(data, existing) {
+  const promotion = {};
+  const operations = asObject(existing?.operation_promotion).operations;
+  if (Array.isArray(operations) && operations.length > 0) promotion.operations = operations;
+  const serverUrl = stringValue(data.get('remote_mcp_url'));
+  if (serverUrl) promotion.remoteMcp = { serverUrl, tools: splitValues(data.get('remote_mcp_tools'), /[\s,]+/) };
+  return promotion;
+}
+
+function tokenExchangePayload(data) {
+  const exchange = {};
+  const revocationUrl = stringValue(data.get('oauth_revocation_url'));
+  if (revocationUrl) exchange.revocationUrl = revocationUrl;
+  const clientAuth = stringValue(data.get('oauth_client_auth'));
+  if (clientAuth && clientAuth !== 'body') exchange.clientAuth = clientAuth;
+  const params = parseParamLines(data.get('oauth_authorization_params'));
+  if (Object.keys(params).length > 0) exchange.authorizationParams = params;
+  return exchange;
+}
+
+function accountLabelPayload(data) {
+  const field = stringValue(data.get('oauth_account_field'));
+  return field ? { field } : {};
+}
+
+function parseParamLines(value) {
+  const params = {};
+  for (const line of String(value ?? '').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const separator = trimmed.indexOf('=');
+    if (separator < 1) {
+      throw new Error(`Extra authorization parameters need one name=value per line. "${trimmed}" is missing a name or "=".`);
+    }
+    params[trimmed.slice(0, separator).trim()] = trimmed.slice(separator + 1).trim();
+  }
+  return params;
+}
+
+function paramLines(tokenExchange) {
+  const params = asObject(asObject(tokenExchange).authorizationParams);
+  return Object.entries(params).map(([name, value]) => `${name}=${value}`).join('\n');
+}
+
+function readText(record, key) {
+  const value = asObject(record)[key];
+  return typeof value === 'string' ? value : '';
+}
+
+function accountLabelField(accountLabel) {
+  return readText(accountLabel, 'field') || readText(accountLabel, 'tokenResponseField');
+}
+
+function promotedOperationIds(descriptor) {
+  const operations = asObject(descriptor?.operation_promotion).operations;
+  return new Set(Array.isArray(operations) ? operations.filter(entry => typeof entry === 'string') : []);
+}
+
+function promotionSummary(count) {
+  if (count === 0) return 'No operations are exposed as their own tools.';
+  const plural = count === 1 ? '' : 's';
+  return `${count} operation${plural} exposed as tools.`;
+}
+
+function joinList(value) {
+  return Array.isArray(value) ? value.join(', ') : '';
+}
+
+function asObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+async function removeDescriptor(manager, id) {
+  const descriptor = findDescriptor(manager, id);
+  if (!descriptor) return;
+  const approved = await confirmDialog(
+    `Delete ${descriptor.display_name}? Its API definition and any saved connection will no longer be available.`,
+    'Delete integration',
+  );
+  if (!approved) return;
+  const response = await del(`${DESCRIPTORS_PATH}/${encodeURIComponent(id)}`).catch(() => null);
+  if (!response || (response.status !== 200 && response.status !== 204)) {
+    manager.notify('The integration could not be deleted.', 'error');
+    return;
+  }
+  manager.notify('Integration deleted.', 'success');
+  await manager.onChanged();
+}
+
+async function openSpec(manager, id) {
+  const descriptor = findDescriptor(manager, id);
+  if (!descriptor) return;
+  manager.editing = descriptor;
+  manager.mode = 'spec';
+  manager.loading = true;
+  manager.spec = null;
+  manager.operations = [];
+  render(manager);
+  const path = `${DESCRIPTORS_PATH}/${encodeURIComponent(id)}/spec`;
+  const [specResponse, operationsResponse] = await Promise.all([
+    get(path).catch(() => null),
+    get(`${path}/operations`).catch(() => null),
+  ]);
+  manager.spec = specResponse?.status === 200 ? specResponse.body : null;
+  manager.operations = operationsResponse?.status === 200 && Array.isArray(operationsResponse.body?.operations)
+    ? operationsResponse.body.operations
+    : [];
+  manager.loading = false;
+  render(manager);
+}
+
+async function readSelectedSpec(manager, input) {
+  const file = input.files?.[0];
+  if (!file) return;
+  const textarea = manager.host.querySelector('[name="spec_text"]');
+  const error = manager.host.querySelector('[data-form-error]');
+  try {
+    textarea.value = await file.text();
+    clearError(error);
+  } catch {
+    showError(error, new Error('The selected file could not be read.'));
+  }
+}
+
+async function saveSpec(manager, form) {
+  const error = form.querySelector('[data-form-error]');
+  const submit = form.querySelector('[type="submit"]');
+  setBusy(submit, true);
+  clearError(error);
+  try {
+    const data = new FormData(form);
+    const spec = parseSpec(stringValue(data.get('spec_text')));
+    const sourceUrl = stringValue(data.get('source_url'));
+    const id = encodeURIComponent(manager.editing.id);
+    const response = await put(`${DESCRIPTORS_PATH}/${id}/spec`, {
+      body: { spec, source_url: sourceUrl || null },
+    });
+    if (response.status !== 200 && response.status !== 201) {
+      throw new Error(problemDetail(response, 'The API definition could not be imported.'));
+    }
+    manager.notify('API definition imported.', 'success');
+    await openSpec(manager, manager.editing.id);
+  } catch (error_) {
+    showError(error, error_);
+  } finally {
+    setBusy(submit, false);
+  }
+}
+
+function parseSpec(text) {
+  if (!text) throw new Error('Choose a file or paste an OpenAPI definition.');
+  let value;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    try {
+      value = globalThis.jsyaml?.load(text);
+    } catch {
+      throw new Error('The API definition is not valid JSON or YAML.');
+    }
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('The API definition must contain an object.');
+  }
+  return value;
+}
+
+function findDescriptor(manager, id) {
+  return manager.descriptors.find(item => item.id === id) ?? null;
+}
+
+function requiredValue(data, name) {
+  const value = stringValue(data.get(name));
+  if (!value) throw new Error(`${humanize(name)} is required.`);
+  return value;
+}
+
+function stringValue(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function splitValues(value, separator) {
+  return stringValue(value).split(separator).map(item => item.trim()).filter(Boolean);
+}
+
+function problemDetail(response, fallback) {
+  return typeof response?.body?.detail === 'string' ? response.body.detail : fallback;
+}
+
+function humanize(value) {
+  return value.replaceAll('_', ' ').replace(/^./, character => character.toUpperCase());
+}
+
+function staticStrategyLabel(descriptor) {
+  return descriptor.static_api_key?.injection?.location === 'basic' ? 'Basic authentication' : 'API key';
+}
+
+function clearCredentialFields(form) {
+  for (const input of form?.querySelectorAll('input[type="password"]') ?? []) input.value = '';
+}
+
+function clearError(element) {
+  if (element) element.textContent = '';
+}
+
+function showError(element, caught) {
+  if (element) element.textContent = caught instanceof Error ? caught.message : 'Something went wrong.';
+}
+
+function setBusy(button, busy) {
+  if (!button) return;
+  button.disabled = busy;
+  button.setAttribute('aria-busy', String(busy));
+}
+
+function formatBytes(value) {
+  const bytes = Number(value);
+  if (!Number.isFinite(bytes) || bytes < 1024) return `${Math.max(0, bytes || 0)} B`;
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}

--- a/src/web-console/ui/integrations.css
+++ b/src/web-console/ui/integrations.css
@@ -12,6 +12,35 @@
 .int-title { font-family: var(--font-heading); font-size: var(--step-1); font-weight: 700; color: var(--ink-900); }
 .int-sub { padding: 4px 16px 0; color: var(--ink-500); font-size: var(--step--1); max-width: 70ch; }
 
+.int-nav {
+  display: flex;
+  gap: 4px;
+  margin: 14px 16px 0;
+  padding: 4px;
+  width: fit-content;
+  max-width: calc(100% - 32px);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-1);
+}
+
+.int-nav-item {
+  border: 0;
+  border-radius: var(--radius-sm);
+  padding: 7px 12px;
+  background: transparent;
+  color: var(--ink-500);
+  font: inherit;
+  font-size: var(--step--1);
+  cursor: pointer;
+}
+
+.int-nav-item.is-active {
+  background: var(--paper-strong);
+  color: var(--ink-900);
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+}
+
 .int-grid {
   padding: 16px;
   display: grid;
@@ -42,6 +71,7 @@
 .int-card-id { flex: 1; min-width: 0; }
 .int-card-name { font-family: var(--font-heading); font-weight: 700; color: var(--ink-900); }
 .int-card-cat { font-size: var(--step--1); color: var(--ink-500); }
+.int-provider-id { font-family: var(--font-mono); font-size: 11px; color: var(--ink-500); }
 
 .int-chip {
   font-size: 10.5px;
@@ -80,6 +110,257 @@
 }
 
 .int-actions { display: flex; gap: 8px; margin-top: auto; padding-top: 4px; }
+.int-actions--compact { flex-wrap: wrap; justify-content: flex-end; margin: 0; }
 .int-danger { color: #dc2626; } /* NOSONAR — destructive */
 
 .int-loading { text-align: center; padding: 40px; color: var(--ink-500); font-size: 13px; }
+
+.int-notice,
+.int-empty {
+  margin: 16px;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-1);
+  color: var(--ink-700);
+  font-size: var(--step--1);
+}
+
+.int-notice--error { border-color: rgba(239, 68, 68, 0.35); color: #991b1b; } /* NOSONAR — semantic error */
+
+.int-empty {
+  min-height: 130px;
+  display: grid;
+  place-content: center;
+  gap: 4px;
+  text-align: center;
+}
+
+.int-empty strong { color: var(--ink-900); }
+.int-empty span { color: var(--ink-500); }
+
+.int-section-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 16px 8px;
+}
+
+.int-section-head h2,
+.int-section-head h3 {
+  margin: 0;
+  color: var(--ink-900);
+  font-family: var(--font-heading);
+}
+
+.int-section-head p {
+  margin: 4px 0 0;
+  max-width: 68ch;
+  color: var(--ink-500);
+  font-size: var(--step--1);
+}
+
+.int-descriptor-list {
+  display: grid;
+  gap: 10px;
+  padding: 8px 16px 24px;
+}
+
+.int-descriptor-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--paper-strong);
+}
+
+.int-descriptor-main {
+  min-width: 0;
+  display: grid;
+  gap: 5px;
+}
+
+.int-editor {
+  width: min(920px, 100%);
+  padding-bottom: 28px;
+}
+
+.int-back {
+  margin: 0 0 8px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--signal);
+  font: inherit;
+  font-size: var(--step--1);
+  cursor: pointer;
+}
+
+.int-form {
+  display: grid;
+  gap: 14px;
+  padding: 8px 16px;
+}
+
+.int-form-section,
+.int-advanced,
+.int-spec-summary,
+.int-operations {
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--paper-strong);
+}
+
+.int-form-section h3,
+.int-operations h3 {
+  margin: 0 0 14px;
+  color: var(--ink-900);
+  font-family: var(--font-heading);
+  font-size: var(--step-0);
+}
+
+.int-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.int-auth-fields { margin-top: 14px; }
+
+.int-field {
+  display: grid;
+  gap: 5px;
+  color: var(--ink-700);
+  font-size: var(--step--1);
+}
+
+.int-field > span { font-weight: 650; color: var(--ink-900); }
+
+.int-field input,
+.int-field select,
+.int-field textarea {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 9px 10px;
+  background: var(--surface-0);
+  color: var(--ink-900);
+  font: inherit;
+}
+
+.int-field textarea {
+  resize: vertical;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.int-field input:focus,
+.int-field select:focus,
+.int-field textarea:focus {
+  border-color: var(--signal);
+  outline: 2px solid color-mix(in srgb, var(--signal) 18%, transparent);
+}
+
+.int-field input:disabled { background: var(--surface-2); color: var(--ink-500); }
+.int-field small,
+.int-field-help { color: var(--ink-500); font-size: 11px; line-height: 1.45; }
+.int-field-help { margin: 10px 0 0; }
+
+.int-advanced summary {
+  cursor: pointer;
+  color: var(--ink-900);
+  font-weight: 650;
+}
+
+.int-advanced .int-field { margin-top: 14px; }
+.int-auth-advanced { margin-top: 14px; background: var(--surface-1); }
+
+.int-form-error {
+  min-height: 18px;
+  color: #b91c1c; /* NOSONAR — semantic error */
+  font-size: var(--step--1);
+}
+
+.int-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.int-spec-summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 8px 16px;
+  color: var(--ink-700);
+  font-size: var(--step--1);
+}
+
+.int-operation-list { display: grid; gap: 8px; }
+
+.int-operation {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: flex-start;
+  padding: 10px 0;
+  border-top: 1px solid var(--line);
+  cursor: pointer;
+}
+
+.int-operation input[type="checkbox"] {
+  margin: 2px 0 0;
+  width: 15px;
+  height: 15px;
+  flex: none;
+  cursor: pointer;
+}
+
+.int-operation:hover { background: var(--surface-2); }
+.int-operation:focus-within { outline: 2px solid var(--signal); outline-offset: -2px; }
+
+.int-operation:first-child { border-top: 0; }
+.int-operation strong,
+.int-operation code { display: block; overflow-wrap: anywhere; }
+.int-operation code { margin-top: 2px; color: var(--ink-500); font-size: 11px; }
+.int-operation p { margin: 5px 0 0; color: var(--ink-500); font-size: var(--step--1); }
+
+.int-method {
+  min-width: 52px;
+  border-radius: var(--radius-sm);
+  padding: 3px 6px;
+  background: var(--surface-2);
+  color: var(--ink-700);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.int-method--write { background: rgba(245, 158, 11, 0.12); color: #92400e; } /* NOSONAR — semantic write */
+
+.int-credential-card {
+  display: grid;
+  gap: 12px;
+  width: min(460px, calc(100vw - 32px));
+}
+
+.int-credential-card h2,
+.int-credential-card p { margin: 0; }
+.int-credential-card p { color: var(--ink-500); font-size: var(--step--1); }
+
+@media (max-width: 680px) {
+  .int-grid { grid-template-columns: minmax(0, 1fr); }
+  .int-form-grid { grid-template-columns: minmax(0, 1fr); }
+  .int-section-head,
+  .int-descriptor-card,
+  .int-spec-summary { align-items: stretch; flex-direction: column; }
+  .int-actions--compact { justify-content: flex-start; }
+}

--- a/src/web-console/ui/integrations.js
+++ b/src/web-console/ui/integrations.js
@@ -29,6 +29,7 @@ const state = {
   loading: true,
   catalogError: false,
   descriptorError: false,
+  descriptorsTruncated: false,
   view: 'connections',
 };
 
@@ -71,7 +72,7 @@ async function load() {
     get('/me/integrations', { signal: controller.signal }).catch(() => null),
     canManageDescriptors()
       ? loadAllDescriptors(controller.signal)
-      : Promise.resolve({ descriptors: [], error: false }),
+      : Promise.resolve({ descriptors: [], error: false, truncated: false }),
   ]);
   if (controller.signal.aborted || version !== loadVersion) return;
 
@@ -81,13 +82,14 @@ async function load() {
     : new Map(catalogResponse.body.integrations.map(status => [status.provider, status]));
   state.descriptors = descriptorsResult.descriptors;
   state.descriptorError = descriptorsResult.error;
+  state.descriptorsTruncated = descriptorsResult.truncated;
 
   await loadMissingProviderStatuses(controller, version);
   if (controller.signal.aborted || version !== loadVersion) return;
 
   state.loading = false;
   renderConnections();
-  descriptorManager?.setDescriptors(state.descriptors, state.descriptorError);
+  descriptorManager?.setDescriptors(state.descriptors, state.descriptorError, state.descriptorsTruncated);
 }
 
 async function loadAllDescriptors(signal) {
@@ -98,15 +100,17 @@ async function loadAllDescriptors(signal) {
     const query = cursor ? `?cursor=${encodeURIComponent(cursor)}` : '';
     const response = await get(`${DESCRIPTORS_PATH}${query}`, { signal }).catch(() => null);
     if (response?.status !== 200 || !Array.isArray(response.body?.descriptors)) {
-      return { descriptors, error: true };
+      return { descriptors, error: true, truncated: false };
     }
     descriptors.push(...response.body.descriptors);
     const nextCursor = typeof response.body.next_cursor === 'string' ? response.body.next_cursor : null;
-    if (!nextCursor || seenCursors.has(nextCursor)) return { descriptors, error: false };
+    if (!nextCursor || seenCursors.has(nextCursor)) return { descriptors, error: false, truncated: false };
     seenCursors.add(nextCursor);
     cursor = nextCursor;
   }
-  return { descriptors, error: true };
+  // Page cap reached: what we have is valid, there is simply more of it. Reporting this as a load
+  // failure would be wrong, and reporting nothing would hide that the list is incomplete.
+  return { descriptors, error: false, truncated: true };
 }
 
 async function loadMissingProviderStatuses(controller, version) {
@@ -295,8 +299,13 @@ async function connect(providerId) {
     notify(problemDetail(response, 'The connection could not be started.'), 'error');
     return;
   }
-  if (typeof response.body?.authorize_url === 'string' && response.body.authorize_url) {
-    globalThis.location.href = response.body.authorize_url;
+  const authorizeUrl = httpsUrlOrNull(response.body?.authorize_url);
+  if (authorizeUrl) {
+    globalThis.location.href = authorizeUrl;
+    return;
+  }
+  if (response.body?.authorize_url) {
+    notify('The provider returned an unusable sign-in address.', 'error');
     return;
   }
   notify('Integration connected.', 'success');
@@ -446,6 +455,20 @@ function rawFormValue(data, name) {
   return typeof value === 'string' ? value : '';
 }
 
+// Descriptors are stored server-side and only ever reached over HTTPS, but this is the one place a
+// server-supplied string becomes a navigation, so the scheme is checked here too rather than trusted.
+function httpsUrlOrNull(value) {
+  if (typeof value !== 'string' || !value) return null;
+  try {
+    return new URL(value).protocol === 'https:' ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+// Clears every field: this form only exists for the duration of one connect, so nothing here is
+// worth preserving. The descriptor editor deliberately clears only password inputs — see the note
+// on its own clearCredentialFields.
 function clearCredentialFields(form) {
   for (const input of form?.querySelectorAll('input') ?? []) input.value = '';
 }

--- a/src/web-console/ui/integrations.js
+++ b/src/web-console/ui/integrations.js
@@ -1,54 +1,49 @@
 /**
- * Integrations tab — a catalog of third-party service connections the console
- * acts with on the user's behalf (today: GitHub portfolio sync). Each provider
- * holds encrypted OAuth credentials server-side; the tokens never reach the
- * browser — this surface only shows status + what each connection can do, and
- * drives connect / manage / disconnect (= grant / re-grant / revoke).
+ * Data-driven integration catalog and connection management.
  *
- * Slice A: provider presentation metadata lives here (GitHub only) and is merged
- * with live status from GET /me/integrations; actions use the existing GitHub
- * routes. Slice B will serve the catalog (name/category/capabilities) and generic
- * /:provider routes from the backend registry — at which point PROVIDERS and
- * ROUTES below collapse into what the API returns. See
- * /dollhouse/docs/web-console/INTEGRATIONS-DESIGN.md.
+ * Provider presentation comes from the server catalog and visible integration
+ * descriptors. Credential values are submitted directly from short-lived
+ * modal fields and are never copied into module state or rendered back.
  */
 
-import { get, post, del } from './api.js';
+import { del, get, post } from './api.js';
 import { noConsoleRoute } from './console-meta.js';
+import { createIntegrationDescriptorManager } from './integration-descriptors.js';
 import { confirmDialog, escapeHtml, relAgo } from './ui-utils.js';
 
-// UI-side provider catalog (Slice A). One entry per known provider.
-const PROVIDERS = [
-  {
-    id: 'github',
-    name: 'GitHub',
-    category: 'Source control',
-    icon: '\u{1F5C2}', // card index dividers — neutral repo glyph (CSP: text only)
-    blurb: 'Sync your portfolio to and from a GitHub repository.',
-  },
-];
-
-// Per-provider action routes (Slice A hardcodes GitHub's; Slice B → /:provider/*).
-const ROUTES = {
-  github: {
-    connect: '/me/integrations/github/connect',
-    disconnect: '/me/integrations/github',
-  },
-};
+const DESCRIPTORS_PATH = '/me/integrations/descriptors';
+const PROVIDER_ROUTE = '/me/integrations/:provider';
+const MAX_DESCRIPTOR_PAGES = 50;
 
 let host;
 let notify = () => {};
 let hasRoute = noConsoleRoute;
-
-const state = { byProvider: new Map(), loading: true, error: false };
+let descriptorManager;
+let loadController;
+let loadVersion = 0;
 let globalListenersBound = false;
+
+const state = {
+  statuses: new Map(),
+  descriptors: [],
+  loading: true,
+  catalogError: false,
+  descriptorError: false,
+  view: 'connections',
+};
 
 export async function init(panelEl, ctx = {}) {
   host = panelEl;
   notify = ctx.toast || notify;
   hasRoute = ctx.hasRoute || hasRoute;
-  host.innerHTML = shell();
-  host.querySelector('#int-refresh').addEventListener('click', () => load());
+  host.innerHTML = shell(canManageDescriptors());
+  descriptorManager = createIntegrationDescriptorManager({
+    host: host.querySelector('#int-descriptors'),
+    notify,
+    hasRoute,
+    onChanged: load,
+  });
+  host.addEventListener('click', onHostClick);
   await load();
   bindGlobalListeners();
 }
@@ -60,85 +55,163 @@ function bindGlobalListeners() {
 }
 
 function onTabActivated(event) {
-  if (event.detail?.name === 'integrations') load();
+  if (event.detail?.name === 'integrations') void load();
 }
 
 async function load() {
+  loadController?.abort();
+  const controller = new AbortController();
+  loadController = controller;
+  const version = ++loadVersion;
   state.loading = true;
-  state.error = false;
-  renderBody();
-  const res = await get('/me/integrations').catch(() => null);
-  if (res?.status !== 200 || !Array.isArray(res.body?.integrations)) {
-    state.error = true;
-    state.loading = false;
-    renderBody();
+  state.catalogError = false;
+  renderConnections();
+
+  const [catalogResponse, descriptorsResult] = await Promise.all([
+    get('/me/integrations', { signal: controller.signal }).catch(() => null),
+    canManageDescriptors()
+      ? loadAllDescriptors(controller.signal)
+      : Promise.resolve({ descriptors: [], error: false }),
+  ]);
+  if (controller.signal.aborted || version !== loadVersion) return;
+
+  state.catalogError = catalogResponse?.status !== 200 || !Array.isArray(catalogResponse.body?.integrations);
+  state.statuses = state.catalogError
+    ? new Map()
+    : new Map(catalogResponse.body.integrations.map(status => [status.provider, status]));
+  state.descriptors = descriptorsResult.descriptors;
+  state.descriptorError = descriptorsResult.error;
+
+  await loadMissingProviderStatuses(controller, version);
+  if (controller.signal.aborted || version !== loadVersion) return;
+
+  state.loading = false;
+  renderConnections();
+  descriptorManager?.setDescriptors(state.descriptors, state.descriptorError);
+}
+
+async function loadAllDescriptors(signal) {
+  const descriptors = [];
+  const seenCursors = new Set();
+  let cursor = null;
+  for (let page = 0; page < MAX_DESCRIPTOR_PAGES; page += 1) {
+    const query = cursor ? `?cursor=${encodeURIComponent(cursor)}` : '';
+    const response = await get(`${DESCRIPTORS_PATH}${query}`, { signal }).catch(() => null);
+    if (response?.status !== 200 || !Array.isArray(response.body?.descriptors)) {
+      return { descriptors, error: true };
+    }
+    descriptors.push(...response.body.descriptors);
+    const nextCursor = typeof response.body.next_cursor === 'string' ? response.body.next_cursor : null;
+    if (!nextCursor || seenCursors.has(nextCursor)) return { descriptors, error: false };
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+  return { descriptors, error: true };
+}
+
+async function loadMissingProviderStatuses(controller, version) {
+  const missing = state.descriptors
+    .map(descriptor => descriptor.provider)
+    .filter(provider => !state.statuses.has(provider) && canUseProviderRoute('GET', provider));
+  const responses = await Promise.all(missing.map(async provider => {
+    const response = await get(providerPath(provider), { signal: controller.signal }).catch(() => null);
+    return { provider, response };
+  }));
+  if (controller.signal.aborted || version !== loadVersion) return;
+  for (const { provider, response } of responses) {
+    if (response?.status === 200) state.statuses.set(provider, response.body);
+  }
+}
+
+function shell(showDescriptorNav) {
+  return `
+    <div class="int-bar">
+      <span class="int-title">Integrations</span>
+      <button class="btn btn-ghost" id="int-refresh" type="button">&#x21bb; Refresh</button>
+    </div>
+    <p class="int-sub">Connect services for DollhouseMCP to use on your behalf. Credentials are stored encrypted and never shown.</p>
+    ${showDescriptorNav ? `
+      <div class="int-nav" role="tablist" aria-label="Integration views">
+        <button class="int-nav-item is-active" data-int-view="connections" role="tab" aria-selected="true" type="button">Connections</button>
+        <button class="int-nav-item" data-int-view="descriptors" role="tab" aria-selected="false" type="button">Custom integrations</button>
+      </div>` : ''}
+    <div id="int-connections"></div>
+    <div id="int-descriptors" hidden></div>`;
+}
+
+function renderConnections() {
+  const body = host?.querySelector('#int-connections');
+  if (!body) return;
+  if (state.loading) {
+    body.innerHTML = '<div class="int-loading">Loading integrations…</div>';
     return;
   }
-  state.byProvider = new Map(res.body.integrations.map(i => [i.provider, i]));
-  state.loading = false;
-  state.error = false;
-  renderBody();
+  const providers = providerCatalog();
+  const catalogMarkup = providers.length === 0
+    ? '<div class="int-empty"><strong>No integrations are available.</strong><span>This deployment has not advertised any providers.</span></div>'
+    : `<div class="int-grid">${providers.map(providerCard).join('')}</div>`;
+  body.innerHTML = `
+    ${state.catalogError ? '<div class="int-notice int-notice--error">Some integration status information could not be loaded.</div>' : ''}
+    ${catalogMarkup}`;
 }
 
-/* ── Markup ─────────────────────────────────────────────────────────────── */
-
-function shell() {
-  return `
-  <div class="int-bar">
-    <span class="int-title">Integrations</span>
-    <button class="btn btn-ghost" id="int-refresh" type="button">&#x21bb; Refresh</button>
-  </div>
-  <p class="int-sub">Connect third-party services for DollhouseMCP to use on your behalf. Credentials are stored encrypted and never shown.</p>
-  <div id="int-body"></div>`;
+function providerCatalog() {
+  const providers = new Map();
+  for (const status of state.statuses.values()) {
+    providers.set(status.provider, {
+      id: status.provider,
+      name: displayName(status.display_name, status.provider),
+      category: displayName(status.category, 'Integration'),
+      descriptor: null,
+      status,
+    });
+  }
+  for (const descriptor of state.descriptors) {
+    const existing = providers.get(descriptor.provider);
+    providers.set(descriptor.provider, {
+      id: descriptor.provider,
+      name: descriptor.display_name,
+      category: descriptor.category,
+      descriptor,
+      status: existing?.status ?? disconnectedStatus(descriptor),
+    });
+  }
+  return [...providers.values()].sort((left, right) => left.name.localeCompare(right.name));
 }
 
-function renderBody() {
-  const body = host?.querySelector('#int-body');
-  if (!body) return;
-  if (state.loading) { body.innerHTML = '<div class="int-loading">Loading integrations…</div>'; return; }
-  if (state.error) { body.innerHTML = '<div class="int-loading">Couldn\'t load your integrations.</div>'; return; }
-
-  body.innerHTML = `<div class="int-grid">${PROVIDERS.map(p => providerCard(p, state.byProvider.get(p.id))).join('')}</div>`;
-
-  body.querySelectorAll('[data-connect]').forEach(b => b.addEventListener('click', () => connect(b.dataset.connect)));
-  body.querySelectorAll('[data-disconnect]').forEach(b => b.addEventListener('click', () => disconnect(b.dataset.disconnect)));
-}
-
-function providerCard(provider, status) {
+function providerCard(provider) {
+  const status = provider.status;
   const connected = status?.status === 'connected';
   const errored = status?.status === 'error';
-  const routes = providerRouteAvailability(provider);
+  const routes = providerRouteAvailability(provider.id);
   let cardBody;
   if (connected) cardBody = connectedBody(provider, status, routes);
   else if (errored) cardBody = erroredBody(provider, status, routes);
   else cardBody = disconnectedBody(provider, routes);
   return `
-    <div class="int-card${connected ? ' int-card--connected' : ''}">
+    <article class="int-card${connected ? ' int-card--connected' : ''}">
       <div class="int-card-head">
-        <span class="int-icon" aria-hidden="true">${provider.icon}</span>
+        <span class="int-icon" aria-hidden="true">${providerGlyph(provider)}</span>
         <div class="int-card-id">
           <div class="int-card-name">${escapeHtml(provider.name)}</div>
           <div class="int-card-cat">${escapeHtml(provider.category)}</div>
         </div>
         ${statusChip(status)}
       </div>
-      <div class="int-card-body">
-        ${cardBody}
-      </div>
-    </div>`;
+      <div class="int-card-body">${cardBody}</div>
+    </article>`;
 }
 
-function providerRouteAvailability(provider) {
+function providerRouteAvailability(providerId) {
   return {
-    canConnect: hasRoute('POST', `/me/integrations/${provider.id}/connect`),
-    canDisconnect: hasRoute('DELETE', `/me/integrations/${provider.id}`),
+    canConnect: canUseProviderRoute('POST', providerId, '/connect'),
+    canDisconnect: canUseProviderRoute('DELETE', providerId),
   };
 }
 
 function statusChip(status) {
-  const s = status?.status;
-  if (s === 'connected') return '<span class="int-chip int-chip--ok">Connected</span>';
-  if (s === 'error') return '<span class="int-chip int-chip--err">Error</span>';
+  if (status?.status === 'connected') return '<span class="int-chip int-chip--ok">Connected</span>';
+  if (status?.status === 'error') return '<span class="int-chip int-chip--err">Error</span>';
   return '<span class="int-chip int-chip--off">Not connected</span>';
 }
 
@@ -148,8 +221,8 @@ function connectedBody(provider, status, routes) {
     <div class="int-caps">${capabilityChips(status)}</div>
     <div class="int-meta">connected ${relAgo(status.connected_at)}${status.last_sync_at ? ` · last sync ${relAgo(status.last_sync_at)}` : ''}</div>
     <div class="int-actions">
-      ${routes.canConnect ? `<button class="btn btn-ghost" data-connect="${provider.id}" type="button">Reconnect</button>` : ''}
-      ${routes.canDisconnect ? `<button class="btn btn-ghost int-danger" data-disconnect="${provider.id}" type="button">Disconnect</button>` : ''}
+      ${routes.canConnect ? `<button class="btn btn-ghost" data-connect="${escapeHtml(provider.id)}" type="button">Reconnect</button>` : ''}
+      ${routes.canDisconnect ? `<button class="btn btn-ghost int-danger" data-disconnect="${escapeHtml(provider.id)}" type="button">Disconnect</button>` : ''}
     </div>`;
 }
 
@@ -157,57 +230,236 @@ function erroredBody(provider, status, routes) {
   return `
     <div class="int-alert">Connection error${status.error_reason ? `: ${escapeHtml(formatReason(status.error_reason))}` : ''}</div>
     <div class="int-actions">
-      ${routes.canConnect ? `<button class="btn btn-primary" data-connect="${provider.id}" type="button">Reconnect</button>` : ''}
-      ${routes.canDisconnect ? `<button class="btn btn-ghost int-danger" data-disconnect="${provider.id}" type="button">Disconnect</button>` : ''}
+      ${routes.canConnect ? `<button class="btn btn-primary" data-connect="${escapeHtml(provider.id)}" type="button">Reconnect</button>` : ''}
+      ${routes.canDisconnect ? `<button class="btn btn-ghost int-danger" data-disconnect="${escapeHtml(provider.id)}" type="button">Disconnect</button>` : ''}
     </div>`;
 }
 
 function disconnectedBody(provider, routes) {
   return `
-    <div class="int-blurb">${escapeHtml(provider.blurb)}</div>
+    <div class="int-blurb">${providerDescription(provider)}</div>
     <div class="int-actions">
-      ${routes.canConnect ? `<button class="btn btn-primary" data-connect="${provider.id}" type="button">Connect</button>` : '<span class="int-meta">Not available in this deployment.</span>'}
+      ${routes.canConnect
+        ? `<button class="btn btn-primary" data-connect="${escapeHtml(provider.id)}" type="button">Connect</button>`
+        : '<span class="int-meta">Not available in this deployment.</span>'}
     </div>`;
 }
 
-// Capability chips derived from the provider status (GitHub: sync directions + repo scope).
 function capabilityChips(status) {
   const chips = [];
-  const dirs = Array.isArray(status.sync_directions) ? status.sync_directions : [];
-  if (dirs.includes('push')) chips.push('Portfolio sync ↑↓');
-  else if (dirs.includes('pull')) chips.push('Portfolio sync ↓ (read-only)');
+  const directions = Array.isArray(status.sync_directions) ? status.sync_directions : [];
+  if (directions.includes('push')) chips.push('Portfolio sync ↑↓');
+  else if (directions.includes('pull')) chips.push('Portfolio sync ↓');
   if (status.repository_selection === 'selected') chips.push('Selected repositories');
   else if (status.repository_selection === 'all') chips.push('All repositories');
+  if (Array.isArray(status.scopes)) chips.push(...status.scopes.slice(0, 4));
   if (chips.length === 0) chips.push('Connected');
-  return chips.map(c => `<span class="int-cap">${escapeHtml(c)}</span>`).join('');
+  return chips.map(chip => `<span class="int-cap">${escapeHtml(chip)}</span>`).join('');
 }
 
-/* ── Actions ────────────────────────────────────────────────────────────── */
+async function onHostClick(event) {
+  const button = event.target.closest('button');
+  if (!button || !host.contains(button)) return;
+  if (button.id === 'int-refresh') await load();
+  if (button.dataset.intView) selectView(button.dataset.intView);
+  if (button.dataset.connect) await connect(button.dataset.connect);
+  if (button.dataset.disconnect) await disconnect(button.dataset.disconnect);
+}
+
+function selectView(view) {
+  state.view = view === 'descriptors' ? 'descriptors' : 'connections';
+  const showingDescriptors = state.view === 'descriptors';
+  host.querySelector('#int-connections').hidden = showingDescriptors;
+  host.querySelector('#int-descriptors').hidden = !showingDescriptors;
+  for (const button of host.querySelectorAll('[data-int-view]')) {
+    const active = button.dataset.intView === state.view;
+    button.classList.toggle('is-active', active);
+    button.setAttribute('aria-selected', String(active));
+  }
+  if (showingDescriptors) descriptorManager?.show();
+}
 
 async function connect(providerId) {
-  const route = ROUTES[providerId];
-  if (!route) { notify('That integration isn\'t available yet.', 'warn'); return; }
-  // Request full read/write so portfolio sync works both directions.
-  const res = await post(route.connect, { body: { contents_permission: 'write' } }).catch(() => null);
-  const url = res?.status === 200 ? res.body?.authorize_url : null;
-  if (!url) { notify('Couldn\'t start the connection. Try again.', 'error'); return; }
-  // Hand off to the provider's authorization page; it returns to /me/integrations.
-  globalThis.location.href = url;
+  const provider = providerCatalog().find(item => item.id === providerId);
+  if (!provider) return;
+  let body = { return_to: '/me/integrations' };
+  if (provider.id === 'github') body.contents_permission = 'write';
+  if (provider.descriptor?.auth_strategy === 'static_api_key') {
+    const credentials = await credentialDialog(provider);
+    if (!credentials) return;
+    body = credentials;
+  }
+  const response = await post(`${providerPath(providerId)}/connect`, { body }).catch(() => null);
+  clearCredentialObject(body);
+  if (!response || (response.status !== 200 && response.status !== 201)) {
+    notify(problemDetail(response, 'The connection could not be started.'), 'error');
+    return;
+  }
+  if (typeof response.body?.authorize_url === 'string' && response.body.authorize_url) {
+    globalThis.location.href = response.body.authorize_url;
+    return;
+  }
+  notify('Integration connected.', 'success');
+  await load();
 }
 
 async function disconnect(providerId) {
-  const route = ROUTES[providerId];
-  if (!route) return;
-  const provider = PROVIDERS.find(p => p.id === providerId);
-  const ok = await confirmDialog(`Disconnect ${provider ? provider.name : 'this integration'}? Its stored access will be revoked.`, 'Disconnect');
-  if (!ok) return;
-  const res = await del(route.disconnect).catch(() => null);
-  if (!res || (res.status !== 200 && res.status !== 204)) { notify('Could not disconnect. Try again.', 'error'); return; }
+  const provider = providerCatalog().find(item => item.id === providerId);
+  if (!provider) return;
+  const approved = await confirmDialog(
+    `Disconnect ${provider.name}? Its stored access will be revoked.`,
+    'Disconnect',
+  );
+  if (!approved) return;
+  const response = await del(providerPath(providerId)).catch(() => null);
+  if (!response || (response.status !== 200 && response.status !== 204)) {
+    notify(problemDetail(response, 'The integration could not be disconnected.'), 'error');
+    return;
+  }
   notify('Disconnected.', 'success');
   await load();
 }
 
-/* ── Helpers ────────────────────────────────────────────────────────────── */
+function credentialDialog(provider) {
+  return new Promise(resolve => {
+    document.getElementById('int-credential-modal')?.remove();
+    const basic = provider.descriptor?.static_api_key?.injection?.location === 'basic';
+    const modal = document.createElement('div');
+    modal.className = 'confirm-modal';
+    modal.id = 'int-credential-modal';
+    modal.innerHTML = `
+      <div class="confirm-backdrop"></div>
+      <form class="confirm-card int-credential-card" role="dialog" aria-modal="true" aria-labelledby="int-credential-title">
+        <h2 id="int-credential-title">Connect ${escapeHtml(provider.name)}</h2>
+        <p>${basic ? 'Enter the username and password for this service.' : 'Enter the API key issued by this service.'} The value is encrypted and will not be shown again.</p>
+        ${basic
+          ? `${credentialField('Username', 'username', 'username', 'username')}
+             ${credentialField('Password', 'password', 'password', 'current-password')}`
+          : credentialField('API key', 'api_key', 'password', 'off')}
+        ${credentialField('Account label (optional)', 'account_label', 'text', 'off', false)}
+        <div class="int-form-error" role="alert" data-credential-error></div>
+        <div class="confirm-actions">
+          <button class="btn btn-ghost" data-credential-cancel type="button">Cancel</button>
+          <button class="btn btn-primary" type="submit">Connect</button>
+        </div>
+      </form>`;
+    document.body.appendChild(modal);
+    const form = modal.querySelector('form');
+    const close = value => {
+      clearCredentialFields(form);
+      modal.remove();
+      document.removeEventListener('keydown', onKey);
+      resolve(value);
+    };
+    const onKey = event => {
+      if (event.key === 'Escape') close(null);
+    };
+    modal.querySelector('.confirm-backdrop').addEventListener('click', () => close(null));
+    modal.querySelector('[data-credential-cancel]').addEventListener('click', () => close(null));
+    form.addEventListener('submit', event => {
+      event.preventDefault();
+      const data = new FormData(form);
+      const payload = basic
+        ? {
+          username: formValue(data, 'username'),
+          password: rawFormValue(data, 'password'),
+          account_label: formValue(data, 'account_label') || undefined,
+        }
+        : {
+          api_key: rawFormValue(data, 'api_key'),
+          account_label: formValue(data, 'account_label') || undefined,
+        };
+      const valid = basic ? payload.username && payload.password : payload.api_key;
+      if (!valid) {
+        form.querySelector('[data-credential-error]').textContent = 'Enter the required credential.';
+        return;
+      }
+      close(payload);
+    });
+    document.addEventListener('keydown', onKey);
+    form.querySelector('input').focus();
+  });
+}
+
+function credentialField(label, name, type, autocomplete, required = true) {
+  return `
+    <label class="int-field">
+      <span>${escapeHtml(label)}</span>
+      <input type="${type}" name="${name}" autocomplete="${autocomplete}"${required ? ' required' : ''}>
+    </label>`;
+}
+
+function canManageDescriptors() {
+  return hasRoute('GET', DESCRIPTORS_PATH);
+}
+
+function canUseProviderRoute(method, providerId, suffix = '') {
+  return hasRoute(method, `${providerPath(providerId)}${suffix}`)
+    || hasRoute(method, `${PROVIDER_ROUTE}${suffix}`);
+}
+
+function providerPath(providerId) {
+  return `/me/integrations/${encodeURIComponent(providerId)}`;
+}
+
+function disconnectedStatus(descriptor) {
+  return {
+    provider: descriptor.provider,
+    display_name: descriptor.display_name,
+    category: descriptor.category,
+    status: 'disconnected',
+  };
+}
+
+function displayName(value, fallback) {
+  return typeof value === 'string' && value.trim() ? value : titleCase(fallback);
+}
+
+function titleCase(value) {
+  return String(value).replaceAll(/[-_]+/g, ' ').replaceAll(/\b\w/g, character => character.toUpperCase());
+}
+
+function providerGlyph(provider) {
+  if (provider.id === 'github') return '\u{1F5C2}';
+  if (provider.descriptor?.auth_strategy === 'oauth2_authorization_code') return '\u{1F517}';
+  return '\u{1F511}';
+}
+
+function providerDescription(provider) {
+  if (provider.id === 'github') return 'Sync your portfolio to and from a GitHub repository.';
+  if (provider.descriptor?.auth_strategy === 'oauth2_authorization_code') {
+    return 'Authorize DollhouseMCP through this service’s OAuth sign-in flow.';
+  }
+  if (provider.descriptor?.static_api_key?.injection?.location === 'basic') {
+    return 'Connect with a username and password issued by this service.';
+  }
+  return 'Connect with an API key issued by this service.';
+}
+
+function formValue(data, name) {
+  const value = data.get(name);
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function rawFormValue(data, name) {
+  const value = data.get(name);
+  return typeof value === 'string' ? value : '';
+}
+
+function clearCredentialFields(form) {
+  for (const input of form?.querySelectorAll('input') ?? []) input.value = '';
+}
+
+function clearCredentialObject(value) {
+  if (!value || typeof value !== 'object') return;
+  for (const key of ['api_key', 'username', 'password']) {
+    if (typeof value[key] === 'string') value[key] = '';
+  }
+}
+
+function problemDetail(response, fallback) {
+  return typeof response?.body?.detail === 'string' ? response.body.detail : fallback;
+}
 
 function formatReason(reason) {
   return String(reason).replaceAll('_', ' ');

--- a/src/web-console/ui/integrations.js
+++ b/src/web-console/ui/integrations.js
@@ -287,6 +287,9 @@ async function connect(providerId) {
   const provider = providerCatalog().find(item => item.id === providerId);
   if (!provider) return;
   let body = { return_to: '/me/integrations' };
+  // GitHub alone needs the scope named at connect time so portfolio writes work once connected.
+  // It is not a general connect parameter — do not extend it to other providers; a provider that
+  // needs extra parameters should carry them on its descriptor instead.
   if (provider.id === 'github') body.contents_permission = 'write';
   if (provider.descriptor?.auth_strategy === 'static_api_key') {
     const credentials = await credentialDialog(provider);

--- a/tests/integration/web-console-e2e/harness/integrationsUiMock.ts
+++ b/tests/integration/web-console-e2e/harness/integrationsUiMock.ts
@@ -1,0 +1,382 @@
+import type { Page, Route } from '@playwright/test';
+
+import { mutationProtocolProblem } from './requestProtocolMock.js';
+
+const BASE = '/api/v1/me/integrations';
+const DESCRIPTORS = `${BASE}/descriptors`;
+
+interface MockDescriptor {
+  id: string;
+  provider: string;
+  ownership: 'curated' | 'byo';
+  display_name: string;
+  category: string;
+  auth_strategy: 'oauth2_authorization_code' | 'static_api_key';
+  api_hosts: string[];
+  oauth: Record<string, unknown> | null;
+  static_api_key: {
+    injection: { location: 'header' | 'query' | 'basic'; name: string; value_prefix: string | null };
+  } | null;
+  has_client_secret: boolean;
+  operation_promotion: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MockOperation {
+  operation_id: string;
+  method: string;
+  path: string;
+  read_write_class: string;
+  summary: string | null;
+  description: string | null;
+  required_scopes: string[];
+}
+
+export interface IntegrationsUiMockState {
+  descriptors: MockDescriptor[];
+  /** Operations the stored spec resolves to. Override before importing to model a larger API. */
+  operations: MockOperation[];
+  connectedProviders: Set<string>;
+  staticConnects: number;
+  descriptorWrites: number;
+  specWrites: number;
+  receivedApiKey: boolean;
+  receivedBasicCredential: boolean;
+  receivedClientSecret: boolean;
+  clientSecretWrites: number;
+}
+
+export async function installIntegrationsUiMock(page: Page): Promise<IntegrationsUiMockState> {
+  const state: IntegrationsUiMockState = {
+    descriptors: [curatedDescriptor(), staticDescriptor(), basicDescriptor()],
+    operations: [{
+      operation_id: 'listTasks',
+      method: 'GET',
+      path: '/tasks',
+      read_write_class: 'read',
+      summary: 'List tasks',
+      description: null,
+      required_scopes: [],
+    }],
+    connectedProviders: new Set(),
+    staticConnects: 0,
+    descriptorWrites: 0,
+    specWrites: 0,
+    receivedApiKey: false,
+    receivedBasicCredential: false,
+    receivedClientSecret: false,
+    clientSecretWrites: 0,
+  };
+  await page.route('**/api/v1/me/integrations**', route => handleRoute(route, state));
+  return state;
+}
+
+async function handleRoute(route: Route, state: IntegrationsUiMockState): Promise<void> {
+  const request = route.request();
+  const url = new URL(request.url());
+  const path = url.pathname;
+  const method = request.method();
+  if (method !== 'GET') {
+    const problem = mutationProtocolProblem(request.headers());
+    if (problem) {
+      await fulfill(route, problem.status, problem.body);
+      return;
+    }
+  }
+  const response = responseFor(method, path, request.postDataJSON(), state);
+  await fulfill(route, response.status, response.body);
+}
+
+function responseFor(
+  method: string,
+  path: string,
+  body: unknown,
+  state: IntegrationsUiMockState,
+): { status: number; body: unknown } {
+  if (path === BASE && method === 'GET') {
+    return {
+      status: 200,
+      body: {
+        integrations: [
+          providerStatus('github', 'GitHub', 'Source control', false),
+          providerStatus('curated-oauth', 'Curated OAuth', 'Productivity', false),
+        ],
+      },
+    };
+  }
+  if (path === DESCRIPTORS && method === 'GET') {
+    return { status: 200, body: { descriptors: state.descriptors, next_cursor: null } };
+  }
+  if (path === DESCRIPTORS && method === 'POST') return createDescriptor(body, state);
+
+  const specMatch = /^\/api\/v1\/me\/integrations\/descriptors\/([^/]+)\/spec(?:\/operations)?$/.exec(path);
+  if (specMatch) return specResponse(method, path, decodeURIComponent(specMatch[1]), body, state);
+
+  const descriptorMatch = /^\/api\/v1\/me\/integrations\/descriptors\/([^/]+)$/.exec(path);
+  if (descriptorMatch) {
+    return descriptorResponse(method, decodeURIComponent(descriptorMatch[1]), body, state);
+  }
+
+  const connectMatch = /^\/api\/v1\/me\/integrations\/([^/]+)\/connect$/.exec(path);
+  if (connectMatch && method === 'POST') {
+    return connectResponse(decodeURIComponent(connectMatch[1]), body, state);
+  }
+  const providerMatch = /^\/api\/v1\/me\/integrations\/([^/]+)$/.exec(path);
+  if (providerMatch) {
+    const provider = decodeURIComponent(providerMatch[1]);
+    if (method === 'DELETE') state.connectedProviders.delete(provider);
+    const descriptor = state.descriptors.find(item => item.provider === provider);
+    return {
+      status: 200,
+      body: providerStatus(
+        provider,
+        descriptor?.display_name ?? provider,
+        descriptor?.category ?? 'Integration',
+        state.connectedProviders.has(provider),
+      ),
+    };
+  }
+  return { status: 404, body: { detail: 'Not found' } };
+}
+
+function connectResponse(provider: string, body: unknown, state: IntegrationsUiMockState) {
+  const input = record(body);
+  const descriptor = state.descriptors.find(item => item.provider === provider);
+  if (descriptor?.auth_strategy === 'static_api_key') {
+    state.staticConnects += 1;
+    if (descriptor.static_api_key?.injection.location === 'basic') {
+      state.receivedBasicCredential = typeof input.username === 'string'
+        && input.username.length > 0
+        && typeof input.password === 'string'
+        && input.password.length > 0;
+    } else {
+      state.receivedApiKey = typeof input.api_key === 'string' && input.api_key.length > 0;
+    }
+    state.connectedProviders.add(provider);
+    return {
+      status: 200,
+      body: providerStatus(provider, descriptor.display_name, descriptor.category, true),
+    };
+  }
+  return { status: 200, body: { authorize_url: 'https://provider.example/authorize' } };
+}
+
+function createDescriptor(body: unknown, state: IntegrationsUiMockState) {
+  const input = record(body);
+  const descriptor = descriptorFromInput(`byo-${state.descriptorWrites + 2}`, input);
+  state.receivedClientSecret = typeof record(input.oauth).client_secret === 'string';
+  if (state.receivedClientSecret) state.clientSecretWrites += 1;
+  descriptor.has_client_secret = state.receivedClientSecret;
+  state.descriptors.push(descriptor);
+  state.descriptorWrites += 1;
+  return { status: 201, body: descriptor };
+}
+
+function descriptorResponse(method: string, id: string, body: unknown, state: IntegrationsUiMockState) {
+  const index = state.descriptors.findIndex(item => item.id === id);
+  if (index < 0) return { status: 404, body: { detail: 'Not found' } };
+  if (method === 'PATCH') {
+    const input = record(body);
+    const includesClientSecret = typeof record(input.oauth).client_secret === 'string';
+    state.receivedClientSecret ||= includesClientSecret;
+    if (includesClientSecret) state.clientSecretWrites += 1;
+    state.descriptors[index] = {
+      ...state.descriptors[index],
+      ...descriptorFromInput(id, input, state.descriptors[index]),
+      has_client_secret: state.descriptors[index].has_client_secret || state.receivedClientSecret,
+    };
+    state.descriptorWrites += 1;
+    return { status: 200, body: state.descriptors[index] };
+  }
+  if (method === 'DELETE') {
+    state.descriptors.splice(index, 1);
+    return { status: 204, body: null };
+  }
+  return { status: 200, body: state.descriptors[index] };
+}
+
+function specResponse(method: string, path: string, id: string, body: unknown, state: IntegrationsUiMockState) {
+  const descriptor = state.descriptors.find(item => item.id === id);
+  if (!descriptor) return { status: 404, body: { detail: 'Not found' } };
+  if (path.endsWith('/operations')) {
+    if (state.specWrites === 0) return { status: 404, body: { detail: 'No spec' } };
+    return {
+      status: 200,
+      body: { descriptor_id: id, spec_hash: 'abcdef1234567890', operations: state.operations },
+    };
+  }
+  if (method === 'PUT') {
+    const input = record(body);
+    if (record(input.spec).openapi) state.specWrites += 1;
+  }
+  if (state.specWrites === 0) return { status: 404, body: { detail: 'No spec' } };
+  return {
+    status: method === 'PUT' ? 201 : 200,
+    body: {
+      descriptor_id: id,
+      provider: descriptor.provider,
+      spec_hash: 'abcdef1234567890',
+      source_url: null,
+      operation_count: state.operations.length,
+      spec_bytes: 180,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+  };
+}
+
+// Mirrors the real authoring service: a PATCH that omits a field preserves the stored value rather
+// than clearing it, so partial updates (for example promoting operations) can't wipe the rest.
+function descriptorFromInput(id: string, input: Record<string, unknown>, existing?: MockDescriptor): MockDescriptor {
+  const now = new Date().toISOString();
+  const strategy = resolveStrategy(input.auth_strategy, existing);
+  return {
+    id,
+    provider: stringField(input.provider) || existing?.provider || 'custom-provider',
+    ownership: 'byo',
+    display_name: stringField(input.display_name) || existing?.display_name || 'Custom provider',
+    category: stringField(input.category) || existing?.category || 'Integration',
+    auth_strategy: strategy,
+    api_hosts: input.api_hosts === undefined ? (existing?.api_hosts ?? []) : stringArray(input.api_hosts),
+    oauth: strategy === 'oauth2_authorization_code'
+      ? publicOauth(record(input.oauth), existing?.oauth)
+      : null,
+    static_api_key: staticApiKeyFromInput(strategy, input, existing),
+    has_client_secret: existing?.has_client_secret ?? false,
+    operation_promotion: input.operation_promotion === undefined
+      ? (existing?.operation_promotion ?? {})
+      : record(input.operation_promotion),
+    created_at: existing?.created_at ?? now,
+    updated_at: now,
+  };
+}
+
+function resolveStrategy(value: unknown, existing?: MockDescriptor): MockDescriptor['auth_strategy'] {
+  if (value === undefined) return existing?.auth_strategy ?? 'oauth2_authorization_code';
+  return value === 'static_api_key' ? 'static_api_key' : 'oauth2_authorization_code';
+}
+
+function staticApiKeyFromInput(
+  strategy: MockDescriptor['auth_strategy'],
+  input: Record<string, unknown>,
+  existing?: MockDescriptor,
+): MockDescriptor['static_api_key'] {
+  if (strategy !== 'static_api_key') return null;
+  if (input.static_api_key === undefined) return existing?.static_api_key ?? null;
+  return record(input.static_api_key) as MockDescriptor['static_api_key'];
+}
+
+function publicOauth(input: Record<string, unknown>, existing: Record<string, unknown> | null | undefined) {
+  return {
+    client_id: stringField(input.client_id) || stringField(existing?.client_id),
+    authorization_url: stringField(input.authorization_url) || stringField(existing?.authorization_url),
+    token_url: stringField(input.token_url) || stringField(existing?.token_url),
+    scopes: stringArray(input.scopes),
+    pkce: stringField(input.pkce) || 'required',
+    refresh: stringField(input.refresh) || 'none',
+    token_exchange: {},
+    account_label: {},
+  };
+}
+
+function staticDescriptor(): MockDescriptor {
+  return {
+    id: 'byo-1',
+    provider: 'acme-tasks',
+    ownership: 'byo',
+    display_name: 'Acme Tasks',
+    category: 'Project management',
+    auth_strategy: 'static_api_key',
+    api_hosts: ['api.acme.test'],
+    oauth: null,
+    static_api_key: {
+      injection: { location: 'header', name: 'X-API-Key', value_prefix: null },
+    },
+    has_client_secret: false,
+    operation_promotion: {},
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function basicDescriptor(): MockDescriptor {
+  return {
+    id: 'byo-basic',
+    provider: 'legacy-reports',
+    ownership: 'byo',
+    display_name: 'Legacy Reports',
+    category: 'Reporting',
+    auth_strategy: 'static_api_key',
+    api_hosts: ['reports.legacy.test'],
+    oauth: null,
+    static_api_key: {
+      injection: { location: 'basic', name: 'Authorization', value_prefix: null },
+    },
+    has_client_secret: false,
+    operation_promotion: {},
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function curatedDescriptor(): MockDescriptor {
+  return {
+    id: 'curated-1',
+    provider: 'curated-oauth',
+    ownership: 'curated',
+    display_name: 'Curated OAuth',
+    category: 'Productivity',
+    auth_strategy: 'oauth2_authorization_code',
+    api_hosts: ['api.curated.test'],
+    oauth: {
+      client_id: 'public-client',
+      authorization_url: 'https://auth.curated.test/authorize',
+      token_url: 'https://auth.curated.test/token',
+      scopes: ['read'],
+      pkce: 'required',
+      refresh: 'rotating',
+      token_exchange: {},
+      account_label: {},
+    },
+    static_api_key: null,
+    has_client_secret: true,
+    operation_promotion: {},
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function providerStatus(provider: string, displayName: string, category: string, connected: boolean) {
+  return {
+    provider,
+    display_name: displayName,
+    category,
+    status: connected ? 'connected' : 'disconnected',
+    account_label: connected ? `${provider} account` : null,
+    scopes: [],
+    error_reason: null,
+    connected_at: connected ? new Date().toISOString() : null,
+    last_sync_at: null,
+  };
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function stringField(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter(item => typeof item === 'string') : [];
+}
+
+async function fulfill(route: Route, status: number, body: unknown): Promise<void> {
+  await route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: body === null ? '' : JSON.stringify(body),
+  });
+}

--- a/tests/integration/web-console-e2e/harness/integrationsUiMock.ts
+++ b/tests/integration/web-console-e2e/harness/integrationsUiMock.ts
@@ -208,7 +208,10 @@ function specResponse(method: string, path: string, id: string, body: unknown, s
   }
   if (method === 'PUT') {
     const input = record(body);
-    if (record(input.spec).openapi) state.specWrites += 1;
+    // Accept any recognisable definition, not just OpenAPI 3 — gating on `openapi` alone made a
+    // successful PUT of a Swagger 2.0 document look like no spec had ever been stored.
+    const spec = record(input.spec);
+    if (spec.openapi || spec.swagger) state.specWrites += 1;
   }
   if (state.specWrites === 0) return { status: 404, body: { detail: 'No spec' } };
   return {

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -9,6 +9,7 @@ import { SEED_PASSWORD } from '../harness/seed.js';
 import { installPortfolioUiMock } from '../harness/portfolioUiMock.js';
 import { installSelfServiceUiMock } from '../harness/selfServiceUiMock.js';
 import { installSessionUiMock } from '../harness/sessionUiMock.js';
+import { installIntegrationsUiMock } from '../harness/integrationsUiMock.js';
 import {
   installOperationsUiMock,
   OPERATIONS_PRIVATE_MARKER,
@@ -44,6 +45,21 @@ const BULK_SESSION_ACTION = '#sess-revoke-others';
 const USER_DRAWER = '.ua-drawer';
 const AUTH_ME_URL = '**/api/v1/auth/me';
 const ADMIN_USER_SESSIONS_URL = '**/api/v1/admin/accounts/users/*/sessions';
+const INTEGRATIONS_TAB = '.console-tab[data-tab="integrations"]';
+const INTEGRATION_DESCRIPTOR_CARD = '.int-descriptor-card';
+const INTEGRATION_OPERATION_ROW = '.int-operation';
+const INTEGRATION_ROUTES = [
+  { method: 'GET', path: '/api/v1/me/integrations/:provider' },
+  { method: 'POST', path: '/api/v1/me/integrations/:provider/connect' },
+  { method: 'DELETE', path: '/api/v1/me/integrations/:provider' },
+  { method: 'GET', path: '/api/v1/me/integrations/descriptors' },
+  { method: 'POST', path: '/api/v1/me/integrations/descriptors' },
+  { method: 'PATCH', path: '/api/v1/me/integrations/descriptors/:id' },
+  { method: 'DELETE', path: '/api/v1/me/integrations/descriptors/:id' },
+  { method: 'PUT', path: '/api/v1/me/integrations/descriptors/:id/spec' },
+  { method: 'GET', path: '/api/v1/me/integrations/descriptors/:id/spec' },
+  { method: 'GET', path: '/api/v1/me/integrations/descriptors/:id/spec/operations' },
+] as const;
 
 interface TextFileFixture {
   readonly name: string;
@@ -360,6 +376,175 @@ test('portfolio guided authoring serializes agent and ensemble settings', async 
       purpose: 'Draft the final response.',
     }],
   });
+});
+
+test('integration catalog connects static credentials without rendering them back', async ({ page }) => {
+  await includeManifestRoutes(page, INTEGRATION_ROUTES);
+  const mock = await installIntegrationsUiMock(page);
+  await loginFromConsole(page);
+
+  await page.locator(INTEGRATIONS_TAB).click();
+  await expect(page.locator('.int-card')).toHaveCount(4);
+  const acmeCard = page.locator('.int-card', { hasText: 'Acme Tasks' });
+  await expect(acmeCard).toContainText('Not connected');
+  await acmeCard.locator('[data-connect]').click();
+
+  const secretMarker = 'e2e-api-key-private-marker';
+  await page.locator('#int-credential-modal [name="api_key"]').fill(secretMarker);
+  await page.locator('#int-credential-modal [name="account_label"]').fill('Work account');
+  await page.locator('#int-credential-modal button[type="submit"]').click();
+
+  await expect(acmeCard).toContainText('Connected');
+  await expect(page.locator('body')).not.toContainText(secretMarker);
+  expect(mock.staticConnects).toBe(1);
+  expect(mock.receivedApiKey).toBe(true);
+
+  const basicCard = page.locator('.int-card', { hasText: 'Legacy Reports' });
+  await basicCard.locator('[data-connect]').click();
+  await page.locator('#int-credential-modal [name="username"]').fill('report-user');
+  await page.locator('#int-credential-modal [name="password"]').fill('private-password-marker');
+  await page.locator('#int-credential-modal button[type="submit"]').click();
+  await expect(basicCard).toContainText('Connected');
+  await expect(page.locator('body')).not.toContainText('private-password-marker');
+  expect(mock.staticConnects).toBe(2);
+  expect(mock.receivedBasicCredential).toBe(true);
+});
+
+test('integration descriptor management stays hidden when its route is unavailable', async ({ page }) => {
+  await filterManifestRoutes(page, new Set(['GET /api/v1/me/integrations/descriptors']));
+  await installIntegrationsUiMock(page);
+  await loginFromConsole(page);
+
+  await page.locator(INTEGRATIONS_TAB).click();
+  await expect(page.locator('[data-int-view="descriptors"]')).toHaveCount(0);
+  await expect(page.locator('.int-card', { hasText: 'GitHub' })).toBeVisible();
+});
+
+test('custom integration authoring keeps secrets write-only and imports OpenAPI files', async ({ page }) => {
+  await includeManifestRoutes(page, INTEGRATION_ROUTES);
+  const mock = await installIntegrationsUiMock(page);
+  await loginFromConsole(page);
+
+  await page.locator(INTEGRATIONS_TAB).click();
+  await page.locator('[data-int-view="descriptors"]').click();
+  await expect(page.locator(INTEGRATION_DESCRIPTOR_CARD, { hasText: 'Curated OAuth' }).locator('[data-descriptor-edit]')).toHaveCount(0);
+  await page.locator('[data-descriptor-create]').click();
+
+  const secretMarker = 'e2e-oauth-client-secret-marker';
+  await page.locator('[name="display_name"]').fill('Browser Calendar');
+  await page.locator('[name="provider"]').fill('browser-calendar');
+  await page.locator('[name="category"]').fill('Calendar');
+  await page.locator('[name="api_hosts"]').fill('api.calendar.test');
+  await page.locator('[name="oauth_client_id"]').fill('browser-client');
+  await page.locator('[name="oauth_client_secret"]').fill(secretMarker);
+  await page.locator('[name="oauth_authorization_url"]').fill('https://auth.calendar.test/authorize');
+  await page.locator('[name="oauth_token_url"]').fill('https://auth.calendar.test/token');
+  await page.locator('#int-descriptor-form button[type="submit"]').click();
+
+  await expect(page.locator(INTEGRATION_DESCRIPTOR_CARD, { hasText: 'Browser Calendar' })).toBeVisible();
+  await expect(page.locator('body')).not.toContainText(secretMarker);
+  expect(mock.receivedClientSecret).toBe(true);
+  expect(mock.clientSecretWrites).toBe(1);
+
+  let customCard = page.locator(INTEGRATION_DESCRIPTOR_CARD, { hasText: 'Browser Calendar' });
+  await customCard.locator('[data-descriptor-edit]').click();
+  await expect(page.locator('[name="oauth_client_secret"]')).toHaveValue('');
+  await page.locator('[name="display_name"]').fill('Browser Calendar Updated');
+  await page.locator('#int-descriptor-form button[type="submit"]').click();
+  await expect(page.locator(INTEGRATION_DESCRIPTOR_CARD, { hasText: 'Browser Calendar Updated' })).toBeVisible();
+  expect(mock.clientSecretWrites).toBe(1);
+
+  customCard = page.locator(INTEGRATION_DESCRIPTOR_CARD, { hasText: 'Browser Calendar Updated' });
+  await customCard.locator('[data-descriptor-spec]').click();
+  await setTextInputFile(page, '[name="spec_file"]', {
+    name: 'calendar.openapi.yaml',
+    mimeType: 'application/yaml',
+    content: [
+      'openapi: 3.0.3',
+      'info:',
+      '  title: Calendar API',
+      '  version: 1.0.0',
+      'paths:',
+      '  /tasks:',
+      '    get:',
+      '      operationId: listTasks',
+      '      summary: List tasks',
+      '      responses:',
+      "        '200':",
+      '          description: OK',
+    ].join('\n'),
+  });
+  await expect(page.locator('[name="spec_text"]')).toHaveValue(/openapi: 3\.0\.3/u);
+  await page.locator('#int-spec-form button[type="submit"]').click();
+
+  await expect(page.locator('.int-spec-summary')).toContainText('1 operations discovered');
+  await expect(page.locator(INTEGRATION_OPERATION_ROW)).toContainText('listTasks');
+  expect(mock.specWrites).toBe(1);
+  expect(mock.descriptorWrites).toBe(2);
+
+  await page.locator('[data-descriptor-back]').first().click();
+  customCard = page.locator(INTEGRATION_DESCRIPTOR_CARD, { hasText: 'Browser Calendar Updated' });
+  await customCard.locator('[data-descriptor-delete]').click();
+  await page.locator('#confirm-modal [data-confirm="1"]').click();
+  await expect(customCard).toHaveCount(0);
+});
+
+test('selecting discovered operations promotes them without disturbing the remote MCP settings', async ({ page }) => {
+  await includeManifestRoutes(page, INTEGRATION_ROUTES);
+  const mock = await installIntegrationsUiMock(page);
+  // Pre-existing remote MCP config on the same descriptor: promoting operations sends the whole
+  // operation_promotion object, so this is what a partial write would silently drop.
+  const remoteMcp = { serverUrl: 'https://api.acme.test/mcp', tools: ['search'] };
+  const seeded = mock.descriptors.find(item => item.provider === 'acme-tasks');
+  if (!seeded) throw new Error('The acme-tasks descriptor is missing from the mock seed.');
+  seeded.operation_promotion = { remoteMcp };
+  // Two operations, so selecting one proves only that one is promoted.
+  mock.operations = [
+    { operation_id: 'listTasks', method: 'GET', path: '/tasks', read_write_class: 'read', summary: 'List tasks', description: null, required_scopes: [] },
+    { operation_id: 'createTask', method: 'POST', path: '/tasks', read_write_class: 'write', summary: 'Create a task', description: null, required_scopes: [] },
+  ];
+  await loginFromConsole(page);
+
+  await page.locator(INTEGRATIONS_TAB).click();
+  await page.locator('[data-int-view="descriptors"]').click();
+  await page.locator(INTEGRATION_DESCRIPTOR_CARD, { hasText: 'Acme Tasks' })
+    .locator('[data-descriptor-spec]').click();
+
+  await setTextInputFile(page, '[name="spec_file"]', {
+    name: 'acme.openapi.yaml',
+    mimeType: 'application/yaml',
+    content: [
+      'openapi: 3.0.3',
+      'info:',
+      '  title: Acme API',
+      '  version: 1.0.0',
+      'paths:',
+      '  /tasks:',
+      '    get:',
+      '      operationId: listTasks',
+      '      responses:',
+      "        '200':",
+      '          description: OK',
+    ].join('\n'),
+  });
+  await page.locator('#int-spec-form button[type="submit"]').click();
+  await expect(page.locator(INTEGRATION_OPERATION_ROW)).toHaveCount(2);
+
+  // Nothing is promoted until the operator chooses, so both start unticked.
+  const listTasks = page.locator(INTEGRATION_OPERATION_ROW, { hasText: 'listTasks' }).locator('input[type="checkbox"]');
+  await expect(listTasks).not.toBeChecked();
+  await listTasks.check();
+  await page.locator('#int-promotion-form button[type="submit"]').click();
+
+  await expect.poll(() => mock.descriptors.find(item => item.provider === 'acme-tasks')?.operation_promotion)
+    .toEqual({ remoteMcp, operations: ['listTasks'] });
+
+  // Re-opening reflects the stored selection rather than resetting it.
+  await page.locator('[data-descriptor-back]').first().click();
+  await page.locator(INTEGRATION_DESCRIPTOR_CARD, { hasText: 'Acme Tasks' })
+    .locator('[data-descriptor-spec]').click();
+  await expect(page.locator(INTEGRATION_OPERATION_ROW, { hasText: 'listTasks' }).locator('input[type="checkbox"]')).toBeChecked();
+  await expect(page.locator(INTEGRATION_OPERATION_ROW, { hasText: 'createTask' }).locator('input[type="checkbox"]')).not.toBeChecked();
 });
 
 test('portfolio imports a reviewed file without silently overwriting a duplicate', async ({ page }) => {

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -489,6 +489,39 @@ test('custom integration authoring keeps secrets write-only and imports OpenAPI 
   await expect(customCard).toHaveCount(0);
 });
 
+test('a malformed authorization parameter is rejected before anything is saved', async ({ page }) => {
+  await includeManifestRoutes(page, INTEGRATION_ROUTES);
+  const mock = await installIntegrationsUiMock(page);
+  await loginFromConsole(page);
+
+  await page.locator(INTEGRATIONS_TAB).click();
+  await page.locator('[data-int-view="descriptors"]').click();
+  await page.locator('[data-descriptor-create]').click();
+
+  await page.locator('[name="display_name"]').fill('Param Check');
+  await page.locator('[name="provider"]').fill('param-check');
+  await page.locator('[name="category"]').fill('Testing');
+  await page.locator('[name="api_hosts"]').fill('api.param-check.test');
+  await page.locator('[name="oauth_client_id"]').fill('param-client');
+  await page.locator('[name="oauth_authorization_url"]').fill('https://auth.param-check.test/authorize');
+  await page.locator('[name="oauth_token_url"]').fill('https://auth.param-check.test/token');
+
+  await page.locator('.int-auth-advanced > summary').click();
+  const params = page.locator('[name="oauth_authorization_params"]');
+  await params.fill('audience=https://api.param-check.test\nprompt');
+  await page.locator('#int-descriptor-form button[type="submit"]').click();
+
+  // Rejected in the browser: the operator is told which line is wrong and nothing reaches the API.
+  await expect(page.locator('#int-descriptor-form [data-form-error]')).toContainText('name=value');
+  expect(mock.descriptorWrites).toBe(0);
+
+  // The same form saves once the line is well-formed, so the guard isn't rejecting valid input.
+  await params.fill('audience=https://api.param-check.test\nprompt=consent');
+  await page.locator('#int-descriptor-form button[type="submit"]').click();
+  await expect(page.locator(INTEGRATION_DESCRIPTOR_CARD, { hasText: 'Param Check' })).toBeVisible();
+  expect(mock.descriptorWrites).toBe(1);
+});
+
 test('selecting discovered operations promotes them without disturbing the remote MCP settings', async ({ page }) => {
   await includeManifestRoutes(page, INTEGRATION_ROUTES);
   const mock = await installIntegrationsUiMock(page);

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -477,7 +477,7 @@ test('custom integration authoring keeps secrets write-only and imports OpenAPI 
   await expect(page.locator('[name="spec_text"]')).toHaveValue(/openapi: 3\.0\.3/u);
   await page.locator('#int-spec-form button[type="submit"]').click();
 
-  await expect(page.locator('.int-spec-summary')).toContainText('1 operations discovered');
+  await expect(page.locator('.int-spec-summary')).toContainText('1 operation discovered');
   await expect(page.locator(INTEGRATION_OPERATION_ROW)).toContainText('listTasks');
   expect(mock.specWrites).toBe(1);
   expect(mock.descriptorWrites).toBe(2);

--- a/tests/integration/web-console-e2e/specs/me-integrations.e2e-spec.ts
+++ b/tests/integration/web-console-e2e/specs/me-integrations.e2e-spec.ts
@@ -1,7 +1,11 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
 import { setupWorld, type World } from '../harness/world.js';
 
 let world: World;
 beforeAll(async () => { world = await setupWorld(); });
+
+const DESCRIPTORS = '/api/v1/me/integrations/descriptors';
 
 describe('/me/integrations', () => {
   it('lists integrations', async () => {
@@ -25,5 +29,130 @@ describe('/me/integrations', () => {
   it('disconnect is idempotent and never errors', async () => {
     const res = await world.clients.userA.delete('/api/v1/me/integrations/github');
     expect([200, 204, 404]).toContain(res.status);
+  });
+});
+
+describe('/me/integrations/descriptors', () => {
+  let descriptorId = '';
+  const provider = 'e2e-custom-tasks';
+
+  it('creates and lists an owner-scoped custom descriptor without exposing credentials', async () => {
+    const created = await world.clients.userA.post(DESCRIPTORS, {
+      body: {
+        provider,
+        display_name: 'E2E Custom Tasks',
+        category: 'Testing',
+        auth_strategy: 'static_api_key',
+        api_hosts: ['api.e2e-custom.test'],
+        static_api_key: {
+          injection: {
+            location: 'header',
+            name: 'Authorization',
+            value_prefix: 'Bearer ',
+          },
+        },
+        operation_promotion: {},
+      },
+    });
+
+    expect(created.status).toBe(201);
+    expect(created.body).toMatchObject({
+      provider,
+      ownership: 'byo',
+      auth_strategy: 'static_api_key',
+      has_client_secret: false,
+    });
+    expect(JSON.stringify(created.body)).not.toContain('ciphertext');
+    descriptorId = created.body.id;
+
+    const listed = await world.clients.userA.get(DESCRIPTORS);
+    expect(listed.status).toBe(200);
+    expect(listed.body.descriptors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: descriptorId, provider }),
+    ]));
+  });
+
+  it('returns 404 for descriptor access from another user', async () => {
+    const path = `${DESCRIPTORS}/${descriptorId}`;
+    const [read, update, remove] = await Promise.all([
+      world.clients.userB.get(path),
+      world.clients.userB.patch(path, { body: { display_name: 'Foreign edit' } }),
+      world.clients.userB.delete(path),
+    ]);
+
+    expect(read.status).toBe(404);
+    expect(update.status).toBe(404);
+    expect(remove.status).toBe(404);
+
+    const foreignList = await world.clients.userB.get(DESCRIPTORS);
+    expect(foreignList.status).toBe(200);
+    expect(foreignList.body.descriptors).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: descriptorId }),
+    ]));
+  });
+
+  it('imports spec metadata and exposes derived operations without returning the document', async () => {
+    const path = `${DESCRIPTORS}/${descriptorId}/spec`;
+    const imported = await world.clients.userA.put(path, {
+      body: {
+        source_url: 'https://api.e2e-custom.test/openapi.json',
+        spec: {
+          openapi: '3.1.0',
+          info: { title: 'E2E Custom Tasks', version: '1.0.0' },
+          servers: [{ url: 'https://api.e2e-custom.test' }],
+          paths: {
+            '/tasks': {
+              get: {
+                operationId: 'listTasks',
+                summary: 'List tasks',
+                responses: { 200: { description: 'ok' } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(imported.status).toBe(200);
+    expect(imported.body).toMatchObject({
+      descriptor_id: descriptorId,
+      provider,
+      operation_count: 1,
+    });
+    expect(imported.body.spec).toBeUndefined();
+
+    const operations = await world.clients.userA.get(`${path}/operations`);
+    expect(operations.status).toBe(200);
+    expect(operations.body.operations).toEqual([
+      expect.objectContaining({
+        operation_id: 'listTasks',
+        method: 'GET',
+        path: '/tasks',
+        read_write_class: 'read',
+      }),
+    ]);
+
+    const foreign = await world.clients.userB.get(`${path}/operations`);
+    expect(foreign.status).toBe(404);
+  });
+
+  it('connects a static credential without reflecting the secret and cleans up', async () => {
+    const secret = 'e2e-static-private-marker';
+    const connected = await world.clients.userA.post(`/api/v1/me/integrations/${provider}/connect`, {
+      body: { api_key: secret, account_label: 'E2E account' },
+    });
+
+    expect(connected.status).toBe(200);
+    expect(connected.body).toMatchObject({
+      provider,
+      status: 'connected',
+      account_label: 'E2E account',
+    });
+    expect(JSON.stringify(connected.body)).not.toContain(secret);
+
+    const removed = await world.clients.userA.delete(`${DESCRIPTORS}/${descriptorId}`);
+    expect(removed.status).toBe(204);
+    const absent = await world.clients.userA.get(`${DESCRIPTORS}/${descriptorId}`);
+    expect(absent.status).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary

The console's Connections list was a hardcoded GitHub-only array with a fixed
action-route table. This replaces it with a catalog built from the configured
provider statuses combined with the visible descriptor pages, and adds a
separate surface for authoring your own integrations.

Users can now define an integration, import its OpenAPI definition, and choose
which of the discovered operations are exposed as tools — without leaving the
console or hand-writing configuration.

## Connections catalog

Built from `GET /me/integrations` plus visible descriptors, so a runtime-authored
provider that isn't in the boot-time registry still appears. Supports literal and
parameterized `/:provider` routes, generic OAuth redirects, static API-key and
Basic credentials, and confirmed disconnects. Existing GitHub behaviour is
unchanged.

## Custom integration authoring

Create, edit, and delete owner-scoped descriptors with guided fields for
identity, allowed hosts, and authentication. Curated descriptors stay read-only.
OpenAPI definitions can be imported by file or paste, and discovered operations
are listed with method, path, and read/write classification.

Everything is expressed as ordinary form controls — operation promotion, OAuth
token-exchange settings, and the account-label mapping included. Operation
selection lives on the API-definition screen rather than the create form, because
the operation IDs only exist once a spec has been imported; asking for them
earlier is not answerable.

Selecting an operation turns it into its own named tool. Unselected operations
remain reachable through the general-purpose request tool. Because the stored
promotion settings are replaced wholesale by the API and are now edited from two
screens, each screen carries the other's portion through unchanged so that saving
in one place cannot silently discard the other.

## Credential handling

Client secrets and passwords are never rendered back — the DTO only exposes
`has_client_secret`. Plaintext is never held in module state, password fields are
cleared after submission and on teardown, and the submitted credential object is
wiped on both the success and failure paths. Leaving a secret blank while editing
preserves the stored value rather than clearing it.

## Testing

Console API E2E covers descriptor CRUD, DTO redaction, spec ingestion, derived
operations, and cross-user denial. Browser E2E covers the connect journey,
authoring with a write-only client secret, OpenAPI import, and operation
selection. The wired integration suite exercises BYO authoring through the
gateway.
