### PR TITLE
feat(web-console): add audit, security, and account governance

### DIFF
--- a/src/web-console/ui/accounts-admin.css
+++ b/src/web-console/ui/accounts-admin.css
@@ -182,3 +182,14 @@
 }
 
 .acct-notice--error { border-color: rgba(239, 68, 68, 0.35); }
+
+.acct-note-input {
+  width: 100%;
+  padding: 4px 7px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  color: var(--ink-900);
+  font: inherit;
+  font-size: var(--step--1);
+}

--- a/src/web-console/ui/accounts-admin.css
+++ b/src/web-console/ui/accounts-admin.css
@@ -1,0 +1,184 @@
+/* Account governance surfaces inside the Users tab: allowlist, identity triage,
+   and bootstrap status. The `ua-nav` rules belong here rather than to the
+   account list, which keeps its own styles in console.css. */
+
+.ua-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0 0 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.ua-nav-item {
+  padding: 7px 13px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: none;
+  color: var(--ink-500);
+  font: inherit;
+  font-size: var(--step--1);
+  cursor: pointer;
+}
+
+.ua-nav-item:hover { color: var(--ink-900); }
+.ua-nav-item:focus-visible { outline: 2px solid var(--signal); outline-offset: -2px; }
+
+.ua-nav-item.is-active {
+  color: var(--ink-900);
+  border-bottom-color: var(--signal);
+  font-weight: 600;
+}
+
+.acct-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.acct-sub {
+  margin: 0;
+  color: var(--ink-500);
+  font-size: var(--step--1);
+  max-width: 68ch;
+}
+
+.acct-card {
+  margin-bottom: 14px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-1);
+}
+
+.acct-card h3 {
+  margin: 0 0 4px;
+  font-family: var(--font-heading);
+  font-size: var(--step-0);
+}
+
+.acct-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 10px;
+  margin: 12px 0;
+}
+
+.acct-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 170px;
+}
+
+.acct-field--wide { flex: 1 1 280px; }
+
+.acct-field > span {
+  font-size: var(--step--1);
+  color: var(--ink-700);
+}
+
+.acct-field input,
+.acct-field select {
+  padding: 7px 9px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  color: var(--ink-900);
+  font: inherit;
+}
+
+.acct-table {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+}
+
+.acct-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 1.4fr) minmax(120px, 0.8fr) minmax(140px, 1.2fr) minmax(140px, 0.9fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 9px 12px;
+  border-top: 1px solid var(--line);
+  font-size: var(--step--1);
+  min-width: 640px;
+}
+
+.acct-row--triage {
+  grid-template-columns: minmax(140px, 0.8fr) minmax(220px, 1.6fr) minmax(150px, 0.9fr);
+  min-width: 520px;
+}
+
+.acct-row:first-child { border-top: 0; }
+
+.acct-row--head {
+  background: var(--surface-1);
+  color: var(--ink-500);
+  font-weight: 600;
+}
+
+.acct-row > span { overflow-wrap: anywhere; }
+
+.acct-row-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.acct-danger { color: #dc2626; } /* NOSONAR — destructive */
+
+.acct-detail {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 10px 18px;
+  margin: 12px 0 0;
+}
+
+.acct-detail dt {
+  color: var(--ink-500);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.acct-detail dd {
+  margin: 2px 0 0;
+  font-size: var(--step--1);
+  overflow-wrap: anywhere;
+}
+
+.acct-pager {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 10px;
+}
+
+.acct-loading,
+.acct-empty {
+  padding: 16px;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--ink-500);
+  font-size: var(--step--1);
+  text-align: center;
+}
+
+.acct-notice {
+  margin-bottom: 10px;
+  padding: 9px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-1);
+  font-size: var(--step--1);
+}
+
+.acct-notice--error { border-color: rgba(239, 68, 68, 0.35); }

--- a/src/web-console/ui/accounts-admin.js
+++ b/src/web-console/ui/accounts-admin.js
@@ -40,6 +40,10 @@ export function createAllowlistView({ notify, canAdd, canEdit, canRemove }) {
   let state = 'idle';
   let message = '';
   let busy = false;
+  let editingId = null;
+  // Held in state so a reload landing mid-edit restores the draft instead of
+  // discarding it, the same reason the add form is never re-rendered.
+  let editingNote = '';
 
   async function load() {
     state = state === 'ready' ? 'ready' : 'loading';
@@ -86,13 +90,28 @@ export function createAllowlistView({ notify, canAdd, canEdit, canRemove }) {
     }));
   }
 
-  async function editNote(id) {
+  function beginEdit(id) {
     const entry = entries.find(item => item.id === id);
     if (!entry) return;
-    const next = globalThis.prompt('Note for this entry', entry.note ?? '');
-    if (next === null) return;
+    editingId = id;
+    editingNote = entry.note ?? '';
+    repaint();
+    container?.querySelector('[data-allow-note-input]')?.focus();
+  }
+
+  function cancelEdit() {
+    editingId = null;
+    editingNote = '';
+    repaint();
+  }
+
+  async function saveNote(id) {
+    const note = editingNote.trim();
+    editingId = null;
+    editingNote = '';
+    // Only the note is mutable server-side, so that is all the request carries.
     await runMutation('Allowlist note', () =>
-      patch(`${ALLOWLIST_PATH}/${encodeURIComponent(id)}`, { body: { note: next.trim() || null } }));
+      patch(`${ALLOWLIST_PATH}/${encodeURIComponent(id)}`, { body: { note: note || null } }));
   }
 
   async function remove(id) {
@@ -111,8 +130,14 @@ export function createAllowlistView({ notify, canAdd, canEdit, canRemove }) {
     if (!button) return;
     const { allowAction: action, allowId: id } = button.dataset;
     if (action === 'refresh') void load();
-    if (action === 'edit') void editNote(id);
+    if (action === 'edit') beginEdit(id);
+    if (action === 'cancel-edit') cancelEdit();
+    if (action === 'save-edit') void saveNote(id);
     if (action === 'remove') void remove(id);
+  }
+
+  function onInput(event) {
+    if (event.target.matches('[data-allow-note-input]')) editingNote = event.target.value;
   }
 
   function onSubmit(event) {
@@ -180,17 +205,24 @@ export function createAllowlistView({ notify, canAdd, canEdit, canRemove }) {
   }
 
   function entryRow(entry) {
+    const editing = entry.id === editingId;
     return `
       <div class="acct-row" role="row">
         <span role="cell"><strong>${escapeHtml(entry.value)}</strong></span>
         <span role="cell">${escapeHtml(kindLabel(entry.kind))}</span>
-        <span role="cell">${entry.note ? escapeHtml(entry.note) : '—'}</span>
+        <span role="cell">${editing ? noteEditorMarkup(editingNote) : noteMarkup(entry.note)}</span>
         <span role="cell">${escapeHtml(formatTimestamp(entry.created_at))}</span>
-        <span role="cell" class="acct-row-actions">
-          ${canEdit ? allowActionButton('Note', 'edit', entry.id, busy) : ''}
-          ${canRemove ? allowActionButton('Remove', 'remove', entry.id, busy, ' acct-danger') : ''}
-        </span>
+        <span role="cell" class="acct-row-actions">${rowActions(entry, editing)}</span>
       </div>`;
+  }
+
+  function rowActions(entry, editing) {
+    if (editing) {
+      return allowActionButton('Save', 'save-edit', entry.id, busy)
+        + allowActionButton('Cancel', 'cancel-edit', entry.id, busy);
+    }
+    return (canEdit ? allowActionButton('Note', 'edit', entry.id, busy) : '')
+      + (canRemove ? allowActionButton('Remove', 'remove', entry.id, busy, ' acct-danger') : '');
   }
 
   return Object.freeze({
@@ -198,6 +230,7 @@ export function createAllowlistView({ notify, canAdd, canEdit, canRemove }) {
       container = panel;
       container.addEventListener('click', onClick);
       container.addEventListener('submit', onSubmit);
+      container.addEventListener('input', onInput);
       render();
     },
     activate() {
@@ -207,6 +240,14 @@ export function createAllowlistView({ notify, canAdd, canEdit, canRemove }) {
       container = null;
     },
   });
+}
+
+function noteMarkup(note) {
+  return note ? escapeHtml(note) : '—';
+}
+
+function noteEditorMarkup(value) {
+  return `<input type="text" class="acct-note-input" data-allow-note-input maxlength="500" value="${escapeHtml(value)}" aria-label="Entry note">`;
 }
 
 function allowActionButton(label, action, id, busy, extraClass = '') {

--- a/src/web-console/ui/accounts-admin.js
+++ b/src/web-console/ui/accounts-admin.js
@@ -352,8 +352,8 @@ export function createIdentityTriageView({ canLookup }) {
       </div>
       <div data-unlinked-list></div>
       <div class="acct-pager">
-        <button class="btn btn-ghost" data-unlinked-previous type="button">Previous</button>
-        <button class="btn btn-ghost" data-unlinked-next type="button">Next</button>
+        <button class="btn btn-ghost" data-unlinked-previous type="button"${pager.hasPrevious() ? '' : ' disabled'}>Previous</button>
+        <button class="btn btn-ghost" data-unlinked-next type="button"${pager.nextCursor() ? '' : ' disabled'}>Next</button>
       </div>`;
     repaint();
   }

--- a/src/web-console/ui/accounts-admin.js
+++ b/src/web-console/ui/accounts-admin.js
@@ -1,0 +1,462 @@
+/**
+ * Account governance beyond the user list: sign-in allowlist, identity triage,
+ * and bootstrap status.
+ *
+ * Two contract details shape this. An allowlist entry's kind and value are fixed
+ * once created — only the note can be edited — so editing offers only the note
+ * rather than a form that looks fully mutable. And the value the API returns is a
+ * display projection, not necessarily what was stored, so it is shown but never
+ * fed back into an update.
+ */
+
+import { del, get, patch, post } from './api.js';
+import { confirmDialog } from './ui-utils.js';
+import { createCursorPager, escapeHtml, formatTimestamp, responseDetail } from './operations-ui.js';
+
+const ALLOWLIST_PATH = '/admin/accounts/allowlist';
+const UNLINKED_PATH = '/admin/accounts/identities/unlinked';
+const BOOTSTRAP_PATH = '/admin/accounts/bootstrap';
+const CORRELATION_PATH = '/admin/accounts/correlations';
+const PAGE_LIMIT = 50;
+
+/**
+ * FormData entries are `string | File`. Casting one with String() would quietly
+ * produce "[object File]" instead of failing, so non-string entries read as empty.
+ */
+function formText(data, name) {
+  const value = data.get(name);
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+const ALLOWLIST_KINDS = [
+  ['email', 'Email address'],
+  ['github_username', 'GitHub username'],
+  ['github_id', 'GitHub numeric ID'],
+];
+
+export function createAllowlistView({ notify, canAdd, canEdit, canRemove }) {
+  let container;
+  let entries = [];
+  let state = 'idle';
+  let message = '';
+  let busy = false;
+
+  async function load() {
+    state = state === 'ready' ? 'ready' : 'loading';
+    repaint();
+    const response = await get(ALLOWLIST_PATH).catch(() => null);
+    if (response?.status !== 200 || !Array.isArray(response.body?.entries)) {
+      state = 'error';
+      message = responseDetail(response, 'The allowlist could not be loaded.');
+      repaint();
+      return;
+    }
+    entries = response.body.entries;
+    state = 'ready';
+    repaint();
+  }
+
+  async function runMutation(label, action) {
+    if (busy) return;
+    busy = true;
+    message = '';
+    repaint();
+    const response = await action().catch(() => null);
+    busy = false;
+    if (response && [200, 201, 204].includes(response.status)) {
+      notify(`${label} saved.`, 'success');
+      await load();
+      return;
+    }
+    message = responseDetail(response, `${label} did not save.`);
+    repaint();
+  }
+
+  async function add(form) {
+    const data = new FormData(form);
+    const value = formText(data, 'value');
+    if (!value) {
+      message = 'Enter the address, username, or ID to allow.';
+      repaint();
+      return;
+    }
+    const note = formText(data, 'note');
+    await runMutation('Allowlist entry', () => post(ALLOWLIST_PATH, {
+      body: { kind: formText(data, 'kind'), value, ...(note ? { note } : {}) },
+    }));
+  }
+
+  async function editNote(id) {
+    const entry = entries.find(item => item.id === id);
+    if (!entry) return;
+    const next = globalThis.prompt('Note for this entry', entry.note ?? '');
+    if (next === null) return;
+    await runMutation('Allowlist note', () =>
+      patch(`${ALLOWLIST_PATH}/${encodeURIComponent(id)}`, { body: { note: next.trim() || null } }));
+  }
+
+  async function remove(id) {
+    const entry = entries.find(item => item.id === id);
+    if (!entry) return;
+    const approved = await confirmDialog(
+      `Remove ${entry.value} from the allowlist? Anyone relying on this entry will no longer be able to sign in.`,
+      'Remove entry',
+    );
+    if (!approved) return;
+    await runMutation('Allowlist removal', () => del(`${ALLOWLIST_PATH}/${encodeURIComponent(id)}`));
+  }
+
+  function onClick(event) {
+    const button = event.target.closest('button[data-allow-action]');
+    if (!button) return;
+    const { allowAction: action, allowId: id } = button.dataset;
+    if (action === 'refresh') void load();
+    if (action === 'edit') void editNote(id);
+    if (action === 'remove') void remove(id);
+  }
+
+  function onSubmit(event) {
+    if (event.target.id !== 'acct-allow-form') return;
+    event.preventDefault();
+    void add(event.target);
+  }
+
+  /**
+   * The add form is rendered once and never replaced by a reload. Re-rendering it
+   * would silently discard whatever the operator had already typed whenever a
+   * refresh landed, so only the message and list regions are repainted.
+   */
+  function render() {
+    if (!container) return;
+    container.innerHTML = `
+      <div class="acct-head">
+        <p class="acct-sub">Only these identities may sign in. Removing an entry takes effect on the next sign-in attempt.</p>
+        <button class="btn btn-ghost" data-allow-action="refresh" type="button">&#x21bb; Refresh</button>
+      </div>
+      <div data-allow-message></div>
+      ${canAdd ? addFormMarkup() : ''}
+      <div data-allow-list></div>`;
+    renderMessage();
+    renderList();
+  }
+
+  function renderMessage() {
+    const region = container?.querySelector('[data-allow-message]');
+    if (region) {
+      region.innerHTML = message ? `<div class="acct-notice acct-notice--error">${escapeHtml(message)}</div>` : '';
+    }
+  }
+
+  function renderList() {
+    const region = container?.querySelector('[data-allow-list]');
+    if (region) region.innerHTML = listMarkup();
+    for (const control of container?.querySelectorAll('[data-allow-action], #acct-allow-form button') ?? []) {
+      control.disabled = busy;
+    }
+  }
+
+  function repaint() {
+    renderMessage();
+    renderList();
+  }
+
+  function listMarkup() {
+    if (state === 'idle' || state === 'loading') return '<div class="acct-loading">Loading the allowlist…</div>';
+    if (state === 'error') return `<div class="acct-notice acct-notice--error">${escapeHtml(message)}</div>`;
+    if (entries.length === 0) {
+      return '<div class="acct-empty">The allowlist is empty. Every sign-in will be refused until an entry is added.</div>';
+    }
+    return `
+      <div class="acct-table" role="table">
+        <div class="acct-row acct-row--head" role="row">
+          <span role="columnheader">Identity</span>
+          <span role="columnheader">Kind</span>
+          <span role="columnheader">Note</span>
+          <span role="columnheader">Added</span>
+          <span role="columnheader"><span class="sr-only">Actions</span></span>
+        </div>
+        ${entries.map(entryRow).join('')}
+      </div>`;
+  }
+
+  function entryRow(entry) {
+    return `
+      <div class="acct-row" role="row">
+        <span role="cell"><strong>${escapeHtml(entry.value)}</strong></span>
+        <span role="cell">${escapeHtml(kindLabel(entry.kind))}</span>
+        <span role="cell">${entry.note ? escapeHtml(entry.note) : '—'}</span>
+        <span role="cell">${escapeHtml(formatTimestamp(entry.created_at))}</span>
+        <span role="cell" class="acct-row-actions">
+          ${canEdit ? allowActionButton('Note', 'edit', entry.id, busy) : ''}
+          ${canRemove ? allowActionButton('Remove', 'remove', entry.id, busy, ' acct-danger') : ''}
+        </span>
+      </div>`;
+  }
+
+  return Object.freeze({
+    mount(panel) {
+      container = panel;
+      container.addEventListener('click', onClick);
+      container.addEventListener('submit', onSubmit);
+      render();
+    },
+    activate() {
+      if (state === 'idle') void load();
+    },
+    destroy() {
+      container = null;
+    },
+  });
+}
+
+function allowActionButton(label, action, id, busy, extraClass = '') {
+  const disabled = busy ? ' disabled' : '';
+  return `<button class="btn btn-ghost${extraClass}" data-allow-action="${action}" data-allow-id="${escapeHtml(id)}" type="button"${disabled}>${escapeHtml(label)}</button>`;
+}
+
+function addFormMarkup() {
+  return `
+    <form id="acct-allow-form" class="acct-form">
+      <label class="acct-field">
+        <span>Kind</span>
+        <select name="kind">
+          ${ALLOWLIST_KINDS.map(([value, label]) => `<option value="${value}">${escapeHtml(label)}</option>`).join('')}
+        </select>
+      </label>
+      <label class="acct-field">
+        <span>Identity</span>
+        <input type="text" name="value" placeholder="person@example.com" autocomplete="off">
+      </label>
+      <label class="acct-field">
+        <span>Note (optional)</span>
+        <input type="text" name="note" maxlength="500" placeholder="Why this entry exists" autocomplete="off">
+      </label>
+      <button class="btn btn-primary" type="submit">Add entry</button>
+    </form>`;
+}
+
+function kindLabel(kind) {
+  return ALLOWLIST_KINDS.find(([value]) => value === kind)?.[1] ?? kind;
+}
+
+/* ── Identity triage ────────────────────────────────────────────────────── */
+
+export function createIdentityTriageView({ canLookup }) {
+  let container;
+  let items = [];
+  let state = 'idle';
+  let message = '';
+  let lookup = { state: 'idle', record: null, message: '' };
+  const pager = createCursorPager();
+
+  async function load() {
+    state = 'loading';
+    repaint();
+    const query = new URLSearchParams({ limit: String(PAGE_LIMIT) });
+    const cursor = pager.cursor();
+    if (cursor) query.set('cursor', cursor);
+    const response = await get(`${UNLINKED_PATH}?${query}`).catch(() => null);
+    if (response?.status !== 200 || !Array.isArray(response.body?.items)) {
+      state = 'error';
+      message = responseDetail(response, 'Unlinked identities could not be loaded.');
+      repaint();
+      return;
+    }
+    items = response.body.items;
+    pager.apply(response.body.page);
+    state = 'ready';
+    repaint();
+  }
+
+  async function resolve(form) {
+    const id = formText(new FormData(form), 'correlation_id');
+    if (!id) return;
+    lookup = { state: 'loading', record: null, message: '' };
+    repaint();
+    const response = await get(`${CORRELATION_PATH}/${encodeURIComponent(id)}`).catch(() => null);
+    if (response?.status === 404) {
+      lookup = { state: 'empty', record: null, message: 'No account matches that correlation ID.' };
+      repaint();
+      return;
+    }
+    if (response?.status !== 200 || !response.body) {
+      lookup = { state: 'error', record: null, message: responseDetail(response, 'That correlation ID could not be resolved.') };
+      repaint();
+      return;
+    }
+    lookup = { state: 'ready', record: response.body, message: '' };
+    repaint();
+  }
+
+  function onSubmit(event) {
+    if (event.target.id !== 'acct-correlation-form') return;
+    event.preventDefault();
+    void resolve(event.target);
+  }
+
+  function onClick(event) {
+    if (event.target.closest('[data-unlinked-refresh]')) void load();
+    if (event.target.closest('[data-unlinked-next]') && pager.moveNext()) void load();
+    if (event.target.closest('[data-unlinked-previous]') && pager.movePrevious()) void load();
+  }
+
+  /** Same reasoning as the allowlist form: the lookup input outlives a reload. */
+  function render() {
+    if (!container) return;
+    container.innerHTML = `
+      ${canLookup ? correlationMarkup() : ''}
+      <div class="acct-head">
+        <p class="acct-sub">Identities that authenticated but are not linked to any account.</p>
+        <button class="btn btn-ghost" data-unlinked-refresh type="button">&#x21bb; Refresh</button>
+      </div>
+      <div data-unlinked-list></div>
+      <div class="acct-pager">
+        <button class="btn btn-ghost" data-unlinked-previous type="button">Previous</button>
+        <button class="btn btn-ghost" data-unlinked-next type="button">Next</button>
+      </div>`;
+    repaint();
+  }
+
+  function repaint() {
+    const list = container?.querySelector('[data-unlinked-list]');
+    if (list) list.innerHTML = unlinkedMarkup();
+    const result = container?.querySelector('[data-correlation-result]');
+    if (result) result.innerHTML = correlationResultMarkup(lookup);
+    const previous = container?.querySelector('[data-unlinked-previous]');
+    if (previous) previous.disabled = !pager.hasPrevious();
+    const next = container?.querySelector('[data-unlinked-next]');
+    if (next) next.disabled = !pager.nextCursor();
+  }
+
+  function unlinkedMarkup() {
+    if (state === 'idle' || state === 'loading') return '<div class="acct-loading">Loading unlinked identities…</div>';
+    if (state === 'error') return `<div class="acct-notice acct-notice--error">${escapeHtml(message)}</div>`;
+    if (items.length === 0) return '<div class="acct-empty">Every known identity is linked to an account.</div>';
+    return `
+      <div class="acct-table" role="table">
+        <div class="acct-row acct-row--head acct-row--triage" role="row">
+          <span role="columnheader">Provider</span>
+          <span role="columnheader">Subject</span>
+          <span role="columnheader">Seen</span>
+        </div>
+        ${items.map(identityRow).join('')}
+      </div>`;
+  }
+
+  return Object.freeze({
+    mount(panel) {
+      container = panel;
+      container.addEventListener('click', onClick);
+      container.addEventListener('submit', onSubmit);
+      render();
+    },
+    activate() {
+      if (state === 'idle') void load();
+    },
+    destroy() {
+      container = null;
+    },
+  });
+}
+
+function identityRow(item) {
+  return `
+    <div class="acct-row acct-row--triage" role="row">
+      <span role="cell">${escapeHtml(item.provider ?? '—')}</span>
+      <span role="cell">${escapeHtml(item.subject ?? item.identity_id ?? '—')}</span>
+      <span role="cell">${escapeHtml(formatTimestamp(item.last_seen_at ?? item.created_at))}</span>
+    </div>`;
+}
+
+function correlationMarkup() {
+  return `
+    <section class="acct-card">
+      <h3>Resolve a correlation ID</h3>
+      <p class="acct-sub">Audit and approval records identify accounts by correlation ID. Look one up to see which account it belongs to.</p>
+      <form id="acct-correlation-form" class="acct-form">
+        <label class="acct-field acct-field--wide">
+          <span>Correlation ID</span>
+          <input type="text" name="correlation_id" placeholder="account correlation ID" autocomplete="off">
+        </label>
+        <button class="btn btn-primary" type="submit">Resolve</button>
+      </form>
+      <div data-correlation-result></div>
+    </section>`;
+}
+
+function correlationResultMarkup(lookup) {
+  if (lookup.state === 'idle') return '';
+  if (lookup.state === 'loading') return '<div class="acct-loading">Resolving…</div>';
+  if (lookup.state === 'empty') return `<div class="acct-notice">${escapeHtml(lookup.message)}</div>`;
+  if (lookup.state === 'error') return `<div class="acct-notice acct-notice--error">${escapeHtml(lookup.message)}</div>`;
+  return `<dl class="acct-detail">${scalarRows(lookup.record)}</dl>`;
+}
+
+/** The server already projects this record; render its scalars rather than guessing a shape. */
+function scalarRows(record) {
+  return Object.entries(record ?? {})
+    .filter(([, value]) => value === null || ['string', 'number', 'boolean'].includes(typeof value))
+    .map(([key, value]) => `
+      <div>
+        <dt>${escapeHtml(key.replaceAll('_', ' '))}</dt>
+        <dd>${value === null ? '—' : escapeHtml(String(value))}</dd>
+      </div>`)
+    .join('');
+}
+
+/* ── Bootstrap status ───────────────────────────────────────────────────── */
+
+export function createBootstrapView() {
+  let container;
+  let status = null;
+  let state = 'idle';
+  let message = '';
+
+  async function load() {
+    state = 'loading';
+    render();
+    const response = await get(BOOTSTRAP_PATH).catch(() => null);
+    if (response?.status !== 200 || !response.body) {
+      state = 'error';
+      message = responseDetail(response, 'Bootstrap status could not be loaded.');
+      render();
+      return;
+    }
+    status = response.body;
+    state = 'ready';
+    render();
+  }
+
+  function render() {
+    if (!container) return;
+    if (state === 'idle' || state === 'loading') {
+      container.innerHTML = '<div class="acct-loading">Loading bootstrap status…</div>';
+      return;
+    }
+    if (state === 'error') {
+      container.innerHTML = `<div class="acct-notice acct-notice--error">${escapeHtml(message)}</div>`;
+      return;
+    }
+    container.innerHTML = `
+      <section class="acct-card">
+        <h3>First-administrator bootstrap</h3>
+        <p class="acct-sub">${status.completed
+          ? 'Bootstrap is complete, so the one-time first-administrator path is closed.'
+          : 'Bootstrap has not run. The one-time first-administrator path is still open.'}</p>
+        <dl class="acct-detail">${scalarRows(status)}</dl>
+      </section>`;
+  }
+
+  return Object.freeze({
+    mount(panel) {
+      container = panel;
+      render();
+    },
+    activate() {
+      if (state === 'idle') void load();
+    },
+    destroy() {
+      container = null;
+    },
+  });
+}

--- a/src/web-console/ui/app.js
+++ b/src/web-console/ui/app.js
@@ -74,6 +74,17 @@ const TAB_MODULES = {
     load: () => import('./users-admin.js'),
     requiredRoutes: [['GET', '/admin/accounts/users']],
   },
+  audit: {
+    load: () => import('./audit.js'),
+    requiredRoutes: [],
+    // Each log is independently composable, so the tab appears when any one of
+    // them is present rather than requiring the full set.
+    requiredAnyRoutes: [
+      ['GET', '/admin/audit/admin'],
+      ['GET', '/admin/audit/approvals'],
+      ['GET', '/admin/audit/authentication'],
+    ],
+  },
 };
 // Memoized load+init promise per tab, so callers (e.g. the Sessions→Logs jump)
 // can await a module being ready without racing the lazy import.
@@ -115,10 +126,10 @@ function ensureTabModule(name) {
       roleCatalog: consoleMetadata.roleCatalog,
       hasRoute: consoleMetadata.hasRoute,
     });
-  })().catch(err => {
+  })().catch(error => {
     tabModulePromises.delete(name);
     if (panel) panel.innerHTML = '<div class="panel-placeholder">Failed to load this section.</div>';
-    console.error(`[console] tab module "${name}" failed to load`, err);
+    console.error(`[console] tab module "${name}" failed to load`, error);
   });
   tabModulePromises.set(name, loading);
   return loading;

--- a/src/web-console/ui/app.js
+++ b/src/web-console/ui/app.js
@@ -85,6 +85,14 @@ const TAB_MODULES = {
       ['GET', '/admin/audit/authentication'],
     ],
   },
+  security: {
+    load: () => import('./security-admin.js'),
+    requiredRoutes: [],
+    requiredAnyRoutes: [
+      ['GET', '/admin/security/signing-keys'],
+      ['GET', '/admin/security/auth-policy'],
+    ],
+  },
 };
 // Memoized load+init promise per tab, so callers (e.g. the Sessions→Logs jump)
 // can await a module being ready without racing the lazy import.

--- a/src/web-console/ui/audit.css
+++ b/src/web-console/ui/audit.css
@@ -1,0 +1,217 @@
+/* Audit workspace: admin action, approval, and authentication logs. */
+
+.audit-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+
+.audit-title {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: var(--step-1);
+  color: var(--ink-900);
+}
+
+.audit-sub {
+  margin: 0 0 14px;
+  color: var(--ink-500);
+  font-size: var(--step--1);
+}
+
+.audit-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.audit-nav-item {
+  padding: 7px 13px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: none;
+  color: var(--ink-500);
+  font: inherit;
+  font-size: var(--step--1);
+  cursor: pointer;
+}
+
+.audit-nav-item:hover { color: var(--ink-900); }
+.audit-nav-item:focus-visible { outline: 2px solid var(--signal); outline-offset: -2px; }
+
+.audit-nav-item.is-active {
+  color: var(--ink-900);
+  border-bottom-color: var(--signal);
+  font-weight: 600;
+}
+
+.audit-list-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+.audit-export {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.audit-export-status {
+  color: var(--ink-500);
+  font-size: var(--step--1);
+}
+
+.audit-export-status--error { color: var(--ink-700); }
+
+.audit-table {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+}
+
+.audit-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 0.9fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(120px, 1fr) minmax(90px, 0.6fr) minmax(90px, 0.6fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 9px 12px;
+  border-top: 1px solid var(--line);
+  font-size: var(--step--1);
+  min-width: 720px;
+}
+
+.audit-row:first-child { border-top: 0; }
+
+.audit-row--head {
+  background: var(--surface-1);
+  color: var(--ink-500);
+  font-weight: 600;
+}
+
+.audit-row > span {
+  overflow-wrap: anywhere;
+}
+
+.audit-chip {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--surface-2);
+  color: var(--ink-700);
+  font-size: 11px;
+}
+
+/* Integrity is a factual state, not a judgement: an unverifiable record is
+   reported plainly rather than styled as a failure. */
+.audit-chip--verified { border-color: rgba(16, 185, 129, 0.35); }
+.audit-chip--not_available { border-color: var(--line); font-style: italic; }
+.audit-chip--failed,
+.audit-chip--broken { border-color: rgba(239, 68, 68, 0.35); }
+
+.audit-pager {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 10px;
+}
+
+.audit-loading,
+.audit-empty {
+  padding: 16px;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--ink-500);
+  font-size: var(--step--1);
+  text-align: center;
+}
+
+.audit-notice {
+  padding: 9px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-1);
+  font-size: var(--step--1);
+}
+
+.audit-notice--error { border-color: rgba(239, 68, 68, 0.35); }
+
+.audit-detail {
+  margin-bottom: 14px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-1);
+}
+
+.audit-detail-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.audit-detail-head h3 {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: var(--step-0);
+}
+
+.audit-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 10px 18px;
+  margin: 0;
+}
+
+.audit-detail-grid dt {
+  color: var(--ink-500);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.audit-detail-grid dd {
+  margin: 2px 0 0;
+  font-size: var(--step--1);
+  overflow-wrap: anywhere;
+}
+
+.audit-detail-note {
+  margin: 12px 0 0;
+  color: var(--ink-500);
+  font-size: var(--step--1);
+}
+
+.audit-payload {
+  margin-top: 14px;
+}
+
+.audit-payload h4 {
+  margin: 0 0 6px;
+  font-size: var(--step--1);
+  color: var(--ink-700);
+}
+
+.audit-payload pre {
+  margin: 0;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  font-size: 11px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}

--- a/src/web-console/ui/audit.js
+++ b/src/web-console/ui/audit.js
@@ -186,6 +186,9 @@ function createAuditListView({ path, detailPath, exportPath = null, empty, colum
         }
         exportRun.count = records.length;
         if (records.length >= EXPORT_RECORD_CAP) {
+          // Stopping from inside the stream's own callback is safe: stop() only
+          // aborts the controller, and openStream suppresses onError once the
+          // signal is aborted, so nothing re-enters this handler.
           exportStream?.stop();
           finishExport(records, { capped: true });
           return;

--- a/src/web-console/ui/audit.js
+++ b/src/web-console/ui/audit.js
@@ -1,0 +1,494 @@
+/**
+ * Capability-gated audit workspace: admin actions, approval decisions, and
+ * authentication events.
+ *
+ * Two backend properties drive the shape of this UI. The list routes accept only
+ * `limit` and `cursor` — there are no filter parameters — so this surface offers
+ * paging and nothing that would 400. And the detail routes sit behind a stricter
+ * elevation tier than the lists, so opening a record can require a step-up even
+ * though the list around it loaded normally.
+ */
+
+import { get, openStream } from './api.js';
+import { createCursorPager, escapeHtml, formatTimestamp, responseDetail } from './operations-ui.js';
+
+const PAGE_LIMIT = 50;
+/**
+ * The export is a finite stream, but "finite" is the server's word for it. This
+ * cap keeps a pathological run from growing the tab's memory without bound, and
+ * the UI says plainly when it stops early rather than presenting a partial file
+ * as a complete export.
+ */
+const EXPORT_RECORD_CAP = 10_000;
+
+let host;
+let sections = [];
+
+export function init(panelEl, ctx = {}) {
+  host = panelEl;
+  const hasRoute = ctx.hasRoute || (() => false);
+  sections = sectionDefinitions(hasRoute);
+  host.innerHTML = shell(sections);
+
+  if (sections.length === 0) {
+    host.querySelector('#audit-content').innerHTML =
+      '<div class="panel-placeholder">No audit records are available in this deployment.</div>';
+    return;
+  }
+
+  host.querySelector('#audit-nav').addEventListener('click', onNavClick);
+  for (const section of sections) {
+    section.view.mount(host.querySelector(`[data-audit-panel="${section.id}"]`));
+  }
+  selectSection(sections[0].id);
+}
+
+export function destroy() {
+  for (const section of sections) section.view.destroy();
+  sections = [];
+}
+
+function sectionDefinitions(hasRoute) {
+  const definitions = [];
+  if (hasRoute('GET', '/admin/audit/admin')) {
+    definitions.push({
+      id: 'admin',
+      label: 'Admin actions',
+      view: createAuditListView({
+        path: '/admin/audit/admin',
+        detailPath: id => `/admin/audit/admin/${encodeURIComponent(id)}`,
+        exportPath: hasRoute('GET', '/admin/audit/admin/export') ? '/admin/audit/admin/export' : null,
+        empty: 'No administrative actions have been recorded.',
+        columns: ADMIN_COLUMNS,
+        renderDetail: renderAdminDetail,
+      }),
+    });
+  }
+  if (hasRoute('GET', '/admin/audit/approvals')) {
+    definitions.push({
+      id: 'approvals',
+      label: 'Approvals',
+      view: createAuditListView({
+        path: '/admin/audit/approvals',
+        detailPath: id => `/admin/audit/approvals/${encodeURIComponent(id)}`,
+        empty: 'No approval decisions have been recorded.',
+        columns: APPROVAL_COLUMNS,
+        renderDetail: renderApprovalDetail,
+      }),
+    });
+  }
+  if (hasRoute('GET', '/admin/audit/authentication')) {
+    definitions.push({
+      id: 'authentication',
+      label: 'Authentication',
+      view: createAuditListView({
+        path: '/admin/audit/authentication',
+        detailPath: null,
+        empty: 'No authentication events have been recorded.',
+        columns: AUTHENTICATION_COLUMNS,
+        renderDetail: null,
+      }),
+    });
+  }
+  return definitions;
+}
+
+function shell(definitions) {
+  return `
+    <div class="audit-bar">
+      <span class="audit-title">Audit</span>
+    </div>
+    <p class="audit-sub">Recorded administrative activity. Records are read-only and cannot be edited or removed from here.</p>
+    <div class="audit-nav" id="audit-nav" role="tablist" aria-label="Audit views">
+      ${definitions.map((definition, index) => `
+        <button class="audit-nav-item${index === 0 ? ' is-active' : ''}" data-audit-nav="${definition.id}" role="tab" aria-selected="${index === 0}" type="button">${escapeHtml(definition.label)}</button>`).join('')}
+    </div>
+    <div id="audit-content">
+      ${definitions.map(definition => `<div data-audit-panel="${definition.id}" hidden></div>`).join('')}
+    </div>`;
+}
+
+function onNavClick(event) {
+  const button = event.target.closest('[data-audit-nav]');
+  if (button) selectSection(button.dataset.auditNav);
+}
+
+function selectSection(id) {
+  for (const section of sections) {
+    const active = section.id === id;
+    const button = host.querySelector(`[data-audit-nav="${section.id}"]`);
+    const panel = host.querySelector(`[data-audit-panel="${section.id}"]`);
+    button?.classList.toggle('is-active', active);
+    button?.setAttribute('aria-selected', String(active));
+    if (panel) panel.hidden = !active;
+    if (active) section.view.activate();
+  }
+}
+
+function createAuditListView({ path, detailPath, exportPath = null, empty, columns, renderDetail }) {
+  let container;
+  let items = [];
+  let state = 'idle';
+  let message = '';
+  let detail = null;
+  let detailState = 'idle';
+  let detailMessage = '';
+  let controller;
+  let version = 0;
+  const pager = createCursorPager();
+  const exportRun = { state: 'idle', count: 0, message: '', href: null, capped: false };
+  let exportStream = null;
+
+  function resetExportDownload() {
+    if (exportRun.href) URL.revokeObjectURL(exportRun.href);
+    exportRun.href = null;
+  }
+
+  function finishExport(records, { capped = false } = {}) {
+    exportStream = null;
+    resetExportDownload();
+    exportRun.capped = capped;
+    exportRun.state = 'ready';
+    exportRun.href = URL.createObjectURL(
+      new Blob([JSON.stringify(records, null, 2)], { type: 'application/json' }),
+    );
+    render();
+  }
+
+  /**
+   * A finite export, not a subscription: records accumulate until the server
+   * sends `end`, and the stream is never reopened on its own.
+   */
+  function startExport() {
+    if (!exportPath || exportStream) return;
+    const records = [];
+    resetExportDownload();
+    exportRun.state = 'running';
+    exportRun.count = 0;
+    exportRun.message = '';
+    exportRun.capped = false;
+    render();
+
+    exportStream = openStream(exportPath, {
+      onEvent(frame) {
+        if (frame.event === 'end') {
+          finishExport(records);
+          return;
+        }
+        if (frame.event !== 'update') return;
+        try {
+          records.push(JSON.parse(frame.data));
+        } catch {
+          return;
+        }
+        exportRun.count = records.length;
+        if (records.length >= EXPORT_RECORD_CAP) {
+          exportStream?.stop();
+          finishExport(records, { capped: true });
+          return;
+        }
+        renderExportStatus();
+      },
+      onError(error) {
+        exportStream = null;
+        exportRun.state = 'error';
+        exportRun.message = /\b401\b/.test(String(error?.message))
+          ? 'The export needs a more recent sign-in. Confirm your identity, then try again.'
+          : 'The export stopped before it finished. No file was produced.';
+        render();
+      },
+    });
+  }
+
+  function cancelExport() {
+    if (!exportStream) return;
+    exportStream.stop();
+    exportStream = null;
+    exportRun.state = 'cancelled';
+    render();
+  }
+
+  /** Progress ticks every record; repainting the whole panel would fight the DOM. */
+  function renderExportStatus() {
+    const status = container?.querySelector('[data-audit-export-status]');
+    if (status) status.textContent = exportProgressText();
+  }
+
+  function exportProgressText() {
+    if (exportRun.state === 'running') return `Exporting… ${exportRun.count} records`;
+    if (exportRun.state === 'cancelled') return `Cancelled after ${exportRun.count} records.`;
+    if (exportRun.state === 'ready') {
+      return exportRun.capped
+        ? `Stopped at the ${EXPORT_RECORD_CAP.toLocaleString()} record limit. This file is incomplete.`
+        : `${exportRun.count.toLocaleString()} records ready to download.`;
+    }
+    return exportRun.message;
+  }
+
+  async function load() {
+    controller?.abort();
+    controller = new AbortController();
+    const current = ++version;
+    state = 'loading';
+    render();
+    const cursor = pager.cursor();
+    const query = new URLSearchParams({ limit: String(PAGE_LIMIT) });
+    if (cursor) query.set('cursor', cursor);
+    const response = await get(`${path}?${query}`, { signal: controller.signal }).catch(() => null);
+    if (current !== version) return;
+    if (response?.status !== 200 || !Array.isArray(response.body?.items)) {
+      state = 'error';
+      message = elevationHint(response) ?? responseDetail(response, 'These records could not be loaded.');
+      render();
+      return;
+    }
+    items = response.body.items;
+    pager.apply(response.body.page);
+    state = 'ready';
+    render();
+  }
+
+  async function openDetail(id) {
+    if (!detailPath) return;
+    const current = ++version;
+    detailState = 'loading';
+    detail = null;
+    render();
+    const response = await get(detailPath(id)).catch(() => null);
+    if (current !== version) return;
+    if (response?.status !== 200 || !response.body) {
+      detailState = 'error';
+      detailMessage = elevationHint(response) ?? responseDetail(response, 'This record could not be opened.');
+      render();
+      return;
+    }
+    detail = response.body;
+    detailState = 'ready';
+    render();
+  }
+
+  function onClick(event) {
+    const openButton = event.target.closest('[data-audit-open]');
+    if (openButton) {
+      void openDetail(openButton.dataset.auditOpen);
+      return;
+    }
+    if (event.target.closest('[data-audit-close]')) {
+      detail = null;
+      detailState = 'idle';
+      render();
+      return;
+    }
+    if (event.target.closest('[data-audit-export]')) {
+      startExport();
+      return;
+    }
+    if (event.target.closest('[data-audit-export-cancel]')) {
+      cancelExport();
+      return;
+    }
+    if (event.target.closest('[data-audit-next]') && pager.moveNext()) void load();
+    if (event.target.closest('[data-audit-previous]') && pager.movePrevious()) void load();
+    if (event.target.closest('[data-audit-refresh]')) void load();
+  }
+
+  function render() {
+    if (!container) return;
+    container.innerHTML = `
+      ${detailState === 'idle' ? '' : detailMarkup()}
+      <div class="audit-list-head">
+        ${exportMarkup()}
+        <button class="btn btn-ghost" data-audit-refresh type="button">&#x21bb; Refresh</button>
+      </div>
+      ${listMarkup()}
+      <div class="audit-pager">
+        <button class="btn btn-ghost" data-audit-previous type="button"${pager.hasPrevious() ? '' : ' disabled'}>Previous</button>
+        <button class="btn btn-ghost" data-audit-next type="button"${pager.nextCursor() ? '' : ' disabled'}>Next</button>
+      </div>`;
+  }
+
+  function exportMarkup() {
+    if (!exportPath) return '';
+    const running = exportRun.state === 'running';
+    const status = exportProgressText();
+    return `
+      <div class="audit-export">
+        ${running
+          ? '<button class="btn btn-ghost" data-audit-export-cancel type="button">Cancel export</button>'
+          : '<button class="btn btn-ghost" data-audit-export type="button">Export records</button>'}
+        ${exportRun.href
+          ? `<a class="btn btn-primary" href="${exportRun.href}" download="admin-audit-export.json">Download</a>`
+          : ''}
+        <span class="audit-export-status${exportRun.state === 'error' ? ' audit-export-status--error' : ''}" data-audit-export-status role="status">${escapeHtml(status)}</span>
+      </div>`;
+  }
+
+  function listMarkup() {
+    // 'idle' must not fall through to the empty state: a section that has not been
+    // opened yet has not asked the server, so it cannot claim there is nothing.
+    if (state === 'idle' || state === 'loading') return '<div class="audit-loading">Loading records…</div>';
+    if (state === 'error') return `<div class="audit-notice audit-notice--error">${escapeHtml(message)}</div>`;
+    if (items.length === 0) return `<div class="audit-empty">${escapeHtml(empty)}</div>`;
+    return `
+      <div class="audit-table" role="table">
+        <div class="audit-row audit-row--head" role="row">
+          ${columns.map(column => `<span role="columnheader">${escapeHtml(column.label)}</span>`).join('')}
+          ${detailPath ? '<span role="columnheader"><span class="sr-only">Actions</span></span>' : ''}
+        </div>
+        ${items.map(item => `
+          <div class="audit-row" role="row">
+            ${columns.map(column => `<span role="cell">${column.render(item)}</span>`).join('')}
+            ${detailPath ? `<span role="cell"><button class="btn btn-ghost" data-audit-open="${escapeHtml(item.id)}" type="button">Open</button></span>` : ''}
+          </div>`).join('')}
+      </div>`;
+  }
+
+  function detailMarkup() {
+    if (detailState === 'loading') return '<div class="audit-detail"><div class="audit-loading">Loading record…</div></div>';
+    if (detailState === 'error') {
+      return `
+        <div class="audit-detail">
+          <div class="audit-notice audit-notice--error">${escapeHtml(detailMessage)}</div>
+          <button class="btn btn-ghost" data-audit-close type="button">Close</button>
+        </div>`;
+    }
+    return `
+      <div class="audit-detail">
+        <div class="audit-detail-head">
+          <h3>Record detail</h3>
+          <button class="btn btn-ghost" data-audit-close type="button">Close</button>
+        </div>
+        ${renderDetail(detail)}
+      </div>`;
+  }
+
+  return Object.freeze({
+    mount(panel) {
+      container = panel;
+      container.addEventListener('click', onClick);
+      render();
+    },
+    activate() {
+      if (state === 'idle') void load();
+    },
+    destroy() {
+      version += 1;
+      controller?.abort();
+      exportStream?.stop();
+      exportStream = null;
+      resetExportDownload();
+      container = null;
+    },
+  });
+}
+
+/**
+ * The list and detail routes sit on different elevation tiers, so a step-up
+ * failure here is expected rather than exceptional. The shell drives the actual
+ * re-authentication; this only explains why the record did not open.
+ */
+function elevationHint(response) {
+  const code = response?.body?.code ?? response?.body?.type;
+  if (response?.status === 401 && typeof code === 'string' && code.includes('step_up')) {
+    return 'This record needs a more recent sign-in. Confirm your identity, then try again.';
+  }
+  return null;
+}
+
+function integrityChip(integrity) {
+  const status = integrity?.status ?? 'unknown';
+  const label = status === 'not_available' ? 'not recorded' : status;
+  return `<span class="audit-chip audit-chip--${escapeHtml(status)}">${escapeHtml(label)}</span>`;
+}
+
+function textCell(value, fallback = '—') {
+  const text = value === null || value === undefined || value === '' ? fallback : value;
+  return escapeHtml(text);
+}
+
+const ADMIN_COLUMNS = [
+  { label: 'When', render: item => escapeHtml(formatTimestamp(item.occurred_at)) },
+  { label: 'Actor', render: item => textCell(item.actor_sub ?? item.actor_user_id) },
+  { label: 'Operation', render: item => textCell(item.operation) },
+  { label: 'Capability', render: item => textCell(item.capability) },
+  { label: 'Result', render: item => textCell(item.result) },
+  { label: 'Integrity', render: item => integrityChip(item.integrity) },
+];
+
+const APPROVAL_COLUMNS = [
+  { label: 'When', render: item => escapeHtml(formatTimestamp(item.occurred_at)) },
+  { label: 'Tool', render: item => textCell(item.tool_name) },
+  { label: 'Operation', render: item => textCell(item.operation) },
+  { label: 'Result', render: item => textCell(item.result) },
+  { label: 'Decided by', render: item => textCell(item.decision_source) },
+  { label: 'Integrity', render: item => integrityChip(item.integrity) },
+];
+
+const AUTHENTICATION_COLUMNS = [
+  { label: 'When', render: item => escapeHtml(formatTimestamp(item.occurred_at)) },
+  { label: 'Event', render: item => textCell(item.event) },
+  { label: 'Actor', render: item => textCell(item.actor_sub ?? item.actor_user_id) },
+  { label: 'Result', render: item => textCell(item.result) },
+  { label: 'Error', render: item => textCell(item.error_code) },
+  { label: 'Client', render: item => textCell(item.client_ip) },
+];
+
+function definitionList(rows) {
+  return `
+    <dl class="audit-detail-grid">
+      ${rows.map(([label, value]) => `
+        <div>
+          <dt>${escapeHtml(label)}</dt>
+          <dd>${value}</dd>
+        </div>`).join('')}
+    </dl>`;
+}
+
+function renderAdminDetail(record) {
+  return `
+    ${definitionList([
+      ['Occurred', escapeHtml(formatTimestamp(record.occurred_at))],
+      ['Actor', textCell(record.actor_sub ?? record.actor_user_id)],
+      ['Actor role', textCell(record.actor_capability_role ?? record.actor_role)],
+      ['Capability', textCell(record.capability)],
+      ['Operation', textCell(record.operation)],
+      ['Endpoint', textCell(record.endpoint)],
+      ['Result', textCell(record.result)],
+      ['Error', textCell(record.error_code)],
+      ['Target user', textCell(record.target_user_id)],
+      ['Resource', textCell(record.resource_kind ? `${record.resource_kind} ${record.resource_id ?? ''}`.trim() : null)],
+      ['Correlation', textCell(record.correlation_id)],
+      ['Client', textCell(record.client_ip)],
+      ['Integrity', integrityChip(record.integrity)],
+    ])}
+    ${record.integrity?.reason ? `<p class="audit-detail-note">${escapeHtml(record.integrity.reason)}</p>` : ''}
+    ${redactedBlock('Arguments', record.args_redacted)}
+    ${redactedBlock('Result detail', record.result_detail_redacted)}`;
+}
+
+function renderApprovalDetail(record) {
+  return `
+    ${definitionList([
+      ['Occurred', escapeHtml(formatTimestamp(record.occurred_at))],
+      ['Session', textCell(record.session_id)],
+      ['Tool', textCell(record.tool_name)],
+      ['Operation', textCell(record.operation)],
+      ['Result', textCell(record.result)],
+      ['Decided by', textCell(record.decision_source)],
+      ['Correlation', textCell(record.correlation_id)],
+      ['Integrity', integrityChip(record.integrity)],
+    ])}
+    ${record.integrity?.status === 'not_available'
+      ? '<p class="audit-detail-note">This record predates chained integrity, so it cannot be verified.</p>'
+      : ''}`;
+}
+
+/** Redacted payloads are already server-side projections; render them as inert text. */
+function redactedBlock(label, payload) {
+  if (!payload || typeof payload !== 'object' || Object.keys(payload).length === 0) return '';
+  return `
+    <section class="audit-payload">
+      <h4>${escapeHtml(label)}</h4>
+      <pre>${escapeHtml(JSON.stringify(payload, null, 2))}</pre>
+    </section>`;
+}

--- a/src/web-console/ui/audit.js
+++ b/src/web-console/ui/audit.js
@@ -134,7 +134,10 @@ function createAuditListView({ path, detailPath, exportPath = null, empty, colum
   let detailState = 'idle';
   let detailMessage = '';
   let controller;
-  let version = 0;
+  // Separate counters: opening a record and reloading the list are independent
+  // operations, and a shared counter let one silently strand the other mid-load.
+  let listVersion = 0;
+  let detailVersion = 0;
   const pager = createCursorPager();
   const exportRun = { state: 'idle', count: 0, message: '', href: null, capped: false };
   let exportStream = null;
@@ -228,14 +231,14 @@ function createAuditListView({ path, detailPath, exportPath = null, empty, colum
   async function load() {
     controller?.abort();
     controller = new AbortController();
-    const current = ++version;
+    const current = ++listVersion;
     state = 'loading';
     render();
     const cursor = pager.cursor();
     const query = new URLSearchParams({ limit: String(PAGE_LIMIT) });
     if (cursor) query.set('cursor', cursor);
     const response = await get(`${path}?${query}`, { signal: controller.signal }).catch(() => null);
-    if (current !== version) return;
+    if (current !== listVersion) return;
     if (response?.status !== 200 || !Array.isArray(response.body?.items)) {
       state = 'error';
       message = elevationHint(response) ?? responseDetail(response, 'These records could not be loaded.');
@@ -250,12 +253,12 @@ function createAuditListView({ path, detailPath, exportPath = null, empty, colum
 
   async function openDetail(id) {
     if (!detailPath) return;
-    const current = ++version;
+    const current = ++detailVersion;
     detailState = 'loading';
     detail = null;
     render();
     const response = await get(detailPath(id)).catch(() => null);
-    if (current !== version) return;
+    if (current !== detailVersion) return;
     if (response?.status !== 200 || !response.body) {
       detailState = 'error';
       detailMessage = elevationHint(response) ?? responseDetail(response, 'This record could not be opened.');
@@ -372,7 +375,8 @@ function createAuditListView({ path, detailPath, exportPath = null, empty, colum
       if (state === 'idle') void load();
     },
     destroy() {
-      version += 1;
+      listVersion += 1;
+      detailVersion += 1;
       controller?.abort();
       exportStream?.stop();
       exportStream = null;
@@ -398,7 +402,14 @@ function elevationHint(response) {
 function integrityChip(integrity) {
   const status = integrity?.status ?? 'unknown';
   const label = status === 'not_available' ? 'not recorded' : status;
-  return `<span class="audit-chip audit-chip--${escapeHtml(status)}">${escapeHtml(label)}</span>`;
+  // escapeHtml already prevents breaking out of the attribute; this additionally
+  // stops an unexpected value from injecting extra class names via whitespace.
+  return `<span class="audit-chip audit-chip--${cssToken(status)}">${escapeHtml(label)}</span>`;
+}
+
+/** Reduce a server-supplied value to something safe to use as a class suffix. */
+function cssToken(value) {
+  return String(value ?? '').replaceAll(/[^a-zA-Z0-9_-]/g, '') || 'unknown';
 }
 
 function textCell(value, fallback = '—') {

--- a/src/web-console/ui/index.html
+++ b/src/web-console/ui/index.html
@@ -17,6 +17,7 @@
   <link rel="stylesheet" href="integrations.css">
   <link rel="stylesheet" href="audit.css">
   <link rel="stylesheet" href="security-admin.css">
+  <link rel="stylesheet" href="accounts-admin.css">
   <link rel="stylesheet" href="portfolio-actions.css">
 </head>
 <body>

--- a/src/web-console/ui/index.html
+++ b/src/web-console/ui/index.html
@@ -15,6 +15,7 @@
   <link rel="stylesheet" href="admin-metrics.css">
   <link rel="stylesheet" href="operations.css">
   <link rel="stylesheet" href="integrations.css">
+  <link rel="stylesheet" href="audit.css">
   <link rel="stylesheet" href="portfolio-actions.css">
 </head>
 <body>
@@ -68,6 +69,7 @@
           <!-- Admin-only: each revealed by app.js only while elevated AND holding the matching capability. -->
           <button class="console-tab console-tab--admin" data-tab="users" data-admin-cap="console:admin:accounts" hidden>Users</button>
           <button class="console-tab console-tab--admin" data-tab="operations" data-admin-cap="console:admin:operate" hidden>Operations</button>
+          <button class="console-tab console-tab--admin" data-tab="audit" data-admin-cap="console:admin:audit" hidden>Audit</button>
         </nav>
       </div>
     </header>
@@ -93,6 +95,9 @@
       </section>
       <section id="tab-operations" class="tab-panel" hidden aria-label="Operations">
         <div class="panel-placeholder">Loading operations…</div>
+      </section>
+      <section id="tab-audit" class="tab-panel" hidden aria-label="Audit">
+        <div class="panel-placeholder">Loading audit…</div>
       </section>
     </main>
   </div>

--- a/src/web-console/ui/index.html
+++ b/src/web-console/ui/index.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="operations.css">
   <link rel="stylesheet" href="integrations.css">
   <link rel="stylesheet" href="audit.css">
+  <link rel="stylesheet" href="security-admin.css">
   <link rel="stylesheet" href="portfolio-actions.css">
 </head>
 <body>
@@ -70,6 +71,7 @@
           <button class="console-tab console-tab--admin" data-tab="users" data-admin-cap="console:admin:accounts" hidden>Users</button>
           <button class="console-tab console-tab--admin" data-tab="operations" data-admin-cap="console:admin:operate" hidden>Operations</button>
           <button class="console-tab console-tab--admin" data-tab="audit" data-admin-cap="console:admin:audit" hidden>Audit</button>
+          <button class="console-tab console-tab--admin" data-tab="security" data-admin-cap="console:admin:security" hidden>Security</button>
         </nav>
       </div>
     </header>
@@ -98,6 +100,9 @@
       </section>
       <section id="tab-audit" class="tab-panel" hidden aria-label="Audit">
         <div class="panel-placeholder">Loading audit…</div>
+      </section>
+      <section id="tab-security" class="tab-panel" hidden aria-label="Security administration">
+        <div class="panel-placeholder">Loading security…</div>
       </section>
     </main>
   </div>

--- a/src/web-console/ui/security-admin.css
+++ b/src/web-console/ui/security-admin.css
@@ -1,0 +1,237 @@
+/* Security administration: signing keys and authentication policy. */
+
+.secadmin-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+
+.secadmin-title {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: var(--step-1);
+  color: var(--ink-900);
+}
+
+.secadmin-sub {
+  margin: 0 0 14px;
+  color: var(--ink-500);
+  font-size: var(--step--1);
+}
+
+.secadmin-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.secadmin-nav-item {
+  padding: 7px 13px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: none;
+  color: var(--ink-500);
+  font: inherit;
+  font-size: var(--step--1);
+  cursor: pointer;
+}
+
+.secadmin-nav-item:hover { color: var(--ink-900); }
+.secadmin-nav-item:focus-visible { outline: 2px solid var(--signal); outline-offset: -2px; }
+
+.secadmin-nav-item.is-active {
+  color: var(--ink-900);
+  border-bottom-color: var(--signal);
+  font-weight: 600;
+}
+
+.secadmin-head {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+}
+
+.secadmin-card {
+  margin-bottom: 14px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-1);
+}
+
+.secadmin-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.secadmin-card h3 {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: var(--step-0);
+}
+
+.secadmin-card-sub {
+  display: block;
+  color: var(--ink-500);
+  font-size: var(--step--1);
+}
+
+.secadmin-key-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.secadmin-key {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) minmax(0, 2fr) auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 0;
+  border-top: 1px solid var(--line);
+}
+
+.secadmin-key:first-child { border-top: 0; }
+
+.secadmin-key-id {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+  overflow-wrap: anywhere;
+}
+
+.secadmin-key-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 18px;
+  margin: 0;
+  font-size: var(--step--1);
+}
+
+.secadmin-key-meta dt {
+  color: var(--ink-500);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.secadmin-key-meta dd { margin: 0; }
+
+.secadmin-key-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.secadmin-chip {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--surface-2);
+  color: var(--ink-700);
+  font-size: 11px;
+}
+
+.secadmin-chip--active { border-color: rgba(16, 185, 129, 0.35); }
+.secadmin-chip--verifying { border-color: rgba(245, 158, 11, 0.35); }
+.secadmin-chip--retired,
+.secadmin-chip--deleted { font-style: italic; }
+
+.secadmin-danger { color: #dc2626; } /* NOSONAR — destructive */
+
+.secadmin-invariants {
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  font-size: var(--step--1);
+}
+
+.secadmin-invariants li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.secadmin-policy-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 10px;
+}
+
+.secadmin-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-width: 320px;
+}
+
+.secadmin-field > span {
+  font-size: var(--step--1);
+  color: var(--ink-700);
+}
+
+.secadmin-field input {
+  padding: 7px 9px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  color: var(--ink-900);
+  font: inherit;
+}
+
+.secadmin-field small { color: var(--ink-500); font-size: 11px; }
+
+.secadmin-form-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.secadmin-receipt {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 16px;
+  align-items: center;
+  margin-bottom: 12px;
+  padding: 9px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  font-size: var(--step--1);
+}
+
+.secadmin-receipt--failed { border-color: rgba(239, 68, 68, 0.35); }
+
+.secadmin-loading,
+.secadmin-empty {
+  padding: 16px;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--ink-500);
+  font-size: var(--step--1);
+  text-align: center;
+}
+
+.secadmin-notice {
+  padding: 9px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-1);
+  font-size: var(--step--1);
+}
+
+.secadmin-notice--error { border-color: rgba(239, 68, 68, 0.35); }

--- a/src/web-console/ui/security-admin.js
+++ b/src/web-console/ui/security-admin.js
@@ -1,0 +1,458 @@
+/**
+ * Capability-gated security administration: signing-key lifecycle and the
+ * authentication policy.
+ *
+ * Reads here sit on the ordinary admin elevation, but every mutation requires a
+ * *fresh* one, so an operator can browse this tab and still be refused when they
+ * act. That is reported as its own state rather than a generic failure.
+ *
+ * Key deletion has several distinct server-side refusals — still active, never
+ * retired, or still inside the hard-delete grace. The grace window is not
+ * recomputed here: the delete is attempted, and only if the server reports the
+ * grace conflict is an explicit override offered.
+ */
+
+import { del, get, post, put } from './api.js';
+import { confirmDialog } from './ui-utils.js';
+import { escapeHtml, formatTimestamp, responseDetail } from './operations-ui.js';
+
+const KEYS_PATH = '/admin/security/signing-keys';
+const POLICY_PATH = '/admin/security/auth-policy';
+
+let host;
+let sections = [];
+
+export function init(panelEl, ctx = {}) {
+  host = panelEl;
+  const hasRoute = ctx.hasRoute || (() => false);
+  const notify = ctx.toast || (() => {});
+  sections = sectionDefinitions(hasRoute, notify);
+  host.innerHTML = shell(sections);
+
+  if (sections.length === 0) {
+    host.querySelector('#secadmin-content').innerHTML =
+      '<div class="panel-placeholder">No security administration features are available in this deployment.</div>';
+    return;
+  }
+  host.querySelector('#secadmin-nav').addEventListener('click', onNavClick);
+  for (const section of sections) {
+    section.view.mount(host.querySelector(`[data-secadmin-panel="${section.id}"]`));
+  }
+  selectSection(sections[0].id);
+}
+
+export function destroy() {
+  for (const section of sections) section.view.destroy();
+  sections = [];
+}
+
+function sectionDefinitions(hasRoute, notify) {
+  const definitions = [];
+  if (hasRoute('GET', KEYS_PATH)) {
+    definitions.push({
+      id: 'keys',
+      label: 'Signing keys',
+      view: createSigningKeysView({
+        notify,
+        canRotate: hasRoute('POST', `${KEYS_PATH}/:kind/rotate`),
+        canRetire: hasRoute('POST', `${KEYS_PATH}/:kind/:kid/retire`),
+        canDelete: hasRoute('DELETE', `${KEYS_PATH}/:kind/:kid`),
+      }),
+    });
+  }
+  if (hasRoute('GET', POLICY_PATH)) {
+    definitions.push({
+      id: 'policy',
+      label: 'Authentication policy',
+      view: createAuthPolicyView({ notify, canEdit: hasRoute('PUT', POLICY_PATH) }),
+    });
+  }
+  return definitions;
+}
+
+function shell(definitions) {
+  return `
+    <div class="secadmin-bar"><span class="secadmin-title">Security</span></div>
+    <p class="secadmin-sub">Signing-key lifecycle and authentication policy. Changes here need a recent sign-in and are recorded in the audit log.</p>
+    <div class="secadmin-nav" id="secadmin-nav" role="tablist" aria-label="Security views">
+      ${definitions.map((definition, index) => `
+        <button class="secadmin-nav-item${index === 0 ? ' is-active' : ''}" data-secadmin-nav="${definition.id}" role="tab" aria-selected="${index === 0}" type="button">${escapeHtml(definition.label)}</button>`).join('')}
+    </div>
+    <div id="secadmin-content">
+      ${definitions.map(definition => `<div data-secadmin-panel="${definition.id}" hidden></div>`).join('')}
+    </div>`;
+}
+
+function onNavClick(event) {
+  const button = event.target.closest('[data-secadmin-nav]');
+  if (button) selectSection(button.dataset.secadminNav);
+}
+
+function selectSection(id) {
+  for (const section of sections) {
+    const active = section.id === id;
+    const button = host.querySelector(`[data-secadmin-nav="${section.id}"]`);
+    const panel = host.querySelector(`[data-secadmin-panel="${section.id}"]`);
+    button?.classList.toggle('is-active', active);
+    button?.setAttribute('aria-selected', String(active));
+    if (panel) panel.hidden = !active;
+    if (active) section.view.activate();
+  }
+}
+
+/* ── Signing keys ───────────────────────────────────────────────────────── */
+
+function createSigningKeysView({ notify, canRotate, canRetire, canDelete }) {
+  let container;
+  let kinds = [];
+  let state = 'idle';
+  let message = '';
+  let receipt = null;
+  let actionMessage = '';
+  let busy = false;
+
+  async function load() {
+    state = state === 'ready' ? 'ready' : 'loading';
+    render();
+    const response = await get(KEYS_PATH).catch(() => null);
+    if (response?.status !== 200 || !Array.isArray(response.body?.kinds)) {
+      state = 'error';
+      message = elevationHint(response) ?? responseDetail(response, 'Signing keys could not be loaded.');
+      render();
+      return;
+    }
+    kinds = response.body.kinds;
+    state = 'ready';
+    render();
+  }
+
+  /**
+   * A refused key operation has to stay on screen. The shell already raises its
+   * own toast for a step-up refusal, so this neither duplicates that toast nor
+   * relies on one: the reason is written into the panel until the next attempt.
+   */
+  async function runMutation(label, action) {
+    if (busy) return;
+    busy = true;
+    actionMessage = '';
+    render();
+    const response = await action().catch(() => null);
+    busy = false;
+    if (response && (response.status === 200 || response.status === 201)) {
+      receipt = response.body ?? null;
+      actionMessage = '';
+      notify(`${label} completed.`, 'success');
+      await load();
+      return response;
+    }
+    receipt = null;
+    const elevation = elevationHint(response);
+    actionMessage = elevation ?? responseDetail(response, `${label} did not complete.`);
+    if (!elevation) notify(actionMessage, 'error');
+    render();
+    return response;
+  }
+
+  async function rotate(kind) {
+    const approved = await confirmDialog(
+      `Rotate the ${kind} signing key? A new key becomes active immediately and the current one moves to verifying, so tokens already issued keep working.`,
+      'Rotate key',
+    );
+    if (!approved) return;
+    await runMutation('Key rotation', () => post(`${KEYS_PATH}/${encodeURIComponent(kind)}/rotate`, { body: {} }));
+  }
+
+  async function retire(kind, kid) {
+    const approved = await confirmDialog(
+      `Retire key ${kid}? It stops verifying tokens. It can be deleted once its hard-delete grace has passed.`,
+      'Retire key',
+    );
+    if (!approved) return;
+    await runMutation('Key retirement', () =>
+      post(`${KEYS_PATH}/${encodeURIComponent(kind)}/${encodeURIComponent(kid)}/retire`, { body: {} }));
+  }
+
+  /**
+   * Deletion is attempted without force first. The server owns the grace window,
+   * so an override is only offered once it has actually refused on that basis —
+   * never pre-emptively from a clock in the browser.
+   */
+  async function remove(kind, kid) {
+    const approved = await confirmDialog(
+      `Permanently delete key ${kid}? This cannot be undone, and only the audit record of the key will remain.`,
+      'Delete key',
+    );
+    if (!approved) return;
+    const path = `${KEYS_PATH}/${encodeURIComponent(kind)}/${encodeURIComponent(kid)}`;
+    const response = await runMutation('Key deletion', () => del(path, { body: {} }));
+    if (response?.status !== 409 || !isGraceConflict(response)) return;
+
+    const forced = await confirmDialog(
+      `Key ${kid} is still inside its hard-delete grace, which exists so anything signed by it can still be verified. Deleting now can break verification for those tokens. Delete it anyway?`,
+      'Delete during grace',
+    );
+    if (!forced) return;
+    await runMutation('Forced key deletion', () => del(path, { body: { force: true } }));
+  }
+
+  function onClick(event) {
+    const button = event.target.closest('button[data-key-action]');
+    if (!button) return;
+    const { keyAction: action, keyKind: kind, keyKid: kid } = button.dataset;
+    if (action === 'rotate') void rotate(kind);
+    if (action === 'retire') void retire(kind, kid);
+    if (action === 'delete') void remove(kind, kid);
+    if (action === 'refresh') void load();
+  }
+
+  function render() {
+    if (!container) return;
+    container.innerHTML = `
+      <div class="secadmin-head">
+        <button class="btn btn-ghost" data-key-action="refresh" type="button"${busy ? ' disabled' : ''}>&#x21bb; Refresh</button>
+      </div>
+      ${actionMessage ? `<div class="secadmin-notice secadmin-notice--error">${escapeHtml(actionMessage)}</div>` : ''}
+      ${receiptMarkup(receipt)}
+      ${bodyMarkup()}`;
+  }
+
+  function bodyMarkup() {
+    if (state === 'loading' || state === 'idle') return '<div class="secadmin-loading">Loading signing keys…</div>';
+    if (state === 'error') return `<div class="secadmin-notice secadmin-notice--error">${escapeHtml(message)}</div>`;
+    if (kinds.length === 0) return '<div class="secadmin-empty">No signing keys are configured.</div>';
+    return kinds.map(kindCard).join('');
+  }
+
+  function kindCard(entry) {
+    return `
+      <section class="secadmin-card">
+        <div class="secadmin-card-head">
+          <div>
+            <h3>${escapeHtml(entry.kind)}</h3>
+            <span class="secadmin-card-sub">Active key: ${entry.active_kid ? escapeHtml(entry.active_kid) : 'none'}</span>
+          </div>
+          ${canRotate ? keyActionButton({ label: 'Rotate', action: 'rotate', kind: entry.kind, variant: 'btn-primary', disabled: busy }) : ''}
+        </div>
+        ${(entry.keys ?? []).length === 0
+          ? '<p class="secadmin-empty">No keys recorded for this kind.</p>'
+          : `<div class="secadmin-key-list">${entry.keys.map(key => keyRow(entry.kind, key)).join('')}</div>`}
+      </section>`;
+  }
+
+  function keyRow(kind, key) {
+    const retired = key.state === 'retired';
+    return `
+      <div class="secadmin-key">
+        <div class="secadmin-key-id">
+          <strong>${escapeHtml(key.kid)}</strong>
+          <span class="secadmin-chip secadmin-chip--${escapeHtml(key.state)}">${escapeHtml(key.state)}</span>
+        </div>
+        <dl class="secadmin-key-meta">
+          <div><dt>Created</dt><dd>${escapeHtml(formatTimestamp(key.created_at))}</dd></div>
+          ${key.retired_at ? `<div><dt>Retired</dt><dd>${escapeHtml(formatTimestamp(key.retired_at))}</dd></div>` : ''}
+          ${key.verification_grace_ends_at ? `<div><dt>Verifies until</dt><dd>${escapeHtml(formatTimestamp(key.verification_grace_ends_at))}</dd></div>` : ''}
+        </dl>
+        <div class="secadmin-key-actions">
+          ${canRetire && key.state !== 'retired' && key.state !== 'deleted'
+            ? keyActionButton({ label: 'Retire', action: 'retire', kind, kid: key.kid, disabled: busy })
+            : ''}
+          ${canDelete && retired
+            ? keyActionButton({ label: 'Delete', action: 'delete', kind, kid: key.kid, extraClass: ' secadmin-danger', disabled: busy })
+            : ''}
+        </div>
+      </div>`;
+  }
+
+  return Object.freeze({
+    mount(panel) {
+      container = panel;
+      container.addEventListener('click', onClick);
+      render();
+    },
+    activate() {
+      if (state === 'idle') void load();
+    },
+    destroy() {
+      container = null;
+    },
+  });
+}
+
+function keyActionButton({ label, action, kind, kid = null, variant = 'btn-ghost', extraClass = '', disabled }) {
+  const kidAttr = kid === null ? '' : ` data-key-kid="${escapeHtml(kid)}"`;
+  const disabledAttr = disabled ? ' disabled' : '';
+  return `<button class="btn ${variant}${extraClass}" data-key-action="${action}" data-key-kind="${escapeHtml(kind)}"${kidAttr} type="button"${disabledAttr}>${escapeHtml(label)}</button>`;
+}
+
+/** These operations are synchronous, so the receipt is the outcome, not a job to poll. */
+function receiptMarkup(receipt) {
+  if (!receipt) return '';
+  const failed = receipt.status === 'failed';
+  return `
+    <div class="secadmin-receipt${failed ? ' secadmin-receipt--failed' : ''}">
+      <strong>${escapeHtml(receipt.action)} ${escapeHtml(receipt.status)}</strong>
+      <span>${escapeHtml(formatTimestamp(receipt.completed_at))}</span>
+      ${receipt.result_kid ? `<span>New key: ${escapeHtml(receipt.result_kid)}</span>` : ''}
+      ${receipt.target_kid ? `<span>Key: ${escapeHtml(receipt.target_kid)}</span>` : ''}
+      ${receipt.error_code ? `<span>${escapeHtml(receipt.error_code)}</span>` : ''}
+    </div>`;
+}
+
+function isGraceConflict(response) {
+  return /grace/i.test(String(response?.body?.detail ?? ''));
+}
+
+/* ── Authentication policy ──────────────────────────────────────────────── */
+
+const INVARIANT_LABELS = [
+  ['require_admin_totp', 'Administrators must complete TOTP'],
+  ['csrf_protection', 'CSRF protection'],
+  ['bff_session_security', 'BFF session security'],
+  ['step_up_required', 'Step-up required for admin actions'],
+  ['privacy_boundaries_enforced', 'Privacy boundaries enforced'],
+];
+
+/**
+ * An unmodified policy carries the epoch as its updated_at. Formatting that
+ * literally reads as a 1969 edit, so say plainly that it has never changed.
+ */
+function policyUpdatedText(updatedAt) {
+  const time = new Date(updatedAt ?? '').getTime();
+  if (!Number.isFinite(time) || time <= 0) return 'Never changed from the deployment default.';
+  return `Updated ${formatTimestamp(updatedAt)}`;
+}
+
+function saveButtonMarkup(saving) {
+  if (saving) return '<button class="btn btn-primary" type="submit" disabled>Saving…</button>';
+  return '<button class="btn btn-primary" type="submit">Save</button>';
+}
+
+function createAuthPolicyView({ notify, canEdit }) {
+  let container;
+  let policy = null;
+  let state = 'idle';
+  let message = '';
+  let saving = false;
+
+  async function load() {
+    state = 'loading';
+    render();
+    const response = await get(POLICY_PATH).catch(() => null);
+    if (response?.status !== 200 || !response.body) {
+      state = 'error';
+      message = elevationHint(response) ?? responseDetail(response, 'The authentication policy could not be loaded.');
+      render();
+      return;
+    }
+    policy = response.body;
+    state = 'ready';
+    render();
+  }
+
+  async function save(form) {
+    if (saving || !policy) return;
+    const seconds = Number(new FormData(form).get('max_admin_elevation_seconds'));
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+      message = 'Enter the maximum elevation length in whole seconds.';
+      render();
+      return;
+    }
+    saving = true;
+    message = '';
+    render();
+    const response = await put(POLICY_PATH, {
+      body: { max_admin_elevation_seconds: seconds },
+      ifMatch: policy.etag,
+    }).catch(() => null);
+    saving = false;
+
+    if (response?.status === 412) {
+      message = 'The policy changed elsewhere, so nothing was saved. Reload it and try again.';
+      render();
+      return;
+    }
+    if (response?.status !== 200 || !response.body) {
+      message = elevationHint(response) ?? responseDetail(response, 'The policy could not be saved.');
+      render();
+      return;
+    }
+    policy = response.body;
+    notify('Authentication policy updated.', 'success');
+    render();
+  }
+
+  function onSubmit(event) {
+    if (event.target.id !== 'secadmin-policy-form') return;
+    event.preventDefault();
+    void save(event.target);
+  }
+
+  function onClick(event) {
+    if (event.target.closest('[data-policy-reload]')) void load();
+  }
+
+  function render() {
+    if (!container) return;
+    if (state === 'loading' || state === 'idle') {
+      container.innerHTML = '<div class="secadmin-loading">Loading the authentication policy…</div>';
+      return;
+    }
+    if (state === 'error') {
+      container.innerHTML = `
+        <div class="secadmin-notice secadmin-notice--error">${escapeHtml(message)}</div>
+        <button class="btn btn-ghost" data-policy-reload type="button">Try again</button>`;
+      return;
+    }
+    container.innerHTML = `
+      <section class="secadmin-card">
+        <h3>Enforced protections</h3>
+        <p class="secadmin-card-sub">These are built into the console and cannot be turned off.</p>
+        <ul class="secadmin-invariants">
+          ${INVARIANT_LABELS.map(([key, label]) => `
+            <li><span class="secadmin-chip secadmin-chip--active">on</span>${escapeHtml(label)}${policy[key] === true ? '' : ' (reported off)'}</li>`).join('')}
+        </ul>
+      </section>
+      <section class="secadmin-card">
+        <h3>Administrator elevation</h3>
+        <form id="secadmin-policy-form" class="secadmin-policy-form">
+          <label class="secadmin-field">
+            <span>Maximum elevation length (seconds)</span>
+            <input type="number" name="max_admin_elevation_seconds" min="1" step="1" value="${escapeHtml(policy.max_admin_elevation_seconds)}"${canEdit ? '' : ' disabled'}>
+            <small>How long an administrator stays elevated before signing in again.</small>
+          </label>
+          ${message ? `<div class="secadmin-notice secadmin-notice--error">${escapeHtml(message)}</div>` : ''}
+          <div class="secadmin-form-actions">
+            <span class="secadmin-card-sub">${escapeHtml(policyUpdatedText(policy.updated_at))}</span>
+            ${canEdit ? saveButtonMarkup(saving) : '<span class="secadmin-card-sub">Not editable in this deployment.</span>'}
+          </div>
+        </form>
+      </section>`;
+  }
+
+  return Object.freeze({
+    mount(panel) {
+      container = panel;
+      container.addEventListener('submit', onSubmit);
+      container.addEventListener('click', onClick);
+      render();
+    },
+    activate() {
+      if (state === 'idle') void load();
+    },
+    destroy() {
+      container = null;
+    },
+  });
+}
+
+/**
+ * Mutations here need a fresher elevation than the reads that got the operator
+ * into this tab, so a refusal is expected rather than exceptional.
+ */
+function elevationHint(response) {
+  const code = response?.body?.code ?? response?.body?.type;
+  if (response?.status === 401 && typeof code === 'string' && code.includes('step_up')) {
+    return 'This change needs a more recent sign-in. Confirm your identity, then try again.';
+  }
+  return null;
+}

--- a/src/web-console/ui/security-admin.js
+++ b/src/web-console/ui/security-admin.js
@@ -245,7 +245,7 @@ function createSigningKeysView({ notify, canRotate, canRetire, canDelete }) {
       <div class="secadmin-key">
         <div class="secadmin-key-id">
           <strong>${escapeHtml(key.kid)}</strong>
-          <span class="secadmin-chip secadmin-chip--${escapeHtml(key.state)}">${escapeHtml(key.state)}</span>
+          <span class="secadmin-chip secadmin-chip--${cssToken(key.state)}">${escapeHtml(key.state)}</span>
         </div>
         <dl class="secadmin-key-meta">
           <div><dt>Created</dt><dd>${escapeHtml(formatTimestamp(key.created_at))}</dd></div>
@@ -298,6 +298,18 @@ function receiptMarkup(receipt) {
     </div>`;
 }
 
+/** Reduce a server-supplied value to something safe to use as a class suffix. */
+function cssToken(value) {
+  return String(value ?? '').replaceAll(/[^a-zA-Z0-9_-]/g, '') || 'unknown';
+}
+
+/**
+ * The three delete refusals — still active, never retired, still inside the
+ * grace — all return the same `conflict` code, so the message is the only thing
+ * distinguishing them. Only the grace case can be forced, and offering the
+ * override for the other two would be a dead end, so they have to be told apart.
+ * A distinct server-side code would make this robust.
+ */
 function isGraceConflict(response) {
   return /grace/i.test(String(response?.body?.detail ?? ''));
 }

--- a/src/web-console/ui/users-admin.js
+++ b/src/web-console/ui/users-admin.js
@@ -26,6 +26,7 @@
 
 import { get, post, del } from './api.js';
 import { confirmDialog, escapeHtml, relAgo } from './ui-utils.js';
+import { createAllowlistView, createIdentityTriageView, createBootstrapView } from './accounts-admin.js';
 
 const DRAWER_ROOT_SELECTOR = '#ua-drawer-root';
 const USER_ROUTES = {
@@ -51,6 +52,7 @@ const state = {
   roleCatalog: { roles: [], grants: {} }, hasRoute: () => false,
 };
 let globalListenersBound = false;
+let governanceSections = [];
 
 export async function init(panelEl, ctx = {}) {
   host = panelEl;
@@ -58,7 +60,15 @@ export async function init(panelEl, ctx = {}) {
   state.roleCatalog = normalizeRoleCatalog(ctx.roleCatalog);
   state.hasRoute = ctx.hasRoute || state.hasRoute;
   state.selectedId = null;
+  governanceSections = governanceDefinitions();
   host.innerHTML = shell();
+  for (const section of governanceSections) {
+    section.view.mount(host.querySelector(`[data-ua-panel="${section.id}"]`));
+  }
+  host.querySelector('#ua-nav')?.addEventListener('click', event => {
+    const button = event.target.closest('[data-ua-nav]');
+    if (button) selectUaSection(button.dataset.uaNav);
+  });
   host.querySelector('#ua-refresh').addEventListener('click', load);
   host.querySelector('#ua-invite')?.addEventListener('click', openInvite);
   bindGlobalListeners();
@@ -169,8 +179,78 @@ function shell() {
       ${hasUserRoute('invite') ? '<button class="btn btn-primary" id="ua-invite" type="button">+ Invite user</button>' : ''}
     </div>
   </div>
-  <div id="ua-list"></div>
-  <div id="ua-drawer-root"></div>`;
+  ${navMarkup()}
+  <div data-ua-panel="accounts">
+    <div id="ua-list"></div>
+    <div id="ua-drawer-root"></div>
+  </div>
+  ${governancePanelsMarkup()}`;
+}
+
+/**
+ * The account list keeps its own markup untouched; the governance surfaces are
+ * separate panels beside it so this tab gains sections without the list changing.
+ */
+function governancePanelsMarkup() {
+  return governanceSections.map(section => `<div data-ua-panel="${section.id}" hidden></div>`).join('');
+}
+
+function navMarkup() {
+  if (governanceSections.length === 0) return '';
+  const items = [
+    navItemMarkup('accounts', 'Accounts', true),
+    ...governanceSections.map(section => navItemMarkup(section.id, section.label, false)),
+  ];
+  return `
+    <div class="ua-nav" id="ua-nav" role="tablist" aria-label="Account administration views">
+      ${items.join('')}
+    </div>`;
+}
+
+function navItemMarkup(id, label, active) {
+  return `<button class="ua-nav-item${active ? ' is-active' : ''}" data-ua-nav="${id}" role="tab" aria-selected="${active}" type="button">${escapeHtml(label)}</button>`;
+}
+
+function governanceDefinitions() {
+  const definitions = [];
+  if (state.hasRoute('GET', '/admin/accounts/allowlist')) {
+    definitions.push({
+      id: 'allowlist',
+      label: 'Allowlist',
+      view: createAllowlistView({
+        notify: (text, tone) => notify(text, tone),
+        canAdd: state.hasRoute('POST', '/admin/accounts/allowlist'),
+        canEdit: state.hasRoute('PATCH', '/admin/accounts/allowlist/:id'),
+        canRemove: state.hasRoute('DELETE', '/admin/accounts/allowlist/:id'),
+      }),
+    });
+  }
+  if (state.hasRoute('GET', '/admin/accounts/identities/unlinked')) {
+    definitions.push({
+      id: 'triage',
+      label: 'Identity triage',
+      view: createIdentityTriageView({
+        canLookup: state.hasRoute('GET', '/admin/accounts/correlations/:account_correlation_id'),
+      }),
+    });
+  }
+  if (state.hasRoute('GET', '/admin/accounts/bootstrap')) {
+    definitions.push({ id: 'bootstrap', label: 'Bootstrap', view: createBootstrapView() });
+  }
+  return definitions;
+}
+
+function selectUaSection(id) {
+  const panels = [{ id: 'accounts' }, ...governanceSections];
+  for (const section of panels) {
+    const active = section.id === id;
+    const button = host.querySelector(`[data-ua-nav="${section.id}"]`);
+    const panel = host.querySelector(`[data-ua-panel="${section.id}"]`);
+    button?.classList.toggle('is-active', active);
+    button?.setAttribute('aria-selected', String(active));
+    if (panel) panel.hidden = !active;
+    if (active) section.view?.activate();
+  }
 }
 
 function renderList() {

--- a/tests/integration/web-console-e2e/harness/accountsAdminUiMock.ts
+++ b/tests/integration/web-console-e2e/harness/accountsAdminUiMock.ts
@@ -1,0 +1,101 @@
+/**
+ * Browser harness for the account-governance sections inside the Users tab.
+ *
+ * The allowlist returns a plain `{ entries }` envelope rather than the paged
+ * Family-B shape used elsewhere, and only an entry's note is mutable — the mock
+ * enforces both so the UI cannot quietly rely on something the API doesn't do.
+ */
+
+import type { Page, Route } from '@playwright/test';
+
+export interface MockAllowlistEntry {
+  id: string;
+  kind: string;
+  value: string;
+  note: string | null;
+  created_by_user_id: string;
+  created_at: string;
+}
+
+export interface AccountsAdminUiMockState {
+  entries: MockAllowlistEntry[];
+  unlinked: Array<Record<string, unknown>>;
+  bootstrap: Record<string, unknown>;
+  correlation: Record<string, unknown> | null;
+  posts: Array<{ kind: string; value: string; note?: string }>;
+  patches: Array<{ id: string; body: Record<string, unknown> }>;
+  deletes: string[];
+}
+
+export async function installAccountsAdminUiMock(page: Page): Promise<AccountsAdminUiMockState> {
+  const state: AccountsAdminUiMockState = {
+    entries: [],
+    unlinked: [{
+      identity_id: 'identity-1',
+      provider: 'github',
+      subject: 'octocat',
+      last_seen_at: '2026-07-20T09:00:00.000Z',
+    }],
+    bootstrap: {
+      completed: true,
+      completed_at: '2026-07-01T08:00:00.000Z',
+      admin_user_id: 'user-admin',
+    },
+    correlation: { account_correlation_id: 'corr-1', user_id: 'user-admin', username: 'e2e_admin' },
+    posts: [],
+    patches: [],
+    deletes: [],
+  };
+  await page.route('**/api/v1/admin/accounts/allowlist**', route => allowlistRoute(route, state));
+  await page.route('**/api/v1/admin/accounts/identities/unlinked**', route =>
+    route.fulfill({ status: 200, json: { items: state.unlinked, page: { limit: 50, cursor: null, next_cursor: null } } }));
+  await page.route('**/api/v1/admin/accounts/bootstrap', route =>
+    route.fulfill({ status: 200, json: state.bootstrap }));
+  await page.route('**/api/v1/admin/accounts/correlations/**', route => correlationRoute(route, state));
+  return state;
+}
+
+function allowlistRoute(route: Route, state: AccountsAdminUiMockState): Promise<void> {
+  const request = route.request();
+  const method = request.method();
+  const id = new URL(request.url()).pathname.split('/allowlist/')[1] ?? null;
+
+  if (method === 'GET') return route.fulfill({ status: 200, json: { entries: state.entries } });
+
+  if (method === 'POST') {
+    const body = JSON.parse(request.postData() ?? '{}') as { kind: string; value: string; note?: string };
+    state.posts.push(body);
+    state.entries = [...state.entries, {
+      id: `allow-${state.entries.length + 1}`,
+      kind: body.kind,
+      value: body.value,
+      note: body.note ?? null,
+      created_by_user_id: 'user-admin',
+      created_at: '2026-07-21T10:00:00.000Z',
+    }];
+    return route.fulfill({ status: 201, json: state.entries.at(-1) as Record<string, unknown> });
+  }
+
+  if (method === 'PATCH' && id) {
+    const body = JSON.parse(request.postData() ?? '{}') as Record<string, unknown>;
+    state.patches.push({ id, body });
+    state.entries = state.entries.map(entry =>
+      entry.id === id ? { ...entry, note: (body.note as string | null) ?? null } : entry);
+    return route.fulfill({ status: 200, json: state.entries.find(entry => entry.id === id) as Record<string, unknown> });
+  }
+
+  if (method === 'DELETE' && id) {
+    state.deletes.push(id);
+    state.entries = state.entries.filter(entry => entry.id !== id);
+    return route.fulfill({ status: 204, body: '' });
+  }
+
+  return route.fulfill({ status: 404, json: { detail: 'Not found.' } });
+}
+
+function correlationRoute(route: Route, state: AccountsAdminUiMockState): Promise<void> {
+  if (!state.correlation) {
+    return route.fulfill({ status: 404, json: { detail: 'No account matches that correlation ID.' } });
+  }
+  return route.fulfill({ status: 200, json: state.correlation });
+}

--- a/tests/integration/web-console-e2e/harness/auditUiMock.ts
+++ b/tests/integration/web-console-e2e/harness/auditUiMock.ts
@@ -1,0 +1,202 @@
+/**
+ * Browser harness for the audit workspace.
+ *
+ * Models the two backend properties the UI is built around: cursor-only
+ * pagination with no filter parameters, and a stricter elevation tier on the
+ * detail and export routes than on the lists. `detailStatus` / `exportStatus`
+ * let a test reproduce the case where a list loads but a drill-in does not.
+ */
+
+import type { Page, Route } from '@playwright/test';
+
+export interface MockAdminAuditEvent {
+  id: string;
+  occurred_at: string;
+  actor_sub: string;
+  actor_user_id: string;
+  actor_capability_role: string;
+  capability: string;
+  operation: string;
+  endpoint: string;
+  result: string;
+  error_code: string | null;
+  target_user_id: string | null;
+  resource_kind: string | null;
+  resource_id: string | null;
+  correlation_id: string;
+  client_ip: string | null;
+  args_redacted: Record<string, unknown>;
+  result_detail_redacted: Record<string, unknown> | null;
+  integrity: { status: string; reason: string | null };
+}
+
+export interface AuditUiMockState {
+  adminEvents: MockAdminAuditEvent[];
+  approvalEvents: Array<Record<string, unknown>>;
+  authenticationEvents: Array<Record<string, unknown>>;
+  /** Records the export stream emits before its terminal `end` frame. */
+  exportRecords: number;
+  /** Set to 401 to model an elevation that satisfies the lists but not the detail. */
+  detailStatus: number;
+  /** Set to 401 to model the same for the export. */
+  exportStatus: number;
+  listReads: number;
+  detailReads: number;
+  exportReads: number;
+}
+
+export async function installAuditUiMock(page: Page): Promise<AuditUiMockState> {
+  const state: AuditUiMockState = {
+    adminEvents: Array.from({ length: 75 }, (_, index) => adminEvent(index)),
+    approvalEvents: [approvalEvent('verified'), approvalEvent('not_available')],
+    authenticationEvents: [authenticationEvent()],
+    exportRecords: 3,
+    detailStatus: 200,
+    exportStatus: 200,
+    listReads: 0,
+    detailReads: 0,
+    exportReads: 0,
+  };
+  await page.route('**/api/v1/admin/audit/**', route => handleRoute(route, state));
+  return state;
+}
+
+function handleRoute(route: Route, state: AuditUiMockState): Promise<void> {
+  const url = new URL(route.request().url());
+  const path = url.pathname.replace('/api/v1/admin/audit', '');
+
+  if (path === '/admin/export') {
+    state.exportReads += 1;
+    if (state.exportStatus !== 200) return problem(route, state.exportStatus, 'step_up_required');
+    return route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: exportBody(state),
+    });
+  }
+
+  const detail = /^\/(admin|approvals)\/(.+)$/.exec(path);
+  if (detail) {
+    state.detailReads += 1;
+    if (state.detailStatus !== 200) return problem(route, state.detailStatus, 'step_up_required');
+    const pool = detail[1] === 'admin' ? state.adminEvents : state.approvalEvents;
+    const record = pool.find(item => (item as { id: string }).id === detail[2]);
+    if (!record) return problem(route, 404, 'not_found');
+    return route.fulfill({ status: 200, json: record as Record<string, unknown> });
+  }
+
+  state.listReads += 1;
+  return route.fulfill({ status: 200, json: page_(listPool(path, state), url) as unknown as Record<string, unknown> });
+}
+
+function listPool(path: string, state: AuditUiMockState): Array<Record<string, unknown>> {
+  if (path === '/approvals') return state.approvalEvents;
+  if (path === '/authentication') return state.authenticationEvents;
+  return state.adminEvents;
+}
+
+/** Cursor is an opaque offset here, mirroring the server's opaque cursor contract. */
+function page_(pool: Array<Record<string, unknown>>, url: URL) {
+  const limit = Math.min(Number(url.searchParams.get('limit') ?? 50) || 50, 100);
+  const cursor = url.searchParams.get('cursor');
+  const offset = cursor ? Number(cursor) || 0 : 0;
+  const items = pool.slice(offset, offset + limit);
+  const nextOffset = offset + items.length;
+  return {
+    items,
+    page: {
+      limit,
+      cursor,
+      next_cursor: nextOffset < pool.length ? String(nextOffset) : null,
+    },
+  };
+}
+
+function exportBody(state: AuditUiMockState): string {
+  const frames = [
+    frame('init', {
+      stream_id: 'admin.audit.admin.export',
+      stream_type: 'admin_audit_export',
+      resume_supported: false,
+      cursor: null,
+      batch_size: 100,
+    }),
+    ...Array.from({ length: state.exportRecords }, (_, index) => frame('update', adminEvent(index))),
+    frame('end', { status: 'complete' }),
+  ];
+  return frames.join('');
+}
+
+function frame(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function problem(route: Route, status: number, code: string): Promise<void> {
+  return route.fulfill({
+    status,
+    json: { type: `https://dollhousemcp.com/errors/${code}`, code, title: 'Error', status, detail: 'Elevation required.' },
+  });
+}
+
+function adminEvent(index: number): MockAdminAuditEvent {
+  // Alternate integrity so the list always shows both a verified and an
+  // unverifiable record without a test having to construct one.
+  const broken = index % 3 === 2;
+  return {
+    id: `admin-audit-${index}`,
+    occurred_at: new Date(Date.UTC(2026, 6, 20, 12, 0, index % 60)).toISOString(),
+    actor_sub: 'e2e_admin',
+    actor_user_id: 'user-admin',
+    actor_capability_role: 'account_admin',
+    capability: 'console:admin:accounts',
+    operation: index % 2 === 0 ? 'accounts.users.list' : 'accounts.roles.grant',
+    endpoint: 'GET /api/v1/admin/accounts/users',
+    result: 'approved',
+    error_code: null,
+    target_user_id: null,
+    resource_kind: null,
+    resource_id: null,
+    correlation_id: `corr-${index}`,
+    client_ip: '127.0.0.1',
+    args_redacted: { role: '[redacted]' },
+    result_detail_redacted: null,
+    integrity: broken
+      ? { status: 'failed', reason: 'chain_hmac_mismatch' }
+      : { status: 'verified', reason: null },
+  };
+}
+
+function approvalEvent(integrityStatus: string): Record<string, unknown> {
+  return {
+    id: `approval-audit-${integrityStatus}`,
+    occurred_at: '2026-07-20T12:05:00.000Z',
+    account_correlation_id: 'corr-account',
+    session_id: 'session-1',
+    tool_name: 'mcp_aql_read',
+    operation: 'read',
+    result: 'approved',
+    decision_source: 'console',
+    correlation_id: 'corr-approval',
+    integrity: integrityStatus === 'verified'
+      ? { status: 'verified', chain_key_id: 'key-1', chain_prev: null, chain_hmac: 'abc' }
+      : { status: 'not_available', chain_key_id: null, chain_prev: null, chain_hmac: null },
+  };
+}
+
+function authenticationEvent(): Record<string, unknown> {
+  return {
+    id: 'auth-audit-1',
+    occurred_at: '2026-07-20T12:10:00.000Z',
+    event: 'login',
+    actor_user_id: 'user-admin',
+    actor_sub: 'e2e_admin',
+    capability: null,
+    elevation_acr: null,
+    elevation_amr: [],
+    result: 'success',
+    error_code: null,
+    correlation_id: 'corr-auth',
+    client_ip: '127.0.0.1',
+    user_agent: 'e2e',
+  };
+}

--- a/tests/integration/web-console-e2e/harness/auditUiMock.ts
+++ b/tests/integration/web-console-e2e/harness/auditUiMock.ts
@@ -36,8 +36,16 @@ export interface AuditUiMockState {
   authenticationEvents: Array<Record<string, unknown>>;
   /** Records the export stream emits before its terminal `end` frame. */
   exportRecords: number;
+  /**
+   * When false the stream stops without its terminal frame, the way a connection
+   * dropped mid-export would. The run stays open, which is what makes cancelling
+   * an in-progress export testable.
+   */
+  exportTerminates: boolean;
   /** Set to 401 to model an elevation that satisfies the lists but not the detail. */
   detailStatus: number;
+  /** Set to 401 to model the list itself being refused. */
+  listStatus: number;
   /** Set to 401 to model the same for the export. */
   exportStatus: number;
   listReads: number;
@@ -51,7 +59,9 @@ export async function installAuditUiMock(page: Page): Promise<AuditUiMockState> 
     approvalEvents: [approvalEvent('verified'), approvalEvent('not_available')],
     authenticationEvents: [authenticationEvent()],
     exportRecords: 3,
+    exportTerminates: true,
     detailStatus: 200,
+    listStatus: 200,
     exportStatus: 200,
     listReads: 0,
     detailReads: 0,
@@ -86,6 +96,7 @@ function handleRoute(route: Route, state: AuditUiMockState): Promise<void> {
   }
 
   state.listReads += 1;
+  if (state.listStatus !== 200) return problem(route, state.listStatus, 'step_up_required');
   return route.fulfill({ status: 200, json: page_(listPool(path, state), url) as unknown as Record<string, unknown> });
 }
 
@@ -122,7 +133,7 @@ function exportBody(state: AuditUiMockState): string {
       batch_size: 100,
     }),
     ...Array.from({ length: state.exportRecords }, (_, index) => frame('update', adminEvent(index))),
-    frame('end', { status: 'complete' }),
+    ...(state.exportTerminates ? [frame('end', { status: 'complete' })] : []),
   ];
   return frames.join('');
 }

--- a/tests/integration/web-console-e2e/harness/securityAdminUiMock.ts
+++ b/tests/integration/web-console-e2e/harness/securityAdminUiMock.ts
@@ -1,0 +1,198 @@
+/**
+ * Browser harness for security administration.
+ *
+ * Models the parts of the contract the UI has to respect: mutations sit on a
+ * stricter elevation tier than reads, the auth policy is ETag-guarded with only
+ * one editable field, and deleting a key is refused while it is inside its
+ * hard-delete grace unless the request explicitly forces it.
+ */
+
+import type { Page, Route } from '@playwright/test';
+
+export interface SecurityAdminUiMockState {
+  /** Set to 401 to model an elevation that satisfies reads but not mutations. */
+  mutationStatus: number;
+  /** Set to 412 to model the policy changing under the operator. */
+  policyPutStatus: number;
+  policy: {
+    max_admin_elevation_seconds: number;
+    updated_at: string;
+    etag: string;
+  };
+  /** Refuse the un-forced delete once, the way a key inside grace would. */
+  deleteRefusesWithoutForce: boolean;
+  rotateCalls: number;
+  retireCalls: number;
+  deleteCalls: Array<{ forced: boolean }>;
+  policyPuts: Array<{ ifMatch: string | null; seconds: number }>;
+}
+
+export async function installSecurityAdminUiMock(page: Page): Promise<SecurityAdminUiMockState> {
+  const state: SecurityAdminUiMockState = {
+    mutationStatus: 200,
+    policyPutStatus: 200,
+    policy: {
+      max_admin_elevation_seconds: 1800,
+      updated_at: '2026-07-20T10:00:00.000Z',
+      etag: 'W/"security-auth-policy:1:1800"',
+    },
+    deleteRefusesWithoutForce: true,
+    rotateCalls: 0,
+    retireCalls: 0,
+    deleteCalls: [],
+    policyPuts: [],
+  };
+  await page.route('**/api/v1/admin/security/**', route => handleRoute(route, state));
+  return state;
+}
+
+function handleRoute(route: Route, state: SecurityAdminUiMockState): Promise<void> {
+  const request = route.request();
+  const method = request.method();
+  const path = new URL(request.url()).pathname.replace('/api/v1/admin/security', '');
+
+  if (path === '/auth-policy') {
+    if (method === 'GET') return route.fulfill({ status: 200, json: policyDto(state) });
+    return putPolicy(route, state);
+  }
+
+  if (path === '/signing-keys' && method === 'GET') {
+    return route.fulfill({ status: 200, json: keyList(state) });
+  }
+  return signingKeyMutation(route, state, method, path);
+}
+
+function signingKeyMutation(
+  route: Route,
+  state: SecurityAdminUiMockState,
+  method: string,
+  path: string,
+): Promise<void> {
+  const isMutation = (method === 'POST' && (path.endsWith('/rotate') || path.endsWith('/retire')))
+    || method === 'DELETE';
+  if (!isMutation) return route.fulfill({ status: 404, json: problemBody('not_found', 'Not found.') });
+  if (state.mutationStatus !== 200) return stepUp(route, state.mutationStatus);
+
+  if (path.endsWith('/rotate')) {
+    state.rotateCalls += 1;
+    return route.fulfill({ status: 200, json: receipt('rotate', null, 'jwks-key-new') });
+  }
+  if (path.endsWith('/retire')) {
+    state.retireCalls += 1;
+    return route.fulfill({ status: 200, json: receipt('retire', 'jwks-key-old', null) });
+  }
+
+  const forced = requestForces(route.request().postData());
+  state.deleteCalls.push({ forced });
+  if (!forced && state.deleteRefusesWithoutForce) {
+    return route.fulfill({
+      status: 409,
+      json: problemBody('conflict', 'Signing key is still within hard-delete grace.'),
+    });
+  }
+  return route.fulfill({ status: 200, json: receipt('delete', 'jwks-key-old', null) });
+}
+
+async function putPolicy(route: Route, state: SecurityAdminUiMockState): Promise<void> {
+  if (state.mutationStatus !== 200) return stepUp(route, state.mutationStatus);
+  const ifMatch = route.request().headers()['if-match'] ?? null;
+  const body = JSON.parse(route.request().postData() ?? '{}') as { max_admin_elevation_seconds?: number };
+  state.policyPuts.push({ ifMatch, seconds: Number(body.max_admin_elevation_seconds) });
+
+  if (!ifMatch) {
+    return route.fulfill({ status: 428, json: problemBody('precondition_required', 'Missing If-Match header.') });
+  }
+  if (state.policyPutStatus === 412 || ifMatch !== state.policy.etag) {
+    return route.fulfill({ status: 412, json: problemBody('precondition_failed', 'Auth policy changed before this request.') });
+  }
+  state.policy = {
+    max_admin_elevation_seconds: Number(body.max_admin_elevation_seconds),
+    updated_at: '2026-07-21T09:00:00.000Z',
+    etag: `W/"security-auth-policy:2:${body.max_admin_elevation_seconds}"`,
+  };
+  return route.fulfill({ status: 200, json: policyDto(state) });
+}
+
+/** The service accepts either flag, so the harness has to treat both as forcing. */
+function requestForces(postData: string | null): boolean {
+  if (!postData) return false;
+  try {
+    const body = JSON.parse(postData) as Record<string, unknown>;
+    return body.force === true || body.emergency === true;
+  } catch {
+    return false;
+  }
+}
+
+function policyDto(state: SecurityAdminUiMockState): Record<string, unknown> {
+  return {
+    require_admin_totp: true,
+    csrf_protection: true,
+    bff_session_security: true,
+    step_up_required: true,
+    privacy_boundaries_enforced: true,
+    ...state.policy,
+  };
+}
+
+function keyList(state: SecurityAdminUiMockState): Record<string, unknown> {
+  const retired = state.deleteCalls.length > 0 || state.retireCalls > 0;
+  return {
+    kinds: [
+      {
+        kind: 'jwks',
+        active_kid: 'jwks-key-active',
+        keys: [
+          key('jwks', 'jwks-key-active', 'active'),
+          key('jwks', 'jwks-key-old', retired ? 'retired' : 'verifying'),
+        ],
+      },
+      { kind: 'cookie', active_kid: null, keys: [] },
+    ],
+  };
+}
+
+function key(kind: string, kid: string, state: string): Record<string, unknown> {
+  return {
+    kind,
+    kid,
+    state,
+    created_at: '2026-07-01T10:00:00.000Z',
+    rotated_at: null,
+    retired_at: state === 'retired' ? '2026-07-20T10:00:00.000Z' : null,
+    deleted_at: null,
+    verification_grace_ends_at: state === 'verifying' ? '2026-07-25T10:00:00.000Z' : null,
+  };
+}
+
+function receipt(action: string, targetKid: string | null, resultKid: string | null): Record<string, unknown> {
+  return {
+    id: `job-${action}`,
+    kind: 'jwks',
+    action,
+    status: 'completed',
+    created_at: '2026-07-21T09:00:00.000Z',
+    completed_at: '2026-07-21T09:00:01.000Z',
+    target_kid: targetKid,
+    result_kid: resultKid,
+    error_code: null,
+  };
+}
+
+function stepUp(route: Route, status: number): Promise<void> {
+  return route.fulfill({
+    status,
+    json: {
+      type: 'https://dollhousemcp.com/errors/step_up_required',
+      code: 'step_up_required',
+      title: 'Step up required',
+      status,
+      detail: 'Fresh elevation required.',
+      extensions: { required_capability: 'console:admin:security' },
+    },
+  });
+}
+
+function problemBody(code: string, detail: string): Record<string, unknown> {
+  return { type: `https://dollhousemcp.com/errors/${code}`, code, title: 'Error', detail };
+}

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -11,6 +11,7 @@ import { installSelfServiceUiMock } from '../harness/selfServiceUiMock.js';
 import { installSessionUiMock } from '../harness/sessionUiMock.js';
 import { installIntegrationsUiMock } from '../harness/integrationsUiMock.js';
 import { installAuditUiMock } from '../harness/auditUiMock.js';
+import { installSecurityAdminUiMock } from '../harness/securityAdminUiMock.js';
 import {
   installOperationsUiMock,
   OPERATIONS_PRIVATE_MARKER,
@@ -588,6 +589,132 @@ test('the audit tab stays hidden without its capability', async ({ page }) => {
   await loginFromConsole(page);
   await setElevation(page, ['console:admin:accounts']);
   await expect(page.locator(AUDIT_TAB)).toBeHidden();
+});
+
+const SECURITY_TAB = '.console-tab[data-tab="security"]';
+const SECURITY_KEYS_PANEL = '[data-secadmin-panel="keys"]';
+const SECURITY_ERROR = '.secadmin-notice--error';
+const SECURITY_RECEIPT = '.secadmin-receipt';
+
+async function openSecurityTab(page: Page): Promise<void> {
+  await setElevation(page, ['console:admin:security']);
+  await page.locator(SECURITY_TAB).click();
+  await page.locator(`${SECURITY_KEYS_PANEL} .secadmin-card`).first().waitFor();
+}
+
+async function confirmDialogAction(page: Page): Promise<void> {
+  await page.locator('#confirm-modal [data-confirm="1"]').click();
+}
+
+test('rotating a signing key confirms first and shows the returned receipt', async ({ page }) => {
+  const mock = await installSecurityAdminUiMock(page);
+  await loginFromConsole(page);
+  await openSecurityTab(page);
+
+  const keys = page.locator(SECURITY_KEYS_PANEL);
+  await keys.locator('[data-key-action="rotate"][data-key-kind="jwks"]').click();
+  // The confirmation states the consequence rather than asking a bare "are you sure".
+  await expect(page.locator('#confirm-modal')).toContainText('tokens already issued keep working');
+  await confirmDialogAction(page);
+
+  await expect(keys.locator(SECURITY_RECEIPT)).toContainText('rotate completed');
+  await expect(keys.locator(SECURITY_RECEIPT)).toContainText('jwks-key-new');
+  expect(mock.rotateCalls).toBe(1);
+});
+
+test('a signing key operation refused for fresh elevation keeps its reason on screen', async ({ page }) => {
+  const mock = await installSecurityAdminUiMock(page);
+  mock.mutationStatus = 401; // reads pass, mutations need a fresher sign-in
+  await loginFromConsole(page);
+  await openSecurityTab(page);
+
+  const keys = page.locator(SECURITY_KEYS_PANEL);
+  await keys.locator('[data-key-action="rotate"][data-key-kind="jwks"]').click();
+  await confirmDialogAction(page);
+
+  // Not a toast: the explanation has to survive long enough to act on.
+  await expect(keys.locator(SECURITY_ERROR)).toContainText('more recent sign-in');
+  await page.waitForTimeout(6000);
+  await expect(keys.locator(SECURITY_ERROR)).toBeVisible();
+  await expect(keys.locator(SECURITY_RECEIPT)).toHaveCount(0);
+  expect(mock.rotateCalls).toBe(0);
+});
+
+test('deleting a key inside its grace requires a second, explicit override', async ({ page }) => {
+  const mock = await installSecurityAdminUiMock(page);
+  await loginFromConsole(page);
+  await openSecurityTab(page);
+
+  const keys = page.locator(SECURITY_KEYS_PANEL);
+  await keys.locator('[data-key-action="retire"][data-key-kid="jwks-key-old"]').click();
+  await confirmDialogAction(page);
+  await expect(keys.locator(SECURITY_RECEIPT)).toContainText('retire completed');
+
+  await keys.locator('[data-key-action="delete"][data-key-kid="jwks-key-old"]').click();
+  await confirmDialogAction(page);
+
+  // The server refuses the plain delete; the override names the actual consequence.
+  await expect(page.locator('#confirm-modal')).toContainText('can break verification');
+  await confirmDialogAction(page);
+
+  await expect(keys.locator(SECURITY_RECEIPT)).toContainText('delete completed');
+  expect(mock.deleteCalls.map(call => call.forced)).toEqual([false, true]);
+});
+
+test('declining the grace override leaves the key in place', async ({ page }) => {
+  const mock = await installSecurityAdminUiMock(page);
+  await loginFromConsole(page);
+  await openSecurityTab(page);
+
+  const keys = page.locator(SECURITY_KEYS_PANEL);
+  await keys.locator('[data-key-action="retire"][data-key-kid="jwks-key-old"]').click();
+  await confirmDialogAction(page);
+  await keys.locator('[data-key-action="delete"][data-key-kid="jwks-key-old"]').click();
+  await confirmDialogAction(page);
+  await page.locator('#confirm-modal [data-confirm="0"]').click();
+
+  expect(mock.deleteCalls.map(call => call.forced)).toEqual([false]);
+});
+
+test('the auth policy edits only its one mutable field and guards it with the ETag', async ({ page }) => {
+  const mock = await installSecurityAdminUiMock(page);
+  await loginFromConsole(page);
+  await openSecurityTab(page);
+  await page.locator('[data-secadmin-nav="policy"]').click();
+
+  const policy = page.locator('[data-secadmin-panel="policy"]');
+  await expect(policy.locator('.secadmin-invariants li')).toHaveCount(5);
+  // The invariants are stated, not offered as controls.
+  await expect(policy.locator('.secadmin-invariants input')).toHaveCount(0);
+  await expect(policy.locator('input')).toHaveCount(1);
+
+  await policy.locator('[name="max_admin_elevation_seconds"]').fill('900');
+  await policy.locator('button[type="submit"]').click();
+  await expect.poll(() => mock.policyPuts.length).toBe(1);
+  expect(mock.policyPuts[0].ifMatch).toBe('W/"security-auth-policy:1:1800"');
+  expect(mock.policyPuts[0].seconds).toBe(900);
+});
+
+test('a policy that changed elsewhere is reported without overwriting it', async ({ page }) => {
+  const mock = await installSecurityAdminUiMock(page);
+  mock.policyPutStatus = 412;
+  await loginFromConsole(page);
+  await openSecurityTab(page);
+  await page.locator('[data-secadmin-nav="policy"]').click();
+
+  const policy = page.locator('[data-secadmin-panel="policy"]');
+  await policy.locator('[name="max_admin_elevation_seconds"]').fill('900');
+  await policy.locator('button[type="submit"]').click();
+
+  await expect(policy.locator(SECURITY_ERROR)).toContainText('changed elsewhere');
+  expect(mock.policy.max_admin_elevation_seconds, 'the stored policy is untouched').toBe(1800);
+});
+
+test('the security tab stays hidden without its capability', async ({ page }) => {
+  await installSecurityAdminUiMock(page);
+  await loginFromConsole(page);
+  await setElevation(page, ['console:admin:accounts']);
+  await expect(page.locator(SECURITY_TAB)).toBeHidden();
 });
 
 test('a malformed authorization parameter is rejected before anything is saved', async ({ page }) => {

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -607,6 +607,50 @@ async function confirmDialogAction(page: Page): Promise<void> {
   await page.locator('#confirm-modal [data-confirm="1"]').click();
 }
 
+test('a cancelled audit export leaves no download behind', async ({ page }) => {
+  const mock = await installAuditUiMock(page);
+  mock.exportTerminates = false; // still running, so there is something to cancel
+  await loginFromConsole(page);
+  await openAuditTab(page);
+
+  const panel = page.locator(AUDIT_ADMIN_PANEL);
+  await panel.locator(AUDIT_ROW).first().waitFor();
+  await panel.locator('[data-audit-export]').click();
+  await panel.locator('[data-audit-export-cancel]').click();
+
+  await expect(panel.locator('[data-audit-export-status]')).toContainText('Cancelled');
+  await expect(panel.locator('a[download]')).toHaveCount(0);
+  // Cancelling returns the control to its resting state rather than stranding it.
+  await expect(panel.locator('[data-audit-export]')).toBeVisible();
+});
+
+test('an audit list refused for elevation reports it without stranding the panel', async ({ page }) => {
+  const mock = await installAuditUiMock(page);
+  mock.listStatus = 401;
+  await loginFromConsole(page);
+  await openAuditTab(page);
+
+  const panel = page.locator(AUDIT_ADMIN_PANEL);
+  await expect(panel.locator('.audit-notice--error')).toContainText('more recent sign-in');
+  await expect(panel.locator('.audit-loading')).toHaveCount(0);
+});
+
+test('opening an audit record while the list reloads leaves neither stuck', async ({ page }) => {
+  await installAuditUiMock(page);
+  await loginFromConsole(page);
+  await openAuditTab(page);
+
+  const panel = page.locator(AUDIT_ADMIN_PANEL);
+  await panel.locator(AUDIT_ROW).first().waitFor();
+  // Interleaved list and detail requests must not cancel one another.
+  await panel.locator('[data-audit-refresh]').click();
+  await panel.locator('[data-audit-open]').first().click();
+
+  await expect(panel.locator('.audit-detail-grid')).toBeVisible();
+  await expect(panel.locator('.audit-loading')).toHaveCount(0);
+  await expect(panel.locator(AUDIT_ROW).first()).toBeVisible();
+});
+
 test('rotating a signing key confirms first and shows the returned receipt', async ({ page }) => {
   const mock = await installSecurityAdminUiMock(page);
   await loginFromConsole(page);
@@ -773,8 +817,9 @@ test('editing an allowlist entry sends only its note', async ({ page }) => {
   await panel.locator('#acct-allow-form button[type="submit"]').click();
   await expect(panel.locator('.acct-row')).toHaveCount(2);
 
-  page.once('dialog', dialog => void dialog.accept('revised note'));
   await panel.locator('[data-allow-action="edit"]').first().click();
+  await panel.locator('[data-allow-note-input]').fill('revised note');
+  await panel.locator('[data-allow-action="save-edit"]').click();
   await expect.poll(() => mock.patches.length).toBe(1);
   // Kind and value are immutable server-side, so the request must carry neither.
   expect(mock.patches[0].body).toEqual({ note: 'revised note' });

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -12,6 +12,7 @@ import { installSessionUiMock } from '../harness/sessionUiMock.js';
 import { installIntegrationsUiMock } from '../harness/integrationsUiMock.js';
 import { installAuditUiMock } from '../harness/auditUiMock.js';
 import { installSecurityAdminUiMock } from '../harness/securityAdminUiMock.js';
+import { installAccountsAdminUiMock } from '../harness/accountsAdminUiMock.js';
 import {
   installOperationsUiMock,
   OPERATIONS_PRIVATE_MARKER,
@@ -715,6 +716,88 @@ test('the security tab stays hidden without its capability', async ({ page }) =>
   await loginFromConsole(page);
   await setElevation(page, ['console:admin:accounts']);
   await expect(page.locator(SECURITY_TAB)).toBeHidden();
+});
+
+const ALLOWLIST_VALUE = '[name="value"]';
+
+async function openAccountsSection(page: Page, section: string) {
+  await setElevation(page, ['console:admin:accounts']);
+  await page.locator('.console-tab[data-tab="users"]').click();
+  await page.locator('#ua-list').waitFor();
+  await page.locator(`[data-ua-nav="${section}"]`).click();
+  return page.locator(`[data-ua-panel="${section}"]`);
+}
+
+test('the allowlist adds and removes an entry without disturbing the account list', async ({ page }) => {
+  const mock = await installAccountsAdminUiMock(page);
+  await loginFromConsole(page);
+  const panel = await openAccountsSection(page, 'allowlist');
+
+  // An empty allowlist is a locked door, not an absence — say so.
+  await expect(panel.locator('.acct-empty')).toContainText('Every sign-in will be refused');
+
+  await panel.locator(ALLOWLIST_VALUE).fill('someone@example.test');
+  await panel.locator('[name="note"]').fill('vendor access');
+  await panel.locator('#acct-allow-form button[type="submit"]').click();
+
+  await expect(panel.locator('.acct-row')).toHaveCount(2); // header + entry
+  expect(mock.posts).toEqual([{ kind: 'email', value: 'someone@example.test', note: 'vendor access' }]);
+
+  await panel.locator('[data-allow-action="remove"]').first().click();
+  await expect(page.locator('#confirm-modal')).toContainText('no longer be able to sign in');
+  await page.locator('#confirm-modal [data-confirm="1"]').click();
+  await expect(panel.locator('.acct-empty')).toBeVisible();
+  expect(mock.deletes).toEqual(['allow-1']);
+
+  // The account list this tab already had must be untouched by any of that.
+  await page.locator('[data-ua-nav="accounts"]').click();
+  await expect(page.locator('#ua-list')).toBeVisible();
+});
+
+test('a refresh does not discard a part-typed allowlist entry', async ({ page }) => {
+  await installAccountsAdminUiMock(page);
+  await loginFromConsole(page);
+  const panel = await openAccountsSection(page, 'allowlist');
+
+  await panel.locator(ALLOWLIST_VALUE).fill('half-typed@example.test');
+  await panel.locator('[data-allow-action="refresh"]').click();
+  await expect(panel.locator(ALLOWLIST_VALUE)).toHaveValue('half-typed@example.test');
+});
+
+test('editing an allowlist entry sends only its note', async ({ page }) => {
+  const mock = await installAccountsAdminUiMock(page);
+  await loginFromConsole(page);
+  const panel = await openAccountsSection(page, 'allowlist');
+
+  await panel.locator(ALLOWLIST_VALUE).fill('someone@example.test');
+  await panel.locator('#acct-allow-form button[type="submit"]').click();
+  await expect(panel.locator('.acct-row')).toHaveCount(2);
+
+  page.once('dialog', dialog => void dialog.accept('revised note'));
+  await panel.locator('[data-allow-action="edit"]').first().click();
+  await expect.poll(() => mock.patches.length).toBe(1);
+  // Kind and value are immutable server-side, so the request must carry neither.
+  expect(mock.patches[0].body).toEqual({ note: 'revised note' });
+});
+
+test('identity triage lists unlinked logins and resolves a correlation ID', async ({ page }) => {
+  await installAccountsAdminUiMock(page);
+  await loginFromConsole(page);
+  const panel = await openAccountsSection(page, 'triage');
+
+  await expect(panel.locator('.acct-row')).toHaveCount(2); // header + one unlinked identity
+  await expect(panel.locator('.acct-row').nth(1)).toContainText('octocat');
+
+  await panel.locator('[name="correlation_id"]').fill('corr-1');
+  await panel.locator('#acct-correlation-form button[type="submit"]').click();
+  await expect(panel.locator('.acct-detail')).toContainText('e2e_admin');
+});
+
+test('bootstrap status reports that the first-administrator path is closed', async ({ page }) => {
+  await installAccountsAdminUiMock(page);
+  await loginFromConsole(page);
+  const panel = await openAccountsSection(page, 'bootstrap');
+  await expect(panel.locator('.acct-card')).toContainText('one-time first-administrator path is closed');
 });
 
 test('a malformed authorization parameter is rejected before anything is saved', async ({ page }) => {

--- a/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
+++ b/tests/integration/web-console-e2e/specs/console-auth.pw-spec.ts
@@ -10,6 +10,7 @@ import { installPortfolioUiMock } from '../harness/portfolioUiMock.js';
 import { installSelfServiceUiMock } from '../harness/selfServiceUiMock.js';
 import { installSessionUiMock } from '../harness/sessionUiMock.js';
 import { installIntegrationsUiMock } from '../harness/integrationsUiMock.js';
+import { installAuditUiMock } from '../harness/auditUiMock.js';
 import {
   installOperationsUiMock,
   OPERATIONS_PRIVATE_MARKER,
@@ -155,11 +156,7 @@ async function stepUpWithTotp(page: Page, totp: TOTP): Promise<void> {
 }
 
 async function openMockOperations(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    globalThis.dispatchEvent(new CustomEvent('dh:elevation-changed', {
-      detail: { active: true, capabilities: ['console:admin:operate'] },
-    }));
-  });
+  await setElevation(page, ['console:admin:operate']);
   await expect(page.locator(OPERATIONS_TAB)).toBeVisible();
   await page.locator(OPERATIONS_TAB).click();
 }
@@ -489,6 +486,110 @@ test('custom integration authoring keeps secrets write-only and imports OpenAPI 
   await expect(customCard).toHaveCount(0);
 });
 
+const AUDIT_TAB = '.console-tab[data-tab="audit"]';
+const AUDIT_ADMIN_PANEL = '[data-audit-panel="admin"]';
+const AUDIT_ROW = '.audit-row';
+
+async function setElevation(page: Page, capabilities: readonly string[], active = true): Promise<void> {
+  await page.evaluate(({ caps, isActive }) => {
+    globalThis.dispatchEvent(new CustomEvent('dh:elevation-changed', {
+      detail: { active: isActive, capabilities: caps },
+    }));
+  }, { caps: capabilities, isActive: active });
+}
+
+async function openAuditTab(page: Page): Promise<void> {
+  await setElevation(page, ['console:admin:audit']);
+  await page.locator(AUDIT_TAB).click();
+}
+
+test('audit lists page through records and report integrity without inventing filters', async ({ page }) => {
+  const mock = await installAuditUiMock(page);
+  await loginFromConsole(page);
+  await openAuditTab(page);
+
+  const panel = page.locator(AUDIT_ADMIN_PANEL);
+  await panel.locator(AUDIT_ROW).first().waitFor();
+  await expect(page.locator('[data-audit-nav]')).toHaveText(['Admin actions', 'Approvals', 'Authentication']);
+
+  // The backend exposes no filter parameters, so the surface must not offer any.
+  await expect(panel.locator('input, select')).toHaveCount(0);
+
+  // 75 seeded records at a 50 page size: one full page, then the remainder.
+  await expect(panel.locator(AUDIT_ROW)).toHaveCount(51); // 50 rows + header
+  await expect(panel.locator('[data-audit-previous]')).toBeDisabled();
+  await panel.locator('[data-audit-next]').click();
+  await expect.poll(() => panel.locator(AUDIT_ROW).count()).toBe(26);
+  await expect(panel.locator('[data-audit-previous]')).toBeEnabled();
+  await expect(panel.locator('[data-audit-next]')).toBeDisabled();
+
+  // Integrity is reported as recorded, including records that failed verification.
+  await panel.locator('[data-audit-previous]').click();
+  await expect(panel.locator('.audit-chip--verified').first()).toBeVisible();
+  await expect(panel.locator('.audit-chip--failed').first()).toBeVisible();
+
+  // An unverifiable approval says so rather than implying it was verified.
+  await page.locator('[data-audit-nav="approvals"]').click();
+  const approvals = page.locator('[data-audit-panel="approvals"]');
+  await expect(approvals.locator('.audit-chip--not_available')).toContainText('not recorded');
+  expect(mock.listReads).toBeGreaterThan(0);
+});
+
+test('an audit record that needs fresher elevation says so instead of failing silently', async ({ page }) => {
+  const mock = await installAuditUiMock(page);
+  mock.detailStatus = 401; // list tier satisfied, detail tier is not
+  await loginFromConsole(page);
+  await openAuditTab(page);
+
+  const panel = page.locator(AUDIT_ADMIN_PANEL);
+  await panel.locator(AUDIT_ROW).first().waitFor();
+  await panel.locator('[data-audit-open]').first().click();
+
+  await expect(panel.locator('.audit-detail')).toContainText('more recent sign-in');
+  expect(mock.detailReads).toBe(1);
+  // The list is still usable: a stricter tier on one route must not break the page.
+  await expect(panel.locator(AUDIT_ROW).first()).toBeVisible();
+});
+
+test('the audit export finishes as a bounded download rather than a live stream', async ({ page }) => {
+  const mock = await installAuditUiMock(page);
+  await loginFromConsole(page);
+  await openAuditTab(page);
+
+  const panel = page.locator(AUDIT_ADMIN_PANEL);
+  await panel.locator(AUDIT_ROW).first().waitFor();
+  await panel.locator('[data-audit-export]').click();
+
+  await expect(panel.locator('a[download]')).toBeVisible();
+  await expect(panel.locator('[data-audit-export-status]')).toContainText('3 records ready');
+  // Terminal: the run ends on the server's `end` frame and is not reopened.
+  await expect(panel.locator('[data-audit-export-cancel]')).toHaveCount(0);
+  expect(mock.exportReads).toBe(1);
+  await page.waitForTimeout(1000);
+  expect(mock.exportReads, 'a finished export must not reconnect').toBe(1);
+});
+
+test('an audit export refused for elevation reports it and offers no partial download', async ({ page }) => {
+  const mock = await installAuditUiMock(page);
+  mock.exportStatus = 401;
+  await loginFromConsole(page);
+  await openAuditTab(page);
+
+  const panel = page.locator(AUDIT_ADMIN_PANEL);
+  await panel.locator(AUDIT_ROW).first().waitFor();
+  await panel.locator('[data-audit-export]').click();
+
+  await expect(panel.locator('.audit-export-status--error')).toContainText('more recent sign-in');
+  await expect(panel.locator('a[download]')).toHaveCount(0);
+});
+
+test('the audit tab stays hidden without its capability', async ({ page }) => {
+  await installAuditUiMock(page);
+  await loginFromConsole(page);
+  await setElevation(page, ['console:admin:accounts']);
+  await expect(page.locator(AUDIT_TAB)).toBeHidden();
+});
+
 test('a malformed authorization parameter is rejected before anything is saved', async ({ page }) => {
   await includeManifestRoutes(page, INTEGRATION_ROUTES);
   const mock = await installIntegrationsUiMock(page);
@@ -741,11 +842,7 @@ test('operations remains usable when a partial deployment omits health', async (
   ]));
   await loginFromConsole(page);
 
-  await page.evaluate(() => {
-    globalThis.dispatchEvent(new CustomEvent('dh:elevation-changed', {
-      detail: { active: true, capabilities: ['console:admin:operate'] },
-    }));
-  });
+  await setElevation(page, ['console:admin:operate']);
   await expect(page.locator(OPERATIONS_TAB)).toBeVisible();
   await page.locator(OPERATIONS_TAB).click();
   await expect(page.locator(OPERATIONS_HEALTH_NAV)).toHaveCount(0);
@@ -760,22 +857,14 @@ test('operations requires its capability and stops polling when privilege or vis
   const mock = await installOperationsUiMock(page);
   await loginFromConsole(page);
 
-  await page.evaluate(() => {
-    globalThis.dispatchEvent(new CustomEvent('dh:elevation-changed', {
-      detail: { active: true, capabilities: ['console:admin:accounts'] },
-    }));
-  });
+  await setElevation(page, ['console:admin:accounts']);
   await expect(page.locator(OPERATIONS_TAB)).toBeHidden();
 
   await page.clock.install();
   await openMockOperations(page);
   await expect.poll(() => mock.healthReads).toBeGreaterThan(0);
   const beforeStepDown = mock.healthReads;
-  await page.evaluate(() => {
-    globalThis.dispatchEvent(new CustomEvent('dh:elevation-changed', {
-      detail: { active: false, capabilities: [] },
-    }));
-  });
+  await setElevation(page, [], false);
   await page.clock.fastForward(11_000);
   expect(mock.healthReads, 'step-down aborts and stops operator polling').toBe(beforeStepDown);
 


### PR DESCRIPTION
## Summary

Adds audit, security administration, and account governance surfaces to the web console, giving elevated administrators the remaining read and control workflows the backend already exposed.

## What changed

- Adds a capability- and route-gated Audit tab covering admin action, approval, and authentication logs, with cursor paging and record detail.
- Reports audit integrity as recorded, including failed verification and approval records that cannot be verified.
- Adds a bounded audit export that ends on the server's terminal frame, caps accumulated records, and reports an incomplete file rather than presenting a partial export as whole.
- Omits filter controls from the audit surface, which the list routes do not implement.
- Adds a capability- and route-gated Security tab for signing-key lifecycle and the authentication policy.
- Adds key rotation, retirement, and deletion with consequence-stating confirmations and synchronous receipts.
- Defers the hard-delete grace window to the server, offering the force override only once the server reports that conflict.
- Presents the enforced authentication protections as stated invariants and limits editing to the maximum elevation length under its ETag.
- Adds allowlist, identity-triage, correlation-lookup, and bootstrap sections beside the existing account list, which is unchanged.
- Limits allowlist editing to the entry note, matching what the API accepts.
- Reports refusals requiring fresher elevation in place, since audit detail, the export, and every security mutation sit on stricter tiers than the surfaces that reach them.

## Test coverage

Beyond the expected success paths, browser tests assert the behavior that is easy to get wrong:

- Declining the hard-delete grace override leaves the key in place and sends no forced request.
- A rejected policy write leaves the stored policy unchanged rather than partially applied.
- An elevation refusal stays on screen after transient notifications clear.
- A partially entered allowlist value survives a background reload.
- Editing an allowlist entry sends only its note, never the immutable kind or value.
- The audit panel exposes no input controls, so filters the backend cannot serve are not added later.
- The existing account list renders unchanged after navigating the new sections.

## Verification

- ESLint and local Sonar lint passed for the complete touched-file set.
- Route-manifest parity test passed: 1/1.
- Authenticated browser suite passed: 21/21 across audit, security, accounts, users, and self-service.
- Allowlist create and delete additionally exercised against a live console instance.