### PR TITLE
Release 2.0.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.0.39] - 2026-07-31
+
+- Fix agent sub-element activation: `activates:` references (canonical filename slugs like `security-analyst`) never resolved elements whose metadata carries display names (`Security Analyst`), so agents silently ran without their declared personas and skills — while their tool sandbox still fully applied. Lookup now matches exact names first, then falls back to the same filename normalization used when saving elements; degenerate references (empty or separator-only) warn instead of resolving. (#2432, #2433)
+- **Behavior change:** agents that previously ran bare will start loading their full declared context (personas and skills) after upgrading — expect richer agent behavior from the shipped defaults such as `code-reviewer`.
+
 ## [2.0.38] - 2026-07-04
 
 - Close the remaining symlink containment bypasses for convert CLI output paths. Output directories that do not exist yet are vetted through their nearest existing ancestor (#2342, #2343), and output bases are now contained canonically: relative outputs (including the default) must truly resolve inside the working directory even when a symlink tries to redirect them, and explicit outside destinations disclose their real location when a symlink diverts them (#2344, #2346).

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dollhousemcp",
   "display_name": "DollhouseMCP",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "description": "Open-source AI customization through modular Dollhouse elements — personas, skills, templates, agents, memories, and ensembles.",
   "long_description": "DollhouseMCP is an MCP server that lets you customize your AI with modular Dollhouse elements. Create personas that shape behavior and permissions, skills that add capabilities, templates for consistent outputs, agents for autonomous multi-step goals, memories for persistent context, and ensembles that bundle elements together. Includes MCP-AQL query language with 5 semantic CRUDE endpoints, Gatekeeper permission system, community collection, and a built-in portfolio browser.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.38",
+      "version": "2.0.39",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.38",
+      "version": "2.0.39",
       "transport": {
         "type": "stdio"
       }

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.38';
-export const BUILD_TIMESTAMP = '2026-07-04T18:32:15.882Z';
+export const PACKAGE_VERSION = '2.0.39';
+export const BUILD_TIMESTAMP = '2026-07-31T15:56:09.337Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';


### PR DESCRIPTION
## Release 2.0.39 — patch

Single fix, from hotfix PR #2433 (already on main):

- **Fix agent sub-element activation** (#2432): `activates:` slug references never resolved display-named elements, so agents silently ran without their declared personas and skills while their tool sandbox still fully applied. Lookup now matches exact names first, then falls back to the canonical filename normalization used at save time; degenerate references warn instead of resolving.

**Behavior change worth noting in release comms:** agents that previously ran bare will start loading their full declared context after upgrading — expect richer agent output from shipped defaults like `code-reviewer`.

This PR contains only the version bump (package.json, package-lock.json, manifest.json, server.json, src/generated/version.ts) and the CHANGELOG entry, per the release flow used for 2.0.36–2.0.38 (#2333, #2341, #2348).

Post-merge steps (per #2432 execution plan): tag `v2.0.39` deliberately as the publish step, then sync main → develop, then the separate beta cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQRTwMr51bnDYYEfaojLdu