### PR TITLE
chore: sync main (v2.0.39) into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.0.39] - 2026-07-31
+
+- Fix agent sub-element activation: `activates:` references (canonical filename slugs like `security-analyst`) never resolved elements whose metadata carries display names (`Security Analyst`), so agents silently ran without their declared personas and skills — while their tool sandbox still fully applied. Lookup now matches exact names first, then falls back to the same filename normalization used when saving elements; degenerate references (empty or separator-only) warn instead of resolving. (#2432, #2433)
+- **Behavior change:** agents that previously ran bare will start loading their full declared context (personas and skills) after upgrading — expect richer agent behavior from the shipped defaults such as `code-reviewer`.
+
 ## [2.0.38] - 2026-07-04
 
 - Close the remaining symlink containment bypasses for convert CLI output paths. Output directories that do not exist yet are vetted through their nearest existing ancestor (#2342, #2343), and output bases are now contained canonically: relative outputs (including the default) must truly resolve inside the working directory even when a symlink tries to redirect them, and explicit outside destinations disclose their real location when a symlink diverts them (#2344, #2346).

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "dollhousemcp",
   "display_name": "DollhouseMCP",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "description": "Open-source AI customization through modular Dollhouse elements — personas, skills, templates, agents, memories, and ensembles.",
   "long_description": "DollhouseMCP is an MCP server that lets you customize your AI with modular Dollhouse elements. Create personas that shape behavior and permissions, skills that add capabilities, templates for consistent outputs, agents for autonomous multi-step goals, memories for persistent context, and ensembles that bundle elements together. Includes MCP-AQL query language with 5 semantic CRUDE endpoints, Gatekeeper permission system, community collection, and a built-in portfolio browser.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dollhousemcp/mcp-server",
-      "version": "2.0.38",
+      "version": "2.0.39",
       "license": "AGPL-3.0-or-later",
       "workspaces": [
         "packages/safety"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/mcp-server",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "description": "DollhouseMCP - A Model Context Protocol (MCP) server that enables dynamic AI persona management from markdown files, allowing Claude and other compatible AI assistants to activate and switch between different behavioral personas.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.DollhouseMCP/mcp-server",
   "title": "DollhouseMCP",
   "description": "OSS to create Personas, Skills, Templates, Agents, and Memories to customize your AI experience.",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "homepage": "https://dollhousemcp.com",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     {
       "registryType": "npm",
       "identifier": "@dollhousemcp/mcp-server",
-      "version": "2.0.38",
+      "version": "2.0.39",
       "transport": {
         "type": "stdio"
       }

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -1559,17 +1559,18 @@ export class AgentManager extends BaseElementManager<Agent> {
       // Issue #2432: activates: references use canonical filename slugs (e.g.
       // 'security-analyst', 'bug-report') while element metadata carries display
       // names ('Security Analyst', 'BugReport'). Exact-name matches win across the
-      // full list; otherwise fall back to normalizeFilename — the same normalization
-      // managers use when saving files — so any reference that matches a saved
-      // filename resolves (including camelCase splits slugify would miss). The
-      // truthiness guard skips empty names, which normalizeFilename maps to
-      // 'unnamed' and could otherwise false-match.
-      const normalizedTarget = this.normalizeFilename(elementName);
+      // full list; otherwise both sides map through the same slug derivation
+      // getElementFilename() uses when saving — normalizeFilename with its
+      // empty-result 'unnamed' fallback — so a reference resolves exactly when it
+      // matches the element's on-disk filename (including camelCase splits and
+      // separator-only names like '---' that save as unnamed.md).
+      const canonicalSlug = (name: string): string => this.normalizeFilename(name) || 'unnamed';
+      const normalizedTarget = canonicalSlug(elementName);
       const element =
         elements.find((e: any) => e.metadata.name === elementName) ??
         elements.find((e: any) =>
-          typeof e.metadata.name === 'string' && e.metadata.name.length > 0 &&
-          this.normalizeFilename(e.metadata.name) === normalizedTarget
+          typeof e.metadata.name === 'string' &&
+          canonicalSlug(e.metadata.name) === normalizedTarget
         );
 
       if (!element) {

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -95,12 +95,12 @@ type AgentCreateMetadata = (Partial<AgentMetadata> & Partial<AgentMetadataV2>) &
 export class AgentManager extends BaseElementManager<Agent> {
   private readonly stateDir: string;
   private readonly stateCache: Map<string, AgentState> = new Map();
-  private triggerValidationService: TriggerValidationService;
-  private validationService: ValidationService;
-  private serializationService: SerializationService;
-  private metadataService: MetadataService;
+  private readonly triggerValidationService: TriggerValidationService;
+  private readonly validationService: ValidationService;
+  private readonly serializationService: SerializationService;
+  private readonly metadataService: MetadataService;
   // Track active agents by name (stable identifier)
-  private activeAgentNames: Set<string> = new Set();
+  private readonly activeAgentNames: Set<string> = new Set();
 
   // Static resolver for element manager lookup (DI pattern)
   // This allows Agent instances to resolve managers without tight coupling
@@ -1559,11 +1559,13 @@ export class AgentManager extends BaseElementManager<Agent> {
       const elements = await manager.list();
       // Issue #2432: activates: references use slugs (e.g. 'security-analyst') while
       // element metadata carries display names (e.g. 'Security Analyst'), so an exact
-      // match alone never resolves the shipped defaults. Fall back to slug comparison.
+      // match alone never resolves the shipped defaults. Exact-name matches are
+      // checked across the full list before any slug comparison, so an element named
+      // literally 'foo-bar' always beats one whose display name slugifies to it.
       const targetSlug = slugify(elementName);
-      const element = elements.find((e: any) =>
-        e.metadata.name === elementName || slugify(e.metadata.name ?? '') === targetSlug
-      );
+      const element =
+        elements.find((e: any) => e.metadata.name === elementName) ??
+        elements.find((e: any) => slugify(e.metadata.name ?? '') === targetSlug);
 
       if (!element) {
         throw new Error(`${elementType} '${elementName}' not found`);

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -1565,13 +1565,21 @@ export class AgentManager extends BaseElementManager<Agent> {
       // matches the element's on-disk filename (including camelCase splits and
       // separator-only names like '---' that save as unnamed.md).
       const canonicalSlug = (name: string): string => this.normalizeFilename(name) || 'unnamed';
-      const normalizedTarget = canonicalSlug(elementName);
+      // The 'unnamed' fallback applies only to candidate elements (mirroring how
+      // they were saved). A reference that is empty or normalizes to nothing
+      // ('', '   ', '---') can never name a saved file — validateActivates() only
+      // warns on such entries, so exclude them here or they would ride the
+      // fallback onto arbitrary separator-only-named elements.
+      const trimmedReference = elementName.trim();
+      const normalizedTarget = trimmedReference ? this.normalizeFilename(trimmedReference) : '';
       const element =
         elements.find((e: any) => e.metadata.name === elementName) ??
-        elements.find((e: any) =>
-          typeof e.metadata.name === 'string' &&
-          canonicalSlug(e.metadata.name) === normalizedTarget
-        );
+        (normalizedTarget
+          ? elements.find((e: any) =>
+              typeof e.metadata.name === 'string' &&
+              canonicalSlug(e.metadata.name) === normalizedTarget
+            )
+          : undefined);
 
       if (!element) {
         throw new Error(`${elementType} '${elementName}' not found`);

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -64,6 +64,7 @@ import { MetadataService } from '../../services/MetadataService.js';
 import { FileWatchService } from '../../services/FileWatchService.js';
 import { ElementMessages } from '../../utils/elementMessages.js';
 import { ElementNotFoundError } from '../../utils/ErrorHandler.js';
+import { slugify } from '../../utils/filesystem.js';
 import { sanitizeGatekeeperPolicy } from '../../handlers/mcp-aql/policies/ElementPolicies.js';
 import { SECURITY_LIMITS } from '../../security/constants.js';
 
@@ -1556,7 +1557,13 @@ export class AgentManager extends BaseElementManager<Agent> {
 
       // Get all elements of this type
       const elements = await manager.list();
-      const element = elements.find((e: any) => e.metadata.name === elementName);
+      // Issue #2432: activates: references use slugs (e.g. 'security-analyst') while
+      // element metadata carries display names (e.g. 'Security Analyst'), so an exact
+      // match alone never resolves the shipped defaults. Fall back to slug comparison.
+      const targetSlug = slugify(elementName);
+      const element = elements.find((e: any) =>
+        e.metadata.name === elementName || slugify(e.metadata.name ?? '') === targetSlug
+      );
 
       if (!element) {
         throw new Error(`${elementType} '${elementName}' not found`);

--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -64,7 +64,6 @@ import { MetadataService } from '../../services/MetadataService.js';
 import { FileWatchService } from '../../services/FileWatchService.js';
 import { ElementMessages } from '../../utils/elementMessages.js';
 import { ElementNotFoundError } from '../../utils/ErrorHandler.js';
-import { slugify } from '../../utils/filesystem.js';
 import { sanitizeGatekeeperPolicy } from '../../handlers/mcp-aql/policies/ElementPolicies.js';
 import { SECURITY_LIMITS } from '../../security/constants.js';
 
@@ -1557,15 +1556,21 @@ export class AgentManager extends BaseElementManager<Agent> {
 
       // Get all elements of this type
       const elements = await manager.list();
-      // Issue #2432: activates: references use slugs (e.g. 'security-analyst') while
-      // element metadata carries display names (e.g. 'Security Analyst'), so an exact
-      // match alone never resolves the shipped defaults. Exact-name matches are
-      // checked across the full list before any slug comparison, so an element named
-      // literally 'foo-bar' always beats one whose display name slugifies to it.
-      const targetSlug = slugify(elementName);
+      // Issue #2432: activates: references use canonical filename slugs (e.g.
+      // 'security-analyst', 'bug-report') while element metadata carries display
+      // names ('Security Analyst', 'BugReport'). Exact-name matches win across the
+      // full list; otherwise fall back to normalizeFilename — the same normalization
+      // managers use when saving files — so any reference that matches a saved
+      // filename resolves (including camelCase splits slugify would miss). The
+      // truthiness guard skips empty names, which normalizeFilename maps to
+      // 'unnamed' and could otherwise false-match.
+      const normalizedTarget = this.normalizeFilename(elementName);
       const element =
         elements.find((e: any) => e.metadata.name === elementName) ??
-        elements.find((e: any) => slugify(e.metadata.name ?? '') === targetSlug);
+        elements.find((e: any) =>
+          typeof e.metadata.name === 'string' && e.metadata.name.length > 0 &&
+          this.normalizeFilename(e.metadata.name) === normalizedTarget
+        );
 
       if (!element) {
         throw new Error(`${elementType} '${elementName}' not found`);

--- a/src/generated/version.ts
+++ b/src/generated/version.ts
@@ -3,7 +3,7 @@
  * Generated at build time by scripts/generate-version.js
  */
 
-export const PACKAGE_VERSION = '2.0.38';
-export const BUILD_TIMESTAMP = '2026-07-04T18:32:15.882Z';
+export const PACKAGE_VERSION = '2.0.39';
+export const BUILD_TIMESTAMP = '2026-07-31T15:56:09.337Z';
 export const BUILD_TYPE: 'npm' | 'git' = 'git';
 export const PACKAGE_NAME = '@dollhousemcp/mcp-server';

--- a/tests/unit/elements/agents/AgentManager.executeAgent.test.ts
+++ b/tests/unit/elements/agents/AgentManager.executeAgent.test.ts
@@ -674,6 +674,63 @@ activates:
       expect(result.activeElements.personas).toHaveLength(1);
       expect(result.activeElements.personas[0].content).toBe('You are a security analyst.');
     });
+
+    it('should prefer an exact-name match over an earlier slug-equivalent display name', async () => {
+      // 'Code Review' slugifies to 'code-review' and is listed FIRST; an element
+      // literally named 'code-review' follows. The exact match must win regardless
+      // of list order (Codex review on PR #2433).
+      AgentManager.resetResolvers();
+      AgentManager.setElementManagerResolver((managerName: string) => {
+        if (managerName === 'PersonaManager') {
+          return {
+            list: async () => [
+              {
+                metadata: { name: 'Code Review', type: 'persona' },
+                content: 'Display-named element that slugifies to code-review.'
+              },
+              {
+                metadata: { name: 'code-review', type: 'persona' },
+                content: 'Exactly-named element.'
+              }
+            ]
+          } as any;
+        }
+        return null;
+      });
+
+      fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
+        if (filePath.includes('precedence-agent.md')) {
+          return `---
+name: "Precedence Agent"
+type: "agent"
+version: "2.0.0"
+
+goal:
+  template: "Do {task}"
+  parameters:
+    - name: task
+      type: string
+      required: true
+
+activates:
+  personas:
+    - code-review
+---
+
+# Precedence Agent`;
+        }
+        throw new Error(`Unexpected file read: ${filePath}`);
+      });
+
+      const result: ExecuteAgentResult = await agentManager.executeAgent(
+        'precedence-agent',
+        { task: 'review' }
+      );
+
+      expect(result.activationWarnings ?? []).toHaveLength(0);
+      expect(result.activeElements.personas).toHaveLength(1);
+      expect(result.activeElements.personas[0].content).toBe('Exactly-named element.');
+    });
   });
 
   /**

--- a/tests/unit/elements/agents/AgentManager.executeAgent.test.ts
+++ b/tests/unit/elements/agents/AgentManager.executeAgent.test.ts
@@ -786,17 +786,19 @@ activates:
       expect(result.activeElements.personas[0].content).toBe('CamelCase-named element.');
     });
 
-    it('should not match elements with empty names against any reference', async () => {
-      // normalizeFilename('') → 'unnamed'; an element with a missing name must
-      // not accidentally resolve a reference that also normalizes to 'unnamed'.
+    it('should resolve separator-only names via the unnamed fallback, mirroring saved filenames', async () => {
+      // getElementFilename() saves a '---' name as unnamed.md (normalizeFilename
+      // yields '' and the || 'unnamed' fallback applies). The lookup must use the
+      // identical slug derivation on both sides so the canonical reference
+      // 'unnamed' resolves the element (Codex review on PR #2433, round 3).
       AgentManager.resetResolvers();
       AgentManager.setElementManagerResolver((managerName: string) => {
         if (managerName === 'PersonaManager') {
           return {
             list: async () => [
               {
-                metadata: { name: '', type: 'persona' },
-                content: 'Element with empty name.'
+                metadata: { name: '---', type: 'persona' },
+                content: 'Separator-only-named element.'
               }
             ]
           } as any;
@@ -805,9 +807,9 @@ activates:
       });
 
       fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
-        if (filePath.includes('empty-name-agent.md')) {
+        if (filePath.includes('unnamed-ref-agent.md')) {
           return `---
-name: "Empty Name Agent"
+name: "Unnamed Ref Agent"
 type: "agent"
 version: "2.0.0"
 
@@ -823,19 +825,71 @@ activates:
     - unnamed
 ---
 
-# Empty Name Agent`;
+# Unnamed Ref Agent`;
         }
         throw new Error(`Unexpected file read: ${filePath}`);
       });
 
       const result: ExecuteAgentResult = await agentManager.executeAgent(
-        'empty-name-agent',
+        'unnamed-ref-agent',
+        { task: 'anything' }
+      );
+
+      expect(result.activationWarnings ?? []).toHaveLength(0);
+      expect(result.activeElements.personas).toHaveLength(1);
+      expect(result.activeElements.personas[0].content).toBe('Separator-only-named element.');
+    });
+
+    it('should not resolve unrelated references against separator-only-named elements', async () => {
+      // The unnamed fallback must only answer to the canonical 'unnamed' slug —
+      // a real reference like 'security-analyst' still warns when absent.
+      AgentManager.resetResolvers();
+      AgentManager.setElementManagerResolver((managerName: string) => {
+        if (managerName === 'PersonaManager') {
+          return {
+            list: async () => [
+              {
+                metadata: { name: '---', type: 'persona' },
+                content: 'Separator-only-named element.'
+              }
+            ]
+          } as any;
+        }
+        return null;
+      });
+
+      fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
+        if (filePath.includes('missing-ref-agent.md')) {
+          return `---
+name: "Missing Ref Agent"
+type: "agent"
+version: "2.0.0"
+
+goal:
+  template: "Do {task}"
+  parameters:
+    - name: task
+      type: string
+      required: true
+
+activates:
+  personas:
+    - security-analyst
+---
+
+# Missing Ref Agent`;
+        }
+        throw new Error(`Unexpected file read: ${filePath}`);
+      });
+
+      const result: ExecuteAgentResult = await agentManager.executeAgent(
+        'missing-ref-agent',
         { task: 'anything' }
       );
 
       expect(result.activationWarnings).toBeDefined();
       expect(result.activationWarnings).toHaveLength(1);
-      expect(result.activationWarnings![0].elementName).toBe('unnamed');
+      expect(result.activationWarnings![0].elementName).toBe('security-analyst');
     });
   });
 

--- a/tests/unit/elements/agents/AgentManager.executeAgent.test.ts
+++ b/tests/unit/elements/agents/AgentManager.executeAgent.test.ts
@@ -731,6 +731,112 @@ activates:
       expect(result.activeElements.personas).toHaveLength(1);
       expect(result.activeElements.personas[0].content).toBe('Exactly-named element.');
     });
+
+    it('should resolve camelCase display names via canonical filename normalization', async () => {
+      // Managers save 'BugReport' as bug-report.md (normalizeFilename splits
+      // camelCase), so activates: references use 'bug-report'. Plain slugify
+      // would produce 'bugreport' and miss — the lookup must use the managers'
+      // canonical normalization (Codex review on PR #2433, round 2).
+      AgentManager.resetResolvers();
+      AgentManager.setElementManagerResolver((managerName: string) => {
+        if (managerName === 'PersonaManager') {
+          return {
+            list: async () => [
+              {
+                metadata: { name: 'BugReport', type: 'persona' },
+                content: 'CamelCase-named element.'
+              }
+            ]
+          } as any;
+        }
+        return null;
+      });
+
+      fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
+        if (filePath.includes('camelcase-agent.md')) {
+          return `---
+name: "CamelCase Agent"
+type: "agent"
+version: "2.0.0"
+
+goal:
+  template: "Do {task}"
+  parameters:
+    - name: task
+      type: string
+      required: true
+
+activates:
+  personas:
+    - bug-report
+---
+
+# CamelCase Agent`;
+        }
+        throw new Error(`Unexpected file read: ${filePath}`);
+      });
+
+      const result: ExecuteAgentResult = await agentManager.executeAgent(
+        'camelcase-agent',
+        { task: 'triage' }
+      );
+
+      expect(result.activationWarnings ?? []).toHaveLength(0);
+      expect(result.activeElements.personas).toHaveLength(1);
+      expect(result.activeElements.personas[0].content).toBe('CamelCase-named element.');
+    });
+
+    it('should not match elements with empty names against any reference', async () => {
+      // normalizeFilename('') → 'unnamed'; an element with a missing name must
+      // not accidentally resolve a reference that also normalizes to 'unnamed'.
+      AgentManager.resetResolvers();
+      AgentManager.setElementManagerResolver((managerName: string) => {
+        if (managerName === 'PersonaManager') {
+          return {
+            list: async () => [
+              {
+                metadata: { name: '', type: 'persona' },
+                content: 'Element with empty name.'
+              }
+            ]
+          } as any;
+        }
+        return null;
+      });
+
+      fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
+        if (filePath.includes('empty-name-agent.md')) {
+          return `---
+name: "Empty Name Agent"
+type: "agent"
+version: "2.0.0"
+
+goal:
+  template: "Do {task}"
+  parameters:
+    - name: task
+      type: string
+      required: true
+
+activates:
+  personas:
+    - unnamed
+---
+
+# Empty Name Agent`;
+        }
+        throw new Error(`Unexpected file read: ${filePath}`);
+      });
+
+      const result: ExecuteAgentResult = await agentManager.executeAgent(
+        'empty-name-agent',
+        { task: 'anything' }
+      );
+
+      expect(result.activationWarnings).toBeDefined();
+      expect(result.activationWarnings).toHaveLength(1);
+      expect(result.activationWarnings![0].elementName).toBe('unnamed');
+    });
   });
 
   /**

--- a/tests/unit/elements/agents/AgentManager.executeAgent.test.ts
+++ b/tests/unit/elements/agents/AgentManager.executeAgent.test.ts
@@ -551,6 +551,131 @@ Project context memory.`;
     });
   });
 
+  describe('Test 4b: Slug vs Display-Name Resolution (#2432)', () => {
+    it('should resolve activates: slug references against elements with display names', async () => {
+      // The shipped defaults reference elements by slug (e.g. 'security-analyst')
+      // while the element files carry display names (name: "Security Analyst").
+      // Before #2432, this lookup failed for every such element.
+      AgentManager.resetResolvers();
+      AgentManager.setElementManagerResolver((managerName: string) => {
+        if (managerName === 'PersonaManager') {
+          return {
+            list: async () => [
+              {
+                metadata: { name: 'Security Analyst', type: 'persona' },
+                content: 'You are a security analyst.'
+              }
+            ]
+          } as any;
+        }
+        if (managerName === 'SkillManager') {
+          return {
+            list: async () => [
+              {
+                metadata: { name: 'Code Review', type: 'skill' },
+                instructions: 'Review code for security and quality issues.'
+              }
+            ]
+          } as any;
+        }
+        return null;
+      });
+
+      fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
+        if (filePath.includes('slug-ref-agent.md')) {
+          return `---
+name: "Slug Ref Agent"
+type: "agent"
+version: "2.0.0"
+
+goal:
+  template: "Review code in {directory}"
+  parameters:
+    - name: directory
+      type: string
+      required: true
+
+activates:
+  personas:
+    - security-analyst
+  skills:
+    - code-review
+---
+
+# Slug Ref Agent`;
+        }
+        throw new Error(`Unexpected file read: ${filePath}`);
+      });
+
+      const result: ExecuteAgentResult = await agentManager.executeAgent(
+        'slug-ref-agent',
+        { directory: 'src' }
+      );
+
+      expect(result.activationWarnings ?? []).toHaveLength(0);
+
+      expect(result.activeElements.personas).toBeDefined();
+      expect(result.activeElements.personas).toHaveLength(1);
+      expect(result.activeElements.personas[0].name).toBe('security-analyst');
+      expect(result.activeElements.personas[0].content).toBe('You are a security analyst.');
+
+      expect(result.activeElements.skills).toBeDefined();
+      expect(result.activeElements.skills).toHaveLength(1);
+      expect(result.activeElements.skills[0].name).toBe('code-review');
+      expect(result.activeElements.skills[0].content).toBe('Review code for security and quality issues.');
+    });
+
+    it('should still resolve exact display-name references unchanged', async () => {
+      AgentManager.resetResolvers();
+      AgentManager.setElementManagerResolver((managerName: string) => {
+        if (managerName === 'PersonaManager') {
+          return {
+            list: async () => [
+              {
+                metadata: { name: 'Security Analyst', type: 'persona' },
+                content: 'You are a security analyst.'
+              }
+            ]
+          } as any;
+        }
+        return null;
+      });
+
+      fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
+        if (filePath.includes('display-ref-agent.md')) {
+          return `---
+name: "Display Ref Agent"
+type: "agent"
+version: "2.0.0"
+
+goal:
+  template: "Do {task}"
+  parameters:
+    - name: task
+      type: string
+      required: true
+
+activates:
+  personas:
+    - Security Analyst
+---
+
+# Display Ref Agent`;
+        }
+        throw new Error(`Unexpected file read: ${filePath}`);
+      });
+
+      const result: ExecuteAgentResult = await agentManager.executeAgent(
+        'display-ref-agent',
+        { task: 'review' }
+      );
+
+      expect(result.activationWarnings ?? []).toHaveLength(0);
+      expect(result.activeElements.personas).toHaveLength(1);
+      expect(result.activeElements.personas[0].content).toBe('You are a security analyst.');
+    });
+  });
+
   /**
    * Test 5: Agent Without Activates (Minimal)
    *

--- a/tests/unit/elements/agents/AgentManager.executeAgent.test.ts
+++ b/tests/unit/elements/agents/AgentManager.executeAgent.test.ts
@@ -891,6 +891,61 @@ activates:
       expect(result.activationWarnings).toHaveLength(1);
       expect(result.activationWarnings![0].elementName).toBe('security-analyst');
     });
+
+    it('should warn on empty references instead of matching unnamed-fallback elements', async () => {
+      // validateActivates() only warns on empty entries, so activates: [''] reaches
+      // the lookup. An empty reference must stay unresolved — not ride the
+      // 'unnamed' fallback onto a separator-only-named element (Codex review on
+      // PR #2433, round 4).
+      AgentManager.resetResolvers();
+      AgentManager.setElementManagerResolver((managerName: string) => {
+        if (managerName === 'PersonaManager') {
+          return {
+            list: async () => [
+              {
+                metadata: { name: '---', type: 'persona' },
+                content: 'Separator-only-named element.'
+              }
+            ]
+          } as any;
+        }
+        return null;
+      });
+
+      fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
+        if (filePath.includes('empty-ref-agent.md')) {
+          return `---
+name: "Empty Ref Agent"
+type: "agent"
+version: "2.0.0"
+
+goal:
+  template: "Do {task}"
+  parameters:
+    - name: task
+      type: string
+      required: true
+
+activates:
+  personas:
+    - ""
+---
+
+# Empty Ref Agent`;
+        }
+        throw new Error(`Unexpected file read: ${filePath}`);
+      });
+
+      const result: ExecuteAgentResult = await agentManager.executeAgent(
+        'empty-ref-agent',
+        { task: 'anything' }
+      );
+
+      expect(result.activationWarnings).toBeDefined();
+      expect(result.activationWarnings).toHaveLength(1);
+      expect(result.activationWarnings![0].elementType).toBe('personas');
+      expect(result.activeElements.personas ?? []).toHaveLength(0);
+    });
   });
 
   /**


### PR DESCRIPTION
Standard post-release sync, pattern of the 2.0.36–2.0.38 sync branches.

Brings into develop:
- Agent `activates:` slug-resolution fix + regression tests (#2432, hotfix PR #2433)
- v2.0.39 version bump + CHANGELOG (release PR #2435)

Merge was conflict-free; `AgentManager.executeAgent` suite green on the merged tree (31/31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQRTwMr51bnDYYEfaojLdu