### PR TITLE
fix(agents): port activates: slug resolution fix to beta

### DIFF
--- a/src/elements/agents/AgentManager.ts
+++ b/src/elements/agents/AgentManager.ts
@@ -1768,7 +1768,26 @@ export class AgentManager extends BaseElementManager<Agent> {
 
       // Get all elements of this type
       const elements = await manager.list();
-      const element = elements.find(e => e.metadata.name === elementName);
+      // Issue #2432: activates: references use canonical filename slugs (e.g.
+      // 'security-analyst', 'bug-report') while element metadata carries display
+      // names ('Security Analyst', 'BugReport'). Exact-name matches win across the
+      // full list; otherwise candidates map through the same slug derivation
+      // getElementFilename() uses when saving — normalizeFilename with its
+      // empty-result 'unnamed' fallback — so a reference resolves exactly when it
+      // matches the element's on-disk filename. The fallback applies only to
+      // candidates: a reference that is empty or normalizes to nothing ('', '   ',
+      // '---') can never name a saved file and stays unresolved.
+      const canonicalSlug = (name: string): string => this.normalizeFilename(name) || 'unnamed';
+      const trimmedReference = elementName.trim();
+      const normalizedTarget = trimmedReference ? this.normalizeFilename(trimmedReference) : '';
+      const element =
+        elements.find(e => e.metadata.name === elementName) ??
+        (normalizedTarget
+          ? elements.find(e =>
+              typeof e.metadata.name === 'string' &&
+              canonicalSlug(e.metadata.name) === normalizedTarget
+            )
+          : undefined);
 
       if (!element) {
         throw new Error(`${elementType} '${elementName}' not found`);

--- a/tests/unit/elements/agents/AgentManager.executeAgent.test.ts
+++ b/tests/unit/elements/agents/AgentManager.executeAgent.test.ts
@@ -560,6 +560,396 @@ Project context memory.`;
     });
   });
 
+  describe('Test 4b: Slug vs Display-Name Resolution (#2432)', () => {
+    it('should resolve activates: slug references against elements with display names', async () => {
+      // The shipped defaults reference elements by slug (e.g. 'security-analyst')
+      // while the element files carry display names (name: "Security Analyst").
+      // Before #2432, this lookup failed for every such element.
+      agentManager.setElementManagerResolver((managerName: string) => {
+        if (managerName === 'PersonaManager') {
+          return {
+            list: async () => [
+              {
+                metadata: { name: 'Security Analyst', type: 'persona' },
+                content: 'You are a security analyst.'
+              }
+            ]
+          } as any;
+        }
+        if (managerName === 'SkillManager') {
+          return {
+            list: async () => [
+              {
+                metadata: { name: 'Code Review', type: 'skill' },
+                instructions: 'Review code for security and quality issues.'
+              }
+            ]
+          } as any;
+        }
+        return null;
+      });
+
+      fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
+        if (filePath.includes('slug-ref-agent.md')) {
+          return `---
+name: "Slug Ref Agent"
+type: "agent"
+version: "2.0.0"
+
+goal:
+  template: "Review code in {directory}"
+  parameters:
+    - name: directory
+      type: string
+      required: true
+
+activates:
+  personas:
+    - security-analyst
+  skills:
+    - code-review
+---
+
+# Slug Ref Agent`;
+        }
+        throw new Error(`Unexpected file read: ${filePath}`);
+      });
+
+      const result: ExecuteAgentResult = await agentManager.executeAgent(
+        'slug-ref-agent',
+        { directory: 'src' }
+      );
+
+      expect(result.activationWarnings ?? []).toHaveLength(0);
+
+      expect(result.activeElements.personas).toBeDefined();
+      expect(result.activeElements.personas).toHaveLength(1);
+      expect(result.activeElements.personas[0].name).toBe('security-analyst');
+      expect(result.activeElements.personas[0].content).toBe('You are a security analyst.');
+
+      expect(result.activeElements.skills).toBeDefined();
+      expect(result.activeElements.skills).toHaveLength(1);
+      expect(result.activeElements.skills[0].name).toBe('code-review');
+      expect(result.activeElements.skills[0].content).toBe('Review code for security and quality issues.');
+    });
+
+    it('should still resolve exact display-name references unchanged', async () => {
+      agentManager.setElementManagerResolver((managerName: string) => {
+        if (managerName === 'PersonaManager') {
+          return {
+            list: async () => [
+              {
+                metadata: { name: 'Security Analyst', type: 'persona' },
+                content: 'You are a security analyst.'
+              }
+            ]
+          } as any;
+        }
+        return null;
+      });
+
+      fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
+        if (filePath.includes('display-ref-agent.md')) {
+          return `---
+name: "Display Ref Agent"
+type: "agent"
+version: "2.0.0"
+
+goal:
+  template: "Do {task}"
+  parameters:
+    - name: task
+      type: string
+      required: true
+
+activates:
+  personas:
+    - Security Analyst
+---
+
+# Display Ref Agent`;
+        }
+        throw new Error(`Unexpected file read: ${filePath}`);
+      });
+
+      const result: ExecuteAgentResult = await agentManager.executeAgent(
+        'display-ref-agent',
+        { task: 'review' }
+      );
+
+      expect(result.activationWarnings ?? []).toHaveLength(0);
+      expect(result.activeElements.personas).toHaveLength(1);
+      expect(result.activeElements.personas[0].content).toBe('You are a security analyst.');
+    });
+
+    it('should prefer an exact-name match over an earlier slug-equivalent display name', async () => {
+      // 'Code Review' slugifies to 'code-review' and is listed FIRST; an element
+      // literally named 'code-review' follows. The exact match must win regardless
+      // of list order (Codex review on PR #2433).
+      agentManager.setElementManagerResolver((managerName: string) => {
+        if (managerName === 'PersonaManager') {
+          return {
+            list: async () => [
+              {
+                metadata: { name: 'Code Review', type: 'persona' },
+                content: 'Display-named element that slugifies to code-review.'
+              },
+              {
+                metadata: { name: 'code-review', type: 'persona' },
+                content: 'Exactly-named element.'
+              }
+            ]
+          } as any;
+        }
+        return null;
+      });
+
+      fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
+        if (filePath.includes('precedence-agent.md')) {
+          return `---
+name: "Precedence Agent"
+type: "agent"
+version: "2.0.0"
+
+goal:
+  template: "Do {task}"
+  parameters:
+    - name: task
+      type: string
+      required: true
+
+activates:
+  personas:
+    - code-review
+---
+
+# Precedence Agent`;
+        }
+        throw new Error(`Unexpected file read: ${filePath}`);
+      });
+
+      const result: ExecuteAgentResult = await agentManager.executeAgent(
+        'precedence-agent',
+        { task: 'review' }
+      );
+
+      expect(result.activationWarnings ?? []).toHaveLength(0);
+      expect(result.activeElements.personas).toHaveLength(1);
+      expect(result.activeElements.personas[0].content).toBe('Exactly-named element.');
+    });
+
+    it('should resolve camelCase display names via canonical filename normalization', async () => {
+      // Managers save 'BugReport' as bug-report.md (normalizeFilename splits
+      // camelCase), so activates: references use 'bug-report'. Plain slugify
+      // would produce 'bugreport' and miss — the lookup must use the managers'
+      // canonical normalization (Codex review on PR #2433, round 2).
+      agentManager.setElementManagerResolver((managerName: string) => {
+        if (managerName === 'PersonaManager') {
+          return {
+            list: async () => [
+              {
+                metadata: { name: 'BugReport', type: 'persona' },
+                content: 'CamelCase-named element.'
+              }
+            ]
+          } as any;
+        }
+        return null;
+      });
+
+      fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
+        if (filePath.includes('camelcase-agent.md')) {
+          return `---
+name: "Camelcase Agent"
+type: "agent"
+version: "2.0.0"
+
+goal:
+  template: "Do {task}"
+  parameters:
+    - name: task
+      type: string
+      required: true
+
+activates:
+  personas:
+    - bug-report
+---
+
+# CamelCase Agent`;
+        }
+        throw new Error(`Unexpected file read: ${filePath}`);
+      });
+
+      const result: ExecuteAgentResult = await agentManager.executeAgent(
+        'camelcase-agent',
+        { task: 'triage' }
+      );
+
+      expect(result.activationWarnings ?? []).toHaveLength(0);
+      expect(result.activeElements.personas).toHaveLength(1);
+      expect(result.activeElements.personas[0].content).toBe('CamelCase-named element.');
+    });
+
+    it('should resolve separator-only names via the unnamed fallback, mirroring saved filenames', async () => {
+      // getElementFilename() saves a '---' name as unnamed.md (normalizeFilename
+      // yields '' and the || 'unnamed' fallback applies). The lookup must use the
+      // identical slug derivation on both sides so the canonical reference
+      // 'unnamed' resolves the element (Codex review on PR #2433, round 3).
+      agentManager.setElementManagerResolver((managerName: string) => {
+        if (managerName === 'PersonaManager') {
+          return {
+            list: async () => [
+              {
+                metadata: { name: '---', type: 'persona' },
+                content: 'Separator-only-named element.'
+              }
+            ]
+          } as any;
+        }
+        return null;
+      });
+
+      fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
+        if (filePath.includes('unnamed-ref-agent.md')) {
+          return `---
+name: "Unnamed Ref Agent"
+type: "agent"
+version: "2.0.0"
+
+goal:
+  template: "Do {task}"
+  parameters:
+    - name: task
+      type: string
+      required: true
+
+activates:
+  personas:
+    - unnamed
+---
+
+# Unnamed Ref Agent`;
+        }
+        throw new Error(`Unexpected file read: ${filePath}`);
+      });
+
+      const result: ExecuteAgentResult = await agentManager.executeAgent(
+        'unnamed-ref-agent',
+        { task: 'anything' }
+      );
+
+      expect(result.activationWarnings ?? []).toHaveLength(0);
+      expect(result.activeElements.personas).toHaveLength(1);
+      expect(result.activeElements.personas[0].content).toBe('Separator-only-named element.');
+    });
+
+    it('should not resolve unrelated references against separator-only-named elements', async () => {
+      // The unnamed fallback must only answer to the canonical 'unnamed' slug —
+      // a real reference like 'security-analyst' still warns when absent.
+      agentManager.setElementManagerResolver((managerName: string) => {
+        if (managerName === 'PersonaManager') {
+          return {
+            list: async () => [
+              {
+                metadata: { name: '---', type: 'persona' },
+                content: 'Separator-only-named element.'
+              }
+            ]
+          } as any;
+        }
+        return null;
+      });
+
+      fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
+        if (filePath.includes('missing-ref-agent.md')) {
+          return `---
+name: "Missing Ref Agent"
+type: "agent"
+version: "2.0.0"
+
+goal:
+  template: "Do {task}"
+  parameters:
+    - name: task
+      type: string
+      required: true
+
+activates:
+  personas:
+    - security-analyst
+---
+
+# Missing Ref Agent`;
+        }
+        throw new Error(`Unexpected file read: ${filePath}`);
+      });
+
+      const result: ExecuteAgentResult = await agentManager.executeAgent(
+        'missing-ref-agent',
+        { task: 'anything' }
+      );
+
+      expect(result.activationWarnings).toBeDefined();
+      expect(result.activationWarnings).toHaveLength(1);
+      expect(result.activationWarnings![0].elementName).toBe('security-analyst');
+    });
+
+    it('should warn on empty references instead of matching unnamed-fallback elements', async () => {
+      // validateActivates() only warns on empty entries, so activates: [''] reaches
+      // the lookup. An empty reference must stay unresolved — not ride the
+      // 'unnamed' fallback onto a separator-only-named element (Codex review on
+      // PR #2433, round 4).
+      agentManager.setElementManagerResolver((managerName: string) => {
+        if (managerName === 'PersonaManager') {
+          return {
+            list: async () => [
+              {
+                metadata: { name: '---', type: 'persona' },
+                content: 'Separator-only-named element.'
+              }
+            ]
+          } as any;
+        }
+        return null;
+      });
+
+      fileOperationsService.readFile.mockImplementation(async (filePath: string) => {
+        if (filePath.includes('empty-ref-agent.md')) {
+          return `---
+name: "Empty Ref Agent"
+type: "agent"
+version: "2.0.0"
+
+goal:
+  template: "Do {task}"
+  parameters:
+    - name: task
+      type: string
+      required: true
+
+activates:
+  personas:
+    - ""
+---
+
+# Empty Ref Agent`;
+        }
+        throw new Error(`Unexpected file read: ${filePath}`);
+      });
+
+      const result: ExecuteAgentResult = await agentManager.executeAgent(
+        'empty-ref-agent',
+        { task: 'anything' }
+      );
+
+      expect(result.activationWarnings).toBeDefined();
+      expect(result.activationWarnings).toHaveLength(1);
+      expect(result.activationWarnings![0].elementType).toBe('personas');
+      expect(result.activeElements.personas ?? []).toHaveLength(0);
+    });
+  });
+
   /**
    * Test 5: Agent Without Activates (Minimal)
    *


### PR DESCRIPTION
## Summary

Beta port of #2432 (fixed on main in #2433, released as v2.0.39) — the final four-round resolver, not the original one-liner:

- Agent `activates:` slug references (`security-analyst`) never resolved display-named elements (`Security Analyst`), so every agent silently ran without its declared personas/skills while its tool sandbox fully applied.
- Lookup now: exact display-name match wins across the full list → candidate-side fallback to the canonical filename slug (`normalizeFilename` + `'unnamed'` fallback, mirroring `getElementFilename()`) → degenerate references (empty/separator-only) warn instead of resolving.

**Behavior change (same note as the v2.0.39 release):** agents that previously ran bare will start loading their full declared context.

## Beta adaptations

- Tests use the instance-level `agentManager.setElementManagerResolver` (#1948 refactor) instead of main's static resolver.
- camelCase fixture agent renamed `Camelcase Agent` — beta's `read()` validates that the metadata name normalizes to the requested identifier; main's did not.

## Tests

All seven regression tests from the main PR ported (Test 4b suite): 31/31 green, `tsc --noEmit` clean, red/green verified (resolution tests fail on unfixed beta code).

Pattern: hotfix/*-beta per #2338/#2342/#2344. Closes out the branch checklist in #2432 (main ✅ v2.0.39, develop via #2436, beta this PR; `codex/hosted-http-integration` inherits on next sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQRTwMr51bnDYYEfaojLdu