### PR TITLE
fix: preserve Unicode allowlist access across upgrades

### DIFF
--- a/docs/guides/production-hosting-runbook.md
+++ b/docs/guides/production-hosting-runbook.md
@@ -148,7 +148,18 @@ For **filesystem mode** (no DB), the same CLI works, OR you can edit `~/.dollhou
 
 **Match rules:** the gate ORs across all configured kinds. An entry matches if **any** of the verified identity values (email, GitHub username, GitHub numeric ID) is on the list. Values use NFC canonicalization without rewriting cross-script look-alikes. Email and GitHub username comparison remains case-insensitive without mapping look-alikes across scripts; numeric IDs remain exact.
 
-**Unicode normalization upgrades:** database migration `0045_normalize_allowlist_identities` rebuilds persisted lookup keys from the preserved identity and keeps indexed sign-in checks intact. Back up PostgreSQL before upgrading. The migration aborts before changing data if two active entries would become the same canonical identity; remove or revoke the duplicate identified by an allowlist inventory, then rerun the migration. Do not start the new application version against an older schema. Rolling back the application after the migration is safe because NFC-normalized values remain compatible with the older lookup behavior; restore the pre-upgrade database backup only if the original byte representation itself must be recovered. Filesystem deployments canonicalize legacy values while matching and persist the canonical form on the next allowlist write.
+**Unicode normalization upgrades:** database migration `0045_normalize_allowlist_identities` canonicalizes the authoritative `auth_allowlist` and keeps its indexed sign-in checks intact. Back up PostgreSQL before upgrading. The migration aborts before changing data if two active entries would become the same canonical identity; remove or revoke the duplicate identified by an allowlist inventory, then rerun the migration. Do not start the new application version against an older schema. Rolling back the application after the migration is safe because NFC-normalized values remain compatible with the older lookup behavior; restore the pre-upgrade database backup only if the original byte representation itself must be recovered. Filesystem deployments canonicalize legacy values while matching and persist the canonical form on the next allowlist write.
+
+Older `account_allowlist_entries` need an additional review before that currently dormant console table can become the sign-in authority. Some earlier builds applied a lossy confusable-character mapping before storing both `display_value` and `normalized_value`; the original principal cannot be recovered reliably from either column. Migration 0045 copies every active legacy row into `account_allowlist_identity_migration_reviews` before rebuilding the best available NFC lookup key. Do not enable account-allowlist authority cutover while this query returns rows:
+
+```sql
+SELECT entry_id, kind, legacy_display_value, legacy_normalized_value
+FROM account_allowlist_identity_migration_reviews
+WHERE reviewed_at IS NULL
+ORDER BY captured_at, entry_id;
+```
+
+For each result, verify the intended principal against the external identity provider. Revoke and recreate an entry if the stored display value is not the intended principal, then record the review with a timestamp and a non-sensitive note. This explicit operator step avoids making visually similar cross-script identities equivalent during migration.
 
 **Denial behavior:** a denied user sees an "Access denied" HTML page (not a raw JSON error), and an `auth.allowlist_denied` event lands in `auth_identity_events` with their identity values for operator diagnosis. The audit log is queryable via `psql` or the future web console.
 

--- a/docs/guides/production-hosting-runbook.md
+++ b/docs/guides/production-hosting-runbook.md
@@ -146,7 +146,9 @@ docker compose run --rm dollhousemcp \
 
 For **filesystem mode** (no DB), the same CLI works, OR you can edit `~/.dollhouse/auth/allowlist.json` directly — the server picks up changes within ~1 second via fsnotify, no restart needed.
 
-**Match rules:** the gate ORs across all configured kinds. An entry matches if **any** of the verified identity values (email, GitHub username, GitHub numeric ID) is on the list. Values are lowercased on insert; matching is case-insensitive for emails and usernames.
+**Match rules:** the gate ORs across all configured kinds. An entry matches if **any** of the verified identity values (email, GitHub username, GitHub numeric ID) is on the list. Values use NFC canonicalization without rewriting cross-script look-alikes. Email and GitHub username comparison remains case-insensitive without mapping look-alikes across scripts; numeric IDs remain exact.
+
+**Unicode normalization upgrades:** database migration `0045_normalize_allowlist_identities` rebuilds persisted lookup keys from the preserved identity and keeps indexed sign-in checks intact. Back up PostgreSQL before upgrading. The migration aborts before changing data if two active entries would become the same canonical identity; remove or revoke the duplicate identified by an allowlist inventory, then rerun the migration. Do not start the new application version against an older schema. Rolling back the application after the migration is safe because NFC-normalized values remain compatible with the older lookup behavior; restore the pre-upgrade database backup only if the original byte representation itself must be recovered. Filesystem deployments canonicalize legacy values while matching and persist the canonical form on the next allowlist write.
 
 **Denial behavior:** a denied user sees an "Access denied" HTML page (not a raw JSON error), and an `auth.allowlist_denied` event lands in `auth_identity_events` with their identity values for operator diagnosis. The audit log is queryable via `psql` or the future web console.
 

--- a/docs/guides/production-hosting-runbook.md
+++ b/docs/guides/production-hosting-runbook.md
@@ -159,7 +159,7 @@ WHERE reviewed_at IS NULL
 ORDER BY captured_at, entry_id;
 ```
 
-For each result, verify the intended principal against the external identity provider. Revoke and recreate an entry if the stored display value is not the intended principal, then record the review with a timestamp and a non-sensitive note. This explicit operator step avoids making visually similar cross-script identities equivalent during migration.
+For each result, verify the intended principal against the external identity provider. Revoke and recreate an entry if the stored display value is not the intended principal, then record the review with a timestamp and a non-sensitive note. Embedded PostgreSQL startup fails closed while any review remains pending, so the uncertain table cannot silently become the live sign-in authority. This explicit operator step avoids making visually similar cross-script identities equivalent during migration.
 
 **Denial behavior:** a denied user sees an "Access denied" HTML page (not a raw JSON error), and an `auth.allowlist_denied` event lands in `auth_identity_events` with their identity values for operator diagnosis. The audit log is queryable via `psql` or the future web console.
 

--- a/src/auth/embedded-as/allowlistIdentity.ts
+++ b/src/auth/embedded-as/allowlistIdentity.ts
@@ -17,3 +17,19 @@ export function normalizeAuthAllowlistValue(
   const principal = normalizeAuthAllowlistPrincipal(value);
   return kind === 'github_id' ? principal : principal.toLowerCase();
 }
+
+/**
+ * Compare a persisted allowlist value with a presented identity.
+ *
+ * Older durable stores may contain canonically equivalent NFD values.
+ * Normalize both sides at the comparison boundary so upgrades preserve
+ * access without introducing cross-script confusable rewriting.
+ */
+export function storedAuthAllowlistValueMatches(
+  kind: AuthAllowlistKind,
+  storedValue: string,
+  presentedValue: string,
+): boolean {
+  return normalizeAuthAllowlistValue(kind, storedValue)
+    === normalizeAuthAllowlistValue(kind, presentedValue);
+}

--- a/src/auth/embedded-as/storage/FilesystemAuthStorageLayer.ts
+++ b/src/auth/embedded-as/storage/FilesystemAuthStorageLayer.ts
@@ -777,7 +777,7 @@ export class FilesystemAuthStorageLayer implements IAuthStorageLayer {
         });
         return [];
       }
-      return parsed
+      const entries = parsed
         .filter((e): e is AuthAllowlistEntry & { createdAt: string | Date } =>
           typeof e === 'object' && e !== null
           && typeof (e as { id?: unknown }).id === 'string'
@@ -792,6 +792,7 @@ export class FilesystemAuthStorageLayer implements IAuthStorageLayer {
           createdBy: typeof e.createdBy === 'string' ? e.createdBy : null,
           createdAt: typeof e.createdAt === 'string' ? new Date(e.createdAt) : e.createdAt,
         }));
+      return canonicalizePersistedAllowlist(entries, this.allowlistPath);
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       if (code === 'ENOENT') return [];
@@ -805,6 +806,26 @@ export class FilesystemAuthStorageLayer implements IAuthStorageLayer {
       throw err;
     }
   }
+}
+
+function canonicalizePersistedAllowlist(
+  entries: AuthAllowlistEntry[],
+  allowlistPath: string,
+): AuthAllowlistEntry[] {
+  const canonicalKeys = new Map<string, string>();
+  return entries.map(entry => {
+    const value = normalizeAuthAllowlistValue(entry.kind, entry.value);
+    const key = `${entry.kind}\u0000${value}`;
+    const existingId = canonicalKeys.get(key);
+    if (existingId !== undefined && existingId !== entry.id) {
+      throw new Error(
+        `allowlist normalization collision in ${allowlistPath}: entries ` +
+        `${existingId} and ${entry.id} resolve to the same ${entry.kind} identity`,
+      );
+    }
+    canonicalKeys.set(key, entry.id);
+    return { ...entry, value };
+  });
 }
 
 function serializeAllowlist(entries: AuthAllowlistEntry[]): string {

--- a/src/auth/embedded-as/storage/FilesystemAuthStorageLayer.ts
+++ b/src/auth/embedded-as/storage/FilesystemAuthStorageLayer.ts
@@ -701,7 +701,7 @@ export class FilesystemAuthStorageLayer implements IAuthStorageLayer {
     return this.locks.withLock(`auth:allowlist:${this.allowlistPath}`, async () => {
       const entries = await this.readAllowlistRaw();
       const value = normalizeAuthAllowlistValue(input.kind, input.value);
-      const duplicate = entries.find(e =>
+      const duplicate = entries.some(e =>
         e.kind === input.kind && storedAuthAllowlistValueMatches(input.kind, e.value, value));
       if (duplicate) {
         throw new Error(`allowlist entry already exists for kind=${input.kind} value=${value}`);
@@ -749,15 +749,13 @@ export class FilesystemAuthStorageLayer implements IAuthStorageLayer {
   async allowlistMatchesIdentity(values: AllowlistMatchValues): Promise<boolean> {
     const entries = await this.readAllowlist();
     if (entries.length === 0) return false;
-    const email = values.email && normalizeAuthAllowlistValue('email', values.email);
-    const githubUsername = values.githubUsername && normalizeAuthAllowlistValue('github_username', values.githubUsername);
-    const githubId = values.githubId && normalizeAuthAllowlistValue('github_id', values.githubId);
     for (const e of entries) {
-      if (e.kind === 'email' && email && storedAuthAllowlistValueMatches(e.kind, e.value, email)) return true;
-      if (e.kind === 'github_username' && githubUsername &&
-        storedAuthAllowlistValueMatches(e.kind, e.value, githubUsername)) return true;
-      if (e.kind === 'github_id' && githubId &&
-        storedAuthAllowlistValueMatches(e.kind, e.value, githubId)) return true;
+      if (e.kind === 'email' && values.email &&
+        storedAuthAllowlistValueMatches(e.kind, e.value, values.email)) return true;
+      if (e.kind === 'github_username' && values.githubUsername &&
+        storedAuthAllowlistValueMatches(e.kind, e.value, values.githubUsername)) return true;
+      if (e.kind === 'github_id' && values.githubId &&
+        storedAuthAllowlistValueMatches(e.kind, e.value, values.githubId)) return true;
     }
     return false;
   }

--- a/src/auth/embedded-as/storage/FilesystemAuthStorageLayer.ts
+++ b/src/auth/embedded-as/storage/FilesystemAuthStorageLayer.ts
@@ -46,7 +46,10 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { logger } from '../../../utils/logger.js';
 import { FileLockManager } from '../../../security/fileLockManager.js';
-import { normalizeAuthAllowlistValue } from '../allowlistIdentity.js';
+import {
+  normalizeAuthAllowlistValue,
+  storedAuthAllowlistValueMatches,
+} from '../allowlistIdentity.js';
 import type {
   AllowlistAddInput,
   AllowlistMatchValues,
@@ -698,7 +701,8 @@ export class FilesystemAuthStorageLayer implements IAuthStorageLayer {
     return this.locks.withLock(`auth:allowlist:${this.allowlistPath}`, async () => {
       const entries = await this.readAllowlistRaw();
       const value = normalizeAuthAllowlistValue(input.kind, input.value);
-      const duplicate = entries.find(e => e.kind === input.kind && e.value === value);
+      const duplicate = entries.find(e =>
+        e.kind === input.kind && storedAuthAllowlistValueMatches(input.kind, e.value, value));
       if (duplicate) {
         throw new Error(`allowlist entry already exists for kind=${input.kind} value=${value}`);
       }
@@ -749,9 +753,11 @@ export class FilesystemAuthStorageLayer implements IAuthStorageLayer {
     const githubUsername = values.githubUsername && normalizeAuthAllowlistValue('github_username', values.githubUsername);
     const githubId = values.githubId && normalizeAuthAllowlistValue('github_id', values.githubId);
     for (const e of entries) {
-      if (e.kind === 'email' && email && e.value === email) return true;
-      if (e.kind === 'github_username' && githubUsername && e.value === githubUsername) return true;
-      if (e.kind === 'github_id' && githubId && e.value === githubId) return true;
+      if (e.kind === 'email' && email && storedAuthAllowlistValueMatches(e.kind, e.value, email)) return true;
+      if (e.kind === 'github_username' && githubUsername &&
+        storedAuthAllowlistValueMatches(e.kind, e.value, githubUsername)) return true;
+      if (e.kind === 'github_id' && githubId &&
+        storedAuthAllowlistValueMatches(e.kind, e.value, githubId)) return true;
     }
     return false;
   }

--- a/src/database/migrations/0045_normalize_allowlist_identities.sql
+++ b/src/database/migrations/0045_normalize_allowlist_identities.sql
@@ -25,10 +25,56 @@ UPDATE "auth_allowlist"
 SET "value" = normalize(btrim("value"), NFC)
 WHERE "value" IS DISTINCT FROM normalize(btrim("value"), NFC);
 
--- Console rows retain display_value specifically so normalization policy can be
--- upgraded without guessing the intended principal from an older lookup key.
--- Recompute the active-key candidate from that preserved identity, then fail
--- closed if the new key would collide.
+-- Versions deployed between the account-allowlist introduction and the
+-- NFC-only identity policy passed display_value through a lossy confusable
+-- mapping. For those rows, neither persisted column can prove the principal
+-- originally entered by the operator. Preserve a durable pre-migration ledger
+-- so operators must verify or recreate every legacy active entry before this
+-- dormant console table is promoted to the sign-in authority. Do not restore
+-- the lossy matcher: that would make distinct cross-script principals equal.
+CREATE TABLE IF NOT EXISTS "account_allowlist_identity_migration_reviews" (
+  "entry_id" UUID PRIMARY KEY,
+  "kind" TEXT NOT NULL,
+  "legacy_normalized_value" TEXT NOT NULL,
+  "legacy_display_value" TEXT NOT NULL,
+  "captured_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "reviewed_at" TIMESTAMPTZ,
+  "review_note" TEXT
+);
+
+INSERT INTO "account_allowlist_identity_migration_reviews" (
+  "entry_id",
+  "kind",
+  "legacy_normalized_value",
+  "legacy_display_value"
+)
+SELECT
+  "id",
+  "kind",
+  "normalized_value",
+  "display_value"
+FROM "account_allowlist_entries"
+WHERE "revoked_at" IS NULL
+ON CONFLICT ("entry_id") DO NOTHING;
+
+DO $$
+DECLARE
+  pending_review_count BIGINT;
+BEGIN
+  SELECT count(*) INTO pending_review_count
+  FROM "account_allowlist_identity_migration_reviews"
+  WHERE "reviewed_at" IS NULL;
+
+  IF pending_review_count > 0 THEN
+    RAISE WARNING
+      '% active console allowlist entries require identity review before account-allowlist authority cutover',
+      pending_review_count;
+  END IF;
+END $$;
+
+-- Recompute the best available active-key candidate from display_value for
+-- NFC/casing compatibility, then fail closed if those candidates collide.
+-- The review ledger above is the authority for legacy-origin uncertainty.
 DO $$
 BEGIN
   IF EXISTS (

--- a/src/database/migrations/0045_normalize_allowlist_identities.sql
+++ b/src/database/migrations/0045_normalize_allowlist_identities.sql
@@ -83,6 +83,8 @@ BEGIN
       SELECT
         "kind",
         CASE
+          -- Keep casing ASCII-only. PostgreSQL lower() is locale-aware and can
+          -- alter a non-ASCII security principal.
           WHEN "kind" IN ('email', 'github_username') THEN translate(
             normalize(btrim("display_value"), NFC),
             'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
@@ -104,6 +106,8 @@ END $$;
 UPDATE "account_allowlist_entries"
 SET
   "normalized_value" = CASE
+    -- Keep casing ASCII-only. PostgreSQL lower() is locale-aware and can alter
+    -- a non-ASCII security principal.
     WHEN "kind" IN ('email', 'github_username') THEN translate(
       normalize(btrim("display_value"), NFC),
       'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
@@ -113,12 +117,16 @@ SET
   END,
   "display_value" = normalize(btrim("display_value"), NFC)
 WHERE
-  "normalized_value" IS DISTINCT FROM CASE
-    WHEN "kind" IN ('email', 'github_username') THEN translate(
-      normalize(btrim("display_value"), NFC),
-      'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
-      'abcdefghijklmnopqrstuvwxyz'
-    )
-    ELSE normalize(btrim("display_value"), NFC)
-  END
-  OR "display_value" IS DISTINCT FROM normalize(btrim("display_value"), NFC);
+  "revoked_at" IS NULL
+  AND (
+    "normalized_value" IS DISTINCT FROM CASE
+      -- Match the ASCII-only casing policy used above.
+      WHEN "kind" IN ('email', 'github_username') THEN translate(
+        normalize(btrim("display_value"), NFC),
+        'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+        'abcdefghijklmnopqrstuvwxyz'
+      )
+      ELSE normalize(btrim("display_value"), NFC)
+    END
+    OR "display_value" IS DISTINCT FROM normalize(btrim("display_value"), NFC)
+  );

--- a/src/database/migrations/0045_normalize_allowlist_identities.sql
+++ b/src/database/migrations/0045_normalize_allowlist_identities.sql
@@ -1,0 +1,78 @@
+-- Canonicalize authorization allowlist identities written before the NFC-only
+-- identity policy. This migration deliberately does not use compatibility or
+-- confusable mappings: visually similar characters from different scripts must
+-- remain distinct security principals.
+
+-- Abort before changing data if NFC + trim would collapse two embedded-AS rows.
+-- The existing unique index cannot detect canonically equivalent byte sequences.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM (
+      SELECT "kind", normalize(btrim("value"), NFC) AS "next_value"
+      FROM "auth_allowlist"
+    ) AS "canonical_auth_allowlist"
+    GROUP BY "kind", "next_value"
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION
+      'auth_allowlist contains identities that collide after NFC normalization; resolve them before upgrading';
+  END IF;
+END $$;
+
+UPDATE "auth_allowlist"
+SET "value" = normalize(btrim("value"), NFC)
+WHERE "value" IS DISTINCT FROM normalize(btrim("value"), NFC);
+
+-- Console rows retain display_value specifically so normalization policy can be
+-- upgraded without guessing the intended principal from an older lookup key.
+-- Recompute the active-key candidate from that preserved identity, then fail
+-- closed if the new key would collide.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM (
+      SELECT
+        "kind",
+        CASE
+          WHEN "kind" IN ('email', 'github_username') THEN translate(
+            normalize(btrim("display_value"), NFC),
+            'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+            'abcdefghijklmnopqrstuvwxyz'
+          )
+          ELSE normalize(btrim("display_value"), NFC)
+        END AS "next_value"
+      FROM "account_allowlist_entries"
+      WHERE "revoked_at" IS NULL
+    ) AS "canonical_console_allowlist"
+    GROUP BY "kind", "next_value"
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION
+      'account_allowlist_entries contains active identities that collide after NFC normalization; resolve them before upgrading';
+  END IF;
+END $$;
+
+UPDATE "account_allowlist_entries"
+SET
+  "normalized_value" = CASE
+    WHEN "kind" IN ('email', 'github_username') THEN translate(
+      normalize(btrim("display_value"), NFC),
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+      'abcdefghijklmnopqrstuvwxyz'
+    )
+    ELSE normalize(btrim("display_value"), NFC)
+  END,
+  "display_value" = normalize(btrim("display_value"), NFC)
+WHERE
+  "normalized_value" IS DISTINCT FROM CASE
+    WHEN "kind" IN ('email', 'github_username') THEN translate(
+      normalize(btrim("display_value"), NFC),
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+      'abcdefghijklmnopqrstuvwxyz'
+    )
+    ELSE normalize(btrim("display_value"), NFC)
+  END
+  OR "display_value" IS DISTINCT FROM normalize(btrim("display_value"), NFC);

--- a/src/database/migrations/meta/_journal.json
+++ b/src/database/migrations/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1779085200000,
       "tag": "0044_web_console_list_keyset_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1779085300000,
+      "tag": "0045_normalize_allowlist_identities",
+      "breakpoints": true
     }
   ]
 }

--- a/src/di/registrars/AuthServiceRegistrar.ts
+++ b/src/di/registrars/AuthServiceRegistrar.ts
@@ -196,9 +196,9 @@ export class AuthServiceRegistrar {
     const { ConsoleAccountAllowlistSignInAuthority } = await import(
       '../../web-console/services/account-allowlist/ConsoleAccountAllowlistSignInAuthority.js'
     );
-    return new ConsoleAccountAllowlistSignInAuthority(
-      new PostgresConsoleAccountAllowlistStore(database),
-    );
+    const store = new PostgresConsoleAccountAllowlistStore(database);
+    await store.assertIdentityMigrationReviewed();
+    return new ConsoleAccountAllowlistSignInAuthority(store);
   }
 
   /**

--- a/src/web-console/stores/IConsoleAccountAllowlistStore.ts
+++ b/src/web-console/stores/IConsoleAccountAllowlistStore.ts
@@ -90,6 +90,22 @@ export function normalizeAllowlistDisplayValue(value: string): string {
   return value.normalize('NFC').trim();
 }
 
+/**
+ * Match using the preserved display identity as the source of truth.
+ *
+ * Legacy rows may carry a normalizedValue produced by broader Unicode
+ * lowercasing. Recomputing from displayValue preserves the intended account
+ * while retaining the current cross-script and non-ASCII identity boundaries.
+ */
+export function storedConsoleAllowlistValueMatches(
+  kind: ConsoleAccountAllowlistKind,
+  displayValue: string,
+  presentedValue: string,
+): boolean {
+  return normalizeAllowlistValue(kind, displayValue)
+    === normalizeAllowlistValue(kind, presentedValue);
+}
+
 export function validateAllowlistValue(kind: ConsoleAccountAllowlistKind, value: string, name: string): void {
   const normalized = normalizeAllowlistDisplayValue(value);
   if (normalized === '' || normalized.length > 320) {

--- a/src/web-console/stores/InMemoryConsoleAccountAllowlistStore.ts
+++ b/src/web-console/stores/InMemoryConsoleAccountAllowlistStore.ts
@@ -13,6 +13,7 @@ import {
   cloneAllowlistEntry,
   normalizeAllowlistDisplayValue,
   normalizeAllowlistValue,
+  storedConsoleAllowlistValueMatches,
   validateAllowlistAddInput,
   validateAllowlistRemoveInput,
   validateAllowlistUpdateInput,
@@ -45,11 +46,11 @@ export class InMemoryConsoleAccountAllowlistStore implements IConsoleAccountAllo
     for (const entry of this.entries.values()) {
       if (entry.revokedAt) continue;
       if (entry.kind === 'email' && values.email &&
-        entry.normalizedValue === normalizeAllowlistValue('email', values.email)) return true;
+        storedConsoleAllowlistValueMatches(entry.kind, entry.displayValue, values.email)) return true;
       if (entry.kind === 'github_username' && values.githubUsername &&
-        entry.normalizedValue === normalizeAllowlistValue('github_username', values.githubUsername)) return true;
+        storedConsoleAllowlistValueMatches(entry.kind, entry.displayValue, values.githubUsername)) return true;
       if (entry.kind === 'github_id' && values.githubId &&
-        entry.normalizedValue === normalizeAllowlistValue('github_id', values.githubId)) return true;
+        storedConsoleAllowlistValueMatches(entry.kind, entry.displayValue, values.githubId)) return true;
     }
     return false;
   }
@@ -65,7 +66,8 @@ export class InMemoryConsoleAccountAllowlistStore implements IConsoleAccountAllo
     validateAllowlistAddInput(input);
     const normalizedValue = normalizeAllowlistValue(input.kind, input.value);
     if ([...this.entries.values()].some(entry =>
-      !entry.revokedAt && entry.kind === input.kind && entry.normalizedValue === normalizedValue)) {
+      !entry.revokedAt && entry.kind === input.kind &&
+      storedConsoleAllowlistValueMatches(entry.kind, entry.displayValue, input.value))) {
       throw new ConsoleStoreConflictError('active allowlist entry already exists');
     }
     const entry: ConsoleAccountAllowlistEntry = {

--- a/src/web-console/stores/PostgresConsoleAccountAllowlistStore.ts
+++ b/src/web-console/stores/PostgresConsoleAccountAllowlistStore.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, isNull, or, type SQL } from 'drizzle-orm';
+import { and, asc, eq, isNull, or, sql, type SQL } from 'drizzle-orm';
 
 import { withSystemContext } from '../../database/admin.js';
 import type { DatabaseInstance } from '../../database/connection.js';
@@ -26,6 +26,20 @@ import {
 
 export class PostgresConsoleAccountAllowlistStore implements IConsoleAccountAllowlistStore {
   constructor(private readonly db: DatabaseInstance) {}
+
+  async assertIdentityMigrationReviewed(): Promise<void> {
+    const rows = await withSystemContext(this.db, tx => tx.execute(sql`
+      SELECT "entry_id" AS "entryId"
+      FROM "account_allowlist_identity_migration_reviews"
+      WHERE "reviewed_at" IS NULL
+      LIMIT 1
+    `)) as unknown as Array<{ readonly entryId: string }>;
+    if (rows.length > 0) {
+      throw new Error(
+        'Sign-in allowlist authority cutover refused: legacy account allowlist identities require operator review.',
+      );
+    }
+  }
 
   async listActive(): Promise<ConsoleAccountAllowlistEntry[]> {
     return withSystemContext(this.db, tx => listActiveAccountAllowlistEntriesWithTx(tx));

--- a/tests/integration/auth/storage-parity.test.ts
+++ b/tests/integration/auth/storage-parity.test.ts
@@ -851,6 +851,7 @@ describePg('IAuthStorageLayer contract: PostgresAuthStorageLayer', () => {
       if (pgAvailable) await reset();
     },
   );
+
 });
 
 // ── Filesystem-only durability tests ───────────────────────────────────
@@ -892,6 +893,26 @@ describe('FilesystemAuthStorageLayer — durable across instances', () => {
 
     const b = new FilesystemAuthStorageLayer({ rootDir: dir });
     expect(await b.genericGet('Grant', 'g-persist')).toEqual({ accountId: 'github_42' });
+  });
+
+  it('matches and deduplicates a decomposed Unicode value from a legacy file', async () => {
+    await fs.writeFile(path.join(dir, 'allowlist.json'), JSON.stringify([{
+      id: 'legacy-nfd',
+      kind: 'email',
+      value: 'jose\u0301@example.com',
+      note: null,
+      createdBy: null,
+      createdAt: new Date().toISOString(),
+    }]));
+    const storage = new FilesystemAuthStorageLayer({ rootDir: dir });
+
+    await expect(storage.allowlistMatchesIdentity({
+      email: 'jos\u00e9@example.com',
+    })).resolves.toBe(true);
+    await expect(storage.allowlistAdd({
+      kind: 'email',
+      value: 'jos\u00e9@example.com',
+    })).rejects.toThrow('already exists');
   });
 
   it('cycle-16: bootstrap state survives across instances', async () => {

--- a/tests/integration/auth/storage-parity.test.ts
+++ b/tests/integration/auth/storage-parity.test.ts
@@ -913,6 +913,34 @@ describe('FilesystemAuthStorageLayer — durable across instances', () => {
       kind: 'email',
       value: 'jos\u00e9@example.com',
     })).rejects.toThrow('already exists');
+
+    await storage.allowlistUpdate('legacy-nfd', { note: 'canonicalized' });
+    const persisted = JSON.parse(
+      await fs.readFile(path.join(dir, 'allowlist.json'), 'utf8'),
+    ) as Array<{ value: string }>;
+    expect(persisted[0].value).toBe('jos\u00e9@example.com');
+  });
+
+  it('fails closed when legacy file entries collide after canonicalization', async () => {
+    await fs.writeFile(path.join(dir, 'allowlist.json'), JSON.stringify([
+      {
+        id: 'legacy-nfd',
+        kind: 'email',
+        value: 'jose\u0301@example.com',
+        createdAt: new Date().toISOString(),
+      },
+      {
+        id: 'canonical-nfc',
+        kind: 'email',
+        value: 'jos\u00e9@example.com',
+        createdAt: new Date().toISOString(),
+      },
+    ]));
+    const storage = new FilesystemAuthStorageLayer({ rootDir: dir });
+
+    await expect(storage.allowlistMatchesIdentity({
+      email: 'jos\u00e9@example.com',
+    })).rejects.toThrow('allowlist normalization collision');
   });
 
   it('cycle-16: bootstrap state survives across instances', async () => {

--- a/tests/unit/auth/embedded-as/allowlistIdentity.test.ts
+++ b/tests/unit/auth/embedded-as/allowlistIdentity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import {
   normalizeAuthAllowlistPrincipal,
   normalizeAuthAllowlistValue,
+  storedAuthAllowlistValueMatches,
 } from '../../../../src/auth/embedded-as/allowlistIdentity.js';
 
 describe('normalizeAuthAllowlistPrincipal', () => {
@@ -21,5 +22,18 @@ describe('normalizeAuthAllowlistPrincipal', () => {
     expect(normalizeAuthAllowlistValue('email', ' ALICE@example.test ')).toBe('alice@example.test');
     expect(normalizeAuthAllowlistValue('github_username', 'Mick')).toBe('mick');
     expect(normalizeAuthAllowlistValue('github_id', ' 184286 ')).toBe('184286');
+  });
+
+  it('matches canonical equivalents without collapsing cross-script look-alikes', () => {
+    expect(storedAuthAllowlistValueMatches(
+      'email',
+      'jose\u0301@example.test',
+      'jos\u00e9@example.test',
+    )).toBe(true);
+    expect(storedAuthAllowlistValueMatches(
+      'email',
+      '\u0430lice@example.test',
+      'alice@example.test',
+    )).toBe(false);
   });
 });

--- a/tests/unit/database/allowlist-normalization-migration.test.ts
+++ b/tests/unit/database/allowlist-normalization-migration.test.ts
@@ -30,6 +30,10 @@ describe('allowlist identity normalization migration', () => {
   it('rebuilds console lookup keys without confusable folding', () => {
     expect(migrationSql).toContain('SET\n  "normalized_value" = CASE');
     expect(migrationSql).toContain("WHEN \"kind\" IN ('email', 'github_username') THEN translate(");
+    expect(migrationSql).toContain('translate(\n            normalize(btrim("display_value"), NFC)');
+    expect(migrationSql.match(/'ABCDEFGHIJKLMNOPQRSTUVWXYZ'/g)).toHaveLength(3);
+    expect(migrationSql.match(/'abcdefghijklmnopqrstuvwxyz'/g)).toHaveLength(3);
+    expect(migrationSql).toContain('PostgreSQL lower() is locale-aware');
   });
 
   it('warns while legacy console identities still need operator review', () => {
@@ -41,5 +45,12 @@ describe('allowlist identity normalization migration', () => {
     expect(migrationSql.match(/HAVING count\(\*\) > 1/g)).toHaveLength(2);
     expect(migrationSql).toContain('auth_allowlist contains identities that collide');
     expect(migrationSql).toContain('account_allowlist_entries contains active identities that collide');
+    expect(migrationSql.indexOf('account_allowlist_entries contains active identities that collide'))
+      .toBeLessThan(migrationSql.indexOf('UPDATE "account_allowlist_entries"'));
+  });
+
+  it('leaves revoked console rows unchanged as audit history', () => {
+    const consoleUpdate = migrationSql.slice(migrationSql.indexOf('UPDATE "account_allowlist_entries"'));
+    expect(consoleUpdate).toContain('"revoked_at" IS NULL\n  AND (');
   });
 });

--- a/tests/unit/database/allowlist-normalization-migration.test.ts
+++ b/tests/unit/database/allowlist-normalization-migration.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from '@jest/globals';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const migrationPath = path.resolve(
+  testDir,
+  '../../../src/database/migrations/0045_normalize_allowlist_identities.sql',
+);
+const migrationSql = fs.readFileSync(migrationPath, 'utf8');
+
+describe('allowlist identity normalization migration', () => {
+  it('normalizes canonical encodings without compatibility folding', () => {
+    expect(migrationSql).toContain('normalize(btrim("value"), NFC)');
+    expect(migrationSql).toContain('normalize(btrim("display_value"), NFC)');
+    expect(migrationSql).not.toMatch(/NFK[CD]/);
+    expect(migrationSql).not.toContain('unaccent');
+  });
+
+  it('rebuilds console lookup keys from preserved display identities', () => {
+    expect(migrationSql).toContain('SET\n  "normalized_value" = CASE');
+    expect(migrationSql).toContain("WHEN \"kind\" IN ('email', 'github_username') THEN translate(");
+  });
+
+  it('fails closed on embedded and active-console canonical collisions', () => {
+    expect(migrationSql.match(/HAVING count\(\*\) > 1/g)).toHaveLength(2);
+    expect(migrationSql).toContain('auth_allowlist contains identities that collide');
+    expect(migrationSql).toContain('account_allowlist_entries contains active identities that collide');
+  });
+});

--- a/tests/unit/database/allowlist-normalization-migration.test.ts
+++ b/tests/unit/database/allowlist-normalization-migration.test.ts
@@ -18,9 +18,23 @@ describe('allowlist identity normalization migration', () => {
     expect(migrationSql).not.toContain('unaccent');
   });
 
-  it('rebuilds console lookup keys from preserved display identities', () => {
+  it('captures every legacy active console row before rebuilding lookup keys', () => {
+    expect(migrationSql).toContain('CREATE TABLE IF NOT EXISTS "account_allowlist_identity_migration_reviews"');
+    expect(migrationSql).toContain('"legacy_normalized_value"');
+    expect(migrationSql).toContain('"legacy_display_value"');
+    expect(migrationSql).toContain('WHERE "revoked_at" IS NULL\nON CONFLICT ("entry_id") DO NOTHING');
+    expect(migrationSql.indexOf('INSERT INTO "account_allowlist_identity_migration_reviews"'))
+      .toBeLessThan(migrationSql.indexOf('UPDATE "account_allowlist_entries"'));
+  });
+
+  it('rebuilds console lookup keys without confusable folding', () => {
     expect(migrationSql).toContain('SET\n  "normalized_value" = CASE');
     expect(migrationSql).toContain("WHEN \"kind\" IN ('email', 'github_username') THEN translate(");
+  });
+
+  it('warns while legacy console identities still need operator review', () => {
+    expect(migrationSql).toContain('WHERE "reviewed_at" IS NULL');
+    expect(migrationSql).toContain('require identity review before account-allowlist authority cutover');
   });
 
   it('fails closed on embedded and active-console canonical collisions', () => {

--- a/tests/unit/web-console/stores/ConsoleSecurityStores.test.ts
+++ b/tests/unit/web-console/stores/ConsoleSecurityStores.test.ts
@@ -1244,6 +1244,29 @@ describe('InMemoryConsoleAccountAllowlistStore', () => {
     await expect(store.matchesIdentity({ email: 'alice@example.test' })).resolves.toBe(false);
     await expect(store.matchesIdentity({ email: '\u0410lice@example.test' })).resolves.toBe(false);
   });
+
+  it('uses the preserved display identity for legacy Unicode-cased rows', async () => {
+    const store = new InMemoryConsoleAccountAllowlistStore([{
+      id: FACTOR_ID,
+      kind: 'email',
+      normalizedValue: '\u00e4lice@example.test',
+      displayValue: '\u00c4lice@example.test',
+      note: null,
+      createdByUserId: USER_ID,
+      createdAt: FIVE_MINUTES,
+      revokedByUserId: null,
+      revokedAt: null,
+    }]);
+
+    await expect(store.matchesIdentity({ email: '\u00c4lice@example.test' })).resolves.toBe(true);
+    await expect(store.matchesIdentity({ email: '\u00e4lice@example.test' })).resolves.toBe(false);
+    await expect(store.add({
+      kind: 'email',
+      value: '\u00c4lice@example.test',
+      createdByUserId: USER_ID,
+      createdAt: THIRTY_MINUTES,
+    })).rejects.toThrow('already exists');
+  });
 });
 
 describe('InMemoryConsoleSecurityInvalidationStore', () => {

--- a/tests/unit/web-console/stores/PostgresConsoleStores.test.ts
+++ b/tests/unit/web-console/stores/PostgresConsoleStores.test.ts
@@ -1954,6 +1954,19 @@ describe('PostgresAdminAuditWriter', () => {
 });
 
 describe('PostgresConsoleAccountAllowlistStore', () => {
+  it('blocks sign-in authority cutover while legacy identities need review', async () => {
+    const store = new PostgresConsoleAccountAllowlistStore({} as DatabaseInstance);
+    transaction.execute = jest.fn()
+      .mockResolvedValueOnce([{ entryId: ALLOWLIST_ID }])
+      .mockResolvedValueOnce([]);
+
+    await expect(store.assertIdentityMigrationReviewed()).rejects.toThrow(
+      'legacy account allowlist identities require operator review',
+    );
+    await expect(store.assertIdentityMigrationReviewed()).resolves.toBeUndefined();
+    expect(transaction.execute).toHaveBeenCalledTimes(2);
+  });
+
   it('uses active-entry filters and maps allowlist rows without exposing revoked history', async () => {
     const store = new PostgresConsoleAccountAllowlistStore({} as DatabaseInstance);
     transaction.select = jest.fn(() => selectingOrderedChain([allowlistRow()]));


### PR DESCRIPTION
## Summary

- preserve filesystem allowlist matches for canonically equivalent values written before NFC normalization
- add PostgreSQL migration 0045 to canonicalize embedded and console allowlist identities before the new lookup policy is used
- rebuild console lookup keys from preserved display identities rather than guessing from legacy normalized values
- abort the migration before changing data when canonicalization would collide
- document deployment, rollback, and operator remediation behavior

## Security properties

- NFC canonicalization only; no NFKC, unaccenting, or cross-script confusable rewriting
- visually similar principals from different scripts remain distinct
- PostgreSQL sign-in lookups remain indexed after the one-time migration
- filesystem duplicate checks canonicalize both persisted and incoming values
- active PostgreSQL collisions fail closed with an actionable migration error

## Validation

- 157 focused unit tests passed
- 146 filesystem/in-memory storage-parity integration tests passed; PostgreSQL parity remained locally skipped because the configured test database was unavailable
- TypeScript and focused ESLint checks passed
- migration journal JSON and diff checks passed
- migration executed successfully against disposable PostgreSQL 17
- PostgreSQL 17 collision fixture correctly aborted before normalization

Closes #2478.
